### PR TITLE
Copy yarn patches to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
 COPY --chown=node:node .yarn/plugins ./.yarn/plugins
+COPY --chown=node:node .yarn/patches ./.yarn/patches
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn workspaces focus --production
 COPY --chown=node:node assets ./assets


### PR DESCRIPTION
The local patches generated by yarn need to be included in the final image. If not included, yarn will not be able to find this folder which is referenced under the package "resolutions".