### PR TITLE
Batch mutiple token prices per request to Coingecko

### DIFF
--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -5,6 +5,9 @@ import { faker } from '@faker-js/faker';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { AssetPrice } from '@/domain/prices/entities/asset-price.entity';
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
+import { INetworkService } from '@/datasources/network/network.service.interface';
+import { sortBy } from 'lodash';
+import { ILoggingService } from '@/logging/logging.interface';
 
 const mockCacheFirstDataSource = jest.mocked({
   get: jest.fn(),
@@ -13,7 +16,17 @@ const mockCacheFirstDataSource = jest.mocked({
 const mockCacheService = jest.mocked({
   deleteByKey: jest.fn(),
   expire: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
 } as unknown as ICacheService);
+
+const mockNetworkService = jest.mocked({
+  get: jest.fn(),
+} as unknown as INetworkService);
+
+const mockLoggingService = {
+  debug: jest.fn(),
+} as unknown as ILoggingService;
 
 describe('CoingeckoAPI', () => {
   let service: CoingeckoApi;
@@ -49,7 +62,9 @@ describe('CoingeckoAPI', () => {
     service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockNetworkService,
       mockCacheService,
+      mockLoggingService,
     );
   });
 
@@ -61,7 +76,9 @@ describe('CoingeckoAPI', () => {
         new CoingeckoApi(
           fakeConfigurationService,
           mockCacheFirstDataSource,
+          mockNetworkService,
           mockCacheService,
+          mockLoggingService,
         ),
     ).toThrow();
   });
@@ -93,7 +110,9 @@ describe('CoingeckoAPI', () => {
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockNetworkService,
       mockCacheService,
+      mockLoggingService,
     );
 
     const fiatCodes = await service.getFiatCodes();
@@ -108,26 +127,31 @@ describe('CoingeckoAPI', () => {
     });
   });
 
-  it('should return the token price (using an API key)', async () => {
-    const expectedAssetPrice: AssetPrice = { gnosis: { eur: 98.86 } };
-    mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
+  it('should return and cache one token price (using an API key)', async () => {
     const chainName = faker.string.sample();
     const tokenAddress = faker.finance.ethereumAddress();
     const fiatCode = faker.finance.currencyCode();
+    const price = faker.number.float({ precision: 0.01 });
+    const coingeckoPrice: AssetPrice = {
+      [tokenAddress]: { [fiatCode]: price },
+    };
+    mockCacheService.get.mockResolvedValue(undefined);
+    mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
 
-    const assetPrice = await service.getTokenPrice({
+    const assetPrice = await service.getTokenPrices({
       chainName,
-      tokenAddress,
+      tokenAddresses: [tokenAddress],
       fiatCode,
     });
 
-    expect(assetPrice).toBe(expectedAssetPrice);
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
-      cacheDir: new CacheDir(
-        `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
-        '',
-      ),
-      networkRequest: {
+    const expectedCacheDir = new CacheDir(
+      `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
+      '',
+    );
+    expect(assetPrice).toEqual([[tokenAddress, price]]);
+    expect(mockNetworkService.get).toBeCalledWith(
+      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
@@ -136,47 +160,350 @@ describe('CoingeckoAPI', () => {
           vs_currencies: fiatCode,
         },
       },
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
-      expireTimeSeconds: pricesCacheTtlSeconds,
-    });
+    );
+    expect(mockCacheService.get).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
+    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      expectedCacheDir,
+      JSON.stringify([tokenAddress, price]),
+      pricesCacheTtlSeconds,
+    );
   });
 
-  it('should return the token price (with no API key)', async () => {
-    const expectedAssetPrice = { gnosis: { eur: 98.86 } };
-    mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
+  it('should return and cache one token price (with no API key)', async () => {
+    fakeConfigurationService.set('prices.apiKey', null);
     const chainName = faker.string.sample();
     const tokenAddress = faker.finance.ethereumAddress();
     const fiatCode = faker.finance.currencyCode();
-    fakeConfigurationService.set('prices.apiKey', null);
+    const price = faker.number.float({ precision: 0.01 });
+    const coingeckoPrice: AssetPrice = {
+      [tokenAddress]: { [fiatCode]: price },
+    };
+    mockCacheService.get.mockResolvedValue(undefined);
+    mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockNetworkService,
       mockCacheService,
+      mockLoggingService,
     );
 
-    const assetPrice = await service.getTokenPrice({
+    const assetPrice = await service.getTokenPrices({
       chainName,
-      tokenAddress,
+      tokenAddresses: [tokenAddress],
       fiatCode,
     });
 
-    expect(assetPrice).toBe(expectedAssetPrice);
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
-      cacheDir: new CacheDir(
-        `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
-        '',
-      ),
-      networkRequest: {
+    const expectedCacheDir = new CacheDir(
+      `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
+      '',
+    );
+    expect(assetPrice).toEqual([[tokenAddress, price]]);
+    expect(mockNetworkService.get).toBeCalledWith(
+      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      {
         params: {
           contract_addresses: tokenAddress,
           vs_currencies: fiatCode,
         },
       },
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
-      expireTimeSeconds: pricesCacheTtlSeconds,
+    );
+    expect(mockCacheService.get).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
+    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      expectedCacheDir,
+      JSON.stringify([tokenAddress, price]),
+      pricesCacheTtlSeconds,
+    );
+  });
+
+  it('should return and cache multiple token prices', async () => {
+    const chainName = faker.string.sample();
+    const fiatCode = faker.finance.currencyCode();
+    const firstTokenAddress = faker.finance.ethereumAddress();
+    const firstPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const secondTokenAddress = faker.finance.ethereumAddress();
+    const secondPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const thirdTokenAddress = faker.finance.ethereumAddress();
+    const thirdPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const coingeckoPrice: AssetPrice = {
+      [firstTokenAddress]: { [fiatCode]: firstPrice },
+      [secondTokenAddress]: { [fiatCode]: secondPrice },
+      [thirdTokenAddress]: { [fiatCode]: thirdPrice },
+    };
+    mockCacheService.get.mockResolvedValue(undefined);
+    mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
+
+    const assetPrice = await service.getTokenPrices({
+      chainName,
+      tokenAddresses: [
+        firstTokenAddress,
+        secondTokenAddress,
+        thirdTokenAddress,
+      ],
+      fiatCode,
     });
+
+    expect(assetPrice).toEqual([
+      [firstTokenAddress, firstPrice],
+      [secondTokenAddress, secondPrice],
+      [thirdTokenAddress, thirdPrice],
+    ]);
+    expect(mockNetworkService.get).toBeCalledWith(
+      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      {
+        headers: {
+          'x-cg-pro-api-key': coingeckoApiKey,
+        },
+        params: {
+          contract_addresses: [
+            firstTokenAddress,
+            secondTokenAddress,
+            thirdTokenAddress,
+          ].join(','),
+          vs_currencies: fiatCode,
+        },
+      },
+    );
+    expect(mockCacheService.get).toHaveBeenCalledTimes(3);
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${secondTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.set).toHaveBeenCalledTimes(3);
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
+        '',
+      ),
+      JSON.stringify([firstTokenAddress, firstPrice]),
+      pricesCacheTtlSeconds,
+    );
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${secondTokenAddress}_${fiatCode}`,
+        '',
+      ),
+      JSON.stringify([secondTokenAddress, secondPrice]),
+      pricesCacheTtlSeconds,
+    );
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
+        '',
+      ),
+      JSON.stringify([thirdTokenAddress, thirdPrice]),
+      pricesCacheTtlSeconds,
+    );
+  });
+
+  it('should cache new token prices only', async () => {
+    const chainName = faker.string.sample();
+    const fiatCode = faker.finance.currencyCode();
+    const firstTokenAddress = faker.finance.ethereumAddress();
+    const firstPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const secondTokenAddress = faker.finance.ethereumAddress();
+    const secondPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const thirdTokenAddress = faker.finance.ethereumAddress();
+    const thirdPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const coingeckoPrice: AssetPrice = {
+      [firstTokenAddress]: { [fiatCode]: firstPrice },
+      [thirdTokenAddress]: { [fiatCode]: thirdPrice },
+    };
+    mockCacheService.get.mockResolvedValueOnce(undefined);
+    mockCacheService.get.mockResolvedValueOnce(
+      JSON.stringify([secondTokenAddress, secondPrice]),
+    );
+    mockCacheService.get.mockResolvedValueOnce(undefined);
+    mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
+
+    const assetPrices = await service.getTokenPrices({
+      chainName,
+      tokenAddresses: [
+        firstTokenAddress,
+        secondTokenAddress,
+        thirdTokenAddress,
+      ],
+      fiatCode,
+    });
+
+    expect(sortBy(assetPrices, (i) => i[0])).toEqual(
+      sortBy(
+        [
+          [firstTokenAddress, firstPrice],
+          [secondTokenAddress, secondPrice],
+          [thirdTokenAddress, thirdPrice],
+        ],
+        (i) => i[0],
+      ),
+    );
+    expect(mockNetworkService.get).toBeCalledWith(
+      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      {
+        headers: {
+          'x-cg-pro-api-key': coingeckoApiKey,
+        },
+        params: {
+          contract_addresses: [firstTokenAddress, thirdTokenAddress].join(','),
+          vs_currencies: fiatCode,
+        },
+      },
+    );
+    expect(mockCacheService.get).toHaveBeenCalledTimes(3);
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${secondTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.set).toHaveBeenCalledTimes(2);
+    expect(mockCacheService.set).toHaveBeenNthCalledWith(
+      1,
+      new CacheDir(
+        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
+        '',
+      ),
+      JSON.stringify([firstTokenAddress, firstPrice]),
+      pricesCacheTtlSeconds,
+    );
+    expect(mockCacheService.set).toHaveBeenNthCalledWith(
+      2,
+      new CacheDir(
+        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
+        '',
+      ),
+      JSON.stringify([thirdTokenAddress, thirdPrice]),
+      pricesCacheTtlSeconds,
+    );
+  });
+
+  it('should cache not found token prices with an extended TTL', async () => {
+    const chainName = faker.string.sample();
+    const fiatCode = faker.finance.currencyCode();
+    const firstTokenAddress = faker.finance.ethereumAddress();
+    const firstPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const secondTokenAddress = faker.finance.ethereumAddress();
+    const secondPrice = faker.number.float({ min: 0.01, precision: 0.01 });
+    const thirdTokenAddress = faker.finance.ethereumAddress();
+    const coingeckoPrice: AssetPrice = {
+      [firstTokenAddress]: { [fiatCode]: firstPrice },
+    };
+    mockCacheService.get.mockResolvedValueOnce(undefined);
+    mockCacheService.get.mockResolvedValueOnce(
+      JSON.stringify([secondTokenAddress, secondPrice]),
+    );
+    mockCacheService.get.mockResolvedValueOnce(undefined);
+    mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
+
+    const assetPrices = await service.getTokenPrices({
+      chainName,
+      tokenAddresses: [
+        firstTokenAddress,
+        secondTokenAddress,
+        thirdTokenAddress,
+      ],
+      fiatCode,
+    });
+
+    expect(sortBy(assetPrices, (i) => i[0])).toEqual(
+      sortBy(
+        [
+          [firstTokenAddress, firstPrice],
+          [secondTokenAddress, secondPrice],
+          [thirdTokenAddress, null],
+        ],
+        (i) => i[0],
+      ),
+    );
+    expect(mockNetworkService.get).toBeCalledWith(
+      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      {
+        headers: {
+          'x-cg-pro-api-key': coingeckoApiKey,
+        },
+        params: {
+          contract_addresses: [firstTokenAddress, thirdTokenAddress].join(','),
+          vs_currencies: fiatCode,
+        },
+      },
+    );
+    expect(mockCacheService.get).toHaveBeenCalledTimes(3);
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${secondTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.set).toHaveBeenCalledTimes(2);
+    expect(mockCacheService.set).toHaveBeenNthCalledWith(
+      1,
+      new CacheDir(
+        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
+        '',
+      ),
+      JSON.stringify([firstTokenAddress, firstPrice]),
+      pricesCacheTtlSeconds,
+    );
+    expect(mockCacheService.set.mock.calls[1][0]).toEqual(
+      new CacheDir(
+        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.set.mock.calls[1][1]).toEqual(
+      JSON.stringify([thirdTokenAddress, null]),
+    );
+    expect(mockCacheService.set.mock.calls[1][2]).toBeGreaterThanOrEqual(
+      (fakeConfigurationService.get(
+        'prices.notFoundPriceTtlSeconds',
+      ) as number) - CoingeckoApi.notFoundTtlRangeSeconds,
+    );
+    expect(mockCacheService.set.mock.calls[1][2]).toBeLessThanOrEqual(
+      (fakeConfigurationService.get(
+        'prices.notFoundPriceTtlSeconds',
+      ) as number) + CoingeckoApi.notFoundTtlRangeSeconds,
+    );
   });
 
   it('should return the native coin price (using an API key)', async () => {
@@ -216,7 +543,9 @@ describe('CoingeckoAPI', () => {
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
+      mockNetworkService,
       mockCacheService,
+      mockLoggingService,
     );
 
     await service.getNativeCoinPrice({ nativeCoinId, fiatCode });
@@ -236,34 +565,5 @@ describe('CoingeckoAPI', () => {
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       expireTimeSeconds: pricesCacheTtlSeconds,
     });
-  });
-
-  it('should call CacheService.expire when registering a not found token price', async () => {
-    const chainName = faker.string.sample();
-    const tokenAddress = faker.finance.ethereumAddress();
-    const fiatCode = faker.finance.currencyCode();
-
-    await service.registerNotFoundTokenPrice({
-      chainName,
-      tokenAddress,
-      fiatCode,
-    });
-
-    const expectedCacheDir = new CacheDir(
-      `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
-      '',
-    );
-    expect(mockCacheService.expire).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.expire.mock.calls[0][0]).toBe(expectedCacheDir.key);
-    expect(mockCacheService.expire.mock.calls[0][1]).toBeGreaterThanOrEqual(
-      (fakeConfigurationService.get(
-        'prices.notFoundPriceTtlSeconds',
-      ) as number) - CoingeckoApi.notFoundTtlRangeSeconds,
-    );
-    expect(mockCacheService.expire.mock.calls[0][1]).toBeLessThanOrEqual(
-      (fakeConfigurationService.get(
-        'prices.notFoundPriceTtlSeconds',
-      ) as number) + CoingeckoApi.notFoundTtlRangeSeconds,
-    );
   });
 });

--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -148,7 +148,7 @@ describe('CoingeckoAPI', () => {
       `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
       '',
     );
-    expect(assetPrice).toEqual([[tokenAddress, price]]);
+    expect(assetPrice).toEqual([{ [tokenAddress]: { [fiatCode]: price } }]);
     expect(mockNetworkService.get).toBeCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
@@ -166,7 +166,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenCalledTimes(1);
     expect(mockCacheService.set).toHaveBeenCalledWith(
       expectedCacheDir,
-      JSON.stringify([tokenAddress, price]),
+      JSON.stringify({ [tokenAddress]: { [fiatCode]: price } }),
       pricesCacheTtlSeconds,
     );
   });
@@ -200,7 +200,7 @@ describe('CoingeckoAPI', () => {
       `${chainName}_token_price_${tokenAddress}_${fiatCode}`,
       '',
     );
-    expect(assetPrice).toEqual([[tokenAddress, price]]);
+    expect(assetPrice).toEqual([{ [tokenAddress]: { [fiatCode]: price } }]);
     expect(mockNetworkService.get).toBeCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
@@ -215,7 +215,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenCalledTimes(1);
     expect(mockCacheService.set).toHaveBeenCalledWith(
       expectedCacheDir,
-      JSON.stringify([tokenAddress, price]),
+      JSON.stringify({ [tokenAddress]: { [fiatCode]: price } }),
       pricesCacheTtlSeconds,
     );
   });
@@ -248,9 +248,9 @@ describe('CoingeckoAPI', () => {
     });
 
     expect(assetPrice).toEqual([
-      [firstTokenAddress, firstPrice],
-      [secondTokenAddress, secondPrice],
-      [thirdTokenAddress, thirdPrice],
+      { [firstTokenAddress]: { [fiatCode]: firstPrice } },
+      { [secondTokenAddress]: { [fiatCode]: secondPrice } },
+      { [thirdTokenAddress]: { [fiatCode]: thirdPrice } },
     ]);
     expect(mockNetworkService.get).toBeCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
@@ -293,7 +293,7 @@ describe('CoingeckoAPI', () => {
         `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
         '',
       ),
-      JSON.stringify([firstTokenAddress, firstPrice]),
+      JSON.stringify({ [firstTokenAddress]: { [fiatCode]: firstPrice } }),
       pricesCacheTtlSeconds,
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
@@ -301,7 +301,7 @@ describe('CoingeckoAPI', () => {
         `${chainName}_token_price_${secondTokenAddress}_${fiatCode}`,
         '',
       ),
-      JSON.stringify([secondTokenAddress, secondPrice]),
+      JSON.stringify({ [secondTokenAddress]: { [fiatCode]: secondPrice } }),
       pricesCacheTtlSeconds,
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
@@ -309,7 +309,7 @@ describe('CoingeckoAPI', () => {
         `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
         '',
       ),
-      JSON.stringify([thirdTokenAddress, thirdPrice]),
+      JSON.stringify({ [thirdTokenAddress]: { [fiatCode]: thirdPrice } }),
       pricesCacheTtlSeconds,
     );
   });
@@ -329,7 +329,7 @@ describe('CoingeckoAPI', () => {
     };
     mockCacheService.get.mockResolvedValueOnce(undefined);
     mockCacheService.get.mockResolvedValueOnce(
-      JSON.stringify([secondTokenAddress, secondPrice]),
+      JSON.stringify({ [secondTokenAddress]: { [fiatCode]: secondPrice } }),
     );
     mockCacheService.get.mockResolvedValueOnce(undefined);
     mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
@@ -344,14 +344,14 @@ describe('CoingeckoAPI', () => {
       fiatCode,
     });
 
-    expect(sortBy(assetPrices, (i) => i[0])).toEqual(
+    expect(sortBy(assetPrices, (i) => Object.keys(i)[0])).toEqual(
       sortBy(
         [
-          [firstTokenAddress, firstPrice],
-          [secondTokenAddress, secondPrice],
-          [thirdTokenAddress, thirdPrice],
+          { [firstTokenAddress]: { [fiatCode]: firstPrice } },
+          { [secondTokenAddress]: { [fiatCode]: secondPrice } },
+          { [thirdTokenAddress]: { [fiatCode]: thirdPrice } },
         ],
-        (i) => i[0],
+        (i) => Object.keys(i)[0],
       ),
     );
     expect(mockNetworkService.get).toBeCalledWith(
@@ -392,7 +392,7 @@ describe('CoingeckoAPI', () => {
         `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
         '',
       ),
-      JSON.stringify([firstTokenAddress, firstPrice]),
+      JSON.stringify({ [firstTokenAddress]: { [fiatCode]: firstPrice } }),
       pricesCacheTtlSeconds,
     );
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
@@ -401,7 +401,7 @@ describe('CoingeckoAPI', () => {
         `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
         '',
       ),
-      JSON.stringify([thirdTokenAddress, thirdPrice]),
+      JSON.stringify({ [thirdTokenAddress]: { [fiatCode]: thirdPrice } }),
       pricesCacheTtlSeconds,
     );
   });
@@ -417,9 +417,11 @@ describe('CoingeckoAPI', () => {
     const coingeckoPrice: AssetPrice = {
       [firstTokenAddress]: { [fiatCode]: firstPrice },
     };
-    mockCacheService.get.mockResolvedValueOnce(undefined);
     mockCacheService.get.mockResolvedValueOnce(
-      JSON.stringify([secondTokenAddress, secondPrice]),
+      JSON.stringify({ [firstTokenAddress]: { [fiatCode]: null } }),
+    );
+    mockCacheService.get.mockResolvedValueOnce(
+      JSON.stringify({ [secondTokenAddress]: { [fiatCode]: secondPrice } }),
     );
     mockCacheService.get.mockResolvedValueOnce(undefined);
     mockNetworkService.get.mockResolvedValue({ data: coingeckoPrice });
@@ -434,14 +436,14 @@ describe('CoingeckoAPI', () => {
       fiatCode,
     });
 
-    expect(sortBy(assetPrices, (i) => i[0])).toEqual(
+    expect(sortBy(assetPrices, (i) => Object.keys(i)[0])).toEqual(
       sortBy(
         [
-          [firstTokenAddress, firstPrice],
-          [secondTokenAddress, secondPrice],
-          [thirdTokenAddress, null],
+          { [firstTokenAddress]: { [fiatCode]: null } },
+          { [secondTokenAddress]: { [fiatCode]: secondPrice } },
+          { [thirdTokenAddress]: { [fiatCode]: null } },
         ],
-        (i) => i[0],
+        (i) => Object.keys(i)[0],
       ),
     );
     expect(mockNetworkService.get).toBeCalledWith(
@@ -451,7 +453,7 @@ describe('CoingeckoAPI', () => {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
         params: {
-          contract_addresses: [firstTokenAddress, thirdTokenAddress].join(','),
+          contract_addresses: thirdTokenAddress,
           vs_currencies: fiatCode,
         },
       },
@@ -475,31 +477,16 @@ describe('CoingeckoAPI', () => {
         '',
       ),
     );
-    expect(mockCacheService.set).toHaveBeenCalledTimes(2);
-    expect(mockCacheService.set).toHaveBeenNthCalledWith(
-      1,
-      new CacheDir(
-        `${chainName}_token_price_${firstTokenAddress}_${fiatCode}`,
-        '',
-      ),
-      JSON.stringify([firstTokenAddress, firstPrice]),
-      pricesCacheTtlSeconds,
+    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.set.mock.calls[0][1]).toEqual(
+      JSON.stringify({ [thirdTokenAddress]: { [fiatCode]: null } }),
     );
-    expect(mockCacheService.set.mock.calls[1][0]).toEqual(
-      new CacheDir(
-        `${chainName}_token_price_${thirdTokenAddress}_${fiatCode}`,
-        '',
-      ),
-    );
-    expect(mockCacheService.set.mock.calls[1][1]).toEqual(
-      JSON.stringify([thirdTokenAddress, null]),
-    );
-    expect(mockCacheService.set.mock.calls[1][2]).toBeGreaterThanOrEqual(
+    expect(mockCacheService.set.mock.calls[0][2]).toBeGreaterThanOrEqual(
       (fakeConfigurationService.get(
         'prices.notFoundPriceTtlSeconds',
       ) as number) - CoingeckoApi.notFoundTtlRangeSeconds,
     );
-    expect(mockCacheService.set.mock.calls[1][2]).toBeLessThanOrEqual(
+    expect(mockCacheService.set.mock.calls[0][2]).toBeLessThanOrEqual(
       (fakeConfigurationService.get(
         'prices.notFoundPriceTtlSeconds',
       ) as number) + CoingeckoApi.notFoundTtlRangeSeconds,

--- a/src/datasources/prices-api/coingecko-api.service.ts
+++ b/src/datasources/prices-api/coingecko-api.service.ts
@@ -9,6 +9,12 @@ import {
   CacheService,
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
+import {
+  NetworkService,
+  INetworkService,
+} from '@/datasources/network/network.service.interface';
+import { difference } from 'lodash';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 @Injectable()
 export class CoingeckoApi implements IPricesApi {
@@ -33,7 +39,9 @@ export class CoingeckoApi implements IPricesApi {
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     private readonly dataSource: CacheFirstDataSource,
+    @Inject(NetworkService) private readonly networkService: INetworkService,
     @Inject(CacheService) private readonly cacheService: ICacheService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
     this.apiKey = this.configurationService.get<string>('prices.apiKey');
     this.baseUrl =
@@ -86,38 +94,45 @@ export class CoingeckoApi implements IPricesApi {
       );
     }
   }
-  async getTokenPrice(args: {
+
+  async getTokenPrices(args: {
     chainName: string;
-    tokenAddress: string;
+    tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<AssetPrice> {
-    try {
-      const cacheDir = CacheRouter.getTokenPriceCacheDir(args);
-      const url = `${this.baseUrl}/simple/token_price/${args.chainName}`;
-      return await this.dataSource.get({
-        cacheDir,
-        url,
-        networkRequest: {
-          params: {
-            vs_currencies: args.fiatCode,
-            contract_addresses: args.tokenAddress,
-          },
-          ...(this.apiKey && {
-            headers: {
-              [CoingeckoApi.pricesProviderHeader]: this.apiKey,
-            },
+  }): Promise<[string, number | null][]> {
+    const cachedAssetPrices = await this._getAssetPricesFromCache(args);
+    const notCachedAddresses = difference(
+      args.tokenAddresses,
+      cachedAssetPrices.map((assetPrice) => assetPrice[0]),
+    );
+    const retrievedAssetPrices = await this._getAssetPricesFromProvider({
+      ...args,
+      notCachedAddresses,
+    });
+
+    const assetPrices = await Promise.all(
+      notCachedAddresses.map(async (notCachedAddress) => {
+        const price =
+          retrievedAssetPrices.data[notCachedAddress]?.[args.fiatCode];
+        const assetPrice: [string, number | null] = [
+          notCachedAddress,
+          price ?? null,
+        ];
+        await this.cacheService.set(
+          CacheRouter.getTokenPriceCacheDir({
+            ...args,
+            tokenAddress: notCachedAddress,
           }),
-        },
-        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
-        expireTimeSeconds: this.pricesTtlSeconds,
-      });
-    } catch (error) {
-      throw new DataSourceError(
-        `Error getting ${
-          args.tokenAddress
-        } price from provider${this._mapProviderError(error)}`,
-      );
-    }
+          JSON.stringify(assetPrice),
+          price
+            ? this.pricesTtlSeconds
+            : this._getRandomNotFoundTokenPriceTtl(),
+        );
+        return assetPrice;
+      }),
+    );
+
+    return [cachedAssetPrices, assetPrices].flat();
   }
 
   async getFiatCodes(): Promise<string[]> {
@@ -146,16 +161,6 @@ export class CoingeckoApi implements IPricesApi {
     }
   }
 
-  async registerNotFoundTokenPrice(args: {
-    chainName: string;
-    tokenAddress: string;
-    fiatCode: string;
-  }): Promise<void> {
-    const cacheDir = CacheRouter.getTokenPriceCacheDir(args);
-    const expireTimeSeconds = this._getRandomNotFoundTokenPriceTtl();
-    return this.cacheService.expire(cacheDir.key, expireTimeSeconds);
-  }
-
   private _mapProviderError(error: any): string {
     const errorCode = error?.status?.error_code;
     return errorCode ? ` [status: ${errorCode}]` : '';
@@ -171,5 +176,57 @@ export class CoingeckoApi implements IPricesApi {
     const max =
       this.notFoundPriceTtlSeconds + CoingeckoApi.notFoundTtlRangeSeconds;
     return Math.floor(Math.random() * (max - min) + min);
+  }
+
+  private async _getAssetPricesFromCache(args: {
+    chainName: string;
+    tokenAddresses: string[];
+    fiatCode: string;
+  }): Promise<[string, number][]> {
+    const result = await Promise.all(
+      args.tokenAddresses.map(async (tokenAddress) => {
+        const cacheDir = CacheRouter.getTokenPriceCacheDir({
+          ...args,
+          tokenAddress,
+        });
+        const cached = await this.cacheService.get(cacheDir);
+        const { key, field } = cacheDir;
+        if (cached != null) {
+          this.loggingService.debug({ type: 'cache_hit', key, field });
+          return JSON.parse(cached);
+        }
+        this.loggingService.debug({ type: 'cache_miss', key, field });
+        return null;
+      }),
+    );
+
+    return result.filter((i) => i !== null);
+  }
+
+  private async _getAssetPricesFromProvider(args: {
+    chainName: string;
+    notCachedAddresses: string[];
+    fiatCode: string;
+  }): Promise<AssetPrice> {
+    try {
+      const url = `${this.baseUrl}/simple/token_price/${args.chainName}`;
+      return await this.networkService.get(url, {
+        params: {
+          vs_currencies: args.fiatCode,
+          contract_addresses: args.notCachedAddresses.join(','),
+        },
+        ...(this.apiKey && {
+          headers: {
+            [CoingeckoApi.pricesProviderHeader]: this.apiKey,
+          },
+        }),
+      });
+    } catch (error) {
+      throw new DataSourceError(
+        `Error getting ${
+          args.notCachedAddresses
+        } price from provider${this._mapProviderError(error)}`,
+      );
+    }
   }
 }

--- a/src/datasources/prices-api/coingecko-api.service.ts
+++ b/src/datasources/prices-api/coingecko-api.service.ts
@@ -100,6 +100,15 @@ export class CoingeckoApi implements IPricesApi {
     }
   }
 
+  /**
+   * Gets prices for a set of token addresses, trying to get them from cache first.
+   * For those not found in the cache, it trying to retrieve them from the Coingecko API.
+   *
+   * @param chainName Coingecko's name for the chain (see configuration)
+   * @param tokenAddresses Array of token addresses which prices are being retrieved
+   * @param fiatCode
+   * @returns Array of {@link AssetPrice}
+   */
   async getTokenPrices(args: {
     chainName: string;
     tokenAddresses: string[];
@@ -146,6 +155,14 @@ export class CoingeckoApi implements IPricesApi {
     }
   }
 
+  private _mapProviderError(error: any): string {
+    const errorCode = error?.status?.error_code;
+    return errorCode ? ` [status: ${errorCode}]` : '';
+  }
+
+  /**
+   * For an array of token addresses, gets the prices available from cache.
+   */
   private async _getTokenPricesFromCache(args: {
     chainName: string;
     tokenAddresses: string[];
@@ -171,6 +188,10 @@ export class CoingeckoApi implements IPricesApi {
     return result.filter((i) => i !== null);
   }
 
+  /**
+   * For an array of token addresses, gets the prices available from the Coingecko API.
+   * Stores both retrieved prices and not-found prices in cache.
+   */
   private async _getTokenPricesFromNetwork(args: {
     chainName: string;
     tokenAddresses: string[];
@@ -199,6 +220,9 @@ export class CoingeckoApi implements IPricesApi {
     );
   }
 
+  /**
+   * Does the actual price requests to the Coingecko API, using the {@link NetworkService}.
+   */
   private async _requestPricesFromNetwork(args: {
     chainName: string;
     tokenAddresses: string[];
@@ -230,16 +254,11 @@ export class CoingeckoApi implements IPricesApi {
    * Gets a random integer value between (notFoundPriceTtlSeconds - notFoundTtlRangeSeconds)
    * and (notFoundPriceTtlSeconds + notFoundTtlRangeSeconds).
    */
-  private _getRandomNotFoundTokenPriceTtl(): number {
+  private _getRandomNotFoundTokenPriceTtl() {
     const min =
       this.notFoundPriceTtlSeconds - CoingeckoApi.notFoundTtlRangeSeconds;
     const max =
       this.notFoundPriceTtlSeconds + CoingeckoApi.notFoundTtlRangeSeconds;
     return Math.floor(Math.random() * (max - min) + min);
-  }
-
-  private _mapProviderError(error: any): string {
-    const errorCode = error?.status?.error_code;
-    return errorCode ? ` [status: ${errorCode}]` : '';
   }
 }

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -86,8 +86,8 @@ export class BalancesRepository implements IBalancesRepository {
     );
 
     const tokenAddresses = simpleBalances
-      .map((sb) => sb.tokenAddress)
-      .filter((a): a is string => a !== null);
+      .map((simpleBalance) => simpleBalance.tokenAddress)
+      .filter((address): address is string => address !== null);
 
     const prices = tokenAddresses.length
       ? await this._getTokenPrices(args.chainId, args.fiatCode, tokenAddresses)

--- a/src/domain/interfaces/prices-api.interface.ts
+++ b/src/domain/interfaces/prices-api.interface.ts
@@ -12,7 +12,7 @@ export interface IPricesApi {
     chainName: string;
     tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<[string, number | null][]>;
+  }): Promise<AssetPrice[]>;
 
   getFiatCodes(): Promise<string[]>;
 }

--- a/src/domain/interfaces/prices-api.interface.ts
+++ b/src/domain/interfaces/prices-api.interface.ts
@@ -8,23 +8,11 @@ export interface IPricesApi {
     fiatCode: string;
   }): Promise<AssetPrice>;
 
-  getTokenPrice(args: {
+  getTokenPrices(args: {
     chainName: string;
-    tokenAddress: string;
+    tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<AssetPrice>;
+  }): Promise<[string, number | null][]>;
 
   getFiatCodes(): Promise<string[]>;
-
-  /**
-   * Registers a price reference for token address as not-found.
-   * This function allows the clients of this interface to signal that a price couldn't
-   * be parsed from its {@link AssetPrice}. This allows the underlying implementation
-   * to delay subsequent requests targeting the same token address.
-   */
-  registerNotFoundTokenPrice(args: {
-    chainName: string;
-    tokenAddress: string;
-    fiatCode: string;
-  }): Promise<void>;
 }

--- a/src/domain/prices/prices.repository.interface.ts
+++ b/src/domain/prices/prices.repository.interface.ts
@@ -1,3 +1,5 @@
+import { AssetPrice } from '@/domain/prices/entities/asset-price.entity';
+
 export const IPricesRepository = Symbol('IPricesRepository');
 
 export interface IPricesRepository {
@@ -10,7 +12,7 @@ export interface IPricesRepository {
     chainName: string;
     tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<[string, number | null][]>;
+  }): Promise<AssetPrice[]>;
 
   getFiatCodes(): Promise<string[]>;
 }

--- a/src/domain/prices/prices.repository.interface.ts
+++ b/src/domain/prices/prices.repository.interface.ts
@@ -6,11 +6,11 @@ export interface IPricesRepository {
     fiatCode: string;
   }): Promise<number>;
 
-  getTokenPrice(args: {
+  getTokenPrices(args: {
     chainName: string;
-    tokenAddress: string;
+    tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<number>;
+  }): Promise<[string, number | null][]>;
 
   getFiatCodes(): Promise<string[]>;
 }

--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -25,29 +25,20 @@ export class PricesRepository implements IPricesRepository {
     return assetPrice?.[args.nativeCoinId]?.[lowerCaseFiatCode];
   }
 
-  async getTokenPrice(args: {
+  async getTokenPrices(args: {
     chainName: string;
-    tokenAddress: string;
+    tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<number> {
+  }): Promise<[string, number | null][]> {
     const lowerCaseFiatCode = args.fiatCode.toLowerCase();
-    const lowerCaseTokenAddress = args.tokenAddress.toLowerCase();
-    const result = await this.coingeckoApi.getTokenPrice({
+    const lowerCaseTokenAddresses = args.tokenAddresses.map((address) =>
+      address.toLowerCase(),
+    );
+    return this.coingeckoApi.getTokenPrices({
       chainName: args.chainName,
-      tokenAddress: lowerCaseTokenAddress,
+      tokenAddresses: lowerCaseTokenAddresses,
       fiatCode: lowerCaseFiatCode,
     });
-
-    const tokenPrice = result?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
-    if (!tokenPrice) {
-      await this.coingeckoApi.registerNotFoundTokenPrice({
-        chainName: args.chainName,
-        tokenAddress: lowerCaseTokenAddress,
-        fiatCode: lowerCaseFiatCode,
-      });
-    }
-
-    return tokenPrice;
   }
 
   async getFiatCodes(): Promise<string[]> {

--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -3,6 +3,7 @@ import { IPricesApi } from '../interfaces/prices-api.interface';
 import { IPricesRepository } from './prices.repository.interface';
 import { AssetPriceValidator } from './asset-price.validator';
 import { FiatCodesValidator } from './fiat-codes.validator';
+import { AssetPrice } from '@/domain/prices/entities/asset-price.entity';
 
 @Injectable()
 export class PricesRepository implements IPricesRepository {
@@ -29,7 +30,7 @@ export class PricesRepository implements IPricesRepository {
     chainName: string;
     tokenAddresses: string[];
     fiatCode: string;
-  }): Promise<[string, number | null][]> {
+  }): Promise<AssetPrice[]> {
     const lowerCaseFiatCode = args.fiatCode.toLowerCase();
     const lowerCaseTokenAddresses = args.tokenAddresses.map((address) =>
       address.toLowerCase(),


### PR DESCRIPTION
This PR adds batching to Coingecko API token price requests. Main change:
- `CoingeckoApi` uses an `INetworkService` directly to get the prices, instead of relying on `CacheFirstDataSource`. This way `CoingeckoApi` can attempt to retrieve several token prices from the `ICacheService` first, and request the not cached ones to `INetworkService` at once.