### PR TITLE
chore: add Alerts docs

### DIFF
--- a/src/domain/alerts/alerts.repository.interface.ts
+++ b/src/domain/alerts/alerts.repository.interface.ts
@@ -4,7 +4,15 @@ import { AlertLog } from '@/routes/alerts/entities/alert.dto.entity';
 export const IAlertsRepository = Symbol('IAlertsRepository');
 
 export interface IAlertsRepository {
+  /**
+   * Adds the {@link contracts} to the Alerts provider
+   * @param contracts - the network-specific {@link AlertsRegistration} to add
+   */
   addContracts(contracts: Array<AlertsRegistration>): Promise<void>;
 
+  /**
+   * Parses and notifies the user about the {@link log} from the Alerts provider
+   * @param log - the {@link AlertLog} to decode
+   */
   handleAlertLog(log: AlertLog): void;
 }


### PR DESCRIPTION
As per [suggestion](https://github.com/safe-global/safe-client-gateway/pull/801#discussion_r1383088848), this adds documentation for the `addContracts` and `handleAlertLog` methods of `alerts.repository`:

- `addContracts` - adds network-specific contract details to the Alerts provider
- `handleAlertLog` - parses and notifies the user about the log from the Alerts provider