### PR TITLE
Add Safe Relay domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@nestjs/serve-static": "^4.0.0",
     "@nestjs/swagger": "^7.1.7",
     "@node-redis/json": "^1.0.2",
+    "@openzeppelin/contracts": "^4.9.3",
+    "@safe-global/safe-deployments": "^1.26.0",
     "@types/lodash": "^4.14.197",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@nestjs/serve-static": "^4.0.0",
     "@nestjs/swagger": "^7.1.7",
     "@node-redis/json": "^1.0.2",
-    "@openzeppelin/contracts": "^4.9.3",
     "@safe-global/safe-deployments": "^1.26.0",
     "@types/lodash": "^4.14.197",
     "ajv": "^8.12.0",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -37,6 +37,7 @@ export default (): ReturnType<typeof configuration> => ({
     host: faker.internet.domainName(),
     port: faker.internet.port().toString(),
   },
+  relay: { limit: faker.number.int({ min: 1 }) },
   safeConfig: {
     baseUri: faker.internet.url({ appendSlash: false }),
   },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -51,6 +51,9 @@ export default () => ({
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',
   },
+  relay: {
+    limit: parseInt(process.env.RELAY_THROTTLE_LIMIT ?? `${5}`),
+  },
   safeConfig: {
     baseUri:
       process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.safe.global/',

--- a/src/domain/interfaces/relay-api.interface.ts
+++ b/src/domain/interfaces/relay-api.interface.ts
@@ -1,0 +1,5 @@
+export interface RelayApi {
+  getRelayCount(args: { chainId: string; address: string }): Promise<number>;
+
+  relay(args: { chainId: string; data: string; to: string }): Promise<unknown>;
+}

--- a/src/domain/relay/contracts/contract.helper.ts
+++ b/src/domain/relay/contracts/contract.helper.ts
@@ -1,0 +1,42 @@
+import {
+  ContractFunctionArgsMapper,
+  decode,
+  isCall,
+} from '@/domain/relay/entities/contract-function.entity';
+import { Hex } from 'viem/src/types/misc';
+import { Abi } from 'viem';
+
+/**
+ * The {@link ContractHelper} is an abstraction which, given a contract ABI,
+ * provides functionality to query and decode interactions done with that ABI
+ */
+export abstract class ContractHelper {
+  protected abstract readonly abi: readonly unknown[] | Abi;
+
+  /**
+   * Decodes the function {@link data} using the specified {@link argsMapper}.
+   *
+   * An error is thrown in the following conditions:
+   *
+   * - the {@link argsMapper} function name does not match the function call set in
+   * {@link data}
+   * - the provided {@link argsMapper} throws an error (e.g.: unexpected arg format).
+   *
+   * @param argsMapper - the mapper to be used to decode the args provided in {@link data}
+   * @param data - the data to be used for decoding the arguments
+   */
+  decode<B>(argsMapper: ContractFunctionArgsMapper<B>, data: Hex): B {
+    return decode(argsMapper, this.abi, data);
+  }
+
+  /**
+   * Checks if the provided {@link data} represents *any* function call
+   * targeting the provided ABI.
+   *
+   * @param data - the data to be used to check if the function call is part of
+   * the provided ABI
+   */
+  isCall(data: Hex): boolean {
+    return isCall(this.abi, data);
+  }
+}

--- a/src/domain/relay/contracts/erc20-contract.helper.spec.ts
+++ b/src/domain/relay/contracts/erc20-contract.helper.spec.ts
@@ -5,15 +5,20 @@ import { concatHex, getAddress, pad, toHex } from 'viem';
 describe('ERC20 Contract Helper Tests', () => {
   let target: Erc20ContractHelper;
 
+  const transferFunctionSignature = `0xa9059cbb`;
+
   beforeEach(() => {
     target = new Erc20ContractHelper();
   });
 
   it('decodes a transfer correctly', () => {
-    const functionSignature = `0xa9059cbb`;
     const to = getAddress(faker.finance.ethereumAddress());
     const value = toHex(faker.number.bigInt());
-    const callData = concatHex([functionSignature, pad(to), pad(value)]);
+    const callData = concatHex([
+      transferFunctionSignature,
+      pad(to),
+      pad(value),
+    ]);
 
     const actual = target.decode(Erc20ContractHelper.TRANSFER, callData);
 
@@ -34,11 +39,10 @@ describe('ERC20 Contract Helper Tests', () => {
   });
 
   it('isCall returns true for a transfer call', () => {
-    const functionSignature = `0xa9059cbb`;
     const toAddress = getAddress(faker.finance.ethereumAddress());
     const toArg = pad(toAddress);
     const valueArg = pad(toHex(faker.number.hex()));
-    const callData = concatHex([functionSignature, toArg, valueArg]);
+    const callData = concatHex([transferFunctionSignature, toArg, valueArg]);
 
     const actual = target.isCall(callData);
 

--- a/src/domain/relay/contracts/erc20-contract.helper.spec.ts
+++ b/src/domain/relay/contracts/erc20-contract.helper.spec.ts
@@ -1,0 +1,60 @@
+import { Erc20ContractHelper } from '@/domain/relay/contracts/erc20-contract.helper';
+import { faker } from '@faker-js/faker';
+import { concatHex, getAddress, pad, toHex } from 'viem';
+
+describe('ERC20 Contract Helper Tests', () => {
+  let target: Erc20ContractHelper;
+
+  beforeEach(() => {
+    target = new Erc20ContractHelper();
+  });
+
+  it('decodes a transfer correctly', () => {
+    const functionSignature = `0xa9059cbb`;
+    const to = getAddress(faker.finance.ethereumAddress());
+    const value = toHex(faker.number.bigInt());
+    const callData = concatHex([functionSignature, pad(to), pad(value)]);
+
+    const actual = target.decode(Erc20ContractHelper.TRANSFER, callData);
+
+    expect(actual).toEqual({ to });
+  });
+
+  it('decoding a non transfer call throws', () => {
+    const functionSignature = faker.string.hexadecimal({
+      length: 8,
+    }) as `0x${string}`;
+    const arg1 = pad(getAddress(faker.finance.ethereumAddress()));
+    const arg2 = pad(getAddress(faker.finance.ethereumAddress()));
+    const callData = concatHex([functionSignature, arg1, arg2]);
+
+    expect(() => {
+      target.decode(Erc20ContractHelper.TRANSFER, callData);
+    }).toThrow();
+  });
+
+  it('isCall returns true for a transfer call', () => {
+    const functionSignature = `0xa9059cbb`;
+    const toAddress = getAddress(faker.finance.ethereumAddress());
+    const toArg = pad(toAddress);
+    const valueArg = pad(toHex(faker.number.hex()));
+    const callData = concatHex([functionSignature, toArg, valueArg]);
+
+    const actual = target.isCall(callData);
+
+    expect(actual).toBe(true);
+  });
+
+  it('isCall returns false for a erc contract call', () => {
+    const functionSignature = faker.string.hexadecimal({
+      length: 8,
+    }) as `0x${string}`;
+    const arg1 = pad(getAddress(faker.finance.ethereumAddress()));
+    const arg2 = pad(getAddress(faker.finance.ethereumAddress()));
+    const callData = concatHex([functionSignature, arg1, arg2]);
+
+    const actual = target.isCall(callData);
+
+    expect(actual).toBe(false);
+  });
+});

--- a/src/domain/relay/contracts/erc20-contract.helper.ts
+++ b/src/domain/relay/contracts/erc20-contract.helper.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { Hex } from 'viem/src/types/misc';
+import * as erc20Abi from '@openzeppelin/contracts/build/contracts/ERC20.json';
+import { ContractFunctionArgsMapper } from '@/domain/relay/entities/contract-function.entity';
+import { Abi, isHex } from 'viem';
+import { ContractHelper } from '@/domain/relay/contracts/contract.helper';
+
+@Injectable()
+export class Erc20ContractHelper extends ContractHelper {
+  protected readonly abi: readonly unknown[] | Abi = erc20Abi.abi;
+
+  static TRANSFER: ContractFunctionArgsMapper<{ to: Hex }> = {
+    name: 'transfer',
+    mapper(args: readonly unknown[]): { to: Hex } {
+      if (!isHex(args[0])) throw Error('transfer arg is not in hex format');
+      return { to: args[0] };
+    },
+  };
+}

--- a/src/domain/relay/contracts/erc20-contract.helper.ts
+++ b/src/domain/relay/contracts/erc20-contract.helper.ts
@@ -1,13 +1,40 @@
 import { Injectable } from '@nestjs/common';
 import { Hex } from 'viem/src/types/misc';
-import * as erc20Abi from '@openzeppelin/contracts/build/contracts/ERC20.json';
 import { ContractFunctionArgsMapper } from '@/domain/relay/entities/contract-function.entity';
 import { Abi, isHex } from 'viem';
 import { ContractHelper } from '@/domain/relay/contracts/contract.helper';
 
+// Consider adding @openzeppelin/contracts if we need to support more ERC-20 token functions
+const TRANSFER_ABI: readonly unknown[] | Abi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];
+
 @Injectable()
 export class Erc20ContractHelper extends ContractHelper {
-  protected readonly abi: readonly unknown[] | Abi = erc20Abi.abi;
+  protected readonly abi: readonly unknown[] | Abi = TRANSFER_ABI;
 
   static TRANSFER: ContractFunctionArgsMapper<{ to: Hex }> = {
     name: 'transfer',

--- a/src/domain/relay/contracts/safe-contract.helper.spec.ts
+++ b/src/domain/relay/contracts/safe-contract.helper.spec.ts
@@ -1,0 +1,154 @@
+import { faker } from '@faker-js/faker';
+import { concatHex, encodeFunctionData, getAddress, pad, toHex } from 'viem';
+import { SafeContractHelper } from '@/domain/relay/contracts/safe-contract.helper';
+import { CALL_OPERATION } from '@/domain/safe/entities/operation.entity';
+
+const ABI_ITEM = {
+  inputs: [
+    {
+      internalType: 'address',
+      name: 'to',
+      type: 'address',
+    },
+    {
+      internalType: 'uint256',
+      name: 'value',
+      type: 'uint256',
+    },
+    {
+      internalType: 'bytes',
+      name: 'data',
+      type: 'bytes',
+    },
+    {
+      internalType: 'enum Enum.Operation',
+      name: 'operation',
+      type: 'uint8',
+    },
+    {
+      internalType: 'uint256',
+      name: 'safeTxGas',
+      type: 'uint256',
+    },
+    {
+      internalType: 'uint256',
+      name: 'baseGas',
+      type: 'uint256',
+    },
+    {
+      internalType: 'uint256',
+      name: 'gasPrice',
+      type: 'uint256',
+    },
+    {
+      internalType: 'address',
+      name: 'gasToken',
+      type: 'address',
+    },
+    {
+      internalType: 'address payable',
+      name: 'refundReceiver',
+      type: 'address',
+    },
+    {
+      internalType: 'bytes',
+      name: 'signatures',
+      type: 'bytes',
+    },
+  ],
+  name: 'execTransaction',
+  outputs: [
+    {
+      internalType: 'bool',
+      name: 'success',
+      type: 'bool',
+    },
+  ],
+  stateMutability: 'payable',
+  type: 'function',
+};
+
+describe('Safe Contract Helper Tests', () => {
+  let target: SafeContractHelper;
+
+  beforeEach(() => {
+    target = new SafeContractHelper();
+  });
+
+  it('decodes an execTransaction correctly', () => {
+    const to = getAddress(faker.finance.ethereumAddress());
+    const value = faker.number.bigInt();
+    const callData = getExecTransactionCallData({ to, value });
+
+    const actual = target.decode(SafeContractHelper.EXEC_TRANSACTION, callData);
+
+    expect(actual).toEqual({ data: '0x00', to: to, value: value });
+  });
+
+  it('decoding a non execTransaction call throws', () => {
+    const functionSignature = faker.string.hexadecimal({
+      length: 8,
+    }) as `0x${string}`;
+    const arg1 = pad(getAddress(faker.finance.ethereumAddress()));
+    const arg2 = pad(getAddress(faker.finance.ethereumAddress()));
+    const callData = concatHex([functionSignature, arg1, arg2]);
+
+    expect(() => {
+      target.decode(SafeContractHelper.EXEC_TRANSACTION, callData);
+    }).toThrow();
+  });
+
+  it('isCall returns true for a execTransaction call', () => {
+    const callData = getExecTransactionCallData();
+
+    const actual = target.isCall(callData);
+
+    expect(actual).toBe(true);
+  });
+
+  it('isCall returns false for a non safe call', () => {
+    const functionSignature = faker.string.hexadecimal({
+      length: 8,
+    }) as `0x${string}`;
+    const arg1 = pad(getAddress(faker.finance.ethereumAddress()));
+    const arg2 = pad(getAddress(faker.finance.ethereumAddress()));
+    const callData = concatHex([functionSignature, arg1, arg2]);
+
+    const actual = target.isCall(callData);
+
+    expect(actual).toBe(false);
+  });
+});
+
+function getExecTransactionCallData(args?: {
+  to?: `0x${string}`;
+  value?: bigint;
+}): `0x${string}` {
+  const to = args?.to ?? getAddress(faker.finance.ethereumAddress());
+  const value = args?.value ?? faker.number.bigInt();
+  const data = toHex(0);
+  const operation = CALL_OPERATION;
+  const safeTxGas = faker.number.bigInt();
+  const baseGas = faker.number.bigInt();
+  const gasPrice = faker.number.bigInt();
+  const gasToken = getAddress(faker.finance.ethereumAddress());
+  const refundReceiver = getAddress(faker.finance.ethereumAddress());
+  const signatures = faker.string.hexadecimal({ length: 64 * 2 });
+
+  return encodeFunctionData({
+    abi: [ABI_ITEM],
+    functionName: 'execTransaction',
+    args: [
+      to,
+      value,
+      data,
+      operation,
+      safeTxGas,
+      baseGas,
+      gasPrice,
+      gasToken,
+      refundReceiver,
+      signatures,
+    ],
+  });
+}

--- a/src/domain/relay/contracts/safe-contract.helper.spec.ts
+++ b/src/domain/relay/contracts/safe-contract.helper.spec.ts
@@ -66,6 +66,106 @@ describe('Safe Contract Helper Tests', () => {
     expect(actual).toBe(false);
   });
 
+  it.each([
+    {
+      functionName: 'addOwnerWithThreshold',
+      args: [
+        getAddress(faker.finance.ethereumAddress()),
+        toHex(faker.number.bigInt()),
+      ],
+    },
+    {
+      functionName: 'approveHash',
+      args: [pad(toHex(faker.number.bigInt()))],
+    },
+    {
+      functionName: 'approvedHashes',
+      args: [
+        getAddress(faker.finance.ethereumAddress()),
+        pad(toHex(faker.number.bigInt())),
+      ],
+    },
+    {
+      functionName: 'changeThreshold',
+      args: [pad(toHex(faker.number.bigInt()))],
+    },
+    {
+      functionName: 'checkNSignatures',
+      args: [
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt())),
+      ],
+    },
+    {
+      functionName: 'checkSignatures',
+      args: [
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt())),
+      ],
+    },
+    {
+      functionName: 'disableModule',
+      args: [
+        getAddress(faker.finance.ethereumAddress()),
+        getAddress(faker.finance.ethereumAddress()),
+      ],
+    },
+    {
+      functionName: 'enableModule',
+      args: [getAddress(faker.finance.ethereumAddress())],
+    },
+    {
+      functionName: 'execTransactionFromModule',
+      args: [
+        getAddress(faker.finance.ethereumAddress()),
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt())),
+        pad(toHex(faker.number.bigInt({ min: 0, max: 1 }))),
+      ],
+    },
+    {
+      functionName: 'isModuleEnabled',
+      args: [getAddress(faker.finance.ethereumAddress())],
+    },
+    {
+      functionName: 'isOwner',
+      args: [getAddress(faker.finance.ethereumAddress())],
+    },
+    {
+      functionName: 'removeOwner',
+      args: [
+        getAddress(faker.finance.ethereumAddress()),
+        getAddress(faker.finance.ethereumAddress()),
+        toHex(faker.number.bigInt()),
+      ],
+    },
+    {
+      functionName: 'setGuard',
+      args: [getAddress(faker.finance.ethereumAddress())],
+    },
+    {
+      functionName: 'swapOwner',
+      args: [
+        getAddress(faker.finance.ethereumAddress()),
+        getAddress(faker.finance.ethereumAddress()),
+        getAddress(faker.finance.ethereumAddress()),
+      ],
+    },
+  ])('$functionName is valid call', ({ functionName, args }) => {
+    const callData = encodeFunctionData({
+      abi,
+      functionName,
+      args,
+    });
+
+    const actual = target.isCall(callData);
+
+    expect(actual).toBe(true);
+  });
+
   function getExecTransactionCallData(args?: {
     to?: `0x${string}`;
     value?: bigint;

--- a/src/domain/relay/contracts/safe-contract.helper.ts
+++ b/src/domain/relay/contracts/safe-contract.helper.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { getSafeSingletonDeployment } from '@safe-global/safe-deployments';
+import { Abi, isHex } from 'viem';
+import { Hex } from 'viem/src/types/misc';
+import { ContractFunctionArgsMapper } from '@/domain/relay/entities/contract-function.entity';
+import { ContractHelper } from '@/domain/relay/contracts/contract.helper';
+
+@Injectable()
+export class SafeContractHelper extends ContractHelper {
+  protected readonly abi: readonly unknown[] | Abi;
+
+  private static SUPPORTED_SAFE_VERSION = '1.3.0';
+
+  static EXEC_TRANSACTION: ContractFunctionArgsMapper<{
+    data: Hex;
+    to: Hex;
+    value: bigint;
+  }> = {
+    name: 'execTransaction',
+    mapper(args: readonly unknown[]): { data: Hex; to: Hex; value: bigint } {
+      if (!isHex(args[2]) || !isHex(args[0]) || typeof args[1] !== 'bigint')
+        throw Error('Unexpected type for execTransaction args');
+      return { data: args[2], to: args[0], value: args[1] };
+    },
+  };
+
+  constructor() {
+    super();
+    const safeDeployment = getSafeSingletonDeployment({
+      version: SafeContractHelper.SUPPORTED_SAFE_VERSION,
+    });
+    if (!safeDeployment) throw Error('Safe deployment is undefined');
+    this.abi = safeDeployment.abi;
+  }
+}

--- a/src/domain/relay/entities/contract-function.entity.ts
+++ b/src/domain/relay/entities/contract-function.entity.ts
@@ -1,0 +1,56 @@
+import { Abi, decodeFunctionData } from 'viem';
+import { Hex } from 'viem/src/types/misc';
+
+/**
+ * Argument mapper representation for a contract function.
+ *
+ * The generic parameter represents the expected type that should be returned
+ * by the mapper.
+ */
+export type ContractFunctionArgsMapper<B> = {
+  name: string;
+  mapper: (args: readonly unknown[]) => B;
+};
+
+/**
+ * Decodes the arguments of the {@link contractFunction} given the provided
+ * {@link abi}.
+ *
+ * @param contractFunction - the contract function used to decode the arguments
+ * @param abi - the abi of the contract use to check the function call
+ * @param data - the data representing the function call
+ */
+export function decode<B>(
+  contractFunction: ContractFunctionArgsMapper<B>,
+  abi: readonly unknown[] | Abi,
+  data: Hex,
+): B {
+  const { functionName, args } = decodeFunctionData({
+    abi,
+    data,
+  });
+
+  if (contractFunction.name != functionName || !args)
+    throw Error(`Provided data is not a call to ${contractFunction.name}`);
+
+  return contractFunction.mapper(args);
+}
+
+/**
+ * Checks if a {@link data} can represent a call to a target with {@link abi}
+ *
+ * @param abi - the abi of the contract to check the function call with
+ * @param data - the data containing the function call
+ */
+export function isCall(abi: readonly unknown[] | Abi, data: Hex): boolean {
+  try {
+    decodeFunctionData({
+      abi,
+      data,
+    });
+  } catch {
+    return false;
+  }
+
+  return true;
+}

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -52,9 +52,7 @@ export class LimitAddressesMapper {
       // If the ERC20 transfer targets 'self' (the Safe), we consider it to be invalid
       return erc20DecodedData.to !== to;
     } catch {
-      this.loggingService.debug(
-        'execTransaction data is not an ERC20 transfer',
-      );
+      // swallow exception if data is not an ERC20 transfer
     }
 
     // If a transaction does not target 'self' consider it valid

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -62,7 +62,7 @@ export class LimitAddressesMapper {
 
     // Transaction targets 'self'
     // Block transactions targeting self with a value greater than 0
-    if (Number(execTransaction.value) > 0) {
+    if (execTransaction.value > BigInt(0)) {
       return false;
     }
 

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -1,0 +1,74 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { SafeContractHelper } from './contracts/safe-contract.helper';
+import { Erc20ContractHelper } from './contracts/erc20-contract.helper';
+import { Hex } from 'viem/src/types/misc';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+
+export interface RelayPayload {
+  chainId: string;
+  data: Hex;
+  to: Hex;
+  gasLimit: bigint;
+}
+
+@Injectable()
+export class LimitAddressesMapper {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    private readonly safeContract: SafeContractHelper,
+    private readonly erc20Contract: Erc20ContractHelper,
+  ) {}
+
+  getLimitAddresses(relayPayload: RelayPayload): Hex[] {
+    if (this.isValidExecTransactionCall(relayPayload.to, relayPayload.data)) {
+      return [relayPayload.to];
+    }
+
+    // TODO Handle Multisend
+
+    // TODO Handle create proxy with nonce
+
+    throw Error('Cannot get limit addresses – Invalid transfer');
+  }
+
+  private isValidExecTransactionCall(to: string, data: Hex): boolean {
+    let execTransaction: { data: Hex; to: Hex; value: bigint };
+    // If transaction is an execTransaction
+    try {
+      execTransaction = this.safeContract.decode(
+        SafeContractHelper.EXEC_TRANSACTION,
+        data,
+      );
+    } catch (e) {
+      return false;
+    }
+
+    // If data of execTransaction is an ERC20 transfer
+    try {
+      const erc20DecodedData = this.erc20Contract.decode(
+        Erc20ContractHelper.TRANSFER,
+        execTransaction.data,
+      );
+      // If the ERC20 transfer targets 'self' (the Safe), we consider it to be invalid
+      return erc20DecodedData.to !== to;
+    } catch {
+      this.loggingService.debug(
+        'execTransaction data is not an ERC20 transfer',
+      );
+    }
+
+    // If a transaction does not target 'self' consider it valid
+    if (to !== execTransaction.to) {
+      return true;
+    }
+
+    // Transaction targets 'self'
+    // Block transactions targeting self with a value greater than 0
+    if (Number(execTransaction.value) > 0) {
+      return false;
+    }
+
+    const isCancellation = execTransaction.data === '0x';
+    return isCancellation || this.safeContract.isCall(execTransaction.data);
+  }
+}

--- a/src/domain/relay/relay.module.ts
+++ b/src/domain/relay/relay.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SafeContractHelper } from './contracts/safe-contract.helper';
+import { LimitAddressesMapper } from '@/domain/relay/limit-addresses.mapper';
+import { Erc20ContractHelper } from '@/domain/relay/contracts/erc20-contract.helper';
+
+@Module({
+  providers: [LimitAddressesMapper, Erc20ContractHelper, SafeContractHelper],
+  exports: [LimitAddressesMapper],
+})
+export class RelayModule {}

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -22,16 +22,12 @@ export class RelayRepository {
   // Number of relay requests per ttl
   private readonly limit: number;
 
-  @Inject(IConfigurationService)
-  private readonly configurationService: IConfigurationService;
-
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
     @Inject(IConfigurationService) configurationService: IConfigurationService,
     private readonly limitAddressesMapper: LimitAddressesMapper,
     private readonly relayApi: RelayApi,
   ) {
-    this.configurationService = configurationService;
     this.limit = configurationService.getOrThrow('relay.limit');
   }
 

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -1,0 +1,71 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { RelayApi } from '../interfaces/relay-api.interface';
+import { LimitAddressesMapper, RelayPayload } from './limit-addresses.mapper';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { Hex } from 'viem/src/types/misc';
+
+class RelayLimitReachedError extends Error {
+  constructor(
+    readonly address: Hex,
+    readonly current: number,
+    readonly limit: number,
+  ) {
+    super(
+      `Relay limit reached for ${address} | current: ${current} | limit: ${limit}`,
+    );
+  }
+}
+
+@Injectable({})
+export class RelayRepository {
+  // Number of relay requests per ttl
+  private readonly limit: number;
+
+  @Inject(IConfigurationService)
+  private readonly configurationService: IConfigurationService;
+
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    @Inject(IConfigurationService) configurationService: IConfigurationService,
+    private readonly limitAddressesMapper: LimitAddressesMapper,
+    private readonly relayApi: RelayApi,
+  ) {
+    this.configurationService = configurationService;
+    this.limit = configurationService.getOrThrow('relay.limit');
+  }
+
+  async relay(relayPayload: RelayPayload): Promise<unknown> {
+    const relayAddresses =
+      this.limitAddressesMapper.getLimitAddresses(relayPayload);
+    for (const address of relayAddresses) {
+      const canRelay = await this.canRelay({
+        chainId: relayPayload.chainId,
+        address,
+      });
+      if (!canRelay.result) {
+        const error = new RelayLimitReachedError(
+          address,
+          canRelay.currentCount,
+          this.limit,
+        );
+        this.loggingService.info(error.message);
+        throw error;
+      }
+    }
+
+    return this.relayApi.relay(relayPayload);
+  }
+
+  private async canRelay(args: {
+    chainId: string;
+    address: string;
+  }): Promise<{ result: boolean; currentCount: number }> {
+    const currentCount = await this.getRelayCount(args);
+    return { result: currentCount < this.limit, currentCount };
+  }
+
+  getRelayCount(args: { chainId: string; address: string }): Promise<number> {
+    return this.relayApi.getRelayCount(args);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,6 +1408,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openzeppelin/contracts@npm:^4.9.3":
+  version: 4.9.3
+  resolution: "@openzeppelin/contracts@npm:4.9.3"
+  checksum: 4932063e733b35fa7669b9fe2053f69b062366c5c208b0c6cfa1ac451712100c78acff98120c3a4b88d94154c802be05d160d71f37e7d74cadbe150964458838
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -1468,6 +1475,15 @@ __metadata:
   peerDependencies:
     "@redis/client": ^1.0.0
   checksum: 6bbdb0b793dcbd13518aa60a09a980f953554e4c745bfacc1611baa8098f360e0378e8ee6b7faf600a67f1de83f4b68bbec6f95a0740faee6164c14be3a30752
+  languageName: node
+  linkType: hard
+
+"@safe-global/safe-deployments@npm:^1.26.0":
+  version: 1.26.0
+  resolution: "@safe-global/safe-deployments@npm:1.26.0"
+  dependencies:
+    semver: ^7.3.7
+  checksum: ea36c04c42f33f679248b4be9477a608b3ad2b4ac87da7c943bac2720ad556fc4d1f87b9ba43b0737fc0a9217bfc232c27042c3720a02cbf7cd90af286d5cb62
   languageName: node
   linkType: hard
 
@@ -6888,6 +6904,8 @@ __metadata:
     "@nestjs/swagger": ^7.1.7
     "@nestjs/testing": ^10.2.5
     "@node-redis/json": ^1.0.2
+    "@openzeppelin/contracts": ^4.9.3
+    "@safe-global/safe-deployments": ^1.26.0
     "@types/express": ^4.17.17
     "@types/jest": 29.5.4
     "@types/lodash": ^4.14.197
@@ -6979,6 +6997,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.8":
   version: 7.5.2
   resolution: "semver@npm:7.5.2"
@@ -6987,17 +7016,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 3fdf5d1e6f170fe8bcc41669e31787649af91af7f54f05c71d0865bb7aa27e8b92f68b3e6b582483e2c1c648008bc84249d2cd86301771fe5cbf7621d1fe5375
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.5.3, semver@npm:^7.5.4":
-  version: 7.5.4
-  resolution: "semver@npm:7.5.4"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,13 +1408,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^4.9.3":
-  version: 4.9.3
-  resolution: "@openzeppelin/contracts@npm:4.9.3"
-  checksum: 4932063e733b35fa7669b9fe2053f69b062366c5c208b0c6cfa1ac451712100c78acff98120c3a4b88d94154c802be05d160d71f37e7d74cadbe150964458838
-  languageName: node
-  linkType: hard
-
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -6904,7 +6897,6 @@ __metadata:
     "@nestjs/swagger": ^7.1.7
     "@nestjs/testing": ^10.2.5
     "@node-redis/json": ^1.0.2
-    "@openzeppelin/contracts": ^4.9.3
     "@safe-global/safe-deployments": ^1.26.0
     "@types/express": ^4.17.17
     "@types/jest": 29.5.4


### PR DESCRIPTION
- Adds initial version of the Safe Gelato Relay domain
- No changes to the route layer or to the data layer
- Adds dependency to `@safe-global/safe-deployments` – this dependency is used to retrieve the ABI for the Safe contracts
- Adds a `ContractHelper` – the goal of this class is to provide smart-contract decoding functionality to `domain` layer. This class is mostly a wrapper on `viem` functionality but specialises on specific ABI functions (the ABI being the state of the class)
- Adds two implementations of the `ContractHelper`:
  * `Erc20ContractHelper` – uses the ERC20 contract ABI to provide decoding functionality for the `transfer` function
  * `SafeContractHelper` – uses the Safe contract ABI to provide decoding functionality for the `execTransaction` function.


What is out of scope for this Pull Request:
- Safe Relay routes – no routes were implemented. This PR mostly targets the business logic on the domain side
- `data` layer – no datasources were added. This will be where the API which targets the Gelato Relay Service will be added
- Handling of Multisend payloads
- Handling of Create Proxy with Nonce payloads