### PR TITLE
Set ApiOkResponse type for Safe Info endpoint

### DIFF
--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -1,4 +1,4 @@
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Controller, Get, Param } from '@nestjs/common';
 import { SafeState } from '@/routes/safes/entities/safe-info.entity';
 import { SafesService } from '@/routes/safes/safes.service';
@@ -10,6 +10,7 @@ import { SafesService } from '@/routes/safes/safes.service';
 export class SafesController {
   constructor(private readonly service: SafesService) {}
 
+  @ApiOkResponse({ type: SafeState })
   @Get('chains/:chainId/safes/:safeAddress')
   async getSafe(
     @Param('chainId') chainId: string,


### PR DESCRIPTION
The `@ApiOkResponse` decorator was not being applied to the `GET chains/:chainId/safes/:safeAddress` endpoint, thus its schema was not shown on the Swagger UI.