### PR TITLE
Add EmailRegistration guard

### DIFF
--- a/src/routes/email/email-registration.guard.spec.ts
+++ b/src/routes/email/email-registration.guard.spec.ts
@@ -1,0 +1,205 @@
+import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { Hash } from 'viem';
+import { EmailRegistrationGuard } from '@/routes/email/email-registration.guard';
+
+@Controller()
+class TestController {
+  @Post('test/:chainId/:safeAddress')
+  @HttpCode(200)
+  @UseGuards(EmailRegistrationGuard)
+  async validRoute() {}
+
+  @Post('test/invalid/chains/:chainId')
+  @HttpCode(200)
+  @UseGuards(EmailRegistrationGuard)
+  async invalidRouteWithChainId() {}
+
+  @Post('test/invalid/safes/:safeAddress')
+  @HttpCode(200)
+  @UseGuards(EmailRegistrationGuard)
+  async invalidRouteWithSafeAddress() {}
+}
+
+describe('EmailRegistration guard tests', () => {
+  let app;
+
+  const chainId = faker.string.numeric();
+  const safe = faker.finance.ethereumAddress();
+  const emailAddress = faker.internet.email();
+  const timestamp = faker.date.recent().getTime();
+  const privateKey = generatePrivateKey();
+  const account = privateKeyToAccount(privateKey);
+  const accountAddress = account.address;
+  let signature: Hash;
+
+  beforeAll(async () => {
+    const message = `email-register-${chainId}-${safe}-${emailAddress}-${accountAddress}-${timestamp}`;
+    signature = await account.signMessage({ message });
+  });
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 403 on empty body', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 200 on a valid signature', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress: emailAddress,
+        account: accountAddress,
+        signature: signature,
+        timestamp: timestamp,
+      })
+      .expect(200);
+  });
+
+  it('returns 403 on an invalid signature', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress: faker.internet.email(), // different email should have different signature
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the email address is missing from payload', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the account is missing from payload', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the signature is missing from payload', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the timestamp is missing from payload', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without safe address', async () => {
+    const chainId = faker.string.numeric();
+
+    await request(app.getHttpServer())
+      .post(`/test/invalid/chains/${chainId}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without chain id', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/invalid/safes/${safeAddress}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+});

--- a/src/routes/email/email-registration.guard.ts
+++ b/src/routes/email/email-registration.guard.ts
@@ -1,0 +1,71 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { verifyMessage } from 'viem';
+
+/**
+ * The EmailRegistrationGuard guard should be used on routes that require
+ * authenticated actions on registering email addresses.
+ *
+ * This guard therefore validates if the message came from the specified account.
+ *
+ * The following message should be signed:
+ * email-register-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}
+ *
+ * (where ${} represents placeholder values for the respective data)
+ *
+ * To use this guard, the route should have:
+ * - the 'chainId' declared as a parameter
+ * - the 'safeAddress' declared as a parameter
+ * - the 'emailAddress' as part of the JSON body (top level)
+ * - the 'account' as part of the JSON body (top level)
+ * - the 'signature' as part of the JSON body (top level) - see message format to be signed
+ * - the 'timestamp' as part of the JSON body (top level)
+ */
+@Injectable()
+export class EmailRegistrationGuard implements CanActivate {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  private static readonly ACTION_PREFIX = 'email-register';
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const chainId = request.params['chainId'];
+    const safe = request.params['safeAddress'];
+    const emailAddress = request.body['emailAddress'];
+    const account = request.body['account'];
+    const signature = request.body['signature'];
+    const timestamp = request.body['timestamp'];
+
+    // Required fields
+    if (
+      !chainId ||
+      !safe ||
+      !signature ||
+      !emailAddress ||
+      !account ||
+      !timestamp
+    )
+      return false;
+
+    const message = `${EmailRegistrationGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}`;
+
+    try {
+      return await verifyMessage({
+        address: account,
+        message,
+        signature,
+      });
+    } catch (e) {
+      this.loggingService.debug(e);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
The EmailRegistrationGuard is a guard that can be used to authenticate email registrations.

This guard is successful only if the provided signature is valid. The message that will be validated in the signature needs to follow the format:

`email-register-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}`

The guard can be applied to any route that has:

- the 'chainId' declared as a parameter
- the 'safeAddress' declared as a parameter
- the 'emailAddress' as part of the JSON body (top level)
- the 'account' as part of the JSON body (top level)
- the 'signature' as part of the JSON body (top level) - see message format to be signed
- the 'timestamp' as part of the JSON body (top level)