### PR TITLE
Add configuration to set JSON body limit

### DIFF
--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -2,6 +2,7 @@ import { INestApplication, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { json } from 'express';
 
 function configureVersioning(app: INestApplication) {
   app.enableVersioning({
@@ -31,10 +32,23 @@ function configureSwagger(app: INestApplication) {
   });
 }
 
+function configureRequestBodyLimit(app: INestApplication) {
+  const configurationService = app.get<IConfigurationService>(
+    IConfigurationService,
+  );
+
+  const jsonBodySizeLimit =
+    configurationService.get<string>('express.jsonLimit');
+  if (jsonBodySizeLimit) {
+    app.use(json({ limit: jsonBodySizeLimit }));
+  }
+}
+
 export const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
   configureVersioning,
   configureShutdownHooks,
   configureSwagger,
+  configureRequestBodyLimit,
 ];
 
 /**

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -40,6 +40,7 @@ export default (): ReturnType<typeof configuration> => ({
       token: faker.number.int(),
     },
   },
+  express: { jsonLimit: undefined },
   features: {
     pricesProviderChainIds: ['10'],
     humanDescription: true,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -40,7 +40,7 @@ export default (): ReturnType<typeof configuration> => ({
       token: faker.number.int(),
     },
   },
-  express: { jsonLimit: undefined },
+  express: { jsonLimit: '1mb' },
   features: {
     pricesProviderChainIds: ['10'],
     humanDescription: true,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -53,7 +53,7 @@ export default () => ({
     // specifies the number of bytes; if it is a string, the value is passed to the
     // bytes library for parsing. Defaults to '100kb'.
     // https://expressjs.com/en/resources/middleware/body-parser.html
-    jsonLimit: process.env.EXPRESS_JSON_LIMIT,
+    jsonLimit: process.env.EXPRESS_JSON_LIMIT ?? '1mb',
   },
   features: {
     pricesProviderChainIds:

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -48,6 +48,13 @@ export default () => ({
       ),
     },
   },
+  express: {
+    // Controls the maximum request body size. If this is a number, then the value
+    // specifies the number of bytes; if it is a string, the value is passed to the
+    // bytes library for parsing. Defaults to '100kb'.
+    // https://expressjs.com/en/resources/middleware/body-parser.html
+    jsonLimit: process.env.EXPRESS_JSON_LIMIT,
+  },
   features: {
     pricesProviderChainIds:
       process.env.FF_PRICES_PROVIDER_CHAIN_IDS?.split(',') ?? [],


### PR DESCRIPTION
- Adds a new configuration entry which allows setting the JSON body limit of the web server.
- If none is set, it uses the default value of 1Mb.