### PR TITLE
Rename IncomingTransferMapper to TransferMapper

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -18,7 +18,7 @@ import { TransactionItem } from '@/routes/transactions/entities/transaction-item
 import { CreationTransactionMapper } from '@/routes/transactions/mappers/creation-transaction/creation-transaction.mapper';
 import { ModuleTransactionMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction.mapper';
 import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper';
-import { IncomingTransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
+import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 
 class TransactionDomainGroup {
@@ -39,7 +39,7 @@ export class TransactionsHistoryMapper {
     @Inject(IConfigurationService) configurationService: IConfigurationService,
     private readonly multisigTransactionMapper: MultisigTransactionMapper,
     private readonly moduleTransactionMapper: ModuleTransactionMapper,
-    private readonly incomingTransferMapper: IncomingTransferMapper,
+    private readonly transferMapper: TransferMapper,
     private readonly creationTransactionMapper: CreationTransactionMapper,
   ) {
     this.maxNestedTransfers = configurationService.getOrThrow(
@@ -176,11 +176,7 @@ export class TransactionsHistoryMapper {
       .map(
         async (transfer) =>
           new TransactionItem(
-            await this.incomingTransferMapper.mapTransfer(
-              chainId,
-              transfer,
-              safe,
-            ),
+            await this.transferMapper.mapTransfer(chainId, transfer, safe),
           ),
       );
   }

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.ts
@@ -10,7 +10,7 @@ import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/tran
 import { Transaction } from '@/routes/transactions/entities/transaction.entity';
 
 @Injectable()
-export class IncomingTransferMapper {
+export class TransferMapper {
   constructor(private readonly transferInfoMapper: TransferInfoMapper) {}
 
   async mapTransfer(

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -25,7 +25,7 @@ import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transact
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
 import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/transfer-info.mapper';
-import { IncomingTransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
+import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
 import { TransactionsController } from '@/routes/transactions/transactions.controller';
 import { TransactionsService } from '@/routes/transactions/transactions.service';
 
@@ -38,7 +38,7 @@ import { TransactionsService } from '@/routes/transactions/transactions.service'
     DataDecodedParamHelper,
     Erc20TransferMapper,
     Erc721TransferMapper,
-    IncomingTransferMapper,
+    TransferMapper,
     ModuleTransactionDetailsMapper,
     ModuleTransactionMapper,
     ModuleTransactionStatusMapper,

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -35,14 +35,14 @@ import { QueuedItemsMapper } from '@/routes/transactions/mappers/queued-items/qu
 import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transaction-preview.mapper';
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
-import { IncomingTransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
+import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
 
 @Injectable()
 export class TransactionsService {
   constructor(
     @Inject(ISafeRepository) private readonly safeRepository: SafeRepository,
     private readonly multisigTransactionMapper: MultisigTransactionMapper,
-    private readonly incomingTransferMapper: IncomingTransferMapper,
+    private readonly transferMapper: TransferMapper,
     private readonly moduleTransactionMapper: ModuleTransactionMapper,
     private readonly queuedItemsMapper: QueuedItemsMapper,
     private readonly transactionsHistoryMapper: TransactionsHistoryMapper,
@@ -264,7 +264,7 @@ export class TransactionsService {
       transfers.results.map(
         async (transfer) =>
           new IncomingTransfer(
-            await this.incomingTransferMapper.mapTransfer(
+            await this.transferMapper.mapTransfer(
               args.chainId,
               transfer,
               safeInfo,


### PR DESCRIPTION
- Renames `IncomingTransferMapper` to `TransferMapper`. This mapper was first used to map the incoming transfers, but it's called from other places in the app and it's not tied to "incoming" transfers but any transfer.