### PR TITLE
Use object literal for CacheFirstDataSource.get()

### DIFF
--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -49,11 +49,11 @@ describe('CacheFirstDataSource', () => {
       }
     });
 
-    const actual = await cacheFirstDataSource.get(
+    const actual = await cacheFirstDataSource.get({
       cacheDir,
-      targetUrl,
+      url: targetUrl,
       notFoundExpireTimeSeconds,
-    );
+    });
 
     expect(actual).toEqual(data);
     expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
@@ -68,11 +68,11 @@ describe('CacheFirstDataSource', () => {
       Promise.reject(`Unexpected request to ${url}`),
     );
 
-    const actual = await cacheFirstDataSource.get(
+    const actual = await cacheFirstDataSource.get({
       cacheDir,
-      faker.internet.url({ appendSlash: false }),
+      url: faker.internet.url({ appendSlash: false }),
       notFoundExpireTimeSeconds,
-    );
+    });
 
     expect(actual).toEqual(JSON.parse(rawJson));
     expect(mockNetworkService.get).toHaveBeenCalledTimes(0);
@@ -93,7 +93,11 @@ describe('CacheFirstDataSource', () => {
     });
 
     await expect(
-      cacheFirstDataSource.get(cacheDir, targetUrl, notFoundExpireTimeSeconds),
+      cacheFirstDataSource.get({
+        cacheDir,
+        url: targetUrl,
+        notFoundExpireTimeSeconds,
+      }),
     ).rejects.toThrowError(expectedError);
 
     expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
@@ -115,11 +119,19 @@ describe('CacheFirstDataSource', () => {
     });
 
     await expect(
-      cacheFirstDataSource.get(cacheDir, targetUrl, notFoundExpireTimeSeconds),
+      cacheFirstDataSource.get({
+        cacheDir,
+        url: targetUrl,
+        notFoundExpireTimeSeconds,
+      }),
     ).rejects.toThrowError(expectedError);
 
     await expect(
-      cacheFirstDataSource.get(cacheDir, targetUrl, notFoundExpireTimeSeconds),
+      cacheFirstDataSource.get({
+        cacheDir,
+        url: targetUrl,
+        notFoundExpireTimeSeconds,
+      }),
     ).rejects.toThrowError(expectedError);
 
     expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
@@ -154,7 +166,11 @@ describe('CacheFirstDataSource', () => {
     });
 
     await expect(
-      cacheFirstDataSource.get(cacheDir, targetUrl, notFoundExpireTimeSeconds),
+      cacheFirstDataSource.get({
+        cacheDir,
+        url: targetUrl,
+        notFoundExpireTimeSeconds,
+      }),
     ).rejects.toThrowError(expectedError);
 
     expect(mockCache.set).toHaveBeenCalledWith(
@@ -192,13 +208,12 @@ describe('CacheFirstDataSource', () => {
     });
 
     await expect(
-      cacheFirstDataSource.get(
+      cacheFirstDataSource.get({
         cacheDir,
-        targetUrl,
+        url: targetUrl,
         notFoundExpireTimeSeconds,
-        undefined,
-        faker.number.int(),
-      ),
+        expireTimeSeconds: faker.number.int(),
+      }),
     ).rejects.toThrowError(expectedError);
 
     expect(mockCache.set).toHaveBeenCalledWith(

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -77,13 +77,13 @@ describe('ConfigApi', () => {
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir('chains', 'undefined_undefined'),
-      `${baseUri}/api/v1/chains`,
-      notFoundExpirationTimeInSeconds,
-      { params: { limit: undefined, offset: undefined } },
-      expirationTimeInSeconds,
-    );
+    expect(mockDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir('chains', 'undefined_undefined'),
+      url: `${baseUri}/api/v1/chains`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: { params: { limit: undefined, offset: undefined } },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
 
@@ -95,13 +95,12 @@ describe('ConfigApi', () => {
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`${data.chainId}_chain`, ''),
-      `${baseUri}/api/v1/chains/${data.chainId}`,
-      notFoundExpirationTimeInSeconds,
-      undefined,
-      expirationTimeInSeconds,
-    );
+    expect(mockDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir(`${data.chainId}_chain`, ''),
+      url: `${baseUri}/api/v1/chains/${data.chainId}`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
 
@@ -114,13 +113,15 @@ describe('ConfigApi', () => {
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`${chainId}_safe_apps`, 'undefined_undefined'),
-      `${baseUri}/api/v1/safe-apps/`,
-      notFoundExpirationTimeInSeconds,
-      { params: { chainId, clientUrl: undefined, url: undefined } },
-      expirationTimeInSeconds,
-    );
+    expect(mockDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir(`${chainId}_safe_apps`, 'undefined_undefined'),
+      url: `${baseUri}/api/v1/safe-apps/`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: {
+        params: { chainId, clientUrl: undefined, url: undefined },
+      },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
 
@@ -134,13 +135,13 @@ describe('ConfigApi', () => {
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`${chainId}_safe_apps`, `undefined_${url}`),
-      `${baseUri}/api/v1/safe-apps/`,
-      notFoundExpirationTimeInSeconds,
-      { params: { chainId, clientUrl: undefined, url } },
-      expirationTimeInSeconds,
-    );
+    expect(mockDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir(`${chainId}_safe_apps`, `undefined_${url}`),
+      url: `${baseUri}/api/v1/safe-apps/`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: { params: { chainId, clientUrl: undefined, url } },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
 
@@ -154,13 +155,13 @@ describe('ConfigApi', () => {
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
-      `${baseUri}/api/v1/safe-apps/`,
-      notFoundExpirationTimeInSeconds,
-      { params: { chainId, clientUrl, url: undefined } },
-      expirationTimeInSeconds,
-    );
+    expect(mockDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
+      url: `${baseUri}/api/v1/safe-apps/`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: { params: { chainId, clientUrl, url: undefined } },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
 

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -42,13 +42,13 @@ export class ConfigApi implements IConfigApi {
       const url = `${this.baseUri}/api/v1/chains`;
       const params = { limit: args.limit, offset: args.offset };
       const cacheDir = CacheRouter.getChainsCacheDir(args);
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        { params },
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: { params },
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -66,13 +66,13 @@ export class ConfigApi implements IConfigApi {
     try {
       const url = `${this.baseUri}/api/v1/chains/${chainId}`;
       const cacheDir = CacheRouter.getChainCacheDir(chainId);
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: undefined,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -91,13 +91,13 @@ export class ConfigApi implements IConfigApi {
         url: args.url,
       };
       const cacheDir = CacheRouter.getSafeAppsCacheDir(args);
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
-        providerUrl,
-        this.defaultNotFoundExpirationTimeSeconds,
-        { params },
-        this.defaultExpirationTimeInSeconds,
-      );
+        url: providerUrl,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: { params },
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }

--- a/src/datasources/exchange-api/exchange-api.service.spec.ts
+++ b/src/datasources/exchange-api/exchange-api.service.spec.ts
@@ -83,13 +83,12 @@ describe('ExchangeApi', () => {
 
     await target.getFiatCodes();
 
-    expect(mockCacheFirstDataSource.get).toBeCalledWith(
-      new CacheDir('exchange_fiat_codes', ''),
-      `${exchangeBaseUri}/symbols?access_key=${exchangeApiKey}`,
-      notFoundExpirationTimeInSeconds,
-      {},
-      ttl, // 60 seconds
-    );
+    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir('exchange_fiat_codes', ''),
+      url: `${exchangeBaseUri}/symbols?access_key=${exchangeApiKey}`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      expireTimeSeconds: ttl, // 60 seconds
+    });
   });
 
   it('Should return the exchange rates', async () => {
@@ -126,12 +125,11 @@ describe('ExchangeApi', () => {
 
     await target.getRates();
 
-    expect(mockCacheFirstDataSource.get).toBeCalledWith(
-      new CacheDir('exchange_rates', ''),
-      `${exchangeBaseUri}/latest?access_key=${exchangeApiKey}`,
-      notFoundExpirationTimeInSeconds,
-      {},
-      ttl, // 60 seconds
-    );
+    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+      cacheDir: new CacheDir('exchange_rates', ''),
+      url: `${exchangeBaseUri}/latest?access_key=${exchangeApiKey}`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      expireTimeSeconds: ttl, // 60 seconds
+    });
   });
 });

--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -34,13 +34,12 @@ export class ExchangeApi implements IExchangeApi {
 
   async getFiatCodes(): Promise<ExchangeFiatCodes> {
     try {
-      return await this.dataSource.get<ExchangeFiatCodes>(
-        CacheRouter.getExchangeFiatCodesCacheDir(),
-        `${this.baseUrl}/symbols?access_key=${this.apiKey}`,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {},
-        this.cacheTtlSeconds,
-      );
+      return await this.dataSource.get<ExchangeFiatCodes>({
+        cacheDir: CacheRouter.getExchangeFiatCodesCacheDir(),
+        url: `${this.baseUrl}/symbols?access_key=${this.apiKey}`,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.cacheTtlSeconds,
+      });
     } catch (error) {
       throw new DataSourceError('Error getting Fiat Codes from exchange');
     }
@@ -48,13 +47,12 @@ export class ExchangeApi implements IExchangeApi {
 
   async getRates(): Promise<ExchangeRates> {
     try {
-      return await this.dataSource.get<ExchangeRates>(
-        CacheRouter.getExchangeRatesCacheDir(),
-        `${this.baseUrl}/latest?access_key=${this.apiKey}`,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {},
-        this.cacheTtlSeconds,
-      );
+      return await this.dataSource.get<ExchangeRates>({
+        cacheDir: CacheRouter.getExchangeRatesCacheDir(),
+        url: `${this.baseUrl}/latest?access_key=${this.apiKey}`,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.cacheTtlSeconds,
+      });
     } catch (error) {
       throw new DataSourceError('Error getting exchange data');
     }

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -81,12 +81,11 @@ describe('Transaction API Manager Tests', () => {
     const transactionApi = await target.getTransactionApi(chain.chainId);
     await transactionApi.getBackbone();
 
-    expect(dataSourceMock.get).toBeCalledWith(
-      expect.anything(),
-      `${expectedUrl}/api/v1/about`,
-      notFoundExpireTimeSeconds,
-      undefined,
-      expirationTimeInSeconds,
-    );
+    expect(dataSourceMock.get).toBeCalledWith({
+      cacheDir: expect.anything(),
+      url: `${expectedUrl}/api/v1/about`,
+      notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
   });
 });

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -155,13 +155,12 @@ describe('TransactionApi', () => {
       const actual = await service.getSafe(safe.address);
 
       expect(actual).toBe(safe);
-      expect(mockDataSource.get).toBeCalledWith(
-        new CacheDir(`${chainId}_safe_${safe.address}`, ''),
-        `${baseUrl}/api/v1/safes/${safe.address}`,
-        notFoundExpireTimeSeconds,
-        undefined,
-        defaultExpirationTimeInSeconds,
-      );
+      expect(mockDataSource.get).toBeCalledWith({
+        cacheDir: new CacheDir(`${chainId}_safe_${safe.address}`, ''),
+        url: `${baseUrl}/api/v1/safes/${safe.address}`,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+      });
       expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
     });
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -76,18 +76,18 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/balances/usd/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             trusted: args.trusted,
             exclude_spam: args.excludeSpam,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -130,11 +130,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v2/safes/${args.safeAddress}/collectibles/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             limit: args.limit,
             offset: args.offset,
@@ -142,8 +142,8 @@ export class TransactionApi implements ITransactionApi {
             exclude_spam: args.excludeSpam,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -163,13 +163,12 @@ export class TransactionApi implements ITransactionApi {
     try {
       const cacheDir = CacheRouter.getBackboneCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -181,13 +180,12 @@ export class TransactionApi implements ITransactionApi {
     try {
       const cacheDir = CacheRouter.getMasterCopiesCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about/master-copies/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -200,13 +198,12 @@ export class TransactionApi implements ITransactionApi {
         safeAddress,
       });
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -229,13 +226,12 @@ export class TransactionApi implements ITransactionApi {
         contractAddress,
       });
       const url = `${this.baseUrl}/api/v1/contracts/${contractAddress}`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.contractNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.contractNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -255,11 +251,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/delegates/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             safe: args.safeAddress,
             delegate: args.delegate,
@@ -269,7 +265,7 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-      );
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -339,13 +335,12 @@ export class TransactionApi implements ITransactionApi {
         transferId,
       });
       const url = `${this.baseUrl}/api/v1/transfer/${transferId}`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -364,11 +359,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/transfers/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             erc20: args.onlyErc20,
             erc721: args.onlyErc721,
@@ -376,8 +371,8 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -407,11 +402,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/incoming-transfers/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             execution_date__gte: args.executionDateGte,
             execution_date__lte: args.executionDateLte,
@@ -422,8 +417,8 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -462,13 +457,12 @@ export class TransactionApi implements ITransactionApi {
         moduleTransactionId,
       });
       const url = `${this.baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -487,11 +481,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/module-transactions/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             to: args.to,
             module: args.module,
@@ -499,8 +493,8 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -534,11 +528,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/multisig-transactions/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             safe: args.safeAddress,
             ordering: args.ordering,
@@ -554,8 +548,8 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -578,13 +572,12 @@ export class TransactionApi implements ITransactionApi {
         safeTransactionHash,
       });
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -609,13 +602,12 @@ export class TransactionApi implements ITransactionApi {
         safeAddress,
       });
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -635,11 +627,11 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/all-transactions/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             safe: args.safeAddress,
             ordering: args.ordering,
@@ -649,8 +641,8 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -673,13 +665,12 @@ export class TransactionApi implements ITransactionApi {
         address,
       });
       const url = `${this.baseUrl}/api/v1/tokens/${address}`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.tokenNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.tokenNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -697,18 +688,18 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/tokens/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             limit: args.limit,
             offset: args.offset,
           },
         },
-        this.defaultExpirationTimeInSeconds,
-      );
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -723,13 +714,12 @@ export class TransactionApi implements ITransactionApi {
         ownerAddress,
       });
       const url = `${this.baseUrl}/api/v1/owners/${ownerAddress}/safes/`;
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.defaultExpirationTimeInSeconds,
-      );
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -804,15 +794,14 @@ export class TransactionApi implements ITransactionApi {
         chainId: this.chainId,
         messageHash,
       });
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        undefined,
-        this.isMessagesCacheEnabled
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.isMessagesCacheEnabled
           ? this.defaultExpirationTimeInSeconds
           : undefined,
-      );
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -829,20 +818,20 @@ export class TransactionApi implements ITransactionApi {
         chainId: this.chainId,
         ...args,
       });
-      return await this.dataSource.get(
+      return await this.dataSource.get({
         cacheDir,
         url,
-        this.defaultNotFoundExpirationTimeSeconds,
-        {
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: {
           params: {
             limit: args.limit,
             offset: args.offset,
           },
         },
-        this.isMessagesCacheEnabled
+        expireTimeSeconds: this.isMessagesCacheEnabled
           ? this.defaultExpirationTimeInSeconds
           : undefined,
-      );
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }


### PR DESCRIPTION
Uses an object literal for the arguments of `CacheFirstDataSource.get()`. This makes the value association from the caller perspective more explicit.