### PR TITLE
Backmerge release 1.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.18.x'
+          node-version: '18.17.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run format-check
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.18.x'
+          node-version: '18.17.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run lint-check
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.18.x'
+          node-version: '18.17.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # BUILD CONTAINER
 #
-FROM node:18.18 as base
+FROM node:18.17 as base
 ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
@@ -15,7 +15,7 @@ RUN yarn run build
 #
 # PRODUCTION CONTAINER
 #
-FROM node:18.18-alpine as production
+FROM node:18.17-alpine as production
 USER node
 
 ARG VERSION

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-- Node 18.18.0 – https://nodejs.org/en/
+- Node 18.17.0 – https://nodejs.org/en/
 - Docker Compose – https://docs.docker.com/compose/
 
 ## Installation


### PR DESCRIPTION
This reverts commit 39b6b3d48506515f625c073bd08112a548cb9503.

We have observed increased CPU usage since https://github.com/safe-global/safe-client-gateway/releases/tag/v1.8.0 was released.

This is part of an effort to monitor which change caused this increase.