### PR TITLE
Tag docker image with BUILD_NUMBER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-  release:
-    types: [released]
 
 jobs:
   prettier:
@@ -79,10 +77,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
-  docker-publish-staging:
+  docker-publish:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
+    env:
+      IMAGE_CACHE_SOURCE: latest
+      IMAGE_REGISTRY: safeglobal
+      IMAGE_NAME: safe-client-gateway-nest
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -105,48 +107,15 @@ jobs:
           build-args: |
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
-          tags: ${{ env.DOCKER_IMAGE_TAG }}
-          # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
-          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
-          cache-to: type=inline
-
-  docker-publish-release:
-    if: (github.event_name == 'release' && github.event.action == 'released')
-    needs: [prettier, es-lint, tests-finish]
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_CACHE_SOURCE: staging
-      IMAGE_REGISTRY: safeglobal
-      IMAGE_NAME: safe-client-gateway-nest
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          BUILD_NUMBER=${{ github.sha }}
-          echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
-      - uses: docker/setup-qemu-action@v3.0.0
-        with:
-          platforms: arm64
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
-            VERSION=${{ github.ref_name }}
           tags: |
-            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_NUMBER }}
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_CACHE_SOURCE }}
           cache-to: type=inline
 
   autodeploy:
     runs-on: ubuntu-latest
-    needs: [docker-publish-staging]
+    needs: [docker-publish]
     steps:
       - uses: actions/checkout@v4
       - name: Deploy Staging


### PR DESCRIPTION
Instead of relying on a semver approach for production releases and on a `staging` label for staging releases, these two flows are now merged, and the `BUILD_NUMBER` is instead used for the tag. The `BUILD_NUMBER` corresponds to the shorthand git commit hash.