### PR TITLE
Increase TTL for not found token prices

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,9 @@
 #PRICES_PROVIDER_API_KEY=
 # The cache TTL for each token price datapoint.
 #PRICES_TTL_SECONDS=
+# The cache TTL for a missing token price.
+# (default is 259200 [72 hours])
+# NOT_FOUND_PRICE_TTL_SECONDS=
 
 # Alerts provider API
 # The alerts provider API to be used.

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -61,6 +61,7 @@ export default (): ReturnType<typeof configuration> => ({
     baseUri: faker.internet.url({ appendSlash: false }),
     apiKey: faker.string.hexadecimal({ length: 32 }),
     pricesTtlSeconds: faker.number.int(),
+    notFoundPriceTtlSeconds: faker.number.int(),
     chains: {
       1: {
         nativeCoin: faker.string.sample(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -81,6 +81,9 @@ export default () => ({
       'https://api.coingecko.com/api/v3',
     apiKey: process.env.PRICES_PROVIDER_API_KEY,
     pricesTtlSeconds: parseInt(process.env.PRICES_TTL_SECONDS ?? `${300}`),
+    notFoundPriceTtlSeconds: parseInt(
+      process.env.NOT_FOUND_PRICE_TTL_SECONDS ?? `${259200}`,
+    ),
     chains: {
       1: { nativeCoin: 'ethereum', chainName: 'ethereum' },
       10: { nativeCoin: 'ethereum', chainName: 'optimistic-ethereum' },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -82,7 +82,7 @@ export default () => ({
     apiKey: process.env.PRICES_PROVIDER_API_KEY,
     pricesTtlSeconds: parseInt(process.env.PRICES_TTL_SECONDS ?? `${300}`),
     notFoundPriceTtlSeconds: parseInt(
-      process.env.NOT_FOUND_PRICE_TTL_SECONDS ?? `${259200}`,
+      process.env.NOT_FOUND_PRICE_TTL_SECONDS ?? `${72 * 60 * 60}`,
     ),
     chains: {
       1: { nativeCoin: 'ethereum', chainName: 'ethereum' },

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -55,4 +55,8 @@ export class FakeCacheService implements ICacheService {
     this.cache[cacheDir.key][cacheDir.field] = value;
     return Promise.resolve();
   }
+
+  expire() {
+    return Promise.resolve();
+  }
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -15,5 +15,5 @@ export interface ICacheService {
 
   deleteByKeyPattern(pattern: string): Promise<void>;
 
-  expire(key: string, expireTimeSeconds: number);
+  expire(key: string, expireTimeSeconds: number): Promise<void>;
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -14,4 +14,6 @@ export interface ICacheService {
   deleteByKey(key: string): Promise<number>;
 
   deleteByKeyPattern(pattern: string): Promise<void>;
+
+  expire(key: string, expireTimeSeconds: number);
 }

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -53,8 +53,8 @@ export class RedisCacheService
     }
   }
 
-  async expire(key: string, expireTimeSeconds: number) {
-    return await this.client.expire(key, expireTimeSeconds);
+  async expire(key: string, expireTimeSeconds: number): Promise<void> {
+    await this.client.expire(key, expireTimeSeconds);
   }
 
   /**

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -53,6 +53,10 @@ export class RedisCacheService
     }
   }
 
+  async expire(key: string, expireTimeSeconds: number) {
+    return await this.client.expire(key, expireTimeSeconds);
+  }
+
   /**
    * Closes the connection to Redis when the module associated with this service
    * is destroyed. This tries to gracefully close the connection. If the Redis

--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -4,10 +4,15 @@ import { CoingeckoApi } from '@/datasources/prices-api/coingecko-api.service';
 import { faker } from '@faker-js/faker';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { AssetPrice } from '@/domain/prices/entities/asset-price.entity';
+import { ICacheService } from '@/datasources/cache/cache.service.interface';
 
 const mockCacheFirstDataSource = jest.mocked({
   get: jest.fn(),
 } as unknown as CacheFirstDataSource);
+
+const mockCacheService = jest.mocked({
+  deleteByKey: jest.fn(),
+} as unknown as ICacheService);
 
 describe('CoingeckoAPI', () => {
   let service: CoingeckoApi;
@@ -15,6 +20,7 @@ describe('CoingeckoAPI', () => {
   const coingeckoBaseUri = faker.internet.url({ appendSlash: false });
   const coingeckoApiKey = faker.string.sample();
   const pricesCacheTtlSeconds = faker.number.int();
+  const notFoundPriceTtlSeconds = faker.number.int();
   const defaultExpirationTimeInSeconds = faker.number.int();
   const notFoundExpirationTimeInSeconds = faker.number.int();
 
@@ -28,6 +34,10 @@ describe('CoingeckoAPI', () => {
       pricesCacheTtlSeconds,
     );
     fakeConfigurationService.set(
+      'prices.notFoundPriceTtlSeconds',
+      notFoundPriceTtlSeconds,
+    );
+    fakeConfigurationService.set(
       'expirationTimeInSeconds.default',
       defaultExpirationTimeInSeconds,
     );
@@ -38,6 +48,7 @@ describe('CoingeckoAPI', () => {
     service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockCacheService,
     );
   });
 
@@ -46,7 +57,11 @@ describe('CoingeckoAPI', () => {
 
     await expect(
       () =>
-        new CoingeckoApi(fakeConfigurationService, mockCacheFirstDataSource),
+        new CoingeckoApi(
+          fakeConfigurationService,
+          mockCacheFirstDataSource,
+          mockCacheService,
+        ),
     ).toThrow();
   });
 
@@ -77,6 +92,7 @@ describe('CoingeckoAPI', () => {
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockCacheService,
     );
 
     const fiatCodes = await service.getFiatCodes();
@@ -135,6 +151,7 @@ describe('CoingeckoAPI', () => {
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockCacheService,
     );
 
     const assetPrice = await service.getTokenPrice({
@@ -198,6 +215,7 @@ describe('CoingeckoAPI', () => {
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockCacheService,
     );
 
     await service.getNativeCoinPrice({ nativeCoinId, fiatCode });

--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -254,9 +254,16 @@ describe('CoingeckoAPI', () => {
       '',
     );
     expect(mockCacheService.expire).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.expire).toHaveBeenCalledWith(
-      expectedCacheDir.key,
-      fakeConfigurationService.get('prices.notFoundPriceTtlSeconds'),
+    expect(mockCacheService.expire.mock.calls[0][0]).toBe(expectedCacheDir.key);
+    expect(mockCacheService.expire.mock.calls[0][1]).toBeGreaterThanOrEqual(
+      (fakeConfigurationService.get(
+        'prices.notFoundPriceTtlSeconds',
+      ) as number) - CoingeckoApi.notFoundTtlRange,
+    );
+    expect(mockCacheService.expire.mock.calls[0][1]).toBeLessThanOrEqual(
+      (fakeConfigurationService.get(
+        'prices.notFoundPriceTtlSeconds',
+      ) as number) + CoingeckoApi.notFoundTtlRange,
     );
   });
 });

--- a/src/domain/interfaces/prices-api.interface.ts
+++ b/src/domain/interfaces/prices-api.interface.ts
@@ -16,6 +16,12 @@ export interface IPricesApi {
 
   getFiatCodes(): Promise<string[]>;
 
+  /**
+   * Registers a price reference for token address as not-found.
+   * This function allows the clients of this interface to signal that a price couldn't
+   * be parsed from its {@link AssetPrice}. This allows the underlying implementation
+   * to delay subsequent requests targeting the same token address.
+   */
   registerNotFoundTokenPrice(args: {
     chainName: string;
     tokenAddress: string;

--- a/src/domain/interfaces/prices-api.interface.ts
+++ b/src/domain/interfaces/prices-api.interface.ts
@@ -15,4 +15,10 @@ export interface IPricesApi {
   }): Promise<AssetPrice>;
 
   getFiatCodes(): Promise<string[]>;
+
+  registerNotFoundTokenPrice(args: {
+    chainName: string;
+    tokenAddress: string;
+    fiatCode: string;
+  }): Promise<void>;
 }

--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -38,7 +38,17 @@ export class PricesRepository implements IPricesRepository {
       fiatCode: lowerCaseFiatCode,
     });
     const assetPrice = this.assetPriceValidator.validate(result);
-    return assetPrice?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
+    const tokenPrice = assetPrice?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
+
+    if (!tokenPrice) {
+      await this.coingeckoApi.registerNotFoundTokenPrice({
+        chainName: args.chainName,
+        tokenAddress: lowerCaseTokenAddress,
+        fiatCode: lowerCaseFiatCode,
+      });
+    }
+
+    return tokenPrice;
   }
 
   async getFiatCodes(): Promise<string[]> {


### PR DESCRIPTION
**Motivation**
This PR reduces the amount of calls to our token prices provider by increasing the TTL for the addresses that can't be retrieved. So subsequent retries for these addresses are delayed more than the usual token price refreshes.

**Included changes**
- Adds a function to `ICacheService` to allow setting a TTL for a given cache key.
- Injects `CacheService` into `CoingeckoApi`, to make the latter able to register prices as not found.
- Adds logic to `PricesRepositiory` to mark a token price as not found, and therefore adds an extended TTL.