### PR TITLE
FF_MESSAGES_CACHE feature flag cleaning

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -68,9 +68,6 @@
 # Enable human description feature
 #FF_HUMAN_DESCRIPTION=
 
-# Enable messages cache feature
-#FF_MESSAGES_CACHE=
-
 # Enable external provider prices retrieval by chainId
 # Expected format: comma-separated chain ids (example: 1,5,100)
 #FF_PRICES_PROVIDER_CHAIN_IDS=

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -43,7 +43,6 @@ export default (): ReturnType<typeof configuration> => ({
   features: {
     pricesProviderChainIds: ['10'],
     humanDescription: true,
-    messagesCache: true,
     alerts: true,
     recovery: true,
     noncesRoute: true,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -53,7 +53,6 @@ export default () => ({
       process.env.FF_PRICES_PROVIDER_CHAIN_IDS?.split(',') ?? [],
     humanDescription:
       process.env.FF_HUMAN_DESCRIPTION?.toLowerCase() === 'true',
-    messagesCache: process.env.FF_MESSAGES_CACHE?.toLowerCase() === 'true',
     alerts: process.env.FF_ALERTS?.toLowerCase() === 'true',
     recovery: process.env.FF_RECOVERY?.toLowerCase() === 'true',
     noncesRoute: process.env.FF_NONCES_ROUTE?.toLowerCase() === 'true',

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -54,7 +54,6 @@ describe('Transaction API Manager Tests', () => {
       .build();
     const expirationTimeInSeconds = faker.number.int();
     const notFoundExpireTimeSeconds = faker.number.int();
-    const messagesCache = faker.datatype.boolean();
     configurationServiceMock.getOrThrow.mockImplementation((key) => {
       if (key === 'safeTransaction.useVpcUrl') return useVpcUrl;
       else if (key === 'expirationTimeInSeconds.default')
@@ -65,7 +64,6 @@ describe('Transaction API Manager Tests', () => {
         return notFoundExpireTimeSeconds;
       else if (key === 'expirationTimeInSeconds.notFound.token')
         return notFoundExpireTimeSeconds;
-      else if (key === 'features.messagesCache') return messagesCache;
       throw new Error(`Unexpected key: ${key}`);
     });
     configApiMock.getChain.mockResolvedValue(chain);

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -47,7 +47,6 @@ describe('TransactionApi', () => {
 
     defaultExpirationTimeInSeconds = faker.number.int();
     notFoundExpireTimeSeconds = faker.number.int();
-    const messagesCache = faker.datatype.boolean();
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'expirationTimeInSeconds.default') {
         return defaultExpirationTimeInSeconds;
@@ -61,7 +60,6 @@ describe('TransactionApi', () => {
       if (key === 'expirationTimeInSeconds.notFound.token') {
         return notFoundExpireTimeSeconds;
       }
-      if (key === 'features.messagesCache') return messagesCache;
       throw Error(`Unexpected key: ${key}`);
     });
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -34,7 +34,6 @@ export class TransactionApi implements ITransactionApi {
   private readonly defaultNotFoundExpirationTimeSeconds: number;
   private readonly tokenNotFoundExpirationTimeSeconds: number;
   private readonly contractNotFoundExpirationTimeSeconds: number;
-  private readonly isMessagesCacheEnabled: boolean;
 
   constructor(
     private readonly chainId: string,
@@ -61,9 +60,6 @@ export class TransactionApi implements ITransactionApi {
       this.configurationService.getOrThrow<number>(
         'expirationTimeInSeconds.notFound.contract',
       );
-    this.isMessagesCacheEnabled = this.configurationService.getOrThrow<boolean>(
-      'features.messagesCache',
-    );
   }
 
   async getBalances(args: {
@@ -834,9 +830,7 @@ export class TransactionApi implements ITransactionApi {
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
-        expireTimeSeconds: this.isMessagesCacheEnabled
-          ? this.defaultExpirationTimeInSeconds
-          : undefined,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -864,9 +858,7 @@ export class TransactionApi implements ITransactionApi {
             offset: args.offset,
           },
         },
-        expireTimeSeconds: this.isMessagesCacheEnabled
-          ? this.defaultExpirationTimeInSeconds
-          : undefined,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);


### PR DESCRIPTION
This PR cleans `FF_MESSAGES_CACHE` feature flag and its associated code.

The changes on this PR are equivalent to setting the former `FF_MESSAGES_CACHE` permanently to `true`.