### PR TITLE
Store verification code generation date

### DIFF
--- a/migrations/00001_initial/index.sql
+++ b/migrations/00001_initial/index.sql
@@ -4,13 +4,14 @@ CREATE SCHEMA emails;
 DROP TABLE IF EXISTS emails.signer_emails CASCADE;
 CREATE table emails.signer_emails
 (
-    id                   SERIAL PRIMARY KEY,
-    chain_id             int                   NOT NULL,
-    email_address        text                  NOT NULL,
-    safe_address         character varying(42) NOT NULL,
-    signer               character varying(42) NOT NULL,
-    verified             boolean               NOT NULL DEFAULT false,
-    verification_code    text,
-    verification_sent_on timestamp with time zone,
+    id                             SERIAL PRIMARY KEY,
+    chain_id                       int                   NOT NULL,
+    email_address                  text                  NOT NULL,
+    safe_address                   character varying(42) NOT NULL,
+    signer                         character varying(42) NOT NULL,
+    verified                       boolean               NOT NULL DEFAULT false,
+    verification_code              text,
+    verification_code_generated_on timestamp with time zone,
+    verification_sent_on           timestamp with time zone,
     UNIQUE (chain_id, safe_address, signer)
 );

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -44,6 +44,7 @@ describe('Email Datasource Tests', () => {
     const emailAddress = new EmailAddress(faker.internet.email());
     const signer = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -51,6 +52,7 @@ describe('Email Datasource Tests', () => {
       emailAddress,
       signer,
       code,
+      codeGenerationDate,
     });
     const email = await target.getEmail({
       chainId: chainId.toString(),
@@ -75,6 +77,7 @@ describe('Email Datasource Tests', () => {
     const emailAddress = new EmailAddress(faker.internet.email());
     const signer = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -82,6 +85,7 @@ describe('Email Datasource Tests', () => {
       emailAddress,
       signer,
       code,
+      codeGenerationDate,
     });
 
     await expect(
@@ -91,6 +95,7 @@ describe('Email Datasource Tests', () => {
         emailAddress,
         signer,
         code,
+        codeGenerationDate,
       }),
     ).rejects.toThrow(PostgresError);
   });
@@ -101,7 +106,9 @@ describe('Email Datasource Tests', () => {
     const emailAddress = new EmailAddress(faker.internet.email());
     const signer = faker.finance.ethereumAddress();
     const code = faker.number.int({ max: 999998 });
+    const codeGenerationDate = faker.date.recent();
     const newCode = code + 1;
+    const newCodeGenerationDate = faker.date.recent();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -109,6 +116,7 @@ describe('Email Datasource Tests', () => {
       emailAddress,
       signer,
       code: code.toString(),
+      codeGenerationDate,
     });
     const savedEmail = await target.getEmail({
       chainId: chainId.toString(),
@@ -120,6 +128,7 @@ describe('Email Datasource Tests', () => {
       safeAddress,
       signer,
       code: newCode.toString(),
+      codeGenerationDate: newCodeGenerationDate,
     });
 
     const updatedEmail = await target.getEmail({
@@ -138,6 +147,7 @@ describe('Email Datasource Tests', () => {
     const signer = faker.finance.ethereumAddress();
     const sentOn = faker.date.recent();
     const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -145,6 +155,7 @@ describe('Email Datasource Tests', () => {
       emailAddress,
       signer,
       code,
+      codeGenerationDate,
     });
     await target.setVerificationSentDate({
       chainId: chainId.toString(),
@@ -167,6 +178,7 @@ describe('Email Datasource Tests', () => {
     const signer = faker.finance.ethereumAddress();
     const code = faker.number.int({ max: 999998 });
     const newCode = code + 1;
+    const newCodeGenerationDate = faker.date.recent();
 
     await expect(
       target.setVerificationCode({
@@ -174,6 +186,7 @@ describe('Email Datasource Tests', () => {
         safeAddress,
         signer,
         code: newCode.toString(),
+        codeGenerationDate: newCodeGenerationDate,
       }),
     ).rejects.toThrow(EmailAddressDoesNotExistError);
   });
@@ -200,11 +213,13 @@ describe('Email Datasource Tests', () => {
         emailAddress: new EmailAddress(faker.internet.email()),
         signer: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
+        codeGenerationDate: faker.date.recent(),
       },
       {
         emailAddress: new EmailAddress(faker.internet.email()),
         signer: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
+        codeGenerationDate: faker.date.recent(),
       },
     ];
     const nonVerifiedSigners = [
@@ -212,20 +227,28 @@ describe('Email Datasource Tests', () => {
         emailAddress: new EmailAddress(faker.internet.email()),
         signer: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
+        codeGenerationDate: faker.date.recent(),
       },
       {
         emailAddress: new EmailAddress(faker.internet.email()),
         signer: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
+        codeGenerationDate: faker.date.recent(),
       },
     ];
-    for (const { emailAddress, signer, code } of verifiedSigners) {
+    for (const {
+      emailAddress,
+      signer,
+      code,
+      codeGenerationDate,
+    } of verifiedSigners) {
       await target.saveEmail({
         chainId,
         safeAddress,
         emailAddress,
         signer,
         code,
+        codeGenerationDate,
       });
       await target.verifyEmail({
         chainId: chainId,
@@ -233,13 +256,19 @@ describe('Email Datasource Tests', () => {
         signer,
       });
     }
-    for (const { emailAddress, signer, code } of nonVerifiedSigners) {
+    for (const {
+      emailAddress,
+      signer,
+      code,
+      codeGenerationDate,
+    } of nonVerifiedSigners) {
       await target.saveEmail({
         chainId,
         safeAddress,
         emailAddress,
         signer,
         code,
+        codeGenerationDate,
       });
     }
 

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -138,6 +138,7 @@ describe('Email Datasource Tests', () => {
     });
     expect(updatedEmail.verificationCode).not.toBe(savedEmail.verificationCode);
     expect(updatedEmail.verificationSentOn).toBeNull();
+    expect(updatedEmail.verificationGeneratedOn).toEqual(newCodeGenerationDate);
   });
 
   it('sets verification sent date successfully', async () => {

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -63,6 +63,7 @@ export class EmailDataSource implements IEmailDataSource {
       safeAddress: email.safe_address,
       signer: email.signer,
       verificationCode: email.verification_code,
+      verificationGeneratedOn: email.verification_code_generated_on,
       verificationSentOn: email.verification_sent_on,
     };
   }
@@ -94,7 +95,8 @@ export class EmailDataSource implements IEmailDataSource {
     codeGenerationDate: Date;
   }): Promise<void> {
     const [email] = await this.sql<Email[]>`UPDATE emails.signer_emails
-                                            SET verification_code = ${args.code}
+                                            SET verification_code              = ${args.code},
+                                                verification_code_generated_on = ${args.codeGenerationDate}
                                             WHERE chain_id = ${args.chainId}
                                               AND safe_address = ${args.safeAddress}
                                               AND signer = ${args.signer}

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -32,6 +32,7 @@ export class EmailRepository implements IEmailRepository {
         emailAddress: email,
         safeAddress: args.safeAddress,
         signer: args.account,
+        codeGenerationDate: new Date(),
       });
 
       // TODO if successful, send the generated code (result.verification)

--- a/src/domain/email/entities/email.entity.ts
+++ b/src/domain/email/entities/email.entity.ts
@@ -11,6 +11,7 @@ export interface Email {
   safeAddress: string;
   signer: string;
   verificationCode: string | null;
+  verificationGeneratedOn: Date | null;
   verificationSentOn: Date | null;
 }
 

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -35,6 +35,7 @@ export interface IEmailDataSource {
    * @param args.emailAddress - the email address to store
    * @param args.signer - the owner address to which we should link the email address to
    * @param args.code - the generated code to be used to verify this email address
+   * @param args.verificationGeneratedOn – the date which represents when the code was generated
    */
   saveEmail(args: {
     chainId: string;
@@ -42,6 +43,7 @@ export interface IEmailDataSource {
     emailAddress: EmailAddress;
     signer: string;
     code: string;
+    codeGenerationDate: Date;
   }): Promise<void>;
 
   /**
@@ -53,12 +55,14 @@ export interface IEmailDataSource {
    * @param args.safeAddress - the Safe address
    * @param args.signer - the owner address
    * @param args.code - the generated code to be used to verify this email address
+   * @param args.verificationGeneratedOn – the date which represents when the code was generated
    */
   setVerificationCode(args: {
     chainId: string;
     safeAddress: string;
     signer: string;
     code: string;
+    codeGenerationDate: Date;
   }): Promise<void>;
 
   /**


### PR DESCRIPTION
- Adds a new column `verification_code_generated_on`, which stores when the verification code was generated.
- This effectively decouples the code generation time with the time that the verification was sent out (as sending a verification relies on an external system which is not guaranteed to succeed).
- We can then apply different rules to the code generation time and the time the code was sent out.

Note that this changes the initial migration directly as there's no deployment for the database at the moment, so we avoid creating a new migration file. For local database deployments a database schema reset is required.