### PR TITLE
Set default values for trusted and exclude_spam params

### DIFF
--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -118,7 +118,7 @@ describe('Balances Controller (Unit)', () => {
         `${chainResponse.transactionService}/api/v1/safes/0x0000000000000000000000000000000000000001/balances/usd/`,
       );
       expect(networkService.get.mock.calls[1][1]).toStrictEqual({
-        params: { trusted: undefined, exclude_spam: undefined },
+        params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0]).toBe(
         `${exchangeUrl}/latest?access_key=${exchangeApiKey}`,
@@ -292,7 +292,7 @@ describe('Balances Controller (Unit)', () => {
         `${chainResponse.transactionService}/api/v1/safes/0x0000000000000000000000000000000000000001/balances/usd/`,
       );
       expect(networkService.get.mock.calls[1][1]).toStrictEqual({
-        params: { trusted: undefined, exclude_spam: undefined },
+        params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0]).toBe(
         `${exchangeUrl}/latest?access_key=${exchangeApiKey}`,

--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  Query,
+} from '@nestjs/common';
 import { BalancesService } from './balances.service';
 import { Balances } from './entities/balances.entity';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
@@ -17,8 +23,8 @@ export class BalancesController {
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
     @Param('fiatCode') fiatCode: string,
-    @Query('trusted') trusted?: boolean,
-    @Query('exclude_spam') excludeSpam?: boolean,
+    @Query('trusted', new DefaultValuePipe(false)) trusted: boolean,
+    @Query('exclude_spam', new DefaultValuePipe(true)) excludeSpam: boolean,
   ): Promise<Balances> {
     return this.balancesService.getBalances({
       chainId,

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -34,8 +34,8 @@ export class BalancesService {
     chainId: string;
     safeAddress: string;
     fiatCode: string;
-    trusted?: boolean;
-    excludeSpam?: boolean;
+    trusted: boolean;
+    excludeSpam: boolean;
   }): Promise<Balances> {
     const txServiceBalances = await this.balancesRepository.getBalances(args);
 


### PR DESCRIPTION
Closes #734 

- Changes the default values of the `trusted` and `exclude_spam` query parameters if they are not provided in `GET /v1/chains/:chainId/safes/:safeAddress/balances/:fiatCode`. This corresponds to the expected API spec from the Rust client.
- The `trusted` query parameter should have a default value of `false` if none is provided.
- The `exclude_spam` query parameter should have a value of `true` if none is provided.