### PR TITLE
Set default query param values in CollectiblesController

### DIFF
--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -140,8 +140,8 @@ describe('Collectibles Controller (Unit)', () => {
         params: {
           limit: 10,
           offset: 20,
-          exclude_spam: undefined,
-          trusted: undefined,
+          exclude_spam: true,
+          trusted: false,
         },
       });
     });

--- a/src/routes/collectibles/collectibles.controller.ts
+++ b/src/routes/collectibles/collectibles.controller.ts
@@ -1,5 +1,11 @@
-import { ApiOkResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  Query,
+} from '@nestjs/common';
 import { CollectiblesService } from './collectibles.service';
 import { CollectiblePage } from './entities/collectible.page.entity';
 import { Collectible } from './entities/collectible.entity';
@@ -37,8 +43,8 @@ export class CollectiblesController {
     @Param('safeAddress') safeAddress: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
-    @Query('trusted') trusted?: boolean,
-    @Query('exclude_spam') excludeSpam?: boolean,
+    @Query('trusted', new DefaultValuePipe(false)) trusted: boolean,
+    @Query('exclude_spam', new DefaultValuePipe(true)) excludeSpam: boolean,
   ): Promise<Page<Collectible>> {
     return this.service.getCollectibles({
       chainId,

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -19,8 +19,8 @@ export class CollectiblesService {
     safeAddress: string;
     routeUrl: Readonly<URL>;
     paginationData: PaginationData;
-    trusted?: boolean;
-    excludeSpam?: boolean;
+    trusted: boolean;
+    excludeSpam: boolean;
   }): Promise<Page<Collectible>> {
     const collectibles = await this.repository.getCollectibles({
       ...args,


### PR DESCRIPTION
- Changes the default values of the `trusted` and `exclude_spam` query parameters if they are not provided in `GET /v2/chains/:chainId/safes/:safeAddress/collectibles`. This corresponds to the expected API spec from the Rust client.
- The `trusted` query parameter should have a default value of `false` if none is provided.
- The `exclude_spam` query parameter should have a value of `true` if none is provided.