### PR TITLE
feat: add alerts domain with `IAlertsRepository`

### DIFF
--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -3,7 +3,7 @@ import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.
 import { TenderlyApi } from '@/datasources/alerts-api/tenderly-api.service';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { INetworkService } from '@/datasources/network/network.service.interface';
-import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+import { Contract, ContractId } from '@/domain/alerts/entities/alert.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 
 const networkService = {

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+import { Contract, ContractId } from '@/domain/alerts/entities/alert.entity';
 import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
 import {
   INetworkService,

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -3,6 +3,8 @@ import { ExchangeApiModule } from '@/datasources/exchange-api/exchange-api.modul
 import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 import { TransactionApiModule } from '@/datasources/transaction-api/transaction-api.module';
 import { AlertsApiModule } from '@/datasources/alerts-api/alerts-api.module';
+import { IAlertsRepository } from '@/domain/alerts/alerts.repository.interface';
+import { AlertsRepository } from '@/domain/alerts/alerts.repository';
 import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
 import { BalancesRepository } from '@/domain/balances/balances.repository';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
@@ -77,6 +79,7 @@ import { FiatCodesValidator } from '@/domain/prices/fiat-codes.validator';
     TransactionApiModule,
   ],
   providers: [
+    { provide: IAlertsRepository, useClass: AlertsRepository },
     { provide: IBackboneRepository, useClass: BackboneRepository },
     { provide: IBalancesRepository, useClass: BalancesRepository },
     { provide: IChainsRepository, useClass: ChainsRepository },

--- a/src/domain/alerts/alerts.repository.interface.ts
+++ b/src/domain/alerts/alerts.repository.interface.ts
@@ -1,0 +1,7 @@
+import { Alert } from '@/domain/alerts/entities/alert.entity';
+
+export const IAlertsRepository = Symbol('IAlertsRepository');
+
+export interface IAlertsRepository {
+  alert(alert: Alert): void;
+}

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { IAlertsRepository } from '@/domain/alerts/alerts.repository.interface';
+import { Alert } from '@/domain/alerts/entities/alert.entity';
+
+@Injectable()
+export class AlertsRepository implements IAlertsRepository {
+  alert(alert: Alert): void {
+    console.log(alert);
+  }
+}

--- a/src/domain/alerts/entities/alert.entity.ts
+++ b/src/domain/alerts/entities/alert.entity.ts
@@ -1,0 +1,42 @@
+export type Contract = {
+  address: string;
+  chainId: string;
+  displayName?: string;
+};
+
+export type ContractId = `${Contract['chainId']}:${Contract['address']}`;
+
+export type AlertLog = {
+  address: string;
+  topics: Array<string>;
+  data: string;
+};
+
+export type AlertTransaction = {
+  network: string;
+  block_hash: string;
+  block_number: number;
+  hash: string;
+  from: string;
+  to: string;
+  logs: Array<AlertLog>;
+  input: string;
+  value: string;
+  nonce: string;
+  gas: string;
+  gas_used: string;
+  cumulative_gas_used: string;
+  gas_price: string;
+  gas_tip_cap: string;
+  gas_fee_cap: string;
+};
+
+export enum AlertEventType {
+  ALERT = 'ALERT',
+}
+
+export type Alert = {
+  id: string;
+  event_type: AlertEventType.ALERT;
+  transaction: AlertTransaction;
+};

--- a/src/domain/alerts/entities/alerts.entity.ts
+++ b/src/domain/alerts/entities/alerts.entity.ts
@@ -1,7 +1,0 @@
-export type Contract = {
-  address: string;
-  chainId: string;
-  displayName?: string;
-};
-
-export type ContractId = `${Contract['chainId']}:${Contract['address']}`;

--- a/src/domain/interfaces/alerts-api.inferface.ts
+++ b/src/domain/interfaces/alerts-api.inferface.ts
@@ -1,4 +1,4 @@
-import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+import { Contract, ContractId } from '@/domain/alerts/entities/alert.entity';
 
 export const IAlertsApi = Symbol('IAlertsApi');
 


### PR DESCRIPTION
This adds a new `alerts` domain with `IAlertsRepository` in preparation for [Tenderly Alerts](https://tenderly.co/alerting):

- `IAlertsRepository` with `alert` interface for handling Alert payloads.
- `AlertsRepository` implementing `IAlertsRepository`.
- Associated type adjustments.