### PR TITLE
feat: add `AlertsRouteGuard`

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 import { DataSourceErrorFilter } from '@/routes/common/filters/data-source-error.filter';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { RootModule } from '@/routes/root/root.module';
+import { AlertsModule } from '@/routes/alerts/alerts.module';
 
 // See https://github.com/nestjs/nest/issues/11967
 export const configurationModule = ConfigurationModule.register(configuration);
@@ -46,6 +47,7 @@ export const configurationModule = ConfigurationModule.register(configuration);
   imports: [
     // features
     AboutModule,
+    AlertsModule,
     BalancesModule,
     CacheHooksModule,
     ChainsModule,

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -15,7 +15,6 @@ import { alertBuilder } from '@/routes/alerts/entities/__tests__/alerts.builder'
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { Alert } from '@/routes/alerts/entities/alert.dto.entity';
 import { ConfigurationModule } from '@/config/configuration.module';
-import { AlertsModule } from '@/routes/alerts/alerts.module';
 
 // The `x-tenderly-signature` header contains a cryptographic signature. The webhook request signature is
 // a HMAC SHA256 hash of concatenated signing secret, request payload, and timestamp, in this order.
@@ -57,8 +56,7 @@ describe('Alerts (Unit)', () => {
       });
 
       const moduleFixture: TestingModule = await Test.createTestingModule({
-        // TODO remove AlertsModule once it's integrated in the AppModule
-        imports: [AppModule, AlertsModule],
+        imports: [AppModule],
       })
         .overrideModule(CacheModule)
         .useModule(TestCacheModule)
@@ -151,8 +149,7 @@ describe('Alerts (Unit)', () => {
       });
 
       const moduleFixture: TestingModule = await Test.createTestingModule({
-        // TODO remove AlertsModule once it's integrated in the AppModule
-        imports: [AppModule, AlertsModule],
+        imports: [AppModule],
       })
         .overrideModule(CacheModule)
         .useModule(TestCacheModule)

--- a/src/routes/alerts/alerts.controller.ts
+++ b/src/routes/alerts/alerts.controller.ts
@@ -3,6 +3,7 @@ import { ApiExcludeController } from '@nestjs/swagger';
 import { Alert } from '@/routes/alerts/entities/alert.dto.entity';
 import { AlertValidationPipe } from '@/routes/alerts/pipes/alert-validation.pipe';
 import { AlertsService } from '@/routes/alerts/alerts.service';
+import { AlertsRouteGuard } from '@/routes/alerts/guards/alerts-route.guard';
 import { TenderlySignatureGuard } from '@/routes/alerts/guards/tenderly-signature.guard';
 
 @Controller({
@@ -13,6 +14,7 @@ import { TenderlySignatureGuard } from '@/routes/alerts/guards/tenderly-signatur
 export class AlertsController {
   constructor(private readonly alertsService: AlertsService) {}
 
+  @UseGuards(AlertsRouteGuard)
   @UseGuards(TenderlySignatureGuard)
   @Post('/alerts')
   @HttpCode(200)

--- a/src/routes/alerts/guards/alerts-route.guard.ts
+++ b/src/routes/alerts/guards/alerts-route.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+
+@Injectable()
+export class AlertsRouteGuard implements CanActivate {
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {}
+
+  canActivate() {
+    return this.configurationService.getOrThrow<boolean>('features.alerts');
+  }
+}


### PR DESCRIPTION
This enables the `AlertsModule` in the `AppModule`, protecting the `/alerts` route behind a new feature flag dependent `AlertsRouteGuard` as per the recent [reversion of the dynamic `AppModule`](https://github.com/safe-global/safe-client-gateway/pull/820).