### PR TITLE
Fix bad Coingecko API query param

### DIFF
--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -115,7 +115,7 @@ describe('CoingeckoAPI', () => {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
         params: {
-          contract_address: tokenAddress,
+          contract_addresses: tokenAddress,
           vs_currencies: fiatCode,
         },
       },
@@ -151,7 +151,7 @@ describe('CoingeckoAPI', () => {
       ),
       networkRequest: {
         params: {
-          contract_address: tokenAddress,
+          contract_addresses: tokenAddress,
           vs_currencies: fiatCode,
         },
       },

--- a/src/datasources/prices-api/coingecko-api.service.ts
+++ b/src/datasources/prices-api/coingecko-api.service.ts
@@ -86,7 +86,7 @@ export class CoingeckoApi implements IPricesApi {
         networkRequest: {
           params: {
             vs_currencies: args.fiatCode,
-            contract_address: args.tokenAddress,
+            contract_addresses: args.tokenAddress,
           },
           ...(this.apiKey && {
             headers: {


### PR DESCRIPTION
- Fixes the Coingecko query param to hold the ERC20 contract addresses when retrieving prices (bug introduced in [this commit](https://github.com/safe-global/safe-client-gateway/pull/732/commits/a916ab768d1f4d952fe8e94ee69b4a2b1cba5f90#diff-e0b76c0f8409c4ea42ea003122e6c67d26f42543119fb2bbd37ec90de07f5491))