### PR TITLE
refactor: `AppModule.register` to `registerAsync`

### DIFF
--- a/src/app.module.e2e-spec.ts
+++ b/src/app.module.e2e-spec.ts
@@ -4,7 +4,7 @@ import { AppModule } from '@/app.module';
 describe('Application bootstrap', () => {
   it('should init the app', async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
 
     const app = moduleRef.createNestApplication();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,7 +52,9 @@ export class AppModule implements NestModule {
       .forRoutes({ path: '*', method: RequestMethod.ALL });
   }
 
-  static register(configFactory: ConfigFactory = configuration): DynamicModule {
+  static async registerAsync(
+    configFactory: ConfigFactory = configuration,
+  ): Promise<DynamicModule> {
     return {
       module: AppModule,
       imports: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { DefaultAppProvider } from '@/app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 
 async function bootstrap() {
-  const app = await new DefaultAppProvider().provide(AppModule.register());
+  const app = await new DefaultAppProvider().provide(AppModule.registerAsync());
 
   const configurationService: IConfigurationService =
     app.get<IConfigurationService>(IConfigurationService);

--- a/src/routes/about/__tests__/get-about.e2e-spec.ts
+++ b/src/routes/about/__tests__/get-about.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('Get about e2e test', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
 
     app = moduleRef.createNestApplication();

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -18,7 +18,7 @@ describe.skip('Alerts (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -33,7 +33,7 @@ describe('Balances Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -28,7 +28,7 @@ describe('Post Hook Events (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -49,7 +49,7 @@ describe('Chains Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -35,7 +35,7 @@ describe('Collectibles Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -13,7 +13,7 @@ describe('Get contract e2e test', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
 
     app = await new TestAppProvider().provide(moduleRef);

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -24,7 +24,7 @@ describe('Contracts controller', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('Data decode e2e tests', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
 
     app = await new TestAppProvider().provide(moduleRef);

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -30,7 +30,7 @@ describe('Delegates controller', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -33,7 +33,7 @@ describe('Estimations Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -29,7 +29,7 @@ describe('Flush Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -9,7 +9,7 @@ describe('Get health e2e test', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
     app = await new TestAppProvider().provide(moduleRef);
     await app.init();

--- a/src/routes/health/health.controller.spec.ts
+++ b/src/routes/health/health.controller.spec.ts
@@ -21,7 +21,7 @@ describe('Health Controller tests', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -36,7 +36,7 @@ describe('Messages controller', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -28,7 +28,7 @@ describe('Notifications Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -12,7 +12,7 @@ describe('Get safes by owner e2e test', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
 
     app = moduleRef.createNestApplication();

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -24,7 +24,7 @@ describe('Owners Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/root/root.controller.spec.ts
+++ b/src/routes/root/root.controller.spec.ts
@@ -12,7 +12,7 @@ describe('Root Controller tests', () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -13,7 +13,7 @@ describe('Get Safe Apps e2e test', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule.register()],
+      imports: [AppModule.registerAsync()],
     }).compile();
 
     app = await new TestAppProvider().provide(moduleRef);

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -27,7 +27,7 @@ describe('Safe Apps Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -45,7 +45,7 @@ describe('Safes Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -43,7 +43,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -40,7 +40,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -30,7 +30,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -39,7 +39,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -55,7 +55,7 @@ describe('Transactions History Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.registerAsync(configuration)],
     })
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)


### PR DESCRIPTION
This converts `AppModule.register` to `AppModule.registerAsync` in order to preemptively call `configFactory` for feature flags.