### PR TITLE
Make fiatCode case-insensitive on /balances endpoint

### DIFF
--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -21,7 +21,7 @@ export class PricesRepository implements IPricesRepository {
       nativeCoinId: args.nativeCoinId,
       fiatCode: lowerCaseFiatCode,
     });
-    const assetPrice = await this.assetPriceValidator.validate(result);
+    const assetPrice = this.assetPriceValidator.validate(result);
     return assetPrice?.[args.nativeCoinId]?.[lowerCaseFiatCode];
   }
 
@@ -37,7 +37,7 @@ export class PricesRepository implements IPricesRepository {
       tokenAddress: lowerCaseTokenAddress,
       fiatCode: lowerCaseFiatCode,
     });
-    const assetPrice = await this.assetPriceValidator.validate(result);
+    const assetPrice = this.assetPriceValidator.validate(result);
     return assetPrice?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
   }
 

--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -16,10 +16,13 @@ export class PricesRepository implements IPricesRepository {
     nativeCoinId: string;
     fiatCode: string;
   }): Promise<number> {
-    const result = await this.coingeckoApi.getNativeCoinPrice(args);
+    const lowerCaseFiatCode = args.fiatCode.toLowerCase();
+    const result = await this.coingeckoApi.getNativeCoinPrice({
+      nativeCoinId: args.nativeCoinId,
+      fiatCode: lowerCaseFiatCode,
+    });
     const assetPrice = await this.assetPriceValidator.validate(result);
-    const { nativeCoinId, fiatCode } = args;
-    return assetPrice?.[nativeCoinId]?.[fiatCode];
+    return assetPrice?.[args.nativeCoinId]?.[lowerCaseFiatCode];
   }
 
   async getTokenPrice(args: {
@@ -27,10 +30,15 @@ export class PricesRepository implements IPricesRepository {
     tokenAddress: string;
     fiatCode: string;
   }): Promise<number> {
-    const result = await this.coingeckoApi.getTokenPrice(args);
+    const lowerCaseFiatCode = args.fiatCode.toLowerCase();
+    const lowerCaseTokenAddress = args.tokenAddress.toLowerCase();
+    const result = await this.coingeckoApi.getTokenPrice({
+      chainName: args.chainName,
+      tokenAddress: lowerCaseTokenAddress,
+      fiatCode: lowerCaseFiatCode,
+    });
     const assetPrice = await this.assetPriceValidator.validate(result);
-    const { tokenAddress, fiatCode } = args;
-    return assetPrice?.[tokenAddress.toLowerCase()]?.[fiatCode];
+    return assetPrice?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
   }
 
   async getFiatCodes(): Promise<string[]> {

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -329,12 +329,12 @@ describe('Balances Controller (Unit)', () => {
         const chainName = app
           .get(IConfigurationService)
           .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
-        const currency = 'eur';
+        const currency = faker.finance.currencyCode();
         const nativeCoinPriceProviderResponse = {
-          [nativeCoinId]: { [currency]: 1536.75 },
+          [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
         };
         const tokenPriceProviderResponse = {
-          [tokenAddress]: { [currency]: 12.5 },
+          [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
         };
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -352,7 +352,11 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/EUR`)
+          .get(
+            `/v1/chains/${
+              chain.chainId
+            }/safes/${safeAddress}/balances/${currency.toUpperCase()}`,
+          )
           .expect(200)
           .expect({
             fiatTotal: '5110.25',
@@ -402,14 +406,14 @@ describe('Balances Controller (Unit)', () => {
           `${pricesProviderUrl}/simple/price`,
         );
         expect(networkService.get.mock.calls[2][1]).toStrictEqual({
-          params: { ids: 'ethereum', vs_currencies: 'eur' },
+          params: { ids: 'ethereum', vs_currencies: currency.toLowerCase() },
         });
         expect(networkService.get.mock.calls[3][0]).toBe(
           `${pricesProviderUrl}/simple/token_price/${chainName}`,
         );
         expect(networkService.get.mock.calls[3][1]).toStrictEqual({
           params: {
-            vs_currencies: 'eur',
+            vs_currencies: currency.toLowerCase(),
             contract_addresses: tokenAddress.toLowerCase(),
           },
         });
@@ -431,9 +435,9 @@ describe('Balances Controller (Unit)', () => {
         const chainName = app
           .get(IConfigurationService)
           .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
-        const currency = 'eur';
+        const currency = faker.finance.currencyCode();
         const tokenPriceProviderResponse = {
-          [tokenAddress]: { [currency]: 2.5 },
+          [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
         };
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -473,12 +477,12 @@ describe('Balances Controller (Unit)', () => {
             .with('token', null)
             .build(),
         ];
-        const currency = 'usd';
+        const currency = faker.finance.currencyCode();
         const nativeCoinId = app
           .get(IConfigurationService)
           .getOrThrow(`prices.chains.${chain.chainId}.nativeCoin`);
         const nativeCoinPriceProviderResponse = {
-          [nativeCoinId]: { [currency]: 1536.75 },
+          [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
         };
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -494,7 +498,11 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(`/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/usd`)
+          .get(
+            `/v1/chains/${
+              chain.chainId
+            }/safes/${safeAddress}/balances/${currency.toUpperCase()}`,
+          )
           .expect(200)
           .expect({
             fiatTotal: '4610.25',
@@ -530,9 +538,9 @@ describe('Balances Controller (Unit)', () => {
         const chainName = app
           .get(IConfigurationService)
           .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
-        const currency = 'eur';
+        const currency = faker.finance.currencyCode();
         const tokenPriceProviderResponse = {
-          [tokenAddress]: { [currency]: 2.5 },
+          [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
         };
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -614,7 +622,6 @@ describe('Balances Controller (Unit)', () => {
         const chain = chainBuilder().with('chainId', '10').build();
         const safeAddress = faker.finance.ethereumAddress();
         const tokenAddress = faker.finance.ethereumAddress();
-        const currency = 'eur';
         const transactionApiBalancesResponse = [
           simpleBalanceBuilder()
             .with('tokenAddress', tokenAddress)
@@ -640,7 +647,9 @@ describe('Balances Controller (Unit)', () => {
 
         await request(app.getHttpServer())
           .get(
-            `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${currency}`,
+            `/v1/chains/${
+              chain.chainId
+            }/safes/${safeAddress}/balances/${faker.finance.currencyCode()}`,
           )
           .expect(200)
           .expect({
@@ -669,7 +678,6 @@ describe('Balances Controller (Unit)', () => {
         const chain = chainBuilder().with('chainId', '10').build();
         const safeAddress = faker.finance.ethereumAddress();
         const tokenAddress = faker.finance.ethereumAddress();
-        const currency = 'eur';
         const transactionApiBalancesResponse = [
           simpleBalanceBuilder()
             .with('tokenAddress', tokenAddress)
@@ -696,7 +704,9 @@ describe('Balances Controller (Unit)', () => {
 
         await request(app.getHttpServer())
           .get(
-            `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${currency}`,
+            `/v1/chains/${
+              chain.chainId
+            }/safes/${safeAddress}/balances/${faker.finance.currencyCode()}`,
           )
           .expect(200)
           .expect({

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -352,9 +352,7 @@ describe('Balances Controller (Unit)', () => {
         });
 
         await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${currency}`,
-          )
+          .get(`/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/EUR`)
           .expect(200)
           .expect({
             fiatTotal: '5110.25',
@@ -403,9 +401,18 @@ describe('Balances Controller (Unit)', () => {
         expect(networkService.get.mock.calls[2][0]).toBe(
           `${pricesProviderUrl}/simple/price`,
         );
+        expect(networkService.get.mock.calls[2][1]).toStrictEqual({
+          params: { ids: 'ethereum', vs_currencies: 'eur' },
+        });
         expect(networkService.get.mock.calls[3][0]).toBe(
           `${pricesProviderUrl}/simple/token_price/${chainName}`,
         );
+        expect(networkService.get.mock.calls[3][1]).toStrictEqual({
+          params: {
+            vs_currencies: 'eur',
+            contract_addresses: tokenAddress.toLowerCase(),
+          },
+        });
       });
 
       it(`excludeSpam and trusted params are forwarded to tx service`, async () => {


### PR DESCRIPTION
(Context: https://github.com/safe-global/safe-client-gateway/issues/767)
- Parses input `fiatCode`, converting it to lower case, so clients can use both upper or lower cases.