### PR TITLE
Add E2E test database configuration

### DIFF
--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -5,3 +5,10 @@ process.env.ALERTS_PROVIDER_SIGNING_KEY = 'fake-signing-key';
 process.env.ALERTS_PROVIDER_API_KEY = 'fake-api-key';
 process.env.ALERTS_PROVIDER_ACCOUNT = 'fake-account';
 process.env.ALERTS_PROVIDER_PROJECT = 'fake-project';
+
+// For E2E tests, connect to the test database
+process.env.POSTGRES_HOST = 'localhost';
+process.env.POSTGRES_PORT = '5433';
+process.env.POSTGRES_DB = 'test-db';
+process.env.POSTGRES_USER = 'postgres';
+process.env.POSTGRES_PASSWORD = 'postgres';


### PR DESCRIPTION
The database instance used to run tests has a specific configuration and does not follow the defaults set by the application when running in a non-testing environment.

For E2E tests, we should therefore set the database connection to the database used for tests.