### PR TITLE
Slice nested transfers

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -43,6 +43,11 @@ export default (): ReturnType<typeof configuration> => ({
     level: 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
+  mappings: {
+    history: {
+      maxNestedTransfers: faker.number.int({ min: 1, max: 5 }),
+    },
+  },
   prices: {
     baseUri: faker.internet.url({ appendSlash: false }),
     apiKey: faker.string.hexadecimal({ length: 32 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -58,6 +58,13 @@ export default () => ({
     level: process.env.LOG_LEVEL || 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
+  mappings: {
+    history: {
+      maxNestedTransfers: parseInt(
+        process.env.MAX_NESTED_TRANSFERS ?? `${100}`,
+      ),
+    },
+  },
   prices: {
     baseUri:
       process.env.PRICES_PROVIDER_API_BASE_URI ||

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -32,6 +32,8 @@ class TransactionDomainGroup {
 
 @Injectable()
 export class TransactionsHistoryMapper {
+  private static readonly MAX_NESTED_TXS = 10;
+
   constructor(
     private readonly multisigTransactionMapper: MultisigTransactionMapper,
     private readonly moduleTransactionMapper: ModuleTransactionMapper,
@@ -162,16 +164,18 @@ export class TransactionsHistoryMapper {
   }
 
   private mapTransfer(transfers: Transfer[], chainId: string, safe: Safe) {
-    return transfers.map(
-      async (transfer) =>
-        new TransactionItem(
-          await this.incomingTransferMapper.mapTransfer(
-            chainId,
-            transfer,
-            safe,
+    return transfers
+      .slice(0, TransactionsHistoryMapper.MAX_NESTED_TXS)
+      .map(
+        async (transfer) =>
+          new TransactionItem(
+            await this.incomingTransferMapper.mapTransfer(
+              chainId,
+              transfer,
+              safe,
+            ),
           ),
-        ),
-    );
+      );
   }
 
   private mapGroupTransactions(


### PR DESCRIPTION
- Cuts the number of nested transfers in the history to a max value by slicing the `transfers` array within `TransactionsHistoryMapper.mapTransfer`.