### PR TITLE
chore: move E2E vars. to setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
         env:
           EXCHANGE_API_BASE_URI: http://api.exchangeratesapi.io/v1
           EXCHANGE_API_KEY: ${{ secrets.EXCHANGE_API_KEY }}
-          ALERTS_PROVIDER_API_KEY: ${{ secrets.ALERTS_PROVIDER_API_KEY }}
-          ALERTS_PROVIDER_ACCOUNT: ${{ secrets.ALERTS_PROVIDER_ACCOUNT }}
-          ALERTS_PROVIDER_PROJECT: ${{ secrets.ALERTS_PROVIDER_PROJECT }}
           REDIS_HOST: localhost
           REDIS_PORT: 6379
           SAFE_CONFIG_BASE_URI: ${{ secrets.SAFE_CONFIG_BASE_URI }}

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -1,3 +1,6 @@
 process.env.SAFE_CONFIG_BASE_URI = 'https://safe-config.staging.5afe.dev';
 process.env.EXPIRATION_TIME_DEFAULT_SECONDS = `${60}`; // long enough timeout for cache state assertions
 process.env.FF_HUMAN_DESCRIPTION = 'true';
+process.env.ALERTS_PROVIDER_API_KEY = 'fake-api-key';
+process.env.ALERTS_PROVIDER_ACCOUNT = 'fake-account';
+process.env.ALERTS_PROVIDER_PROJECT = 'fake-project';


### PR DESCRIPTION
This moves the `ALERTS_PROVIDER_API_KEY`, `ALERTS_PROVIDER_ACCOUNT`, `ALERTS_PROVIDER_PROJECT` env. vars. to the E2E setup as they are not required in the CI.