### PR TITLE
Fix get-contract E2E test

### DIFF
--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('Get contract e2e test', () => {
     const expectedResponse = {
       address: '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4',
       name: 'CreateCall',
-      displayName: '',
+      displayName: 'Safe: CreateCall 1.3.0',
       logoUri:
         'https://safe-transaction-assets.staging.5afe.dev/contracts/logos/0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4.png',
       contractAbi: {


### PR DESCRIPTION
- Adapts `get-contract` e2e test to the current contract metadata.