### PR TITLE
Remove unused SignerNotOwnerError

### DIFF
--- a/src/domain/email/errors/signer-not-owner.error.ts
+++ b/src/domain/email/errors/signer-not-owner.error.ts
@@ -1,7 +1,0 @@
-export class SignerNotOwnerError extends Error {
-  constructor(chainId: string, safeAddress: string, signer: string) {
-    super(
-      `Signer ${signer} is not an owner of the safe ${safeAddress} on chain ${chainId}.`,
-    );
-  }
-}


### PR DESCRIPTION
Removes `SignerNotOwnerError`. This error was previously used in the domain layer for validating if the signer is an owner. However, that validation is now part of the route layer.