### PR TITLE
Fix code-generator import

### DIFF
--- a/src/domain/email/code-generator.ts
+++ b/src/domain/email/code-generator.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 /**
  * Generates a random number up to six digits
  */


### PR DESCRIPTION
The `crypto` module couldn't be resolved as-is (the import statement was missing).