### PR TITLE
feat: enable `AlertsModule` via feature flag

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,7 +40,7 @@ import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 import { DataSourceErrorFilter } from '@/routes/common/filters/data-source-error.filter';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { RootModule } from '@/routes/root/root.module';
-import { ConfigFactory } from '@nestjs/config/dist/interfaces/config-factory.interface';
+import { AlertsModule } from '@/routes/alerts/alerts.module';
 
 @Module({})
 export class AppModule implements NestModule {
@@ -52,11 +52,13 @@ export class AppModule implements NestModule {
       .forRoutes({ path: '*', method: RequestMethod.ALL });
   }
 
-  static register(configFactory: ConfigFactory = configuration): DynamicModule {
+  static register(configFactory = configuration): DynamicModule {
+    const { features } = configFactory();
     return {
       module: AppModule,
       imports: [
         // features
+        ...(features.alerts ? [AlertsModule] : []),
         AboutModule,
         BalancesModule,
         CacheHooksModule,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -43,6 +43,7 @@ export default (): ReturnType<typeof configuration> => ({
     pricesProviderChainIds: ['10'],
     humanDescription: true,
     messagesCache: true,
+    alerts: true,
   },
   httpClient: { requestTimeout: faker.number.int() },
   log: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -53,6 +53,7 @@ export default () => ({
     humanDescription:
       process.env.FF_HUMAN_DESCRIPTION?.toLowerCase() === 'true',
     messagesCache: process.env.FF_MESSAGES_CACHE?.toLowerCase() === 'true',
+    alerts: process.env.FF_ALERTS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -11,7 +11,7 @@ import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
 import { alertBuilder } from '@/routes/alerts/entities/__tests__/alerts.builder';
 
-describe.skip('Alerts (Unit)', () => {
+describe('Alerts (Unit)', () => {
   let app: INestApplication;
 
   beforeEach(async () => {


### PR DESCRIPTION
This adds the `FF_ALERTS` env. var. to dynamically enable the `AlertsModule`, as well as enabling the `AlertsController` test accordingly.