### PR TITLE
Extend not-found token price TLL use cases

### DIFF
--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -37,9 +37,8 @@ export class PricesRepository implements IPricesRepository {
       tokenAddress: lowerCaseTokenAddress,
       fiatCode: lowerCaseFiatCode,
     });
-    const assetPrice = this.assetPriceValidator.validate(result);
-    const tokenPrice = assetPrice?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
 
+    const tokenPrice = result?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode];
     if (!tokenPrice) {
       await this.coingeckoApi.registerNotFoundTokenPrice({
         chainName: args.chainName,


### PR DESCRIPTION
**Motivation**
In [the previous change](https://github.com/safe-global/safe-client-gateway/pull/840) targeting not-found token prices TTL settings, it was considering the response from the prices provider when a token wasn't found had the format:
```
{
  "address": {}
}
```
[(Example)](https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=0x5aFE3855358E112B5647B952709E6165e1c1eEEe&vs_currencies=eur)

---
But in other cases, it seems to be:
```
{}
```
[(Example)](https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=0x5aFE3855358E112B5647B952709E6165e1c1eEEe&vs_currencies=eur)

So for the second case, a validation error was thrown, and the `PricesRepository.getTokenPrice` exited before the TTL was set.

**Solution**
- Remove the validation for the token price format in this function. This validation was just checking the payload contained at least 1 property, but this is already covered by the check in the next line (`result?.[lowerCaseTokenAddress]?.[lowerCaseFiatCode]`).