### PR TITLE
Add OnlySafeOwner guard

### DIFF
--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -16,6 +16,12 @@ export interface ISafeRepository {
 
   clearSafe(args: { chainId: string; address: string }): Promise<void>;
 
+  isOwner(args: {
+    chainId: string;
+    safeAddress: string;
+    address: string;
+  }): Promise<boolean>;
+
   getCollectibleTransfers(args: {
     chainId: string;
     safeAddress: string;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -19,6 +19,7 @@ import { TransactionTypeValidator } from '@/domain/safe/transaction-type.validat
 import { TransferValidator } from '@/domain/safe/transfer.validator';
 import { AddConfirmationDto } from '@/domain/transactions/entities/add-confirmation.dto.entity';
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
@@ -45,6 +46,20 @@ export class SafeRepository implements ISafeRepository {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
     return transactionService.clearSafe(args.address);
+  }
+
+  async isOwner(args: {
+    chainId: string;
+    safeAddress: string;
+    address: string;
+  }): Promise<boolean> {
+    const safe = await this.getSafe({
+      chainId: args.chainId,
+      address: args.safeAddress,
+    });
+    const owner = getAddress(args.address);
+    const owners = safe.owners.map((rawAddress) => getAddress(rawAddress));
+    return owners.includes(owner);
   }
 
   async getCollectibleTransfers(args: {

--- a/src/routes/email/only-safe-owner.guard.spec.ts
+++ b/src/routes/email/only-safe-owner.guard.spec.ts
@@ -1,0 +1,240 @@
+import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { OnlySafeOwner } from '@/routes/email/only-safe-owner.guard';
+import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+
+const safeRepository = {
+  isOwner: jest.fn(),
+} as unknown as ISafeRepository;
+
+const safeRepositoryMock = jest.mocked(safeRepository);
+
+@Controller()
+class TestController {
+  @Post('test/:chainId/:safeAddress')
+  @HttpCode(200)
+  @UseGuards(OnlySafeOwner)
+  async onlySafeOwnerRoute() {}
+
+  @Post('test/invalid/chains/:chainId')
+  @HttpCode(200)
+  @UseGuards(OnlySafeOwner)
+  async invalidRouteWithChainId() {}
+
+  @Post('test/invalid/safes/:safeAddress')
+  @HttpCode(200)
+  @UseGuards(OnlySafeOwner)
+  async invalidRouteWithSafeAddress() {}
+}
+
+describe('OnlySafeOwner guard tests', () => {
+  let app;
+  // The following address, message and signature represent a valid combination of parameters for validation
+  const testAddress = '0x21509ab252a92b180c539e4d84ea1406f0f87fb8';
+  const testMessage = 'This is a test';
+  const testSignature =
+    '0xcf103c6090c344ffdaa7635d1c41078c5702fd8a8c0528cd980f28c10fb7b3275b7bd803cc99316fc42bf803dcaf982e078d94b094afb3f9853f0dd7ce888aea1c';
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+      providers: [
+        {
+          provide: ISafeRepository,
+          useValue: safeRepositoryMock,
+        },
+      ],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 403 on empty body', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+
+  it('returns 200 on a valid signature from an owner', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+    safeRepositoryMock.isOwner.mockResolvedValue(true);
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        signature: testSignature,
+        message: testMessage,
+        address: testAddress,
+      })
+      .expect(200);
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(1);
+  });
+
+  it('returns 403 on an invalid signature from an owner', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+    const message = 'This is a different test';
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        signature: testSignature,
+        message,
+        address: testAddress,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+
+  it('returns 403 on a valid signature from a non-owner', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+    safeRepositoryMock.isOwner.mockResolvedValue(false);
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        signature: testSignature,
+        message: testMessage,
+        address: testAddress,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(1);
+  });
+
+  it('returns 403 if the address is missing from payload', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        signature: testSignature,
+        message: testMessage,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+
+  it('returns 403 if the message is missing from payload', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        signature: testSignature,
+        address: testAddress,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+
+  it('returns 403 if the signature is missing from payload', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        message: testMessage,
+        address: testAddress,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+
+  it('returns 403 on routes without safe address', async () => {
+    const chainId = faker.string.numeric();
+
+    await request(app.getHttpServer())
+      .post(`/test/invalid/chains/${chainId}`)
+      .send({
+        signature: testSignature,
+        message: testMessage,
+        address: testAddress,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+
+  it('returns 403 on routes without chain id', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/invalid/safes/${safeAddress}`)
+      .send({
+        signature: testSignature,
+        message: testMessage,
+        address: testAddress,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
+  });
+});

--- a/src/routes/email/only-safe-owner.guard.spec.ts
+++ b/src/routes/email/only-safe-owner.guard.spec.ts
@@ -1,6 +1,4 @@
 import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
-import { OnlySafeOwner } from '@/routes/email/only-safe-owner.guard';
-import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
@@ -8,8 +6,8 @@ import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-import { Hash } from 'viem';
+import { OnlySafeOwner } from '@/routes/email/only-safe-owner.guard';
+import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 
 const safeRepository = {
   isOwner: jest.fn(),
@@ -22,7 +20,7 @@ class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
   @UseGuards(OnlySafeOwner)
-  async onlySafeOwnerRoute() {}
+  async validRoute() {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
@@ -37,16 +35,6 @@ class TestController {
 
 describe('OnlySafeOwner guard tests', () => {
   let app;
-
-  const privateKey = generatePrivateKey();
-  const account = privateKeyToAccount(privateKey);
-  const signer = account.address;
-  const message = faker.word.words();
-  let signature: Hash;
-
-  beforeAll(async () => {
-    signature = await account.signMessage({ message });
-  });
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -70,48 +58,58 @@ describe('OnlySafeOwner guard tests', () => {
 
   it('returns 403 on empty body', async () => {
     const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safe = faker.finance.ethereumAddress();
 
     await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
+      .post(`/test/${chainId}/${safe}`)
       .expect(403)
       .expect({
         message: 'Forbidden resource',
         error: 'Forbidden',
         statusCode: 403,
       });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
   });
 
-  it('returns 200 on a valid signature from an owner', async () => {
+  it('returns 200 if account is an owner of the safe', async () => {
     const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-    safeRepositoryMock.isOwner.mockResolvedValue(true);
+    const safe = faker.finance.ethereumAddress();
+    const account = faker.finance.ethereumAddress();
+    safeRepositoryMock.isOwner.mockImplementation((args) => {
+      if (
+        args.chainId !== chainId ||
+        args.address !== account ||
+        args.safeAddress !== safe
+      )
+        return Promise.reject();
+      else return Promise.resolve(true);
+    });
 
     await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
+      .post(`/test/${chainId}/${safe}`)
       .send({
-        signature,
-        message,
-        address: signer,
+        account: account,
       })
       .expect(200);
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(1);
   });
 
-  it('returns 403 on an invalid signature from an owner', async () => {
+  it('returns 403 if account is not an owner of the safe', async () => {
     const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-    const message = 'This is a different test';
+    const safe = faker.finance.ethereumAddress();
+    const account = faker.finance.ethereumAddress();
+    safeRepositoryMock.isOwner.mockImplementation((args) => {
+      if (
+        args.chainId !== chainId ||
+        args.address !== account ||
+        args.safeAddress !== safe
+      )
+        return Promise.reject();
+      else return Promise.resolve(false);
+    });
 
     await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
+      .post(`/test/${chainId}/${safe}`)
       .send({
-        signature,
-        message,
-        address: signer,
+        account: account,
       })
       .expect(403)
       .expect({
@@ -119,101 +117,16 @@ describe('OnlySafeOwner guard tests', () => {
         error: 'Forbidden',
         statusCode: 403,
       });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
-  });
-
-  it('returns 403 on a valid signature from a non-owner', async () => {
-    const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-    safeRepositoryMock.isOwner.mockResolvedValue(false);
-
-    await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
-      .send({
-        signature,
-        message,
-        address: signer,
-      })
-      .expect(403)
-      .expect({
-        message: 'Forbidden resource',
-        error: 'Forbidden',
-        statusCode: 403,
-      });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(1);
-  });
-
-  it('returns 403 if the address is missing from payload', async () => {
-    const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-
-    await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
-      .send({
-        signature,
-        message,
-      })
-      .expect(403)
-      .expect({
-        message: 'Forbidden resource',
-        error: 'Forbidden',
-        statusCode: 403,
-      });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
-  });
-
-  it('returns 403 if the message is missing from payload', async () => {
-    const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-
-    await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
-      .send({
-        signature,
-        address: signer,
-      })
-      .expect(403)
-      .expect({
-        message: 'Forbidden resource',
-        error: 'Forbidden',
-        statusCode: 403,
-      });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
-  });
-
-  it('returns 403 if the signature is missing from payload', async () => {
-    const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-
-    await request(app.getHttpServer())
-      .post(`/test/${chainId}/${safeAddress}`)
-      .send({
-        message: message,
-        address: signer,
-      })
-      .expect(403)
-      .expect({
-        message: 'Forbidden resource',
-        error: 'Forbidden',
-        statusCode: 403,
-      });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
   });
 
   it('returns 403 on routes without safe address', async () => {
     const chainId = faker.string.numeric();
+    const account = faker.finance.ethereumAddress();
 
     await request(app.getHttpServer())
       .post(`/test/invalid/chains/${chainId}`)
       .send({
-        signature,
-        message,
-        address: signer,
+        account: account,
       })
       .expect(403)
       .expect({
@@ -221,19 +134,16 @@ describe('OnlySafeOwner guard tests', () => {
         error: 'Forbidden',
         statusCode: 403,
       });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
   });
 
   it('returns 403 on routes without chain id', async () => {
     const safeAddress = faker.finance.ethereumAddress();
+    const account = faker.finance.ethereumAddress();
 
     await request(app.getHttpServer())
       .post(`/test/invalid/safes/${safeAddress}`)
       .send({
-        signature,
-        message: message,
-        address: signer,
+        account: account,
       })
       .expect(403)
       .expect({
@@ -241,7 +151,5 @@ describe('OnlySafeOwner guard tests', () => {
         error: 'Forbidden',
         statusCode: 403,
       });
-
-    expect(safeRepositoryMock.isOwner).toBeCalledTimes(0);
   });
 });

--- a/src/routes/email/only-safe-owner.guard.spec.ts
+++ b/src/routes/email/only-safe-owner.guard.spec.ts
@@ -6,7 +6,7 @@ import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
-import { OnlySafeOwner } from '@/routes/email/only-safe-owner.guard';
+import { OnlySafeOwnerGuard } from '@/routes/email/only-safe-owner.guard';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 
 const safeRepository = {
@@ -19,17 +19,17 @@ const safeRepositoryMock = jest.mocked(safeRepository);
 class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
-  @UseGuards(OnlySafeOwner)
+  @UseGuards(OnlySafeOwnerGuard)
   async validRoute() {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
-  @UseGuards(OnlySafeOwner)
+  @UseGuards(OnlySafeOwnerGuard)
   async invalidRouteWithChainId() {}
 
   @Post('test/invalid/safes/:safeAddress')
   @HttpCode(200)
-  @UseGuards(OnlySafeOwner)
+  @UseGuards(OnlySafeOwnerGuard)
   async invalidRouteWithSafeAddress() {}
 }
 

--- a/src/routes/email/only-safe-owner.guard.ts
+++ b/src/routes/email/only-safe-owner.guard.ts
@@ -1,0 +1,62 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { verifyMessage } from 'viem';
+
+/**
+ * The OnlySafeOwner guard can be applied to any route that requires proof
+ * that a request was signed by an owner of a Safe.
+ *
+ * This guard does not restrict the contents of the message, i.e.: any security
+ * considerations are left to the route itself.
+ *
+ * To use this guard, the route should have:
+ * - the 'chainId' declared as a parameter
+ * - the 'safeAddress' declared as a parameter
+ * - the 'signature' as part of the JSON body (top level)
+ * - the 'message' as part of the JSON body (top level)
+ * - the 'address' as part of the JSON body (top level)
+ */
+@Injectable()
+export class OnlySafeOwner implements CanActivate {
+  constructor(
+    @Inject(ISafeRepository) private readonly safeRepository: ISafeRepository,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const chainId = request.params['chainId'];
+    const safe = request.params['safeAddress'];
+    const signature = request.body['signature'];
+    const message = request.body['message'];
+    const address = request.body['address'];
+
+    // Required fields
+    if (!chainId || !safe || !signature || !message || !address) return false;
+
+    try {
+      const isValidSignature = await verifyMessage({
+        address,
+        message,
+        signature,
+      });
+      if (!isValidSignature) return false;
+    } catch (e) {
+      this.loggingService.debug(e);
+      return false;
+    }
+
+    return await this.safeRepository.isOwner({
+      chainId,
+      safeAddress: safe,
+      address: address,
+    });
+  }
+}

--- a/src/routes/email/only-safe-owner.guard.ts
+++ b/src/routes/email/only-safe-owner.guard.ts
@@ -18,7 +18,7 @@ import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
  * - the 'account' as part of the JSON body (top level)
  */
 @Injectable()
-export class OnlySafeOwner implements CanActivate {
+export class OnlySafeOwnerGuard implements CanActivate {
   constructor(
     @Inject(ISafeRepository) private readonly safeRepository: ISafeRepository,
   ) {}

--- a/src/routes/email/only-safe-owner.guard.ts
+++ b/src/routes/email/only-safe-owner.guard.ts
@@ -5,28 +5,22 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
-import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { verifyMessage } from 'viem';
 
 /**
- * The OnlySafeOwner guard can be applied to any route that requires proof
- * that a request was signed by an owner of a Safe.
+ * The OnlySafeOwner guard can be applied to any route that requires
+ * that a provided 'account' (owner) is part of a Safe
  *
- * This guard does not restrict the contents of the message, i.e.: any security
- * considerations are left to the route itself.
+ * This guard does not validate that a message came from said owner.
  *
  * To use this guard, the route should have:
  * - the 'chainId' declared as a parameter
  * - the 'safeAddress' declared as a parameter
- * - the 'signature' as part of the JSON body (top level)
- * - the 'message' as part of the JSON body (top level)
- * - the 'address' as part of the JSON body (top level)
+ * - the 'account' as part of the JSON body (top level)
  */
 @Injectable()
 export class OnlySafeOwner implements CanActivate {
   constructor(
     @Inject(ISafeRepository) private readonly safeRepository: ISafeRepository,
-    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -34,29 +28,15 @@ export class OnlySafeOwner implements CanActivate {
 
     const chainId = request.params['chainId'];
     const safe = request.params['safeAddress'];
-    const signature = request.body['signature'];
-    const message = request.body['message'];
-    const address = request.body['address'];
+    const account = request.body['account'];
 
     // Required fields
-    if (!chainId || !safe || !signature || !message || !address) return false;
-
-    try {
-      const isValidSignature = await verifyMessage({
-        address,
-        message,
-        signature,
-      });
-      if (!isValidSignature) return false;
-    } catch (e) {
-      this.loggingService.debug(e);
-      return false;
-    }
+    if (!chainId || !safe || !account) return false;
 
     return await this.safeRepository.isOwner({
       chainId,
       safeAddress: safe,
-      address: address,
+      address: account,
     });
   }
 }


### PR DESCRIPTION
The `OnlySafeOwner` is a guard is a guard that can be used to verify that the `account` provided in a payload is an owner of a Safe.

**This guard does not validate that a message came from said owner.**

To use this guard, the route should have:
- the 'chainId' declared as a parameter
- the 'safeAddress' declared as a parameter
- the 'account' as part of the JSON body (top level)

Additionally, the `ISafeRepository` now has a function `isOwner` which can be used to verify if an address is an owner of the safe.