### PR TITLE
Enable console stdout on VSCode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/src/main.ts",
       "preLaunchTask": "tsc: build - tsconfig.json",
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "console": "integratedTerminal",
+      "outputCapture": "std"
     },
     {
       "type": "node",


### PR DESCRIPTION
- Enables the `stdout` output in the VSCode terminal, which wasn't visible with the old launch configuration.