### PR TITLE
Retrieve verified signer email addresses for a Safe

### DIFF
--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -187,4 +187,68 @@ describe('Email Datasource Tests', () => {
       }),
     ).rejects.toThrow(EmailAddressDoesNotExistError);
   });
+
+  it('gets verified email addresses for a given safe address', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const verifiedSigners = [
+      {
+        emailAddress: faker.internet.email(),
+        signer: faker.finance.ethereumAddress(),
+        code: faker.number.int({ max: 999998 }).toString(),
+      },
+      {
+        emailAddress: faker.internet.email(),
+        signer: faker.finance.ethereumAddress(),
+        code: faker.number.int({ max: 999998 }).toString(),
+      },
+    ];
+    const nonVerifiedSigners = [
+      {
+        emailAddress: faker.internet.email(),
+        signer: faker.finance.ethereumAddress(),
+        code: faker.number.int({ max: 999998 }).toString(),
+      },
+      {
+        emailAddress: faker.internet.email(),
+        signer: faker.finance.ethereumAddress(),
+        code: faker.number.int({ max: 999998 }).toString(),
+      },
+    ];
+    await Promise.all(
+      verifiedSigners.map(async ({ emailAddress, signer, code }) => {
+        await target.saveEmail({
+          chainId,
+          safeAddress,
+          emailAddress,
+          signer,
+          code,
+        });
+        await target.setVerificationSentDate({
+          chainId,
+          safeAddress,
+          signer,
+          sentOn: faker.date.recent(),
+        });
+      }),
+    );
+    await Promise.all(
+      nonVerifiedSigners.map(async ({ emailAddress, signer, code }) => {
+        await target.saveEmail({
+          chainId,
+          safeAddress,
+          emailAddress,
+          signer,
+          code,
+        });
+      }),
+    );
+
+    const result = await target.getVerifiedSignerEmailsBySafeAddress({
+      chainId,
+      safeAddress,
+    });
+
+    expect(result).toBeDefined(); // TODO:
+  });
 });

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -12,10 +12,11 @@ export class EmailDataSource implements IEmailDataSource {
     chainId: string;
     safeAddress: string;
   }): Promise<{ email: string }[]> {
-    const emails = await this.sql<Email[]>`
+    const emails = await this.sql<{ email_address: string }[]>`
       SELECT email_address
       FROM emails.signer_emails
-      WHERE chain_id = ${args.chainId} AND safe_address = ${args.safeAddress} AND verified is true`;
+      WHERE chain_id = ${args.chainId} AND safe_address = ${args.safeAddress} AND verified is true
+      ORDER by id`;
 
     return emails.map((email) => ({ email: email.email_address }));
   }

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -8,6 +8,18 @@ import { Email } from '@/datasources/email/entities/email.entity';
 export class EmailDataSource implements IEmailDataSource {
   constructor(@Inject('DB_INSTANCE') private readonly sql: postgres.Sql) {}
 
+  async getVerifiedSignerEmailsBySafeAddress(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<{ email: string }[]> {
+    const emails = await this.sql<Email[]>`
+      SELECT email_address
+      FROM emails.signer_emails
+      WHERE chain_id = ${args.chainId} AND safe_address = ${args.safeAddress} AND verified is true`;
+
+    return emails.map((email) => ({ email: email.email_address }));
+  }
+
   async saveEmail(args: {
     chainId: string;
     safeAddress: string;

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -2,6 +2,17 @@ export const IEmailDataSource = Symbol('IEmailDataSource');
 
 export interface IEmailDataSource {
   /**
+   * Gets the array of verified emails associated with a Safe address.
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to use as filter
+   */
+  getVerifiedSignerEmailsBySafeAddress(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<{ email: string }[]>;
+
+  /**
    * Saves an email entry in the respective data source.
    *
    * @param args.chainId - the chain id of where the Safe is deployed

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -2,7 +2,7 @@ export const IEmailDataSource = Symbol('IEmailDataSource');
 
 export interface IEmailDataSource {
   /**
-   * Gets the array of verified emails associated with a Safe address.
+   * Gets the verified emails associated with a Safe address.
    *
    * @param args.chainId - the chain id of where the Safe is deployed
    * @param args.safeAddress - the Safe address to use as filter


### PR DESCRIPTION
Datasource changes:
- Adds `getVerifiedSignerEmailsBySafeAddress` to `IEmailDataSource`. This allows the clients of the data source class to retrieve the email addresses associated with a given Safe address, which have been previously verified.