### PR TITLE
Add EmailRepository

### DIFF
--- a/src/datasources/email/email.datasource.module.ts
+++ b/src/datasources/email/email.datasource.module.ts
@@ -8,4 +8,4 @@ import { PostgresDatabaseModule } from '@/datasources/db/postgres-database.modul
   providers: [{ provide: IEmailDataSource, useClass: EmailDataSource }],
   exports: [IEmailDataSource],
 })
-export class EmailDatasourceModule {}
+export class EmailDataSourceModule {}

--- a/src/datasources/email/email.datasource.module.ts
+++ b/src/datasources/email/email.datasource.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { EmailDataSource } from '@/datasources/email/email.datasource';
+import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
+import { PostgresDatabaseModule } from '@/datasources/db/postgres-database.module';
+
+@Module({
+  imports: [PostgresDatabaseModule],
+  providers: [{ provide: IEmailDataSource, useClass: EmailDataSource }],
+  exports: [IEmailDataSource],
+})
+export class EmailDatasourceModule {}

--- a/src/domain/email/code-generator.ts
+++ b/src/domain/email/code-generator.ts
@@ -1,0 +1,8 @@
+/**
+ * Generates a random number up to six digits
+ */
+export default function (): number {
+  const array = new Uint32Array(1);
+  crypto.getRandomValues(array);
+  return array[0] % 1_000_000;
+}

--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -1,0 +1,10 @@
+export const IEmailRepository = Symbol('IEmailRepository');
+
+export interface IEmailRepository {
+  saveEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    emailAddress: string;
+    signer: string;
+  }): Promise<void>;
+}

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -1,0 +1,53 @@
+import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
+import { Inject } from '@nestjs/common';
+import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
+import codeGenerator from '@/domain/email/code-generator';
+import { Email } from '@/domain/email/entities/email.entity';
+import { IEmailRepository } from '@/domain/email/email.repository.interface';
+import { SignerNotOwnerError } from '@/domain/email/errors/signer-not-owner.error';
+import { EmailSaveError } from '@/domain/email/errors/email-save.error';
+
+export class EmailRepository implements IEmailRepository {
+  constructor(
+    @Inject(IEmailDataSource)
+    private readonly emailDataSource: IEmailDataSource,
+    @Inject(ISafeRepository) private readonly safeRepository: ISafeRepository,
+  ) {}
+
+  async saveEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    emailAddress: string;
+    signer: string;
+  }): Promise<void> {
+    const email = new Email(args.emailAddress);
+
+    const safe = await this.safeRepository.getSafe({
+      chainId: args.chainId,
+      address: args.safeAddress,
+    });
+
+    if (!(args.signer in safe.owners)) {
+      // Signer needs to be an owner of the safe
+      throw new SignerNotOwnerError(
+        args.chainId,
+        args.safeAddress,
+        args.signer,
+      );
+    }
+
+    const verificationCode = codeGenerator();
+
+    try {
+      await this.emailDataSource.saveEmail({
+        chainId: args.chainId,
+        code: verificationCode,
+        emailAddress: email.value,
+        safeAddress: args.safeAddress,
+        signer: args.signer,
+      });
+    } catch (e) {
+      throw new EmailSaveError(args.chainId, args.safeAddress, args.signer);
+    }
+  }
+}

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -27,7 +27,7 @@ export class EmailRepository implements IEmailRepository {
       address: args.safeAddress,
     });
 
-    if (!(args.signer in safe.owners)) {
+    if (!safe.owners.includes(args.signer)) {
       // Signer needs to be an owner of the safe
       throw new SignerNotOwnerError(
         args.chainId,

--- a/src/domain/email/entities/email-verification-code.entity.ts
+++ b/src/domain/email/entities/email-verification-code.entity.ts
@@ -1,4 +1,0 @@
-export interface EmailVerificationCode {
-  emailAddress: string;
-  verificationCode?: string;
-}

--- a/src/domain/email/entities/email.entity.spec.ts
+++ b/src/domain/email/entities/email.entity.spec.ts
@@ -1,0 +1,25 @@
+import {
+  Email,
+  InvalidEmailFormatError,
+} from '@/domain/email/entities/email.entity';
+import { faker } from '@faker-js/faker';
+
+describe('Email entity tests', () => {
+  it.each(['test@email.com', faker.internet.email()])(
+    '%s is a valid email',
+    (input) => {
+      const email = new Email(input);
+
+      expect(email.value).toBe(input);
+    },
+  );
+
+  it.each(['', ' ', '@', '@test.com', 'test.com', '.@.com'])(
+    '%s is not a valid email',
+    (input) => {
+      expect(() => {
+        new Email(input);
+      }).toThrow(InvalidEmailFormatError);
+    },
+  );
+});

--- a/src/domain/email/entities/email.entity.ts
+++ b/src/domain/email/entities/email.entity.ts
@@ -1,0 +1,17 @@
+export class InvalidEmailFormatError extends Error {
+  constructor() {
+    super('Provided email is not a recognizable email format.');
+  }
+}
+
+export class Email {
+  // https://www.ietf.org/rfc/rfc5322.txt
+  private static EMAIL_REGEX: RegExp =
+    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+  constructor(readonly value: string) {
+    if (!Email.EMAIL_REGEX.test(value)) {
+      throw new InvalidEmailFormatError();
+    }
+  }
+}

--- a/src/domain/email/errors/email-save.error.ts
+++ b/src/domain/email/errors/email-save.error.ts
@@ -1,0 +1,7 @@
+export class EmailSaveError extends Error {
+  constructor(chainId: string, safeAddress: string, signer: string) {
+    super(
+      `Error while saving provided email was not saved. chainId=${chainId}, safeAddress=${safeAddress}, signer=${signer}`,
+    );
+  }
+}

--- a/src/domain/email/errors/signer-not-owner.error.ts
+++ b/src/domain/email/errors/signer-not-owner.error.ts
@@ -1,0 +1,7 @@
+export class SignerNotOwnerError extends Error {
+  constructor(chainId: string, safeAddress: string, signer: string) {
+    super(
+      `Signer ${signer} is not an owner of the safe ${safeAddress} on chain ${chainId}.`,
+    );
+  }
+}

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -21,8 +21,7 @@ export interface IEmailDataSource {
   /**
    * Sets the verification code for an email entry.
    *
-   * If the reset was successful, the new verification code
-   * {@link EmailVerificationCode} is returned.
+   * If the reset was successful, the new verification code is returned.
    *
    * @param args.chainId - the chain id of where the Safe is deployed
    * @param args.safeAddress - the Safe address

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -1,13 +1,8 @@
-import { EmailVerificationCode } from '@/domain/email/entities/email-verification-code.entity';
-
 export const IEmailDataSource = Symbol('IEmailDataSource');
 
 export interface IEmailDataSource {
   /**
    * Saves an email entry in the respective data source.
-   *
-   * If the email is saved successfully, a verification code
-   * {@link EmailVerificationCode} is returned
    *
    * @param args.chainId - the chain id of where the Safe is deployed
    * @param args.safeAddress - the Safe address to which we should store the email address
@@ -21,7 +16,7 @@ export interface IEmailDataSource {
     emailAddress: string;
     signer: string;
     code: number;
-  }): Promise<EmailVerificationCode>;
+  }): Promise<{ email: string; verificationCode: string | null }>;
 
   /**
    * Sets the verification code for an email entry.
@@ -39,7 +34,7 @@ export interface IEmailDataSource {
     safeAddress: string;
     signer: string;
     code: number;
-  }): Promise<EmailVerificationCode>;
+  }): Promise<{ email: string; verificationCode: string | null }>;
 
   /**
    * Sets the verification date for an email entry.


### PR DESCRIPTION
Domain changes:

- Adds `EmailRepository` – this repository will be the main interfacing point between the datasources and the routes for the email feature.
- For the initial functionality, the ability to save an email was added. It checks if the signer address is part of the Safe, and saves the email entry in the datasource alongside a generated code for validation.

Datasource changes:

- Due to how the types and interfaces are constantly evolving as the feature develops, the return types of the functions in `IEmailDataSource` are now declared in the return declaration. Removed `EmailVerificationCode` as a consequence of that.


## Out of scope:

- The unit tests on the repository will be covered by the route layer. Coverage might temporarily drop as a result.