### PR TITLE
Fix balances endpoint ordering

### DIFF
--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -334,7 +334,7 @@ describe('Balances Controller (Unit)', () => {
           [nativeCoinId]: { [currency]: 1536.75 },
         };
         const tokenPriceProviderResponse = {
-          [tokenAddress]: { [currency]: 2.5 },
+          [tokenAddress]: { [currency]: 12.5 },
         };
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -357,7 +357,7 @@ describe('Balances Controller (Unit)', () => {
           )
           .expect(200)
           .expect({
-            fiatTotal: '4710.25',
+            fiatTotal: '5110.25',
             items: [
               {
                 tokenInfo: {
@@ -382,8 +382,8 @@ describe('Balances Controller (Unit)', () => {
                   logoUri: transactionApiBalancesResponse[1].token?.logoUri,
                 },
                 balance: '4000000000000000000',
-                fiatBalance: '100',
-                fiatConversion: '2.5',
+                fiatBalance: '500',
+                fiatConversion: '12.5',
               },
             ],
           });

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -161,7 +161,7 @@ export class BalancesService {
 
     return <Balances>{
       fiatTotal: getNumberString(fiatTotal),
-      items: orderBy(balances, 'fiatBalance', 'desc'),
+      items: orderBy(balances, (b) => Number(b.fiatBalance), 'desc'),
     };
   }
 


### PR DESCRIPTION
- Fixes the ordering of the balance items. The service was ordering by `fiatBalance` but as this is a `string`, it was ordering by lexicographic order. Hence, it needs to be converted to `number` before ordering (as done for the [old implementation](https://github.com/safe-global/safe-client-gateway/blob/df21dbe3890f0f8a296652d984bad2ad0da6292a/src/routes/balances/balances.service.ts#L93)).
- Modifies the associated tests. This sorting was tested, but the quantities used were already sorted in lexicographic order, so the test was adjusted to actually test the sorting.