### PR TITLE
Dockerfile: add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,11 @@ WORKDIR "/app"
 ENV ROCKET_ENV=production ROCKET_ADDRESS=0.0.0.0 ROCKET_PORT=3666
 EXPOSE $ROCKET_PORT
 
+RUN set -ex; \ 
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/safe-client-gateway ./
 CMD ["./safe-client-gateway"]


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have a nightly compatible version of `rustfmt` installed
```bash
rustup component add rustfmt --toolchain nightly
```
- [x] You ran `cargo +nightly fmt` on the code base before submitting

PR #1073 removed `ca-certificates`  from  the runtime image. However, it is still required.
screenshot:


![微信截图_20230419134919](https://user-images.githubusercontent.com/65291464/232980225-505836f3-d8dd-48fe-9174-d553c87e317a.png)
