### PR TITLE
Return `null` for "empty" `SafeInfo` tags

### DIFF
--- a/src/routes/safes/entities/safe-info.entity.ts
+++ b/src/routes/safes/entities/safe-info.entity.ts
@@ -31,13 +31,13 @@ export class SafeState {
   @ApiProperty({ enum: Object.values(MasterCopyVersionState) })
   readonly implementationVersionState: MasterCopyVersionState;
   @ApiProperty()
-  readonly collectiblesTag: string;
+  readonly collectiblesTag: string | null;
   @ApiProperty()
-  readonly txQueuedTag: string;
+  readonly txQueuedTag: string | null;
   @ApiProperty()
-  readonly txHistoryTag: string;
+  readonly txHistoryTag: string | null;
   @ApiProperty()
-  readonly messagesTag: string;
+  readonly messagesTag: string | null;
 
   constructor(
     address: AddressInfo,
@@ -47,10 +47,10 @@ export class SafeState {
     owners: AddressInfo[],
     implementation: AddressInfo,
     implementationVersionState: MasterCopyVersionState,
-    collectiblesTag: string,
-    txQueuedTag: string,
-    txHistoryTag: string,
-    messagesTag: string,
+    collectiblesTag: string | null,
+    txQueuedTag: string | null,
+    txHistoryTag: string | null,
+    messagesTag: string | null,
     modules: AddressInfo[] | null,
     fallbackHandler: AddressInfo | null,
     guard: AddressInfo | null,

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -543,12 +543,7 @@ describe('Safes Controller (Unit)', () => {
       );
   });
 
-  it('txQueuedTag is now if there are no Multisig transactions', async () => {
-    jest.useFakeTimers();
-
-    const date = faker.date.anytime();
-    jest.setSystemTime(date);
-
+  it('txQueuedTag is null if there are no Multisig transactions', async () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
@@ -595,19 +590,12 @@ describe('Safes Controller (Unit)', () => {
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
-          txQueuedTag: Math.floor(date.getTime() / 1000).toString(),
+          txQueuedTag: null,
         }),
       );
-
-    jest.useRealTimers();
   });
 
-  it('txQueuedTag is now if Multisig transactions throw', async () => {
-    jest.useFakeTimers();
-
-    const date = faker.date.anytime();
-    jest.setSystemTime(date);
-
+  it('txQueuedTag is null if Multisig transactions throw', async () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
@@ -653,11 +641,9 @@ describe('Safes Controller (Unit)', () => {
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
-          txQueuedTag: Math.floor(date.getTime() / 1000).toString(),
+          txQueuedTag: null,
         }),
       );
-
-    jest.useRealTimers();
   });
 
   it('collectiblesTag is computed from Ethereum transaction with executionDate date', async () => {
@@ -730,12 +716,7 @@ describe('Safes Controller (Unit)', () => {
       );
   });
 
-  it('collectiblesTag is now if there are no Ethereum transactions', async () => {
-    jest.useFakeTimers();
-
-    const date = faker.date.anytime();
-    jest.setSystemTime(date);
-
+  it('collectiblesTag is null if there are no Ethereum transactions', async () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
@@ -782,19 +763,12 @@ describe('Safes Controller (Unit)', () => {
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
-          collectiblesTag: Math.floor(date.getTime() / 1000).toString(),
+          collectiblesTag: null,
         }),
       );
-
-    jest.useRealTimers();
   });
 
-  it('collectiblesTag is now if Ethereum transactions throw', async () => {
-    jest.useFakeTimers();
-
-    const date = faker.date.anytime();
-    jest.setSystemTime(date);
-
+  it('collectiblesTag is null if Ethereum transactions throw', async () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
@@ -840,11 +814,9 @@ describe('Safes Controller (Unit)', () => {
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
-          collectiblesTag: Math.floor(date.getTime() / 1000).toString(),
+          collectiblesTag: null,
         }),
       );
-
-    jest.useRealTimers();
   });
 
   it('txHistoryTag is computed from Multisig transaction with modified date', async () => {
@@ -1135,12 +1107,7 @@ describe('Safes Controller (Unit)', () => {
       );
   });
 
-  it('txHistoryTag is now if there are no Multisig/Ethereum/Module transactions', async () => {
-    jest.useFakeTimers();
-
-    const date = faker.date.anytime();
-    jest.setSystemTime(date);
-
+  it('txHistoryTag is null if there are no Multisig/Ethereum/Module transactions', async () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
@@ -1187,11 +1154,9 @@ describe('Safes Controller (Unit)', () => {
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
-          txHistoryTag: Math.floor(date.getTime() / 1000).toString(),
+          txHistoryTag: null,
         }),
       );
-
-    jest.useRealTimers();
   });
 
   it('txHistoryTag is computed from Ethereum transaction if Multisig transactions throw', async () => {
@@ -1314,12 +1279,7 @@ describe('Safes Controller (Unit)', () => {
       );
   });
 
-  it('txHistoryTag is now if Multisig/Ethereum/Module transactions throw', async () => {
-    jest.useFakeTimers();
-
-    const date = faker.date.anytime();
-    jest.setSystemTime(date);
-
+  it('txHistoryTag is null if Multisig/Ethereum/Module transactions throw', async () => {
     const chain = chainBuilder().build();
     const masterCopies = [masterCopyBuilder().build()];
     const masterCopyInfo = contractBuilder().build();
@@ -1363,11 +1323,9 @@ describe('Safes Controller (Unit)', () => {
       .expect(200)
       .expect((response) =>
         expect(response.body).toMatchObject({
-          txHistoryTag: Math.floor(date.getTime() / 1000).toString(),
+          txHistoryTag: null,
         }),
       );
-
-    jest.useRealTimers();
   });
 
   it('messagesTag is the latest modified timestamp', async () => {
@@ -1437,6 +1395,59 @@ describe('Safes Controller (Unit)', () => {
       .expect((response) =>
         expect(response.body).toMatchObject({
           messagesTag: '1689164946',
+        }),
+      );
+  });
+
+  it('messagesTag is null if there are no messages', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
+
+    const messages = pageBuilder().build();
+
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          messagesTag: null,
         }),
       );
   });

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -99,10 +99,10 @@ export class SafesService {
       safe.owners.map((ownerAddress) => new AddressInfo(ownerAddress)),
       masterCopyInfo,
       versionState,
-      this.toUnixTimestampInSecondsOrNow(collectiblesTag).toString(),
-      this.toUnixTimestampInSecondsOrNow(queuedTransactionTag).toString(),
-      this.toUnixTimestampInSecondsOrNow(transactionHistoryTag).toString(),
-      this.toUnixTimestampInSecondsOrNow(messagesTag).toString(),
+      this.toUnixTimestampInSecondsOrNull(collectiblesTag),
+      this.toUnixTimestampInSecondsOrNull(queuedTransactionTag),
+      this.toUnixTimestampInSecondsOrNull(transactionHistoryTag),
+      this.toUnixTimestampInSecondsOrNull(messagesTag),
       moduleAddressesInfo,
       fallbackHandlerInfo,
       guardInfo,
@@ -118,9 +118,8 @@ export class SafesService {
     return new SafeNonces(nonce);
   }
 
-  private toUnixTimestampInSecondsOrNow(date: Date | null): number {
-    const dateValue = date ? date.valueOf() : Date.now();
-    return Math.floor(dateValue / 1000);
+  private toUnixTimestampInSecondsOrNull(date: Date | null): string | null {
+    return date ? Math.floor(date.valueOf() / 1000).toString() : null;
   }
 
   private async getCollectiblesTag(


### PR DESCRIPTION
This returns `null` for `SafeInfo['collectiblesTag']`, `SafeInfo['txQueuedTag']`, `SafeInfo['txHistoryTag']`, `SafeInfo['messagesTag']` if they return no value in order for them to [remain "stable" for the clients](https://github.com/safe-global/safe-wallet-web/issues/2490).