### PR TITLE
fix: remove redundant `isHex` function

### DIFF
--- a/src/routes/common/utils/utils.ts
+++ b/src/routes/common/utils/utils.ts
@@ -1,3 +1,0 @@
-export function isHex(value: unknown): boolean {
-  return typeof value === 'string' && value.startsWith('0x');
-}


### PR DESCRIPTION
With the previous installation of `viem`, we are now using `isHex` from there. As such, our own `isHex` is no longer used. This removes it.