### PR TITLE
Add Timestamp guard

### DIFF
--- a/src/routes/email/timestamp.guard.spec.ts
+++ b/src/routes/email/timestamp.guard.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/configuration';
+import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { TimestampGuard } from '@/routes/email/timestamp.guard';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+
+const MAX_ELAPSED_TIME_MS = 5_000;
+
+@Controller()
+class TestController {
+  @Post('test')
+  @HttpCode(200)
+  @UseGuards(TimestampGuard(MAX_ELAPSED_TIME_MS))
+  async validRoute() {}
+}
+
+describe('TimestampGuard tests', () => {
+  let app;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    await app.close();
+  });
+
+  it('returns 403 on empty body', async () => {
+    await request(app.getHttpServer()).post(`/test`).expect(403).expect({
+      message: 'Forbidden resource',
+      error: 'Forbidden',
+      statusCode: 403,
+    });
+  });
+
+  it('returns 403 if timestamp is not a number', async () => {
+    await request(app.getHttpServer())
+      .post(`/test`)
+      .send({
+        timestamp: faker.word.sample(),
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 200 with 1ms to go', async () => {
+    const timestamp = jest.now();
+    jest.advanceTimersByTime(MAX_ELAPSED_TIME_MS - 1);
+
+    await request(app.getHttpServer())
+      .post(`/test`)
+      .send({
+        timestamp: timestamp,
+      })
+      .expect(200);
+  });
+
+  it('returns 403 with 0ms to go', async () => {
+    const timestamp = jest.now();
+    jest.advanceTimersByTime(MAX_ELAPSED_TIME_MS);
+
+    await request(app.getHttpServer())
+      .post(`/test`)
+      .send({
+        timestamp: timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+});

--- a/src/routes/email/timestamp.guard.ts
+++ b/src/routes/email/timestamp.guard.ts
@@ -1,0 +1,27 @@
+import { CanActivate, ExecutionContext, mixin } from '@nestjs/common';
+
+/**
+ * Returns a guard mixin that can be used to check if a 'timestamp'
+ * provided in the body of the HTTP request is within maxElapsedTimeMs
+ * from the current system time in UTC.
+ *
+ * @param maxElapsedTimeMs - the amount in ms to which this guard should allow
+ * the request to go through
+ */
+export const TimestampGuard = (maxElapsedTimeMs: number) => {
+  class TimestampGuardMixin implements CanActivate {
+    canActivate(context: ExecutionContext) {
+      const request = context.switchToHttp().getRequest();
+
+      const timestampRaw = request.body['timestamp'];
+      const timestamp = parseInt(timestampRaw);
+      if (isNaN(timestamp)) return false;
+
+      // UTC timezone
+      const now = Date.now();
+      return now - timestamp < maxElapsedTimeMs;
+    }
+  }
+
+  return mixin(TimestampGuardMixin);
+};


### PR DESCRIPTION
The `TimestampGuard` can be used to validate that the provided `timestamp` in an HTTP request body is within a certain time frame from the current system time (in UTC).

This timeframe can be set with `maxElapsedTimeMs`. Example:

```typescript
// Route with timestamp guard set to 5000 ms
@Post()
@UseGuards(TimestampGuard(5_000))
async route() {}
```

If the time that passed since the provided `timeframe` and the current system time is greater than `maxElapsedTimeMs`, a 403 is returned and the route is not triggered.