### PR TITLE
Log successful transaction proposal requests

### DIFF
--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule, configurationModule } from './app.module';
+import * as request from 'supertest';
+import { Controller, Get } from '@nestjs/common';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { ClsService } from 'nestjs-cls';
+import { faker } from '@faker-js/faker';
+
+@Controller({ path: 'test' })
+class TestController {
+  constructor(private readonly cls: ClsService) {}
+
+  @Get()
+  getTest() {
+    return this.cls.get('safeAppUserAgent');
+  }
+}
+
+describe('Application Module (Unit Tests)', () => {
+  it('Safe-App-User-Agent is correctly registered in Cls', async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      controllers: [TestController],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    const app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+    const userAgent = faker.word.sample();
+
+    await request(app.getHttpServer())
+      .get(`/test`)
+      .set('Safe-App-User-Agent', userAgent)
+      .expect(200)
+      .expect(userAgent);
+
+    await app.close();
+  });
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -70,6 +70,9 @@ export const configurationModule = ConfigurationModule.register(configuration);
       middleware: {
         generateId: true,
         idGenerator: () => uuidv4(),
+        setup: (cls, req) => {
+          cls.set('safeAppUserAgent', req.headers['safe-app-user-agent']);
+        },
       },
     }),
     configurationModule,

--- a/src/logging/logging.service.spec.ts
+++ b/src/logging/logging.service.spec.ts
@@ -6,6 +6,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 
 const mockClsService = jest.mocked({
   getId: jest.fn(),
+  get: jest.fn(),
 } as unknown as ClsService);
 
 const mockLogger = {

--- a/src/logging/logging.service.ts
+++ b/src/logging/logging.service.ts
@@ -43,6 +43,7 @@ export class RequestScopedLoggingService implements ILoggingService {
 
   private formatMessage(message: string | unknown) {
     const requestId = this.cls.getId();
+    const safeAppUserAgent = this.cls.get('safeAppUserAgent');
     const timestamp = Date.now();
     const dateAsString = new Date(timestamp).toISOString();
 
@@ -50,6 +51,7 @@ export class RequestScopedLoggingService implements ILoggingService {
       message,
       build_number: this.buildNumber,
       request_id: requestId,
+      safe_app_user_agent: safeAppUserAgent,
       timestamp: dateAsString,
       version: this.version,
     };

--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -1,5 +1,4 @@
 const HEADER_IP_ADDRESS = 'X-Real-IP';
-const HEADER_SAFE_APP_USER_AGENT = 'Safe-App-User-Agent';
 
 export function formatRouteLogMessage(
   statusCode: number,
@@ -8,8 +7,6 @@ export function formatRouteLogMessage(
   detail?: string,
 ) {
   const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
-  const safe_app_user_agent =
-    request.header(HEADER_SAFE_APP_USER_AGENT) ?? null;
   const chainId = request.params['chainId'] ?? null;
 
   return {
@@ -19,7 +16,6 @@ export function formatRouteLogMessage(
     response_time_ms: performance.now() - startTimeMs,
     route: request.route.path,
     path: request.url,
-    safe_app_user_agent: safe_app_user_agent,
     status_code: statusCode,
     detail: detail ?? null,
   };

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -86,7 +86,6 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/server-error',
       response_time_ms: expect.any(Number),
       route: '/test/server-error',
-      safe_app_user_agent: null,
       status_code: 500,
     });
     expect(mockLoggingService.info).not.toBeCalled();
@@ -113,7 +112,6 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/server-data-source-error',
       response_time_ms: expect.any(Number),
       route: '/test/server-data-source-error',
-      safe_app_user_agent: null,
       status_code: 501,
     });
     expect(mockLoggingService.info).not.toBeCalled();
@@ -133,7 +131,6 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/client-error',
       response_time_ms: expect.any(Number),
       route: '/test/client-error',
-      safe_app_user_agent: null,
       status_code: 405,
     });
     expect(mockLoggingService.error).not.toBeCalled();
@@ -153,7 +150,6 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/success',
       response_time_ms: expect.any(Number),
       route: '/test/success',
-      safe_app_user_agent: null,
       status_code: 200,
     });
     expect(mockLoggingService.error).not.toBeCalled();
@@ -176,7 +172,6 @@ describe('RouteLoggerInterceptor tests', () => {
       path: `/test/success/${chainId}`,
       response_time_ms: expect.any(Number),
       route: '/test/success/:chainId',
-      safe_app_user_agent: null,
       status_code: 200,
     });
     expect(mockLoggingService.error).not.toBeCalled();
@@ -198,32 +193,10 @@ describe('RouteLoggerInterceptor tests', () => {
       path: '/test/server-error-non-http',
       response_time_ms: expect.any(Number),
       route: '/test/server-error-non-http',
-      safe_app_user_agent: null,
       status_code: 500,
     });
     expect(mockLoggingService.info).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
     expect(mockLoggingService.warn).not.toBeCalled();
-  });
-
-  it('Logs Safe-App-User-Agent header', async () => {
-    const safeAppUserAgentHeader = faker.word.sample();
-
-    await request(app.getHttpServer())
-      .get('/test/success')
-      .set('Safe-App-User-Agent', safeAppUserAgentHeader)
-      .expect(200);
-
-    expect(mockLoggingService.info).toBeCalledWith({
-      chain_id: null,
-      client_ip: null,
-      detail: null,
-      method: 'GET',
-      path: '/test/success',
-      response_time_ms: expect.any(Number),
-      route: '/test/success',
-      safe_app_user_agent: safeAppUserAgentHeader,
-      status_code: 200,
-    });
   });
 });


### PR DESCRIPTION
- Emits an `INFO` log with the type of `propose-transaction-success` when a transaction is successfully proposed to the Safe Transaction Service.
- The log contains the Safe Address and Safe Transaction Hash of said transaction.
- Moves the `safe_app_user_agent` logging from the `RouteLoggerInterceptor` to the `RequestScopedLoggingService`. This means that the `safe_app_user_agent` will now part of the logs generated by the `RequestScopedLoggingService`.