### PR TITLE
fix: increase history `timezone_offset` precision

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -150,7 +150,7 @@ export class TransactionsHistoryMapper {
    */
   private getDayStartForDate(timestamp: Date, timezoneOffset: number): Date {
     if (timezoneOffset != 0) {
-      timestamp.setUTCSeconds(timezoneOffset / 1000);
+      timestamp.setUTCMilliseconds(timezoneOffset);
     }
     return new Date(
       Date.UTC(

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -287,7 +287,7 @@ describe('Transactions History Controller (Unit)', () => {
 
   it('Should change date label with time offset', async () => {
     const safeAddress = faker.finance.ethereumAddress();
-    const timezoneOffset = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
+    const timezoneOffset = 2 * 60 * 60 * 1000 + 1; // 2 hours in milliseconds + 1 millisecond to test precision of offsetting
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
     const moduleTransaction = moduleTransactionToJson(


### PR DESCRIPTION
The `timezone_offset` (in milliseconds) now sets to a precision of milliseconds. It was previously rounding the precision to seconds.