### PR TITLE
feat: add alerts (Tenderly) datasource

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,19 @@
 # The cache TTL for each token price datapoint.
 #PRICES_TTL_SECONDS=
 
+# Alerts provider API
+# The alerts provider API to be used.
+# NOTE: For production usage, a paid subscription is recommended.
+# (default is 'https://api.tenderly.co' if none is set)
+# ALERTS_PROVIDER_API_BASE_URI=
+# The API Key to be used.
+# ALERTS_PROVIDER_API_KEY=
+# The account to be used.
+# ALERTS_PROVIDER_ACCOUNT=
+# The project to be used.
+# ALERTS_PROVIDER_PROJECT=
+
+
 # The base Exchange Rate API to be used.
 # (default is http://api.exchangeratesapi.io/v1 if none is set)
 # The EXCHANGE_API_KEY should always be set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
         env:
           EXCHANGE_API_BASE_URI: http://api.exchangeratesapi.io/v1
           EXCHANGE_API_KEY: ${{ secrets.EXCHANGE_API_KEY }}
+          ALERTS_PROVIDER_API_KEY: ${{ secrets.ALERTS_PROVIDER_API_KEY }}
+          ALERTS_PROVIDER_ACCOUNT: ${{ secrets.ALERTS_PROVIDER_ACCOUNT }}
+          ALERTS_PROVIDER_PROJECT: ${{ secrets.ALERTS_PROVIDER_PROJECT }}
           REDIS_HOST: localhost
           REDIS_PORT: 6379
           SAFE_CONFIG_BASE_URI: ${{ secrets.SAFE_CONFIG_BASE_URI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
         env:
           EXCHANGE_API_BASE_URI: http://api.exchangeratesapi.io/v1
           EXCHANGE_API_KEY: ${{ secrets.EXCHANGE_API_KEY }}
-          ALERTS_PROVIDER_API_KEY: ${{ secrets.ALERTS_PROVIDER_API_KEY }}
-          ALERTS_PROVIDER_ACCOUNT: ${{ secrets.ALERTS_PROVIDER_ACCOUNT }}
-          ALERTS_PROVIDER_PROJECT: ${{ secrets.ALERTS_PROVIDER_PROJECT }}
           REDIS_HOST: localhost
           REDIS_PORT: 6379
           SAFE_CONFIG_BASE_URI: ${{ secrets.SAFE_CONFIG_BASE_URI }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
       EXCHANGE_API_KEY: ${EXCHANGE_API_KEY-example_api_key}
       APPLICATION_PORT: ${APPLICATION_PORT-3000}
       AUTH_TOKEN: ${AUTH_TOKEN-example_auth_token}
+      ALERTS_PROVIDER_API_KEY: ${ALERTS_PROVIDER_API_KEY-example_api_key}
+      ALERTS_PROVIDER_ACCOUNT: ${ALERTS_PROVIDER_ACCOUNT-example_account}
+      ALERTS_PROVIDER_PROJECT: ${ALERTS_PROVIDER_PROJECT-example_project}
     depends_on:
       - redis
       - db

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -13,7 +13,7 @@ describe('Configuration validator', () => {
   it('should detect missing mandatory configuration in production environment', () => {
     process.env.NODE_ENV = 'production';
     expect(() => validate(JSON.parse(fakeJson()))).toThrow(
-      /must have required property 'AUTH_TOKEN'.*must have required property 'EXCHANGE_API_KEY'/,
+      /must have required property 'AUTH_TOKEN'.*must have required property 'EXCHANGE_API_KEY'.*must have required property 'ALERTS_PROVIDER_API_KEY'.*must have required property 'ALERTS_PROVIDER_ACCOUNT'.*must have required property 'ALERTS_PROVIDER_PROJECT'/,
     );
   });
 
@@ -24,6 +24,9 @@ describe('Configuration validator', () => {
         AUTH_TOKEN: faker.string.uuid(),
         EXCHANGE_API_KEY: faker.string.uuid(),
         LOG_LEVEL: faker.word.words(),
+        ALERTS_PROVIDER_API_KEY: faker.string.uuid(),
+        ALERTS_PROVIDER_ACCOUNT: faker.string.alphanumeric(),
+        ALERTS_PROVIDER_PROJECT: faker.string.alphanumeric(),
       }),
     ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
   });
@@ -34,6 +37,9 @@ describe('Configuration validator', () => {
       ...JSON.parse(fakeJson()),
       AUTH_TOKEN: faker.string.uuid(),
       EXCHANGE_API_KEY: faker.string.uuid(),
+      ALERTS_PROVIDER_API_KEY: faker.string.uuid(),
+      ALERTS_PROVIDER_ACCOUNT: faker.string.alphanumeric(),
+      ALERTS_PROVIDER_PROJECT: faker.string.alphanumeric(),
     };
     const validated = validate(expected);
     expect(validated).toBe(expected);

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -9,8 +9,17 @@ const configurationSchema: Schema = {
       type: 'string',
       enum: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'],
     },
+    ALERTS_PROVIDER_API_KEY: { type: 'string' },
+    ALERTS_PROVIDER_ACCOUNT: { type: 'string' },
+    ALERTS_PROVIDER_PROJECT: { type: 'string' },
   },
-  required: ['AUTH_TOKEN', 'EXCHANGE_API_KEY'],
+  required: [
+    'AUTH_TOKEN',
+    'EXCHANGE_API_KEY',
+    'ALERTS_PROVIDER_API_KEY',
+    'ALERTS_PROVIDER_ACCOUNT',
+    'ALERTS_PROVIDER_PROJECT',
+  ],
 };
 
 export function validate(

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -7,6 +7,12 @@ export default (): ReturnType<typeof configuration> => ({
     version: faker.system.semver(),
     buildNumber: faker.string.numeric(),
   },
+  alerts: {
+    baseUri: faker.internet.url({ appendSlash: false }),
+    apiKey: faker.string.hexadecimal({ length: 32 }),
+    account: faker.string.sample(),
+    project: faker.string.sample(),
+  },
   applicationPort: faker.internet.port().toString(),
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -4,6 +4,13 @@ export default () => ({
     version: process.env.APPLICATION_VERSION,
     buildNumber: process.env.APPLICATION_BUILD_NUMBER,
   },
+  alerts: {
+    baseUri:
+      process.env.ALERTS_PROVIDER_API_BASE_URI || 'https://api.tenderly.co',
+    apiKey: process.env.ALERTS_PROVIDER_API_KEY,
+    account: process.env.ALERTS_PROVIDER_ACCOUNT,
+    project: process.env.ALERTS_PROVIDER_PROJECT,
+  },
   applicationPort: process.env.APPLICATION_PORT || '3000',
   auth: {
     token: process.env.AUTH_TOKEN,

--- a/src/datasources/alerts-api/alerts-api.module.ts
+++ b/src/datasources/alerts-api/alerts-api.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HttpErrorFactory } from '../errors/http-error-factory';
+import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
+import { TenderlyApi } from '@/datasources/alerts-api/tenderly-api.service';
+
+@Module({
+  providers: [HttpErrorFactory, { provide: IAlertsApi, useClass: TenderlyApi }],
+  exports: [IAlertsApi],
+})
+export class AlertsApiModule {}

--- a/src/datasources/alerts-api/alerts-api.module.ts
+++ b/src/datasources/alerts-api/alerts-api.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { HttpErrorFactory } from '../errors/http-error-factory';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
 import { TenderlyApi } from '@/datasources/alerts-api/tenderly-api.service';
 

--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -2,14 +2,14 @@ import { faker } from '@faker-js/faker';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { TenderlyApi } from '@/datasources/alerts-api/tenderly-api.service';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { AxiosNetworkService } from '@/datasources/network/axios.network.service';
+import { INetworkService } from '@/datasources/network/network.service.interface';
 import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 
 const networkService = {
   post: jest.fn(),
   delete: jest.fn(),
-} as unknown as AxiosNetworkService;
+} as unknown as INetworkService;
 const mockNetworkService = jest.mocked(networkService);
 
 const httpErrorFactory = {
@@ -66,17 +66,17 @@ describe('TenderlyApi', () => {
         {
           address: faker.finance.ethereumAddress(),
           displayName: faker.word.words(),
-          networkId: faker.string.numeric(),
+          chainId: faker.string.numeric(),
         },
         {
           address: faker.finance.ethereumAddress(),
           displayName: faker.word.words(),
-          networkId: faker.string.numeric(),
+          chainId: faker.string.numeric(),
         },
         {
           address: faker.finance.ethereumAddress(),
           displayName: faker.word.words(),
-          networkId: faker.string.numeric(),
+          chainId: faker.string.numeric(),
         },
       ];
 
@@ -92,7 +92,7 @@ describe('TenderlyApi', () => {
             contracts: contracts.map((contract) => ({
               address: contract.address,
               display_name: contract.displayName,
-              network_id: contract.networkId,
+              network_id: contract.chainId,
             })),
           },
         },

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -44,7 +44,7 @@ export class TenderlyApi implements IAlertsApi {
           contracts: contracts.map((contract) => ({
             address: contract.address,
             display_name: contract.displayName,
-            network_id: contract.networkId,
+            network_id: contract.chainId,
           })),
         },
       });

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -1,43 +1,45 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
 import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
-import { INetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { NetworkRequest } from '@/datasources/network/entities/network.request.entity';
 
 @Injectable()
 export class TenderlyApi implements IAlertsApi {
-  private readonly baseUrl: string;
+  private static readonly HEADER: string = 'X-Access-Key';
+
   private readonly apiKey: string;
+  private readonly baseUrl: string;
   private readonly account: string;
   private readonly project: string;
 
   constructor(
+    @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    @Inject(NetworkService)
     private readonly networkService: INetworkService,
     private readonly httpErrorFactory: HttpErrorFactory,
   ) {
+    this.apiKey = this.configurationService.getOrThrow<string>('alerts.apiKey');
     this.baseUrl =
       this.configurationService.getOrThrow<string>('alerts.baseUri');
-    this.apiKey = this.configurationService.getOrThrow<string>('alerts.apiKey');
     this.account =
       this.configurationService.getOrThrow<string>('alerts.account');
     this.project =
       this.configurationService.getOrThrow<string>('alerts.project');
   }
 
-  private getHeaders(): NetworkRequest['headers'] {
-    return {
-      'X-Access-Key': this.apiKey,
-    };
-  }
-
   async addContracts(contracts: Array<Contract>): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
       await this.networkService.post(url, {
-        headers: this.getHeaders(),
+        headers: {
+          [TenderlyApi.HEADER]: this.apiKey,
+        },
         params: {
           contracts: contracts.map((contract) => ({
             address: contract.address,
@@ -55,7 +57,9 @@ export class TenderlyApi implements IAlertsApi {
     try {
       const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
       await this.networkService.delete(url, {
-        headers: this.getHeaders(),
+        headers: {
+          [TenderlyApi.HEADER]: this.apiKey,
+        },
         params: {
           contract_ids: contractIds,
         },

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
+import { INetworkService } from '@/datasources/network/network.service.interface';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { NetworkRequest } from '@/datasources/network/entities/network.request.entity';
+
+@Injectable()
+export class TenderlyApi implements IAlertsApi {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly account: string;
+  private readonly project: string;
+
+  constructor(
+    private readonly configurationService: IConfigurationService,
+    private readonly networkService: INetworkService,
+    private readonly httpErrorFactory: HttpErrorFactory,
+  ) {
+    this.baseUrl =
+      this.configurationService.getOrThrow<string>('alerts.baseUri');
+    this.apiKey = this.configurationService.getOrThrow<string>('alerts.apiKey');
+    this.account =
+      this.configurationService.getOrThrow<string>('alerts.account');
+    this.project =
+      this.configurationService.getOrThrow<string>('alerts.project');
+  }
+
+  private getHeaders(): NetworkRequest['headers'] {
+    return {
+      'X-Access-Key': this.apiKey,
+    };
+  }
+
+  async addContracts(contracts: Array<Contract>): Promise<void> {
+    try {
+      const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
+      await this.networkService.post(url, {
+        headers: this.getHeaders(),
+        params: {
+          contracts: contracts.map((contract) => ({
+            address: contract.address,
+            display_name: contract.displayName,
+            network_id: contract.networkId,
+          })),
+        },
+      });
+    } catch (error) {
+      this.httpErrorFactory.from(error);
+    }
+  }
+
+  async removeContracts(contractIds: Array<ContractId>): Promise<void> {
+    try {
+      const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
+      await this.networkService.delete(url, {
+        headers: this.getHeaders(),
+        params: {
+          contract_ids: contractIds,
+        },
+      });
+    } catch (error) {
+      this.httpErrorFactory.from(error);
+    }
+  }
+}

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -2,6 +2,7 @@ import { Global, Module } from '@nestjs/common';
 import { ExchangeApiModule } from '@/datasources/exchange-api/exchange-api.module';
 import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 import { TransactionApiModule } from '@/datasources/transaction-api/transaction-api.module';
+import { AlertsApiModule } from '@/datasources/alerts-api/alerts-api.module';
 import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
 import { BalancesRepository } from '@/domain/balances/balances.repository';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
@@ -71,6 +72,7 @@ import { FiatCodesValidator } from '@/domain/prices/fiat-codes.validator';
     ConfigApiModule,
     ExchangeApiModule,
     PricesApiModule,
+    AlertsApiModule,
     HumanDescriptionApiModule,
     TransactionApiModule,
   ],

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -69,10 +69,10 @@ import { FiatCodesValidator } from '@/domain/prices/fiat-codes.validator';
 @Global()
 @Module({
   imports: [
+    AlertsApiModule,
     ConfigApiModule,
     ExchangeApiModule,
     PricesApiModule,
-    AlertsApiModule,
     HumanDescriptionApiModule,
     TransactionApiModule,
   ],

--- a/src/domain/alerts/entities/alerts.entity.ts
+++ b/src/domain/alerts/entities/alerts.entity.ts
@@ -1,0 +1,7 @@
+export type Contract = {
+  address: string;
+  networkId: string;
+  displayName?: string;
+};
+
+export type ContractId = `${Contract['networkId']}:${Contract['address']}`;

--- a/src/domain/alerts/entities/alerts.entity.ts
+++ b/src/domain/alerts/entities/alerts.entity.ts
@@ -1,7 +1,7 @@
 export type Contract = {
   address: string;
-  networkId: string;
+  chainId: string;
   displayName?: string;
 };
 
-export type ContractId = `${Contract['networkId']}:${Contract['address']}`;
+export type ContractId = `${Contract['chainId']}:${Contract['address']}`;

--- a/src/domain/interfaces/alerts-api.inferface.ts
+++ b/src/domain/interfaces/alerts-api.inferface.ts
@@ -1,0 +1,9 @@
+import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+
+export const IAlertsApi = Symbol('IAlertsApi');
+
+export interface IAlertsApi {
+  addContracts(contracts: Array<Contract>): Promise<void>;
+
+  removeContracts(contractIds: Array<ContractId>): Promise<void>;
+}

--- a/src/routes/root/root.controller.spec.ts
+++ b/src/routes/root/root.controller.spec.ts
@@ -1,6 +1,8 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AppModule } from '@/app.module';
+import { AppModule, configurationModule } from '@/app.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { ConfigurationModule } from '@/config/configuration.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
@@ -15,6 +17,8 @@ describe('Root Controller tests', () => {
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
       .compile();
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();


### PR DESCRIPTION
This adds a new `alerts` datasouce, leveraging [the Tenderly API](https://docs-api.tenderly.co/contract-management) in anticipation of Tenderly Alerts for the forthcoming recovery implementation:

- Tenderly-specific configuration for: URL, API key, account and project.
- `IAlertsApi` with `addContracts` and `removeContracts` methods.
- Test-covered `TenderlyApi`, which implements `IAlertsApi`.
- `AlertsModule`, providing the `TenderlyApi`.