### PR TITLE
Change nested transfers mapping

### DIFF
--- a/src/routes/transactions/mappers/transfers/transfer.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.ts
@@ -17,12 +17,18 @@ export class IncomingTransferMapper {
     chainId: string,
     transfer: Transfer,
     safe: Safe,
+    resolveAddressInfo = true,
   ): Promise<Transaction> {
     return new Transaction(
       `${TRANSFER_PREFIX}${TRANSACTION_ID_SEPARATOR}${safe.address}${TRANSACTION_ID_SEPARATOR}${transfer.transferId}`,
       transfer.executionDate.getTime(),
       TransactionStatus.Success,
-      await this.transferInfoMapper.mapTransferInfo(chainId, transfer, safe),
+      await this.transferInfoMapper.mapTransferInfo(
+        chainId,
+        transfer,
+        safe,
+        resolveAddressInfo,
+      ),
       null,
       null,
     );


### PR DESCRIPTION
- Changes the calls to `incomingTransferMapper.mapTransfer` inside the function `mapTransfers`: instead of returning an array of promises, the function awaits these calls sequentially and returns resolved values. This avoids requesting the same token data N times in parallel (and therefore having N cache misses). Now the first call sets the token data in the cache, so subsequent calls produce cache hits.
- Adds a new parameter to `TransferInfoMapper.mapTransferInfo`: `resolveAddressInfo`. This is used to indicate the function whether the addresses in the transfer (`from`, `to`, `tokenAddress` fields) should be resolved to an `AddressInfo`. This can be used to avoid resolving an arbitrary number of addresses when the nested transfers for a given transaction surpasses a threshold (`MAX_NESTED_TXS`).