### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Change import statement paths to path aliases
+4729440761cfe608ab8935d782238ae7fe55343b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
+# .git-blame-ignore-revs
 # Change import statement paths to path aliases
 4729440761cfe608ab8935d782238ae7fe55343b


### PR DESCRIPTION
- Adds `.git-blame-ignore-revs` containing the commit hash for the change in https://github.com/safe-global/safe-client-gateway/pull/749