### PR TITLE
Revert "chore: cancel previous workflows in progress (#807)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   release:
     types: [released]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit 85cfc9b0fda86caeea5dfb98577c53bd9b40849d.

If multiple commits are made to a shared branch (e.g.: `main`) the last will cancel the previous ones which are currently running. While doing so, if one commit "breaks" the pipeline it would be harder to detect which one is as it might have a cancelled status.