### PR TITLE
Add RootController with SwaggerUI redirection

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import configuration from '@/config/entities/configuration';
 import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 import { DataSourceErrorFilter } from '@/routes/common/filters/data-source-error.filter';
 import { ServeStaticModule } from '@nestjs/serve-static';
+import { RootModule } from '@/routes/root/root.module';
 
 // See https://github.com/nestjs/nest/issues/11967
 export const configurationModule = ConfigurationModule.register(configuration);
@@ -59,6 +60,7 @@ export const configurationModule = ConfigurationModule.register(configuration);
     MessagesModule,
     NotificationsModule,
     OwnersModule,
+    RootModule,
     SafeAppsModule,
     SafesModule,
     TransactionsModule,

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -24,7 +24,7 @@ function configureSwagger(app: INestApplication) {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('', app, document, {
+  SwaggerModule.setup('index.html', app, document, {
     customfavIcon: '/favicon.png',
     customSiteTitle: 'Safe Client Gateway',
     customCss: `.topbar-wrapper img { content:url(\'logo.svg\'); }`,

--- a/src/routes/root/root.controller.spec.ts
+++ b/src/routes/root/root.controller.spec.ts
@@ -1,0 +1,31 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import * as request from 'supertest';
+
+describe('Health Controller tests', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  it('should redirect / to /index.html', async () => {
+    await request(app.getHttpServer())
+      .get(`/`)
+      .expect(302)
+      .expect((res) => {
+        expect(res.get('location')).toBe('/index.html');
+      });
+  });
+});

--- a/src/routes/root/root.controller.ts
+++ b/src/routes/root/root.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Res } from '@nestjs/common';
+
+@Controller()
+export class RootController {
+  @Get()
+  getIndex(@Res() res): void {
+    return res.redirect('/index.html');
+  }
+}

--- a/src/routes/root/root.module.ts
+++ b/src/routes/root/root.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { RootController } from '@/routes/root/root.controller';
+
+@Module({
+  controllers: [RootController],
+})
+export class RootModule {}


### PR DESCRIPTION
- Adds `RootController`, which is used to redirect the root path to the SwaggerUI webapp.