### PR TITLE
Clear safe info on MODULE_TRANSACTION events

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -348,6 +348,11 @@ describe('Post Hook Events (Unit)', () => {
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
+    {
+      type: 'MODULE_TRANSACTION',
+      module: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
   ])('$type clears safe info', async (payload) => {
     const safeAddress = faker.finance.ethereumAddress();
     const chainId = faker.string.numeric();

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -77,6 +77,7 @@ export class CacheHooksService {
       // An executed module transaction might affect:
       // - the list of all executed transactions for the safe
       // - the list of module transactions for the safe
+      // - the safe configuration
       case EventType.MODULE_TRANSACTION:
         promises.push(
           this.safeRepository.clearAllExecutedTransactions({
@@ -86,6 +87,10 @@ export class CacheHooksService {
           this.safeRepository.clearModuleTransactions({
             chainId: event.chainId,
             safeAddress: event.address,
+          }),
+          this.safeRepository.clearSafe({
+            chainId: event.chainId,
+            address: event.address,
           }),
         );
         this._logTxEvent(event);


### PR DESCRIPTION
An event of type `MODULE_TRANSACTION` can change the configuration of the safe. Therefore, the Safe configuration stored locally should be cleared.