### PR TITLE
Add Postgres database integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ lerna-debug.log*
 
 # env
 .env
+
+# Database mounted volume
+data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,18 @@ services:
       - ${REDIS_PORT-6379}:${REDIS_PORT-6379}
       - 8001:8001
 
+  db:
+    image: postgres:14.8-alpine
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-safe-client-gateway}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+    ports:
+      - '${POSTGRES_PORT:-5432}:5432'
+
   web:
     build: .
     tty: true
@@ -16,6 +28,7 @@ services:
       AUTH_TOKEN: ${AUTH_TOKEN-example_auth_token}
     depends_on:
       - redis
+      - db
 
   nginx:
     image: nginx:1.25-alpine

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "axios": "^1.5.0",
     "lodash": "^4.17.21",
     "nestjs-cls": "^3.5.1",
+    "postgres": "^3.4.0",
     "redis": "^4.6.10",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^5.0.5",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -11,6 +11,15 @@ export default (): ReturnType<typeof configuration> => ({
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),
   },
+  db: {
+    postgres: {
+      host: faker.internet.ip(),
+      port: faker.internet.port().toString(),
+      database: faker.word.sample(),
+      username: faker.internet.userName(),
+      password: faker.internet.password(),
+    },
+  },
   exchange: {
     baseUri: faker.internet.url({ appendSlash: false }),
     apiKey: faker.string.hexadecimal({ length: 32 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -8,6 +8,15 @@ export default () => ({
   auth: {
     token: process.env.AUTH_TOKEN,
   },
+  db: {
+    postgres: {
+      host: process.env.POSTGRES_HOST || 'localhost',
+      port: process.env.POSTGRES_PORT || '5432',
+      database: process.env.POSTGRES_DB || 'safe-client-gateway',
+      username: process.env.POSTGRES_USER || 'postgres',
+      password: process.env.POSTGRES_PASSWORD || 'postgres',
+    },
+  },
   exchange: {
     baseUri:
       process.env.EXCHANGE_API_BASE_URI ||

--- a/src/datasources/db/postgres-database.hook.ts
+++ b/src/datasources/db/postgres-database.hook.ts
@@ -1,0 +1,23 @@
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import postgres from 'postgres';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+
+@Injectable()
+export class PostgresDatabaseHook implements OnModuleDestroy {
+  private static readonly CONNECTION_CLOSE_TIMEOUT_IN_SECONDS = 5;
+
+  constructor(
+    @Inject('DB_INSTANCE') private readonly db: postgres.Sql,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async onModuleDestroy() {
+    this.loggingService.info('Closing database connection');
+    // Resolves when all queries are finished and the underlying connections are closed
+    await this.db.end({
+      // Any pending queries will be rejected once the timeout is reached
+      timeout: PostgresDatabaseHook.CONNECTION_CLOSE_TIMEOUT_IN_SECONDS,
+    });
+    this.loggingService.info('Database connection closed');
+  }
+}

--- a/src/datasources/db/postgres-database.module.ts
+++ b/src/datasources/db/postgres-database.module.ts
@@ -1,0 +1,27 @@
+import * as postgres from 'postgres';
+import { Module } from '@nestjs/common';
+import { PostgresDatabaseHook } from '@/datasources/db/postgres-database.hook';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+
+function dbFactory(configurationService: IConfigurationService): postgres.Sql {
+  return postgres({
+    host: configurationService.getOrThrow('db.postgres.host'),
+    port: configurationService.getOrThrow('db.postgres.port'),
+    db: configurationService.getOrThrow('db.postgres.database'),
+    user: configurationService.getOrThrow('db.postgres.username'),
+    password: configurationService.getOrThrow('db.postgres.password'),
+  });
+}
+
+@Module({
+  providers: [
+    {
+      provide: 'DB_INSTANCE',
+      useFactory: dbFactory,
+      inject: [IConfigurationService],
+    },
+    PostgresDatabaseHook,
+  ],
+  exports: ['DB_INSTANCE'],
+})
+export class PostgresDatabaseModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,6 +6423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postgres@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "postgres@npm:3.4.0"
+  checksum: b512a352103d95aa7c92188da024e7ee4b95937345903b4d5be59f7a0d21464735e4d45f8ce26601d15026c9a6061b18fb5a96c027ca56cbc5fc0f3b95f05d54
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -6888,6 +6895,7 @@ __metadata:
     jest: 29.7.0
     lodash: ^4.17.21
     nestjs-cls: ^3.5.1
+    postgres: ^3.4.0
     prettier: ^3.0.3
     redis: ^4.6.10
     reflect-metadata: ^0.1.13


### PR DESCRIPTION
- Adds support for connecting to a Postgres database.
- This support is provided via `PostgresDatabaseModule`, which exposes an instance of `postgres.Sql` which represents a connection that can be used for performing queries.
- The `PostgresDatabaseHook` executed whenever the `PostgresDatabaseModule` is destroyed – it cancels any ongoing queries while giving a timeout of 5 seconds for pending queries to complete.
- Adds the `db` container setup in docker-compose.yml. The database contents are mapped to `<PROJ-DIR>/data/db` to allow data persistence across runs.
- The following environment variables can be set to change the configuration of the database instance:
  * `POSTGRES_DB` – the name of the default database. Defaults to `safe-client-gateway` if not set.
  * `POSTGRES_USER` – the database superuser name. Defaults to `postgres`.
  * `POSTGRES_PASSWORD` – the database superuser password. Defaults to `postgres`.
  * `POSTGRES_PORT` – the port where the database instance is running. Defaults to `5432`.

❗️The Database connection is currently optional. It will only result in an error if a query is made and there's no database server running.

## Scope of this Pull Request

The following changes are currently outside of the scope of this Pull Request:
- Initial schemas and tables (feature scope)
- Forward-only migration mechanism
- Query execution abstraction – the library being used to execute the SQL queries uses [Tagged Templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates). Creating an abstraction around how these templates are evaluated was out of scope for this Pull Request and I believe that we can expose the SQL client directly on the `Datasource` layer (i.e.: not create an interface around this client for now).
- Github Action Postgres service – since there are no tests/use-cases currently depending on the database, it is not required.