### PR TITLE
fix: `get-contract` E2E test

### DIFF
--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -31,8 +31,7 @@ describe('Get contract e2e test', () => {
       address: '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4',
       name: 'CreateCall',
       displayName: '',
-      logoUri:
-        'https://safe-transaction-assets.staging.5afe.dev/contracts/logos/0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4.png',
+      logoUri: expect.any(String),
       contractAbi: {
         abi: [
           {

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -31,7 +31,8 @@ describe('Get contract e2e test', () => {
       address: '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4',
       name: 'CreateCall',
       displayName: '',
-      logoUri: null,
+      logoUri:
+        'https://safe-transaction-assets.staging.5afe.dev/contracts/logos/0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4.png',
       contractAbi: {
         abi: [
           {

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -107,18 +107,25 @@ describe('Get contract e2e test', () => {
       trustedForDelegateCall: false,
     };
 
+    let logoUri: string | null = null;
+
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/contracts/${contractAddress}`)
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);
+
+        // logoUri is mutable and may have been updated on the Transaction Service
+        logoUri = body.logoUri;
       });
 
     const cacheContent = await redisClient.hGet(
       `${chainId}_contract_${contractAddress}`,
       '',
     );
-    expect(cacheContent).toEqual(JSON.stringify(expectedResponse));
+    expect(cacheContent).toEqual(
+      JSON.stringify({ ...expectedResponse, logoUri }),
+    );
   });
 
   afterAll(async () => {

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -31,7 +31,8 @@ describe('Get contract e2e test', () => {
       address: '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4',
       name: 'CreateCall',
       displayName: '',
-      logoUri: expect.any(String),
+      logoUri:
+        'https://safe-transaction-assets.staging.5afe.dev/contracts/logos/0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4.png',
       contractAbi: {
         abi: [
           {
@@ -107,25 +108,18 @@ describe('Get contract e2e test', () => {
       trustedForDelegateCall: false,
     };
 
-    let logoUri: string | null = null;
-
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/contracts/${contractAddress}`)
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);
-
-        // logoUri is mutable and may have been updated on the Transaction Service
-        logoUri = body.logoUri;
       });
 
     const cacheContent = await redisClient.hGet(
       `${chainId}_contract_${contractAddress}`,
       '',
     );
-    expect(cacheContent).toEqual(
-      JSON.stringify({ ...expectedResponse, logoUri }),
-    );
+    expect(cacheContent).toEqual(JSON.stringify(expectedResponse));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
A logo was added for `0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4` on the Transaction Service which, in turn, broke our `get-contract.e2e-spec` test. This adds the new `logoUri` to the test.