### PR TITLE
fix: remove `removeContracts`

### DIFF
--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+import { Contract } from '@/domain/alerts/entities/alerts.entity';
 import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
 import {
   INetworkService,
@@ -46,22 +46,6 @@ export class TenderlyApi implements IAlertsApi {
             display_name: contract.displayName,
             network_id: contract.chainId,
           })),
-        },
-      });
-    } catch (error) {
-      this.httpErrorFactory.from(error);
-    }
-  }
-
-  async removeContracts(contractIds: Array<ContractId>): Promise<void> {
-    try {
-      const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
-      await this.networkService.delete(url, {
-        headers: {
-          [TenderlyApi.HEADER]: this.apiKey,
-        },
-        params: {
-          contract_ids: contractIds,
         },
       });
     } catch (error) {

--- a/src/domain/alerts/entities/alerts.entity.ts
+++ b/src/domain/alerts/entities/alerts.entity.ts
@@ -3,5 +3,3 @@ export type Contract = {
   chainId: string;
   displayName?: string;
 };
-
-export type ContractId = `${Contract['chainId']}:${Contract['address']}`;

--- a/src/domain/interfaces/alerts-api.inferface.ts
+++ b/src/domain/interfaces/alerts-api.inferface.ts
@@ -1,9 +1,7 @@
-import { Contract, ContractId } from '@/domain/alerts/entities/alerts.entity';
+import { Contract } from '@/domain/alerts/entities/alerts.entity';
 
 export const IAlertsApi = Symbol('IAlertsApi');
 
 export interface IAlertsApi {
   addContracts(contracts: Array<Contract>): Promise<void>;
-
-  removeContracts(contractIds: Array<ContractId>): Promise<void>;
 }


### PR DESCRIPTION
After agreement, contract addresses will only be added for alerts and not removed (initially). As such, the `removeContracts` method is not needed and, as such, removed.