### PR TITLE
Use builtin parsers for boolean query params

### DIFF
--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -162,8 +162,8 @@ describe('Balances Controller (Unit)', () => {
       // trusted and exclude_spam params are passed
       expect(networkService.get.mock.calls[1][1]).toStrictEqual({
         params: {
-          trusted: trusted.toString(),
-          exclude_spam: excludeSpam.toString(),
+          trusted,
+          exclude_spam: excludeSpam,
         },
       });
     });

--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -3,6 +3,7 @@ import {
   DefaultValuePipe,
   Get,
   Param,
+  ParseBoolPipe,
   Query,
 } from '@nestjs/common';
 import { BalancesService } from './balances.service';
@@ -23,8 +24,10 @@ export class BalancesController {
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
     @Param('fiatCode') fiatCode: string,
-    @Query('trusted', new DefaultValuePipe(false)) trusted: boolean,
-    @Query('exclude_spam', new DefaultValuePipe(true)) excludeSpam: boolean,
+    @Query('trusted', new DefaultValuePipe(false), ParseBoolPipe)
+    trusted: boolean,
+    @Query('exclude_spam', new DefaultValuePipe(true), ParseBoolPipe)
+    excludeSpam: boolean,
   ): Promise<Balances> {
     return this.balancesService.getBalances({
       chainId,

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -184,8 +184,8 @@ describe('Collectibles Controller (Unit)', () => {
         params: {
           limit: PaginationData.DEFAULT_LIMIT,
           offset: PaginationData.DEFAULT_OFFSET,
-          exclude_spam: excludeSpam.toString(),
-          trusted: trusted.toString(),
+          exclude_spam: excludeSpam,
+          trusted,
         },
       });
     });

--- a/src/routes/collectibles/collectibles.controller.ts
+++ b/src/routes/collectibles/collectibles.controller.ts
@@ -4,6 +4,7 @@ import {
   DefaultValuePipe,
   Get,
   Param,
+  ParseBoolPipe,
   Query,
 } from '@nestjs/common';
 import { CollectiblesService } from './collectibles.service';
@@ -43,8 +44,10 @@ export class CollectiblesController {
     @Param('safeAddress') safeAddress: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
-    @Query('trusted', new DefaultValuePipe(false)) trusted: boolean,
-    @Query('exclude_spam', new DefaultValuePipe(true)) excludeSpam: boolean,
+    @Query('trusted', new DefaultValuePipe(false), ParseBoolPipe)
+    trusted: boolean,
+    @Query('exclude_spam', new DefaultValuePipe(true), ParseBoolPipe)
+    excludeSpam: boolean,
   ): Promise<Page<Collectible>> {
     return this.service.getCollectibles({
       chainId,

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -71,7 +71,8 @@ export class TransactionsController {
     @Query('to') to?: string,
     @Query('value') value?: string,
     @Query('nonce') nonce?: string,
-    @Query('executed') executed?: boolean,
+    @Query('executed', new ParseBoolPipe({ optional: true }))
+    executed?: boolean,
   ): Promise<Partial<Page<MultisigTransaction>>> {
     return this.transactionsService.getMultisigTransactions({
       chainId,


### PR DESCRIPTION
- Adds `ParseBoolPipe` to validate boolean query params at controllers.