### PR TITLE
chore: cancel previous in-progress jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   release:
     types: [released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This cancels [any in-progress jobs or runs for the current workflow](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow), e.g. if a subsequent push happens whilst tests a test job is running, the previous test job will be cancelled.