### PR TITLE
Modify VSCode typescript import preferences

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[typescript]": {
-    "typescript.preferences.importModuleSpecifier": "relative"
+    "typescript.preferences.importModuleSpecifier": "non-relative"
   }
 }


### PR DESCRIPTION
- Modifies the import preferences (non-relative imports) for VSCode. This forces the IDE to use non-relative paths (i.e. `"@/*"` path aliases) when automatically importing files.