### PR TITLE
Log Safe-App-User-Agent header

### DIFF
--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -1,4 +1,5 @@
 const HEADER_IP_ADDRESS = 'X-Real-IP';
+const HEADER_SAFE_APP_USER_AGENT = 'Safe-App-User-Agent';
 
 export function formatRouteLogMessage(
   statusCode: number,
@@ -7,6 +8,8 @@ export function formatRouteLogMessage(
   detail?: string,
 ) {
   const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
+  const safe_app_user_agent =
+    request.header(HEADER_SAFE_APP_USER_AGENT) ?? null;
   const chainId = request.params['chainId'] ?? null;
 
   return {
@@ -16,6 +19,7 @@ export function formatRouteLogMessage(
     response_time_ms: performance.now() - startTimeMs,
     route: request.route.path,
     path: request.url,
+    safe_app_user_agent: safe_app_user_agent,
     status_code: statusCode,
     detail: detail ?? null,
   };

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -86,6 +86,7 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/server-error',
       response_time_ms: expect.any(Number),
       route: '/test/server-error',
+      safe_app_user_agent: null,
       status_code: 500,
     });
     expect(mockLoggingService.info).not.toBeCalled();
@@ -112,6 +113,7 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/server-data-source-error',
       response_time_ms: expect.any(Number),
       route: '/test/server-data-source-error',
+      safe_app_user_agent: null,
       status_code: 501,
     });
     expect(mockLoggingService.info).not.toBeCalled();
@@ -131,6 +133,7 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/client-error',
       response_time_ms: expect.any(Number),
       route: '/test/client-error',
+      safe_app_user_agent: null,
       status_code: 405,
     });
     expect(mockLoggingService.error).not.toBeCalled();
@@ -150,6 +153,7 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/success',
       response_time_ms: expect.any(Number),
       route: '/test/success',
+      safe_app_user_agent: null,
       status_code: 200,
     });
     expect(mockLoggingService.error).not.toBeCalled();
@@ -172,6 +176,7 @@ describe('RouteLoggerInterceptor tests', () => {
       path: `/test/success/${chainId}`,
       response_time_ms: expect.any(Number),
       route: '/test/success/:chainId',
+      safe_app_user_agent: null,
       status_code: 200,
     });
     expect(mockLoggingService.error).not.toBeCalled();
@@ -193,10 +198,32 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/server-error-non-http',
       response_time_ms: expect.any(Number),
       route: '/test/server-error-non-http',
+      safe_app_user_agent: null,
       status_code: 500,
     });
     expect(mockLoggingService.info).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
     expect(mockLoggingService.warn).not.toBeCalled();
+  });
+
+  it('Logs Safe-App-User-Agent header', async () => {
+    const safeAppUserAgentHeader = faker.word.sample();
+
+    await request(app.getHttpServer())
+      .get('/test/success')
+      .set('Safe-App-User-Agent', safeAppUserAgentHeader)
+      .expect(200);
+
+    expect(mockLoggingService.info).toBeCalledWith({
+      chain_id: null,
+      client_ip: null,
+      detail: null,
+      method: 'GET',
+      path: '/test/success',
+      response_time_ms: expect.any(Number),
+      route: '/test/success',
+      safe_app_user_agent: safeAppUserAgentHeader,
+      status_code: 200,
+    });
   });
 });


### PR DESCRIPTION
- Adds support to log the value of the header `Safe-App-User-Agent`.
- This header can be used for analytics regarding the source of the request.
- Considerations regarding where the header should be set and by whom are not specified, and we leave that recommendation for the users running this service.