### PR TITLE
feature: Helm chart for Kubernetes deployment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dump.rdb
 **/venv
 
 *.DS_Store*
+
+# helm packages
+safe-client-gateway-*.tgz

--- a/charts/safe-client-gateway/.gitignore
+++ b/charts/safe-client-gateway/.gitignore
@@ -1,0 +1,1 @@
+values-testing.yaml

--- a/charts/safe-client-gateway/Chart.yaml
+++ b/charts/safe-client-gateway/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: safe-client-gateway
+version: 0.1.1
+appVersion: v3.53.0
+description: A Helm chart for installing Safe Client Gateway
+type: application
+icon: "https://raw.githubusercontent.com/safe-global/safe-core-sdk/main/assets/logo.png"

--- a/charts/safe-client-gateway/README.md
+++ b/charts/safe-client-gateway/README.md
@@ -1,0 +1,56 @@
+# Safe Client Gateway Chart
+
+This chart packages the Safe Client Gateway resources. The chart assumes that there is already an existing Redis instance available and connection attribute should be passed in the values of the Helm Chart
+
+## Parameters
+
+### Common parameters
+
+| Name               | Description                                        | Value |
+| ------------------ | -------------------------------------------------- | ----- |
+| `nameOverride`     | String to partially override common.names.fullname | `""`  |
+| `fullnameOverride` | String to fully override common.names.fullname     | `""`  |
+
+### Installation Parameters
+
+| Name                       | Description                                                      | Value                               |
+| -------------------------- | ---------------------------------------------------------------- | ----------------------------------- |
+| `replicas`                 | Replicas for deployment                                          | `1`                                 |
+| `strategy`                 | Strategy for deployment                                          | `Recreate`                          |
+| `commonLabels`             | Labels to add to all related objects                             | `{}`                                |
+| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                                |
+| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                                |
+| `ingress.hostname`         | Default host for the ingress record                              | `safe-client-gateway.cluster.local` |
+| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                                |
+| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                                |
+| `resources`                | Resource specification to deployment                             | `{}`                                |
+| `tolerations`              | Tolerations specifications to deployment                         | `[]`                                |
+| `affinity`                 | Affinity specifications to deployment                            | `{}`                                |
+| `image.registry`           | Docker registry to deployment                                    | `registry.hub.docker.com`           |
+| `image.repository`         | Docker image repository to deployment                            | `safeglobal/safe-client-gateway`    |
+| `image.tag`                | Docker image tag to deployment                                   | `""`                                |
+| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                      |
+| `service.type`             | service type                                                     | `ClusterIP`                         |
+| `service.ports.number`     | service port number                                              | `80`                                |
+| `service.ports.name`       | service port name                                                | `api`                               |
+| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                              |
+
+### Config Service Parameters
+
+| Name                                     | Description                                                                                                                        | Value                             |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `config.configServiceEndpoint`           | The Base URL of the Safe Config Service                                                                                            | `https://safe.cluster.local/cfg/` |
+| `config.secretKey`                       | Rocket Secret Key.                                                                                                                 | `""`                              |
+| `config.webToken`                        | Client Gateway Web Token                                                                                                           | `""`                              |
+| `config.transactionServiceToken`         | Client Gateway Web Token                                                                                                           | `""`                              |
+| `config.secretReferenceKey`              | Reference to an existing secret containing the following entries: ROCKET_SECRET_KEY, WEBHOOK_TOKEN, TRANSACTION_SERVICE_AUTH_TOKEN | `""`                              |
+| `config.extraEnvVars`                    | Add additional extra environment vairables to the configMap                                                                        | `{}`                              |
+| `config.logLevel`                        | Allowed hosts                                                                                                                      | `normal`                          |
+| `config.redis.secretReferenceKey`        | Reference to an existing secret containing the following entries: REDIS_URI                                                        | `""`                              |
+| `config.redis.password`                  | Redis user's password                                                                                                              | `""`                              |
+| `config.redis.host`                      | Redis server host                                                                                                                  | `""`                              |
+| `config.redis.port`                      | Redis server port                                                                                                                  | `6379`                            |
+| `config.redisMainnet.secretReferenceKey` | Reference to an existing secret containing the following entries: REDIS_URI_MAINNET                                                | `""`                              |
+| `config.redisMainnet.password`           | Redis user's password                                                                                                              | `""`                              |
+| `config.redisMainnet.host`               | Redis server host                                                                                                                  | `""`                              |
+| `config.redisMainnet.port`               | Redis server port                                                                                                                  | `6379`                            |

--- a/charts/safe-client-gateway/templates/NOTES.txt
+++ b/charts/safe-client-gateway/templates/NOTES.txt
@@ -1,0 +1,1 @@
+[INFO] Safe Config Service Helm chart deployed successfully

--- a/charts/safe-client-gateway/templates/_helpers.tpl
+++ b/charts/safe-client-gateway/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "safe-client-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "safe-client-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "safe-client-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Default labels
+*/}}
+{{- define "safe-client-gateway.labels" -}}
+helm.sh/chart: {{ include "safe-client-gateway.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "safe-client-gateway.name" . }}
+
+{{- end }}
+
+{{/*
+Redis Secret
+*/}}
+{{- define "safe-client-gateway.redis-secret" -}}
+{{- if .Values.config.redis.secretReferenceKey -}}
+{{- .Values.config.redis.secretReferenceKey }}
+{{- else -}}
+{{ include "safe-client-gateway.name" . }}-redis
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis Mainnet Secret
+*/}}
+{{- define "safe-client-gateway.redis-mainnet-secret" -}}
+{{- if .Values.config.redisMainnet.secretReferenceKey -}}
+{{- .Values.config.redisMainnet.secretReferenceKey }}
+{{- else -}}
+{{ include "safe-client-gateway.name" . }}-redis-mainnet
+{{- end -}}
+{{- end -}}

--- a/charts/safe-client-gateway/templates/configmap.yaml
+++ b/charts/safe-client-gateway/templates/configmap.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+data:
+  ROCKET_ADDRESS: 0.0.0.0
+  SCHEME: http
+  EXCHANGE_API_BASE_URI: http://api.exchangeratesapi.io/latest
+
+  CONFIG_SERVICE_URI: {{ .Values.config.configServiceEndpoint }}
+  ROCKET_LOG_LEVEL: {{ .Values.config.logLevel }}
+  ROCKET_PORT: {{ .Values.service.ports.number | quote }}
+
+  # Hardcoded parameters
+  FEATURE_FLAG_NESTED_DECODING: "true"
+  FEATURE_FLAG_BALANCES_RATE_IMPLEMENTATION: "false"
+  RUST_LOG: "safe_client_gateway=error,safe_client_gateway::monitoring=info"
+  LOG_ALL_ERROR_RESPONSES: "false"
+  VPC_TRANSACTION_SERVICE_URI: "true"
+  CONCURRENT_BALANCE_TOKEN_REQUESTS: "5"
+  INTERNAL_CLIENT_CONNECT_TIMEOUT: "10000"
+  SAFE_APP_INFO_REQUEST_TIMEOUT: "10000"
+  CHAIN_INFO_REQUEST_TIMEOUT: "15000"
+  {{- if .Values.config.extraEnvVars }}
+  {{ .Values.config.extraEnvVars | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/safe-client-gateway/templates/deployment.yaml
+++ b/charts/safe-client-gateway/templates/deployment.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy:
+    type: {{ .Values.strategy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ include "safe-client-gateway.name" . }}
+      app.kubernetes.io/name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ include "safe-client-gateway.name" . }}
+        app.kubernetes.io/name: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: config
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile: 
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 12 }}
+        {{- else }}
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 8192Mi
+          requests:
+            cpu: 1000m
+            memory: 2048Mi
+        {{- end }}
+        envFrom:
+          - configMapRef:
+              name: {{ include "safe-client-gateway.fullname" . }}
+          - secretRef:
+              {{- if .Values.config.secretReferenceKey }}
+              name: {{ .Values.config.secretReferenceKey }}
+              {{- else }}
+              name: {{ include "safe-client-gateway.fullname" . }}
+              {{- end }}
+          - secretRef:
+              name: {{ include "safe-client-gateway.redis-secret" . }}
+          - secretRef:
+              name: {{ include "safe-client-gateway.redis-mainnet-secret" . }}
+        ports:
+        - containerPort: {{ .Values.service.ports.number }}
+          name: {{ .Values.service.ports.name }}
+          protocol: TCP
+        # volumeMounts:
+        #   - name: tmp-volume
+        #     mountPath: /tmp
+      serviceAccountName: {{ include "safe-client-gateway.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # volumes:
+      #   - name: tmp-volume
+      #     emptyDir: {} 
+

--- a/charts/safe-client-gateway/templates/ingress.yaml
+++ b/charts/safe-client-gateway/templates/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
+    {{- .Values.ingress.annotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+                service:
+                    name: {{ include "safe-client-gateway.fullname" . }}
+                    port:
+                        name: {{ .Values.service.ports.name }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ .Values.ingress.hostname }}-tls

--- a/charts/safe-client-gateway/templates/rbac.yaml
+++ b/charts/safe-client-gateway/templates/rbac.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "safe-client-gateway.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}

--- a/charts/safe-client-gateway/templates/secret-redis-mainnet.yaml
+++ b/charts/safe-client-gateway/templates/secret-redis-mainnet.yaml
@@ -1,0 +1,21 @@
+---
+{{- if not .Values.config.redisMainnet.secretReferenceKey  }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}-redis-mainnet
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+type: Opaque
+data:
+  # Format redis://redis-ha.redis.svc.cluster.stage:6379/0 
+  REDIS_URI_MAINNET: "{{- printf "redis://%s@%s:%s" .Values.config.redisMainnet.password .Values.config.redisMainnet.host .Values.config.redisMainnet.port | b64enc -}}"
+{{- end }}

--- a/charts/safe-client-gateway/templates/secret-redis.yaml
+++ b/charts/safe-client-gateway/templates/secret-redis.yaml
@@ -1,0 +1,21 @@
+---
+{{- if not .Values.config.redis.secretReferenceKey  }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}-redis
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+type: Opaque
+data:
+  # Format redis://redis-ha.redis.svc.cluster.stage:6379/0 
+  REDIS_URI: "{{- printf "redis://%s@%s:%s" .Values.config.redis.password .Values.config.redis.host .Values.config.redis.port | b64enc -}}"
+{{- end }}

--- a/charts/safe-client-gateway/templates/secret.yaml
+++ b/charts/safe-client-gateway/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- if not .Values.config.secretReferenceKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+type: Opaque
+data:
+  ROCKET_SECRET_KEY: {{ .Values.config.secretKey | b64enc }}
+  WEBHOOK_TOKEN: {{ .Values.config.webToken | b64enc }}
+  TRANSACTION_SERVICE_AUTH_TOKEN: {{ .Values.config.transactionServiceToken | b64enc }}
+  #EXCHANGE_API_KEY: your_exchange_rate_api_token
+
+
+{{- end }}

--- a/charts/safe-client-gateway/templates/service.yaml
+++ b/charts/safe-client-gateway/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "safe-client-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-client-gateway.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.ports.number }}
+      name: {{ .Values.service.ports.name }}
+      targetPort: {{ .Values.service.ports.name }}
+      nodePort: null
+  selector:
+      app.kubernetes.io/instance: {{ include "safe-client-gateway.name" . }}
+      app.kubernetes.io/name: {{ .Release.Name }}

--- a/charts/safe-client-gateway/values.yaml
+++ b/charts/safe-client-gateway/values.yaml
@@ -1,0 +1,162 @@
+## @section Common parameters
+##
+
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+
+
+
+## @section Installation Parameters
+##
+
+## @param replicas Replicas for deployment
+##
+replicas: 1
+
+## @param strategy Strategy for deployment
+##
+strategy: "Recreate"
+
+## @param commonLabels [object] Labels to add to all related objects
+##
+commonLabels: {}
+
+## @param commonAnnotations [object] Annotations to to all related objects
+##
+commonAnnotations: {}
+
+ingress:
+  ## @param ingress.ingressClassName Name of the ingress class name to be used
+  ##
+  ingressClassName: ""
+
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: safe-client-gateway.cluster.local
+
+  ## @param ingress.annotations Annotations to be added to ingress resources
+  ## @skipingress.annotations
+  ##
+  annotations: {}
+
+## @param nodeSelector Object containing node selection constraint to deployment
+## https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+##
+nodeSelector: {}
+
+## @param resources Resource specification to deployment
+##
+resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+## @param tolerations Tolerations specifications to deployment
+##
+tolerations: []
+
+## @param affinity Affinity specifications to deployment
+##
+affinity: {}
+
+image:
+  ## @param image.registry Docker registry to deployment
+  ##
+  registry: registry.hub.docker.com
+
+  ## @param image.repository Docker image repository to deployment
+  ##
+  repository: safeglobal/safe-client-gateway
+
+  ## @param image.tag Docker image tag to deployment
+  ##
+  tag: ""
+
+  ## @param image.pullPolicy Pull policy to deployment as deinfed in 
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+
+service:
+  ## @param service.type service type
+  ##
+  type: ClusterIP
+  ports:
+    ## @param service.ports.number service port number
+    ##  
+    number: 80
+    ## @param service.ports.name service port name
+    ##
+    name: api
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
+
+## @section Config Service Parameters
+
+config:
+  ## @param config.configServiceEndpoint The Base URL of the Safe Config Service
+  ##
+  configServiceEndpoint: https://safe.cluster.local/cfg/
+
+  ## @param config.secretKey Rocket Secret Key. 
+  # Random string (generated with openssl rand -base64 32)
+  # [string] a 256-bit base64 encoded string (44 characters) to use as the secret key
+  ##
+  secretKey: ""
+
+  ## @param config.webToken Client Gateway Web Token
+  ##
+  webToken: ""
+
+  ## @param config.transactionServiceToken Client Gateway Web Token
+  ##
+  transactionServiceToken: ""
+
+  ## @param config.secretReferenceKey Reference to an existing secret containing the following entries: ROCKET_SECRET_KEY, WEBHOOK_TOKEN, TRANSACTION_SERVICE_AUTH_TOKEN
+  ##
+  secretReferenceKey: ""
+
+  ## @param config.extraEnvVars [object] Add additional extra environment vairables to the configMap
+  ##
+  extraEnvVars: {}
+
+  ## @param config.logLevel Allowed hosts
+  ##
+  logLevel: normal
+
+  redis:
+    ## @param config.redis.secretReferenceKey Reference to an existing secret containing the following entries: REDIS_URI
+    secretReferenceKey: ""
+    ## @param config.redis.password Redis user's password
+    password: ""
+    ## @param config.redis.host Redis server host
+    host: ""
+    ## @param config.redis.port Redis server port
+    port: "6379"
+
+  redisMainnet:
+    ## @param config.redisMainnet.secretReferenceKey Reference to an existing secret containing the following entries: REDIS_URI_MAINNET
+    secretReferenceKey: ""
+    ## @param config.redisMainnet.password Redis user's password
+    password: ""
+    ## @param config.redisMainnet.host Redis server host
+    host: ""
+    ## @param config.redisMainnet.port Redis server port
+    port: "6379"
+
+
+

--- a/scripts/build-and-push-helm-chart.sh
+++ b/scripts/build-and-push-helm-chart.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+: ${1:?"1st parameter <version> missing"}
+: ${1:?"2nd parameter <repository> missing"}
+
+declare version repository
+version="${1}"
+repository="${2}"
+
+helm package charts/safe-client-gateway --version "${version}"
+
+helm push "safe-client-gateway-${version}.tgz" "${repository}"


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have a nightly compatible version of `rustfmt` installed
```bash
rustup component add rustfmt --toolchain nightly
```
- [x] You ran `cargo +nightly fmt` on the code base before submitting

### What was wrong? 👾

The repository was lacking a Helm chart for Kubernetes deployment.

### How was it fixed? 🎯

The Helm chart was added at `charts/safe-client-gateway`, a location adhering to Helm best-practises. The helper script at `scripts/build-and-publish-helm-chart.sh` can be used for releasing new versions of the Helm chart. Documentation of the chart is at `charts/safe-client-gateway`.

This chart is already used successfully to run the Safe infrastructure in Kubernetes.


## Sibling PRs

- https://github.com/safe-global/safe-wallet-web/pull/2330
- https://github.com/safe-global/safe-transaction-service/pull/1601
- https://github.com/safe-global/safe-config-service/pull/911