### PR TITLE
Pad generated code to six characters

### DIFF
--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -43,7 +43,7 @@ describe('Email Datasource Tests', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const emailAddress = faker.internet.email();
     const signer = faker.finance.ethereumAddress();
-    const code = faker.number.int();
+    const code = faker.string.numeric();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -73,7 +73,7 @@ describe('Email Datasource Tests', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const emailAddress = faker.internet.email();
     const signer = faker.finance.ethereumAddress();
-    const code = faker.number.int();
+    const code = faker.string.numeric();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -107,7 +107,7 @@ describe('Email Datasource Tests', () => {
       safeAddress,
       emailAddress,
       signer,
-      code,
+      code: code.toString(),
     });
     const [email] = await sql<Email[]>`SELECT *
                                        FROM emails.signer_emails
@@ -118,7 +118,7 @@ describe('Email Datasource Tests', () => {
       chainId: chainId.toString(),
       safeAddress,
       signer,
-      code: newCode,
+      code: newCode.toString(),
     });
 
     expect(updatedVerificationCode.verificationCode).not.toBe(
@@ -133,7 +133,7 @@ describe('Email Datasource Tests', () => {
     const emailAddress = faker.internet.email();
     const signer = faker.finance.ethereumAddress();
     const sentOn = faker.date.recent();
-    const code = faker.number.int();
+    const code = faker.string.numeric();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -169,7 +169,7 @@ describe('Email Datasource Tests', () => {
         chainId: chainId.toString(),
         safeAddress,
         signer,
-        code: newCode,
+        code: newCode.toString(),
       }),
     ).rejects.toThrow(EmailAddressDoesNotExistError);
   });

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -13,7 +13,7 @@ export class EmailDataSource implements IEmailDataSource {
     safeAddress: string;
     emailAddress: string;
     signer: string;
-    code: number;
+    code: string;
   }): Promise<{ email: string; verificationCode: string | null }> {
     return await this.sql.begin(async (sql) => {
       const [email] = await sql<Email[]>`
@@ -33,7 +33,7 @@ export class EmailDataSource implements IEmailDataSource {
     chainId: string;
     safeAddress: string;
     signer: string;
-    code: number;
+    code: string;
   }): Promise<{ email: string; verificationCode: string | null }> {
     const [email] = await this.sql<Email[]>`UPDATE emails.signer_emails
                                             SET verification_code = ${args.code}

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -38,10 +38,15 @@ export class EmailRepository implements IEmailRepository {
 
     const verificationCode = codeGenerator();
 
+    // Pads the final verification code to 6 characters
+    // The generated code might have less than 6 digits so the version to be
+    // validated against should account with the leading zeroes
+    const paddedVerificationCode = verificationCode.toString().padStart(6, '0');
+
     try {
       await this.emailDataSource.saveEmail({
         chainId: args.chainId,
-        code: verificationCode,
+        code: paddedVerificationCode,
         emailAddress: email.value,
         safeAddress: args.safeAddress,
         signer: args.signer,

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -15,7 +15,7 @@ export interface IEmailDataSource {
     safeAddress: string;
     emailAddress: string;
     signer: string;
-    code: number;
+    code: string;
   }): Promise<{ email: string; verificationCode: string | null }>;
 
   /**
@@ -32,7 +32,7 @@ export interface IEmailDataSource {
     chainId: string;
     safeAddress: string;
     signer: string;
-    code: number;
+    code: string;
   }): Promise<{ email: string; verificationCode: string | null }>;
 
   /**


### PR DESCRIPTION
- Pads the generated code to six characters.
- The code generated by `code-generator` will be up to six digits long, however, the possible leading zeroes were not being taken into account when storing the code.
- The `saveEmail` and `setVerificationCode` functions from `IEmailDataSource` now accept `code` as a string instead of as a number. This is closer to the actual type declared for the code in the database (`text`).