### PR TITLE
feat: add `timezone_offset` to transaction queue

### DIFF
--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -569,7 +569,8 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
   });
 
   it('should get a transaction queue with timezone offset', async () => {
-    const timezoneOffset = 2 * 60 * 60 * 1000 + 1; // 2 hours in milliseconds + 1 millisecond to test precision of offsetting    const chainId = faker.string.numeric();
+    const timezoneOffset = 2 * 60 * 60 * 1000 + 1; // 2 hours in milliseconds + 1 millisecond to test precision of offsetting
+    const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().build();
     const contractResponse = contractBuilder().build();
@@ -606,7 +607,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       },
     );
     networkService.get.mockImplementation((url: string) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -638,7 +639,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
     await request(app.getHttpServer())
       .get(
-        `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued/?timezone_offset=${timezoneOffset}`,
+        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued/?timezone_offset=${timezoneOffset}`,
       )
       .expect(200)
       .then(({ body }) => {

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -606,7 +606,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       },
     );
     networkService.get.mockImplementation((url: string) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -638,7 +638,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
     await request(app.getHttpServer())
       .get(
-        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued/?timezone_offset=${timezoneOffset}`,
+        `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued/?timezone_offset=${timezoneOffset}`,
       )
       .expect(200)
       .then(({ body }) => {

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -152,7 +152,7 @@ export class QueuedItemsMapper {
     // We clone so as to not modify the original dates
     return structuredClone(transactions).map((transaction) => {
       // No need to set the `executionDate` as it will not exist in the queue
-      transaction.modified?.setMilliseconds(timezoneOffset);
+      transaction.modified?.setUTCMilliseconds(timezoneOffset);
       transaction.submissionDate.setUTCMilliseconds(timezoneOffset);
 
       return transaction;

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -138,7 +138,7 @@ export class QueuedItemsMapper {
 
   /**
    * Adjusts the timestamps of transactions array by given offset
-   * @param timestamp transactions to offset the timestamp of
+   * @param transactions transactions to offset the timestamp of
    * @param timezoneOffset UTC timezone offset in milliseconds
    */
   private getTimezoneOffsetTransactions(
@@ -149,8 +149,12 @@ export class QueuedItemsMapper {
       return transactions;
     }
 
-    return transactions.map((transaction) => {
+    // We clone so as to not modify the original dates
+    return structuredClone(transactions).map((transaction) => {
+      // No need to set the `executionDate` as it will not exist in the queue
+      transaction.modified?.setMilliseconds(timezoneOffset);
       transaction.submissionDate.setUTCMilliseconds(timezoneOffset);
+
       return transaction;
     });
   }

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -28,8 +28,11 @@ export class QueuedItemsMapper {
     chainId: string,
     previousPageLastNonce: number | null,
     nextPageFirstNonce: number | null,
+    timezoneOffset: number,
   ): Promise<QueuedItem[]> {
-    const transactionGroups = this.groupByNonce(transactions.results);
+    const transactionGroups = this.groupByNonce(
+      this.getTimezoneOffsetTransactions(transactions.results, timezoneOffset),
+    );
     let lastProcessedNonce = previousPageLastNonce ?? -1;
 
     return flatten(
@@ -131,5 +134,24 @@ export class QueuedItemsMapper {
           transactions: transactions,
         },
     );
+  }
+
+  /**
+   * Adjusts the timestamps of transactions array by given offset
+   * @param timestamp transactions to offset the timestamp of
+   * @param timezoneOffset UTC timezone offset in milliseconds
+   */
+  private getTimezoneOffsetTransactions(
+    transactions: MultisigTransaction[],
+    timezoneOffset: number,
+  ): MultisigTransaction[] {
+    if (timezoneOffset === 0) {
+      return transactions;
+    }
+
+    return transactions.map((transaction) => {
+      transaction.submissionDate.setUTCMilliseconds(timezoneOffset);
+      return transaction;
+    });
   }
 }

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -184,6 +184,8 @@ export class TransactionsController {
     @RouteUrlDecorator() routeUrl: URL,
     @Param('safeAddress') safeAddress: string,
     @PaginationDataDecorator() paginationData: PaginationData,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffset: number,
     @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
     trusted: boolean,
   ): Promise<Partial<Page<QueuedItem>>> {
@@ -193,6 +195,7 @@ export class TransactionsController {
       safeAddress,
       paginationData,
       trusted,
+      timezoneOffset,
     });
   }
 

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -308,6 +308,7 @@ export class TransactionsService {
     safeAddress: string;
     paginationData: PaginationData;
     trusted?: boolean;
+    timezoneOffset: number;
   }): Promise<Page<QueuedItem>> {
     const pagination = this.getAdjustedPaginationForQueue(args.paginationData);
     const safeInfo = await this.safeRepository.getSafe({
@@ -330,6 +331,7 @@ export class TransactionsService {
       args.chainId,
       this.getPreviousPageLastNonce(transactions, args.paginationData),
       this.getNextPageFirstNonce(transactions),
+      args.timezoneOffset,
     );
 
     return {


### PR DESCRIPTION
This implements the missing `timezone_offset` query parameter to the `chains/:chainId/safes/:safeAddress/transactions/queued` endpoint.