### PR TITLE
Fix Alerts module initialization

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -49,6 +49,7 @@ export class AppModule implements NestModule {
   // into account. The .env file loading is done by the ConfigurationModule
   // which is not available at this stage.
   static register(configFactory: ConfigFactory = configuration): DynamicModule {
+    const isAlertsFeatureEnabled = configFactory()['features']['alerts'];
     const isEmailFeatureEnabled = configFactory()['features']['email'];
 
     return {
@@ -56,7 +57,7 @@ export class AppModule implements NestModule {
       imports: [
         // features
         AboutModule,
-        AlertsControllerModule,
+        ...(isAlertsFeatureEnabled ? [AlertsControllerModule] : []),
         BalancesModule,
         CacheHooksModule,
         ChainsModule,

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -174,7 +174,7 @@ describe('Alerts (Unit)', () => {
       await app.close();
     });
 
-    it('returns 403 (Forbidden) for valid signature/invalid payload', async () => {
+    it('returns 404 (Not found) for valid signature/invalid payload', async () => {
       const alert = alertBuilder().build();
       const timestamp = Date.now().toString();
       const signature = fakeTenderlySignature({
@@ -188,7 +188,7 @@ describe('Alerts (Unit)', () => {
         .set('x-tenderly-signature', signature)
         .set('date', timestamp)
         .send(alert)
-        .expect(403);
+        .expect(404);
     });
   });
 });


### PR DESCRIPTION
**Context**
After the change introduced in https://github.com/safe-global/safe-client-gateway/pull/872/files#diff-9961bac5b881a3ac11264f2978fb3625bc5fa90afb3a61585ed6951c1d3d00d5R12, `AlertsControllerModule` dependencies graph now includes `EmailDomainModule` transitively, so this module gets initialized, and therefore the application tries to connect to the emails database.

Changes:
- Checks `FF_ALERTS` is enabled before adding `AlertsControllerModule` to the service dependency injections graph.