### PR TITLE
Bump node version from 18.17.0 to 20.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.17.x'
+          node-version: '20.8.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run format-check
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.17.x'
+          node-version: '20.8.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run lint-check
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.17.x'
+          node-version: '20.8.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # BUILD CONTAINER
 #
-FROM node:18.17 as base
+FROM node:20.8.1 as base
 ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
@@ -15,7 +15,7 @@ RUN yarn run build
 #
 # PRODUCTION CONTAINER
 #
-FROM node:18.17-alpine as production
+FROM node:20.8.1-alpine as production
 USER node
 
 ARG VERSION

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-- Node 18.17.0 – https://nodejs.org/en/
+- Node 20.8.1 – https://nodejs.org/en/
 - Docker Compose – https://docs.docker.com/compose/
 
 ## Installation


### PR DESCRIPTION
Bumps Node from 18.17.0 (LTS) to 20.8.1 (LTS). https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-10-13-version-2081-current-rafaelgss