### PR TITLE
Add recommended nonce endpoint

### DIFF
--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -160,4 +160,15 @@ export interface ISafeRepository {
     safeAddress: string;
     proposeTransactionDto: ProposeTransactionDto;
   }): Promise<unknown>;
+
+  /**
+   * Gets the maximum between the current Safe nonce and the last transaction nonce plus 1.
+   * If there is no last transaction, the Safe nonce is returned.
+   *
+   * @returns recommended nonce for next transaction.
+   */
+  getRecommendedNonce(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<number>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -363,4 +363,23 @@ export class SafeRepository implements ISafeRepository {
       data: args.proposeTransactionDto,
     });
   }
+
+  async getRecommendedNonce(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<number> {
+    const safe = await this.getSafe({
+      chainId: args.chainId,
+      address: args.safeAddress,
+    });
+
+    const lastTransaction = await this.getLastTransactionSortedByNonce({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+    });
+
+    return lastTransaction
+      ? Math.max(safe.nonce, lastTransaction.nonce + 1)
+      : safe.nonce;
+  }
 }

--- a/src/routes/estimations/estimations.service.ts
+++ b/src/routes/estimations/estimations.service.ts
@@ -34,37 +34,14 @@ export class EstimationsService {
       chainId: args.chainId,
       address: args.address,
     });
-    const recommendedNonce = await this.getEstimationRecommendedNonce({
+    const recommendedNonce = await this.safeRepository.getRecommendedNonce({
       chainId: args.chainId,
       safeAddress: args.address,
-      safeNonce: safe.nonce,
     });
     return new EstimationResponse(
       safe.nonce,
       recommendedNonce,
       estimation.safeTxGas,
     );
-  }
-
-  /**
-   * Gets the maximum between the current Safe nonce and the last transaction nonce plus 1.
-   * If there is no last transaction, the Safe nonce is returned.
-   *
-   * @returns recommended nonce for next transaction.
-   */
-  private async getEstimationRecommendedNonce(args: {
-    chainId: string;
-    safeAddress: string;
-    safeNonce: number;
-  }): Promise<number> {
-    const lastTransaction =
-      await this.safeRepository.getLastTransactionSortedByNonce({
-        chainId: args.chainId,
-        safeAddress: args.safeAddress,
-      });
-
-    return lastTransaction
-      ? Math.max(args.safeNonce, lastTransaction.nonce + 1)
-      : args.safeNonce;
   }
 }

--- a/src/routes/safes/entities/recommended-nonce.entity.ts
+++ b/src/routes/safes/entities/recommended-nonce.entity.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RecommendedNonce {
+  @ApiProperty()
+  readonly nonce: number;
+
+  constructor(nonce: number) {
+    this.nonce = nonce;
+  }
+}

--- a/src/routes/safes/safes.controller.recommended-nonce.spec.ts
+++ b/src/routes/safes/safes.controller.recommended-nonce.spec.ts
@@ -1,0 +1,140 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import * as request from 'supertest';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import {
+  multisigTransactionBuilder,
+  toJson as multisigTransactionToJson,
+} from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+
+describe('Safes Controller recommended-nonce (Unit)', () => {
+  let app: INestApplication;
+  let safeConfigUrl;
+  let networkService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration)],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    const configurationService = moduleFixture.get(IConfigurationService);
+    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  it('returns latest transaction nonce + 1 if greater than safe nonce', async () => {
+    const chain = chainBuilder().build();
+    const safeInfo = safeBuilder().with('nonce', 5).build();
+    const multisigTransactions = [
+      multisigTransactionBuilder().with('nonce', 6).build(),
+    ];
+    const multisigTransactionsPage = pageBuilder()
+      .with(
+        'results',
+        multisigTransactions.map((tx) => multisigTransactionToJson(tx)),
+      )
+      .build();
+
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: multisigTransactionsPage });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safeInfo.address}/recommended-nonce`,
+      )
+      .expect(200)
+      .expect({ nonce: multisigTransactions[0].nonce + 1 });
+  });
+
+  it('returns safe nonce if greater than latest transaction', async () => {
+    const chain = chainBuilder().build();
+    const safeInfo = safeBuilder().with('nonce', 10).build();
+    const multisigTransactions = [
+      multisigTransactionBuilder().with('nonce', 6).build(),
+    ];
+    const multisigTransactionsPage = pageBuilder()
+      .with(
+        'results',
+        multisigTransactions.map((tx) => multisigTransactionToJson(tx)),
+      )
+      .build();
+
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: multisigTransactionsPage });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safeInfo.address}/recommended-nonce`,
+      )
+      .expect(200)
+      .expect({ nonce: safeInfo.nonce });
+  });
+
+  it('returns safe nonce if there are no transactions', async () => {
+    const chain = chainBuilder().build();
+    const safeInfo = safeBuilder().build();
+    const multisigTransactionsPage = pageBuilder().with('results', []).build();
+
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: multisigTransactionsPage });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safeInfo.address}/recommended-nonce`,
+      )
+      .expect(200)
+      .expect({ nonce: safeInfo.nonce });
+  });
+});

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -2,6 +2,7 @@ import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Controller, Get, Param } from '@nestjs/common';
 import { SafeState } from '@/routes/safes/entities/safe-info.entity';
 import { SafesService } from '@/routes/safes/safes.service';
+import { RecommendedNonce } from '@/routes/safes/entities/recommended-nonce.entity';
 
 @ApiTags('safes')
 @Controller({
@@ -17,5 +18,14 @@ export class SafesController {
     @Param('safeAddress') safeAddress: string,
   ): Promise<SafeState> {
     return this.service.getSafeInfo({ chainId, safeAddress });
+  }
+
+  @ApiOkResponse({ type: RecommendedNonce })
+  @Get('chains/:chainId/safes/:safeAddress/recommended-nonce')
+  async getRecommendedNonce(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+  ): Promise<RecommendedNonce> {
+    return this.service.getRecommendedNonce({ chainId, safeAddress });
   }
 }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -14,9 +14,10 @@ import { AddressInfoHelper } from '@/routes/common/address-info/address-info.hel
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import {
-  SafeState,
   MasterCopyVersionState,
+  SafeState,
 } from '@/routes/safes/entities/safe-info.entity';
+import { RecommendedNonce } from '@/routes/safes/entities/recommended-nonce.entity';
 
 @Injectable()
 export class SafesService {
@@ -107,6 +108,16 @@ export class SafesService {
       guardInfo,
       safe.version,
     );
+  }
+
+  public async getRecommendedNonce(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<RecommendedNonce> {
+    const recommendedNonce =
+      await this.safeRepository.getRecommendedNonce(args);
+
+    return new RecommendedNonce(recommendedNonce);
   }
 
   private toUnixTimestampInSecondsOrNow(date: Date | null): number {


### PR DESCRIPTION
Closes #681 

- Adds new endpoint: `GET chains/:chainId/safes/:safeAddress/recommended-nonce`
- This endpoint returns the recommended nonce based on the current state of the Safe and the current transactions queued or in history.
- The recommended nonce that is returned is the same one as the one returned by `GET chains/:chainId/safes/:address/multisig-transactions/estimations` but without making any external estimate calls thus this new endpoint is preferred over the estimate one if the nonce is the only property needed to be computed.

The endpoint is as follows:

```javascript
GET chains/:chainId/safes/:safeAddress/recommended-nonce

{
  "nonce": <number>
}
```