### PR TITLE
Fix CacheDir for token prices

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -438,8 +438,8 @@ export class CacheRouter {
     fiatCode: string;
   }): CacheDir {
     return new CacheDir(
-      `${args.nativeCoinId}_${CacheRouter.NATIVE_COIN_PRICE_KEY}`,
-      args.fiatCode,
+      `${args.nativeCoinId}_${CacheRouter.NATIVE_COIN_PRICE_KEY}_${args.fiatCode}`,
+      '',
     );
   }
 
@@ -449,8 +449,8 @@ export class CacheRouter {
     tokenAddress: string;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainName}_${CacheRouter.TOKEN_PRICE_KEY}`,
-      `${args.tokenAddress}_${args.fiatCode}`,
+      `${args.chainName}_${CacheRouter.TOKEN_PRICE_KEY}_${args.tokenAddress}_${args.fiatCode}`,
+      '',
     );
   }
 

--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -107,8 +107,8 @@ describe('CoingeckoAPI', () => {
     expect(assetPrice).toBe(expectedAssetPrice);
     expect(mockCacheFirstDataSource.get).toBeCalledWith({
       cacheDir: new CacheDir(
-        `${chainName}_token_price`,
-        `${tokenAddress}_${fiatCode}`,
+        `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
+        '',
       ),
       networkRequest: {
         headers: {
@@ -146,8 +146,8 @@ describe('CoingeckoAPI', () => {
     expect(assetPrice).toBe(expectedAssetPrice);
     expect(mockCacheFirstDataSource.get).toBeCalledWith({
       cacheDir: new CacheDir(
-        `${chainName}_token_price`,
-        `${tokenAddress}_${fiatCode}`,
+        `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
+        '',
       ),
       networkRequest: {
         params: {
@@ -170,7 +170,10 @@ describe('CoingeckoAPI', () => {
     await service.getNativeCoinPrice({ nativeCoinId, fiatCode });
 
     expect(mockCacheFirstDataSource.get).toBeCalledWith({
-      cacheDir: new CacheDir(`${nativeCoinId}_native_coin_price`, fiatCode),
+      cacheDir: new CacheDir(
+        `${nativeCoinId}_native_coin_price_${fiatCode}`,
+        '',
+      ),
       url: `${coingeckoBaseUri}/simple/price`,
       networkRequest: {
         headers: {
@@ -200,7 +203,10 @@ describe('CoingeckoAPI', () => {
     await service.getNativeCoinPrice({ nativeCoinId, fiatCode });
 
     expect(mockCacheFirstDataSource.get).toBeCalledWith({
-      cacheDir: new CacheDir(`${nativeCoinId}_native_coin_price`, fiatCode),
+      cacheDir: new CacheDir(
+        `${nativeCoinId}_native_coin_price_${fiatCode}`,
+        '',
+      ),
       url: `${coingeckoBaseUri}/simple/price`,
       networkRequest: {
         params: {


### PR DESCRIPTION
- Modifies the `CacheDir` for token/native coins prices. This prevents subsequent requests from renewing the cache TTL for the entire key.