### PR TITLE
Refactor configuration validator tests

### DIFF
--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -1,21 +1,56 @@
 import { faker } from '@faker-js/faker';
 import { fakeJson } from '@/__tests__/faker';
 import { validate } from '@/config/configuration.validator';
+import { omit } from 'lodash';
 
 describe('Configuration validator', () => {
-  it('should bypass this validation on tests', () => {
+  const validConfiguration = {
+    ...JSON.parse(fakeJson()),
+    AUTH_TOKEN: faker.string.uuid(),
+    EXCHANGE_API_KEY: faker.string.uuid(),
+    ALERTS_PROVIDER_SIGNING_KEY: faker.string.uuid(),
+    ALERTS_PROVIDER_API_KEY: faker.string.uuid(),
+    ALERTS_PROVIDER_ACCOUNT: faker.string.alphanumeric(),
+    ALERTS_PROVIDER_PROJECT: faker.string.alphanumeric(),
+    EMAIL_API_APPLICATION_CODE: faker.string.alphanumeric(),
+    EMAIL_API_FROM_EMAIL: faker.internet.email(),
+    EMAIL_API_KEY: faker.string.uuid(),
+    EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
+  };
+
+  it('should bypass this validation on test environment', () => {
     process.env.NODE_ENV = 'test';
     const expected = JSON.parse(fakeJson());
     const validated = validate(expected);
     expect(validated).toBe(expected);
   });
 
-  it('should detect missing mandatory configuration in production environment', () => {
+  it('should return the input configuration if validated in production environment', () => {
     process.env.NODE_ENV = 'production';
-    expect(() => validate(JSON.parse(fakeJson()))).toThrow(
-      /must have required property 'AUTH_TOKEN'.*must have required property 'EXCHANGE_API_KEY'.*must have required property 'ALERTS_PROVIDER_SIGNING_KEY'.*must have required property 'ALERTS_PROVIDER_API_KEY'.*must have required property 'ALERTS_PROVIDER_ACCOUNT'.*must have required property 'ALERTS_PROVIDER_PROJECT'.*must have required property 'EMAIL_API_APPLICATION_CODE'.*must have required property 'EMAIL_API_FROM_EMAIL'.*must have required property 'EMAIL_API_KEY'.*must have required property 'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX'/,
-    );
+    const validated = validate(validConfiguration);
+    expect(validated).toBe(validConfiguration);
   });
+
+  it.each([
+    { key: 'AUTH_TOKEN' },
+    { key: 'EXCHANGE_API_KEY' },
+    { key: 'ALERTS_PROVIDER_SIGNING_KEY' },
+    { key: 'ALERTS_PROVIDER_API_KEY' },
+    { key: 'ALERTS_PROVIDER_ACCOUNT' },
+    { key: 'ALERTS_PROVIDER_PROJECT' },
+    { key: 'EMAIL_API_APPLICATION_CODE' },
+    { key: 'EMAIL_API_FROM_EMAIL' },
+    { key: 'EMAIL_API_KEY' },
+    { key: 'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX' },
+  ])(
+    'should detect that $key is missing in the configuration in production environment',
+    ({ key }) => {
+      process.env.NODE_ENV = 'production';
+      expect(() => validate(omit(validConfiguration, key))).toThrow(
+        `must have required property '${key}'`,
+      );
+    },
+  );
 
   it('should an invalid LOG_LEVEL configuration in production environment', () => {
     expect(() =>
@@ -34,24 +69,5 @@ describe('Configuration validator', () => {
         EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
       }),
     ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
-  });
-
-  it('should return the input configuration if validated in production environment', () => {
-    process.env.NODE_ENV = 'production';
-    const expected = {
-      ...JSON.parse(fakeJson()),
-      AUTH_TOKEN: faker.string.uuid(),
-      EXCHANGE_API_KEY: faker.string.uuid(),
-      ALERTS_PROVIDER_SIGNING_KEY: faker.string.uuid(),
-      ALERTS_PROVIDER_API_KEY: faker.string.uuid(),
-      ALERTS_PROVIDER_ACCOUNT: faker.string.alphanumeric(),
-      ALERTS_PROVIDER_PROJECT: faker.string.alphanumeric(),
-      EMAIL_API_APPLICATION_CODE: faker.string.alphanumeric(),
-      EMAIL_API_FROM_EMAIL: faker.internet.email(),
-      EMAIL_API_KEY: faker.string.uuid(),
-      EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
-    };
-    const validated = validate(expected);
-    expect(validated).toBe(expected);
   });
 });


### PR DESCRIPTION
- Changes the test strategy followed by `configurator.validator.ts` tests, from checking all the errors are thrown for all the missing keys, to having a correct configuration setup and testing each key missing in a separate test.

(Additional context https://github.com/safe-global/safe-client-gateway/pull/872#discussion_r1411927596)