### PR TITLE
Merge alerts, email and recovery features

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -42,6 +42,7 @@ import { RootModule } from '@/routes/root/root.module';
 import { ConfigFactory } from '@nestjs/config/dist/interfaces/config-factory.interface';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { AlertsControllerModule } from '@/routes/alerts/alerts.controller.module';
+import { RecoveryModule } from '@/routes/recovery/recovery.module';
 
 @Module({})
 export class AppModule implements NestModule {
@@ -56,7 +57,6 @@ export class AppModule implements NestModule {
       imports: [
         // features
         AboutModule,
-        AlertsControllerModule,
         BalancesModule,
         CacheHooksModule,
         ChainsModule,
@@ -64,7 +64,9 @@ export class AppModule implements NestModule {
         ContractsModule,
         DataDecodedModule,
         DelegatesModule,
-        ...(isEmailFeatureEnabled ? [EmailControllerModule] : []),
+        ...(isEmailFeatureEnabled
+          ? [AlertsControllerModule, EmailControllerModule, RecoveryModule]
+          : []),
         EstimationsModule,
         FlushModule,
         HealthModule,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -54,8 +54,6 @@ export default (): ReturnType<typeof configuration> => ({
   features: {
     pricesProviderChainIds: ['10'],
     humanDescription: true,
-    alerts: true,
-    recovery: true,
     noncesRoute: true,
     email: true,
   },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -70,8 +70,6 @@ export default () => ({
       process.env.FF_PRICES_PROVIDER_CHAIN_IDS?.split(',') ?? [],
     humanDescription:
       process.env.FF_HUMAN_DESCRIPTION?.toLowerCase() === 'true',
-    alerts: process.env.FF_ALERTS?.toLowerCase() === 'true',
-    recovery: process.env.FF_RECOVERY?.toLowerCase() === 'true',
     noncesRoute: process.env.FF_NONCES_ROUTE?.toLowerCase() === 'true',
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
   },

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -52,7 +52,7 @@ describe('Alerts (Unit)', () => {
         ...defaultConfiguration,
         features: {
           ...defaultConfiguration.features,
-          alerts: true,
+          email: true,
         },
       });
 
@@ -146,7 +146,7 @@ describe('Alerts (Unit)', () => {
         ...defaultConfiguration,
         features: {
           ...defaultConfiguration.features,
-          alerts: false,
+          email: false,
         },
       });
 
@@ -174,7 +174,7 @@ describe('Alerts (Unit)', () => {
       await app.close();
     });
 
-    it('returns 403 (Forbidden) for valid signature/invalid payload', async () => {
+    it('returns 404 (Not found) for valid signature/invalid payload', async () => {
       const alert = alertBuilder().build();
       const timestamp = Date.now().toString();
       const signature = fakeTenderlySignature({
@@ -188,7 +188,7 @@ describe('Alerts (Unit)', () => {
         .set('x-tenderly-signature', signature)
         .set('date', timestamp)
         .send(alert)
-        .expect(403);
+        .expect(404);
     });
   });
 });

--- a/src/routes/alerts/guards/alerts-route.guard.ts
+++ b/src/routes/alerts/guards/alerts-route.guard.ts
@@ -9,6 +9,6 @@ export class AlertsRouteGuard implements CanActivate {
   ) {}
 
   canActivate() {
-    return this.configurationService.getOrThrow<boolean>('features.alerts');
+    return this.configurationService.getOrThrow<boolean>('features.email');
   }
 }


### PR DESCRIPTION
- Removes `features.alerts` and `features.recovery` from the service configuration.
- These features are highly coupled to the email implementation which requires a deployed database.
- Setting `features.email` will now enable or disable the alerts, email and recovery related features.