### PR TITLE
Group NestJS core dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      nest-js-core:
+        patterns:
+          - '@nestjs/common'
+          - '@nestjs/core'
+          - '@nestjs/platform-express'
+          - '@nestjs/testing'
 
   - package-ecosystem: 'docker'
     directory: '/'


### PR DESCRIPTION
- Adds a group named `nest-js-core` which contains the following packages:
  * `@nestjs/common`
  * `@nestjs/core`
  * `@nestjs/platform-express`
  * `@nestjs/testing`
- These dependencies follow the same version and release cycle and should be updated together whenever possible.
- Note that `@nestjs/cli`, `@nestjs/config`, `@nestjs/serve-static`, `@nestjs/swagger` and `@nestjs/schematics` follow a different release cycle of the packages listed above.
- Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups