### PR TITLE
Remove RootController from Swagger

### DIFF
--- a/src/routes/root/root.controller.ts
+++ b/src/routes/root/root.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Res } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
 
 @Controller()
+@ApiExcludeController()
 export class RootController {
   @Get()
   getIndex(@Res() res): void {


### PR DESCRIPTION
Removes the `RootController` from being listed in the OpenAPI specification (Swagger interface).