### PR TITLE
Extend IEmailRepository

### DIFF
--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -1,6 +1,25 @@
 export const IEmailRepository = Symbol('IEmailRepository');
 
 export interface IEmailRepository {
+  /**
+   * Gets the verified emails associated with a Safe address.
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to use as filter
+   */
+  getVerifiedEmailsBySafeAddress(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<string[]>;
+
+  /**
+   * Saves an email entry.
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which we should store the email address
+   * @param args.emailAddress - the email address to store
+   * @param args.account - the owner address to which we should link the email address to
+   */
   saveEmail(args: {
     chainId: string;
     safeAddress: string;

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -39,4 +39,13 @@ export class EmailRepository implements IEmailRepository {
       throw new EmailSaveError(args.chainId, args.safeAddress, args.account);
     }
   }
+
+  async getVerifiedEmailsBySafeAddress(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<string[]> {
+    const emails =
+      await this.emailDataSource.getVerifiedSignerEmailsBySafeAddress(args);
+    return emails.map(({ email }) => email);
+  }
 }


### PR DESCRIPTION
This PR extends the `IEmailRepository` interface and its implementation. The new function added to the interface will be used by https://github.com/safe-global/safe-client-gateway/pull/872 

Domain changes:
- Adds `getVerifiedEmailsBySafeAddress` in order to retrieve the verified email addresses associated with a Safe address.