### PR TITLE
Add functionality to resend email verification

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -36,6 +36,10 @@ export default (): ReturnType<typeof configuration> => ({
     templates: {
       unknownRecoveryTx: faker.string.alphanumeric(),
     },
+    verificationCode: {
+      resendLockWindowMs: faker.number.int(),
+      ttlMs: faker.number.int(),
+    },
   },
   exchange: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -34,6 +34,15 @@ export default () => ({
     templates: {
       unknownRecoveryTx: process.env.EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX,
     },
+    verificationCode: {
+      resendLockWindowMs: parseInt(
+        process.env.EMAIL_VERIFICATION_CODE_RESEND_LOCK_WINDOW_MS ??
+          `${30 * 1000}`,
+      ),
+      ttlMs: parseInt(
+        process.env.EMAIL_VERIFICATION_CODE_TTL_MS ?? `${5 * 60 * 1000}`,
+      ),
+    },
   },
   exchange: {
     baseUri:

--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -26,4 +26,22 @@ export interface IEmailRepository {
     emailAddress: string;
     account: string;
   }): Promise<void>;
+
+  /**
+   * Resends the email verification code for an email registration
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which we should store the email address
+   * @param args.signer - the owner address to which we should link the email address to
+   *
+   * @throws {EmailAlreadyVerifiedError} - if the email is already verified
+   * @throws {ResendVerificationTimespanError} -
+   * if trying to trigger a resend within email.verificationCode.resendLockWindowMs
+   * @throws {InvalidVerificationCodeError} - if a verification code was not set
+   */
+  resendEmailVerification(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<void>;
 }

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -4,13 +4,38 @@ import codeGenerator from '@/domain/email/code-generator';
 import { EmailAddress } from '@/domain/email/entities/email.entity';
 import { IEmailRepository } from '@/domain/email/email.repository.interface';
 import { EmailSaveError } from '@/domain/email/errors/email-save.error';
+import { ResendVerificationTimespanError } from '@/domain/email/errors/verification-timeframe.error';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { EmailAlreadyVerifiedError } from '@/domain/email/errors/email-already-verified.error';
+import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-verification-code.error';
 
 @Injectable()
 export class EmailRepository implements IEmailRepository {
+  private readonly verificationCodeResendLockWindowMs: number;
+  private readonly verificationCodeTtlMs: number;
+
   constructor(
     @Inject(IEmailDataSource)
     private readonly emailDataSource: IEmailDataSource,
-  ) {}
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.verificationCodeResendLockWindowMs =
+      this.configurationService.getOrThrow(
+        'email.verificationCode.resendLockWindowMs',
+      );
+    this.verificationCodeTtlMs = this.configurationService.getOrThrow(
+      'email.verificationCode.ttlMs',
+    );
+  }
+
+  private _generateCode() {
+    const verificationCode = codeGenerator();
+    // Pads the final verification code to 6 characters
+    // The generated code might have less than 6 digits so the version to be
+    // validated against should account with the leading zeroes
+    return verificationCode.toString().padStart(6, '0');
+  }
 
   async saveEmail(args: {
     chainId: string;
@@ -19,24 +44,22 @@ export class EmailRepository implements IEmailRepository {
     account: string;
   }): Promise<void> {
     const email = new EmailAddress(args.emailAddress);
-    const verificationCode = codeGenerator();
-
-    // Pads the final verification code to 6 characters
-    // The generated code might have less than 6 digits so the version to be
-    // validated against should account with the leading zeroes
-    const paddedVerificationCode = verificationCode.toString().padStart(6, '0');
+    const verificationCode = this._generateCode();
 
     try {
       await this.emailDataSource.saveEmail({
         chainId: args.chainId,
-        code: paddedVerificationCode,
+        code: verificationCode,
         emailAddress: email,
         safeAddress: args.safeAddress,
         signer: args.account,
         codeGenerationDate: new Date(),
       });
-
-      // TODO if successful, send the generated code (result.verification)
+      await this._sendEmailVerification({
+        ...args,
+        signer: args.account,
+        code: verificationCode,
+      });
     } catch (e) {
       throw new EmailSaveError(args.chainId, args.safeAddress, args.account);
     }
@@ -49,5 +72,72 @@ export class EmailRepository implements IEmailRepository {
     const emails =
       await this.emailDataSource.getVerifiedSignerEmailsBySafeAddress(args);
     return emails.map(({ email }) => email);
+  }
+
+  async resendEmailVerification(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<void> {
+    let email = await this.emailDataSource.getEmail(args);
+
+    // If the email was already verified, we should not send out a new
+    // verification code
+    if (email.isVerified) {
+      throw new EmailAlreadyVerifiedError(args);
+    }
+
+    // If there's a date for when the verification was sent out,
+    // check if timespan is still valid.
+    if (email.verificationSentOn) {
+      const timespanMs = Date.now() - email.verificationSentOn.getTime();
+      if (timespanMs < this.verificationCodeResendLockWindowMs) {
+        throw new ResendVerificationTimespanError({
+          ...args,
+          timespanMs,
+          lockWindowMs: this.verificationCodeResendLockWindowMs,
+        });
+      }
+    }
+
+    const isCodeValid = email.verificationGeneratedOn
+      ? Date.now() - email.verificationGeneratedOn.getTime() <
+        this.verificationCodeTtlMs
+      : false;
+
+    if (!isCodeValid) {
+      // Expired code. Generate new one
+      await this.emailDataSource.setVerificationCode({
+        chainId: args.chainId,
+        safeAddress: args.safeAddress,
+        signer: args.signer,
+        code: this._generateCode(),
+        codeGenerationDate: new Date(),
+      });
+    }
+
+    email = await this.emailDataSource.getEmail(args);
+    if (!email.verificationCode) {
+      throw new InvalidVerificationCodeError(args);
+    }
+
+    await this._sendEmailVerification({
+      ...args,
+      code: email.verificationCode,
+    });
+  }
+
+  private async _sendEmailVerification(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+    code: string;
+  }) {
+    // TODO send email via provider
+    // Update verification-sent date on a successful response
+    await this.emailDataSource.setVerificationSentDate({
+      ...args,
+      sentOn: new Date(),
+    });
   }
 }

--- a/src/domain/email/errors/email-already-verified.error.ts
+++ b/src/domain/email/errors/email-already-verified.error.ts
@@ -1,0 +1,7 @@
+export class EmailAlreadyVerifiedError extends Error {
+  constructor(args: { chainId: string; safeAddress: string; signer: string }) {
+    super(
+      `The email address is already verified. chainId=${args.chainId}, safeAddress=${args.safeAddress}, signer=${args.signer}`,
+    );
+  }
+}

--- a/src/domain/email/errors/invalid-verification-code.error.ts
+++ b/src/domain/email/errors/invalid-verification-code.error.ts
@@ -1,0 +1,7 @@
+export class InvalidVerificationCodeError extends Error {
+  constructor(args: { chainId: string; safeAddress: string; signer: string }) {
+    super(
+      `The verification code is invalid. chainId=${args.chainId}, safeAddress=${args.safeAddress}, signer=${args.signer} `,
+    );
+  }
+}

--- a/src/domain/email/errors/verification-timeframe.error.ts
+++ b/src/domain/email/errors/verification-timeframe.error.ts
@@ -1,0 +1,13 @@
+export class ResendVerificationTimespanError extends Error {
+  constructor(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+    timespanMs: number;
+    lockWindowMs: number;
+  }) {
+    super(
+      `Verification cannot be re-sent at this time. ${args.timespanMs} ms have elapsed out of ${args.lockWindowMs} ms for signer=${args.signer}, safe=${args.safeAddress}, chainId=${args.chainId}`,
+    );
+  }
+}


### PR DESCRIPTION
- The `IEmailRepository` was extended to have a function for resending email verifications.
- The email verification can be resent if enough time has passed since this action was last triggered successfully. This timeframe is configurable with `EMAIL_VERIFICATION_CODE_RESEND_LOCK_WINDOW_MS` (default is 30 seconds).
- When resending the verification code, if the current code is still valid, then it is re-sent. If it expired, then a new one is generated, stored and re-sent to the same email address. The expiration time of the code can be set via `EMAIL_VERIFICATION_CODE_TTL_MS`.
- If this action is triggered for verified owners, an `EmailAlreadyVerifiedError` is thrown.
- If this action is triggered within `EMAIL_VERIFICATION_CODE_RESEND_LOCK_WINDOW_MS` from the last successful one, a `ResendVerificationTimespanError` is thrown.
- Else, it attempts to set a new code and send it. If the new code was not set, an `InvalidVerificationCodeError` is thrown.

### Out of scope

- Unit testing will be done from the route perspective and will cover the domain layer introduced here