### PR TITLE
fix: rename `Contract` entity to `AlertsRegistration`

### DIFF
--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -3,7 +3,7 @@ import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.
 import { TenderlyApi } from '@/datasources/alerts-api/tenderly-api.service';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { INetworkService } from '@/datasources/network/network.service.interface';
-import { Contract } from '@/domain/alerts/entities/alerts.entity';
+import { AlertsRegistration } from '@/domain/alerts/entities/alerts.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 
 const networkService = {
@@ -61,7 +61,7 @@ describe('TenderlyApi', () => {
   });
 
   it('should add contracts', async () => {
-    const contracts: Array<Contract> = [
+    const contracts: Array<AlertsRegistration> = [
       {
         address: faker.finance.ethereumAddress(),
         displayName: faker.word.words(),

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Contract } from '@/domain/alerts/entities/alerts.entity';
+import { AlertsRegistration } from '@/domain/alerts/entities/alerts.entity';
 import { IAlertsApi } from '@/domain/interfaces/alerts-api.inferface';
 import {
   INetworkService,
@@ -33,7 +33,7 @@ export class TenderlyApi implements IAlertsApi {
       this.configurationService.getOrThrow<string>('alerts.project');
   }
 
-  async addContracts(contracts: Array<Contract>): Promise<void> {
+  async addContracts(contracts: Array<AlertsRegistration>): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
       await this.networkService.post(url, {

--- a/src/domain/alerts/entities/alerts.entity.ts
+++ b/src/domain/alerts/entities/alerts.entity.ts
@@ -1,4 +1,4 @@
-export type Contract = {
+export type AlertsRegistration = {
   address: string;
   chainId: string;
   displayName?: string;

--- a/src/domain/interfaces/alerts-api.inferface.ts
+++ b/src/domain/interfaces/alerts-api.inferface.ts
@@ -1,7 +1,7 @@
-import { Contract } from '@/domain/alerts/entities/alerts.entity';
+import { AlertsRegistration } from '@/domain/alerts/entities/alerts.entity';
 
 export const IAlertsApi = Symbol('IAlertsApi');
 
 export interface IAlertsApi {
-  addContracts(contracts: Array<Contract>): Promise<void>;
+  addContracts(contracts: Array<AlertsRegistration>): Promise<void>;
 }


### PR DESCRIPTION
As per [suggestion](https://github.com/safe-global/safe-client-gateway/pull/801#discussion_r1383065721), this renames the alerts registration entity from `Contract` to `AlertsRegistration`. It could otherwise be confused with the `Contract` domain entity.

