### PR TITLE
Send unknown recovery transaction email

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,6 +33,8 @@
 #EMAIL_API_KEY=
 # The email address to be included in the 'from' section of the emails sent.
 #EMAIL_API_FROM_EMAIL=
+# The email template reference for an unknown recovery transaction notification.
+#EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=
 # The sender name to be included in the 'from' section of the emails sent.
 # (default is 'Safe' if none is set)
 #EMAIL_API_FROM_NAME=

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -13,7 +13,7 @@ describe('Configuration validator', () => {
   it('should detect missing mandatory configuration in production environment', () => {
     process.env.NODE_ENV = 'production';
     expect(() => validate(JSON.parse(fakeJson()))).toThrow(
-      /must have required property 'AUTH_TOKEN'.*must have required property 'EXCHANGE_API_KEY'.*must have required property 'ALERTS_PROVIDER_SIGNING_KEY'.*must have required property 'ALERTS_PROVIDER_API_KEY'.*must have required property 'ALERTS_PROVIDER_ACCOUNT'.*must have required property 'ALERTS_PROVIDER_PROJECT'.*must have required property 'EMAIL_API_APPLICATION_CODE'.*must have required property 'EMAIL_API_FROM_EMAIL'.*must have required property 'EMAIL_API_KEY'/,
+      /must have required property 'AUTH_TOKEN'.*must have required property 'EXCHANGE_API_KEY'.*must have required property 'ALERTS_PROVIDER_SIGNING_KEY'.*must have required property 'ALERTS_PROVIDER_API_KEY'.*must have required property 'ALERTS_PROVIDER_ACCOUNT'.*must have required property 'ALERTS_PROVIDER_PROJECT'.*must have required property 'EMAIL_API_APPLICATION_CODE'.*must have required property 'EMAIL_API_FROM_EMAIL'.*must have required property 'EMAIL_API_KEY'.*must have required property 'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX'/,
     );
   });
 
@@ -31,6 +31,7 @@ describe('Configuration validator', () => {
         EMAIL_API_APPLICATION_CODE: faker.string.alphanumeric(),
         EMAIL_API_FROM_EMAIL: faker.internet.email(),
         EMAIL_API_KEY: faker.string.uuid(),
+        EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
       }),
     ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
   });
@@ -48,6 +49,7 @@ describe('Configuration validator', () => {
       EMAIL_API_APPLICATION_CODE: faker.string.alphanumeric(),
       EMAIL_API_FROM_EMAIL: faker.internet.email(),
       EMAIL_API_KEY: faker.string.uuid(),
+      EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
     };
     const validated = validate(expected);
     expect(validated).toBe(expected);

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -17,6 +17,7 @@ const configurationSchema: Schema = {
     EMAIL_API_APPLICATION_CODE: { type: 'string' },
     EMAIL_API_FROM_EMAIL: { type: 'string', format: 'email' },
     EMAIL_API_KEY: { type: 'string' },
+    EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: { type: 'string' },
   },
   required: [
     'AUTH_TOKEN',
@@ -28,6 +29,7 @@ const configurationSchema: Schema = {
     'EMAIL_API_APPLICATION_CODE',
     'EMAIL_API_FROM_EMAIL',
     'EMAIL_API_KEY',
+    'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX',
   ],
 };
 

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -33,6 +33,9 @@ export default (): ReturnType<typeof configuration> => ({
     apiKey: faker.string.hexadecimal({ length: 32 }),
     fromEmail: faker.internet.email(),
     fromName: faker.person.fullName(),
+    templates: {
+      unknownRecoveryTx: faker.string.alphanumeric(),
+    },
   },
   exchange: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -31,6 +31,9 @@ export default () => ({
     apiKey: process.env.EMAIL_API_KEY,
     fromEmail: process.env.EMAIL_API_FROM_EMAIL,
     fromName: process.env.EMAIL_API_FROM_NAME || 'Safe',
+    templates: {
+      unknownRecoveryTx: process.env.EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX,
+    },
   },
   exchange: {
     baseUri:

--- a/src/datasources/email-api/email-api.module.ts
+++ b/src/datasources/email-api/email-api.module.ts
@@ -1,9 +1,8 @@
 import { PushwooshApi } from '@/datasources/email-api/pushwoosh-api.service';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
-import { Global, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 
-@Global()
 @Module({
   providers: [HttpErrorFactory, { provide: IEmailApi, useClass: PushwooshApi }],
   exports: [IEmailApi],

--- a/src/datasources/email-api/email-api.module.ts
+++ b/src/datasources/email-api/email-api.module.ts
@@ -1,8 +1,9 @@
 import { PushwooshApi } from '@/datasources/email-api/pushwoosh-api.service';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 
+@Global()
 @Module({
   providers: [HttpErrorFactory, { provide: IEmailApi, useClass: PushwooshApi }],
   exports: [IEmailApi],

--- a/src/domain/alerts/alerts.domain.module.ts
+++ b/src/domain/alerts/alerts.domain.module.ts
@@ -5,9 +5,10 @@ import { IAlertsRepository } from '@/domain/alerts/alerts.repository.interface';
 import { DelayModifierDecoder } from '@/domain/alerts/contracts/delay-modifier-decoder.helper';
 import { SafeDecoder } from '@/domain/alerts/contracts/safe-decoder.helper';
 import { MultiSendDecoder } from '@/domain/alerts/contracts/multi-send-decoder.helper';
+import { EmailDomainModule } from '@/domain/email/email.domain.module';
 
 @Module({
-  imports: [AlertsApiModule],
+  imports: [AlertsApiModule, EmailDomainModule],
   providers: [
     { provide: IAlertsRepository, useClass: AlertsRepository },
     DelayModifierDecoder,

--- a/src/domain/alerts/alerts.domain.module.ts
+++ b/src/domain/alerts/alerts.domain.module.ts
@@ -6,9 +6,10 @@ import { DelayModifierDecoder } from '@/domain/alerts/contracts/delay-modifier-d
 import { SafeDecoder } from '@/domain/alerts/contracts/safe-decoder.helper';
 import { MultiSendDecoder } from '@/domain/alerts/contracts/multi-send-decoder.helper';
 import { EmailDomainModule } from '@/domain/email/email.domain.module';
+import { EmailApiModule } from '@/datasources/email-api/email-api.module';
 
 @Module({
-  imports: [AlertsApiModule, EmailDomainModule],
+  imports: [AlertsApiModule, EmailApiModule, EmailDomainModule],
   providers: [
     { provide: IAlertsRepository, useClass: AlertsRepository },
     DelayModifierDecoder,

--- a/src/domain/alerts/alerts.repository.interface.ts
+++ b/src/domain/alerts/alerts.repository.interface.ts
@@ -15,5 +15,5 @@ export interface IAlertsRepository {
    * @param chainId - chain where the alert log was generated
    * @param log - the {@link AlertLog} to decode
    */
-  handleAlertLog(chainId: string, log: AlertLog): void;
+  handleAlertLog(chainId: string, log: AlertLog): Promise<void>;
 }

--- a/src/domain/alerts/alerts.repository.interface.ts
+++ b/src/domain/alerts/alerts.repository.interface.ts
@@ -12,7 +12,8 @@ export interface IAlertsRepository {
 
   /**
    * Parses and notifies the user about the {@link log} from the Alerts provider
+   * @param chainId - chain where the alert log was generated
    * @param log - the {@link AlertLog} to decode
    */
-  handleAlertLog(log: AlertLog): void;
+  handleAlertLog(chainId: string, log: AlertLog): void;
 }

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -1,10 +1,11 @@
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import codeGenerator from '@/domain/email/code-generator';
 import { EmailAddress } from '@/domain/email/entities/email.entity';
 import { IEmailRepository } from '@/domain/email/email.repository.interface';
 import { EmailSaveError } from '@/domain/email/errors/email-save.error';
 
+@Injectable()
 export class EmailRepository implements IEmailRepository {
   constructor(
     @Inject(IEmailDataSource)

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -101,6 +101,7 @@ describe('Alerts (Unit)', () => {
     it.todo('notifies about addOwnerWithThreshold attempts');
     it.todo('notifies about non-addOwnerWithThreshold attempts');
     it.todo('notifies about alerts with multiple logs');
+    it.todo('notifies about an invalid transaction attempt');
 
     it('returns 400 (Bad Request) for valid signature/invalid payload', async () => {
       const alert = {};

--- a/src/routes/alerts/alerts.controller.ts
+++ b/src/routes/alerts/alerts.controller.ts
@@ -18,10 +18,10 @@ export class AlertsController {
   @UseGuards(TenderlySignatureGuard)
   @Post('/alerts')
   @HttpCode(200)
-  postAlert(
+  async postAlert(
     @Body(AlertValidationPipe)
     alertPayload: Alert,
-  ): void {
+  ): Promise<void> {
     this.alertsService.onAlert(alertPayload);
   }
 }

--- a/src/routes/alerts/alerts.service.ts
+++ b/src/routes/alerts/alerts.service.ts
@@ -12,10 +12,11 @@ export class AlertsService {
     private readonly alertsRepository: IAlertsRepository,
   ) {}
 
-  onAlert(alert: Alert): void {
+  async onAlert(alert: Alert): Promise<void> {
     for (const log of alert.transaction.logs) {
       try {
-        this.alertsRepository.handleAlertLog(log);
+        const chainId = alert.transaction.network;
+        await this.alertsRepository.handleAlertLog(chainId, log);
       } catch {
         this.loggingService.warn('Unknown alert received');
       }


### PR DESCRIPTION
This PR implements a notification when an unknown recovery transaction is received in an `AlertLog`. 

Domain changes:
- Injects `IEmailApi` into `AlertsRepository`, to create an email message as a user notification.
- Injects `IEmailRepository` into `AlertsRepository`, to retrieve the email addresses for the notification.

Configuration changes:
- Adds a new key `email.templates.unknownRecoveryTx` to hold the unknown recovery transaction email template reference.

Out of scope:
- At least one test should be added to `AlertsController` tests.