### PR TITLE
Add trusted query param to Transaction History

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -60,6 +60,7 @@ export default (): ReturnType<typeof configuration> => ({
     humanDescription: true,
     noncesRoute: true,
     email: true,
+    trustedTokens: true,
   },
   httpClient: { requestTimeout: faker.number.int() },
   log: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -81,6 +81,7 @@ export default () => ({
       process.env.FF_HUMAN_DESCRIPTION?.toLowerCase() === 'true',
     noncesRoute: process.env.FF_NONCES_ROUTE?.toLowerCase() === 'true',
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
+    trustedTokens: process.env.FF_TRUSTED_TOKENS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/transactions/entities/transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transfer-transaction-info.entity.ts
@@ -35,3 +35,9 @@ export class TransferTransactionInfo extends TransactionInfo {
     this.transferInfo = transferInfo;
   }
 }
+
+export function isTransferTransactionInfo(
+  txInfo: TransactionInfo,
+): txInfo is TransferTransactionInfo {
+  return txInfo.type === 'Transfer';
+}

--- a/src/routes/transactions/entities/transfers/erc20-transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/erc20-transfer.entity.ts
@@ -14,6 +14,8 @@ export class Erc20Transfer extends Transfer {
   logoUri: string | null;
   @ApiPropertyOptional({ type: Number, nullable: true })
   decimals: number | null;
+  @ApiPropertyOptional({ type: Boolean, nullable: true })
+  trusted: boolean | null;
 
   constructor(
     tokenAddress: string,
@@ -22,6 +24,7 @@ export class Erc20Transfer extends Transfer {
     tokenSymbol: string | null = null,
     logoUri: string | null = null,
     decimals: number | null = null,
+    trusted: boolean | null = null,
   ) {
     super('ERC20');
     this.tokenAddress = tokenAddress;
@@ -30,5 +33,10 @@ export class Erc20Transfer extends Transfer {
     this.tokenSymbol = tokenSymbol;
     this.logoUri = logoUri;
     this.decimals = decimals;
+    this.trusted = trusted;
   }
+}
+
+export function isErc20Transfer(transfer: Transfer): transfer is Erc20Transfer {
+  return transfer.type === 'ERC20';
 }

--- a/src/routes/transactions/entities/transfers/erc721-transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/erc721-transfer.entity.ts
@@ -12,6 +12,8 @@ export class Erc721Transfer extends Transfer {
   tokenSymbol: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   logoUri: string | null;
+  @ApiPropertyOptional({ type: Boolean, nullable: true })
+  trusted: boolean | null;
 
   constructor(
     tokenAddress: string,
@@ -19,6 +21,7 @@ export class Erc721Transfer extends Transfer {
     tokenName: string | null = null,
     tokenSymbol: string | null = null,
     logoUri: string | null = null,
+    trusted: boolean | null = null,
   ) {
     super('ERC721');
     this.tokenAddress = tokenAddress;
@@ -26,5 +29,12 @@ export class Erc721Transfer extends Transfer {
     this.tokenName = tokenName;
     this.tokenSymbol = tokenSymbol;
     this.logoUri = logoUri;
+    this.trusted = trusted;
   }
+}
+
+export function isErc721Transfer(
+  transfer: Transfer,
+): transfer is Erc721Transfer {
+  return transfer.type === 'ERC721';
 }

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -73,6 +73,7 @@ export class TransferInfoMapper {
         token?.symbol,
         token?.logoUri,
         token?.decimals,
+        token?.trusted,
       );
     } else if (isERC721Transfer(domainTransfer)) {
       const { tokenAddress, tokenId } = domainTransfer;
@@ -85,6 +86,7 @@ export class TransferInfoMapper {
         token?.name,
         token?.symbol,
         token?.logoUri,
+        token?.trusted,
       );
     } else if (isNativeTokenTransfer(domainTransfer)) {
       return new NativeCoinTransfer(domainTransfer.value);

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -47,6 +47,10 @@ import { NetworkModule } from '@/datasources/network/network.module';
 import { range } from 'lodash';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import {
+  erc20TransferBuilder,
+  toJson as erc20TransferToJson,
+} from '@/domain/safe/entities/__tests__/erc20-transfer.builder';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
@@ -56,8 +60,17 @@ describe('Transactions History Controller (Unit)', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
 
+    const testConfiguration = () => ({
+      ...configuration(),
+      mappings: {
+        history: {
+          maxNestedTransfers: 5,
+        },
+      },
+    });
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(testConfiguration)],
     })
       .overrideModule(EmailDataSourceModule)
       .useModule(TestEmailDatasourceModule)
@@ -713,6 +726,157 @@ describe('Transactions History Controller (Unit)', () => {
         expect(
           body.results.filter((item) => item.type === 'TRANSACTION'),
         ).toHaveLength(maxNestedTransfers);
+      });
+  });
+
+  it('Untrusted token transfers are ignored by default', async () => {
+    const safe = safeBuilder().build();
+    const chain = chainBuilder().build();
+    const untrustedToken = tokenBuilder().with('trusted', false).build();
+    const trustedToken = tokenBuilder().with('trusted', true).build();
+    // Use same date so that groups are created deterministically
+    const date = faker.date.recent();
+    const transfers = [
+      erc20TransferToJson(
+        erc20TransferBuilder()
+          .with('tokenAddress', untrustedToken.address)
+          .with('executionDate', date)
+          .build(),
+      ) as Transfer,
+      erc20TransferToJson(
+        erc20TransferBuilder()
+          .with('tokenAddress', trustedToken.address)
+          .with('executionDate', date)
+          .build(),
+      ) as Transfer,
+    ];
+    const transactionHistoryData = {
+      count: faker.number.int(),
+      next: faker.internet.url(),
+      previous: faker.internet.url(),
+      results: [
+        ethereumTransactionToJson(
+          ethereumTransactionBuilder().with('transfers', transfers).build(),
+        ),
+      ],
+    };
+    networkService.get.mockImplementation((url) => {
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+      const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: chain });
+        case getAllTransactions:
+          return Promise.resolve({ data: transactionHistoryData });
+        case getSafeUrl:
+          return Promise.resolve({ data: safe });
+        case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
+          return Promise.resolve({ data: trustedToken });
+        case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
+          return Promise.resolve({ data: untrustedToken });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history`,
+      )
+      .expect(200)
+      .expect((response) => {
+        // One date label and one transaction
+        expect(response.body['results']).toHaveLength(2);
+        expect(response.body['results'][1]).toMatchObject({
+          transaction: {
+            txInfo: {
+              transferInfo: {
+                tokenAddress: trustedToken.address,
+              },
+            },
+          },
+        });
+      });
+  });
+
+  it('Untrusted transfers are returned when trusted=false', async () => {
+    const safe = safeBuilder().build();
+    const chain = chainBuilder().build();
+    const untrustedToken = tokenBuilder().with('trusted', false).build();
+    const trustedToken = tokenBuilder().with('trusted', true).build();
+    // Use same date so that groups are created deterministically
+    const date = faker.date.recent();
+    const transfers = [
+      erc20TransferToJson(
+        erc20TransferBuilder()
+          .with('tokenAddress', untrustedToken.address)
+          .with('executionDate', date)
+          .build(),
+      ) as Transfer,
+      erc20TransferToJson(
+        erc20TransferBuilder()
+          .with('tokenAddress', trustedToken.address)
+          .with('executionDate', date)
+          .build(),
+      ) as Transfer,
+    ];
+    const transactionHistoryData = {
+      count: faker.number.int(),
+      next: faker.internet.url(),
+      previous: faker.internet.url(),
+      results: [
+        ethereumTransactionToJson(
+          ethereumTransactionBuilder().with('transfers', transfers).build(),
+        ),
+      ],
+    };
+    networkService.get.mockImplementation((url) => {
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+      const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: chain });
+        case getAllTransactions:
+          return Promise.resolve({ data: transactionHistoryData });
+        case getSafeUrl:
+          return Promise.resolve({ data: safe });
+        case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
+          return Promise.resolve({ data: trustedToken });
+        case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
+          return Promise.resolve({ data: untrustedToken });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+      )
+      .expect(200)
+      .expect((response) => {
+        // One date label and one transaction
+        expect(response.body['results']).toHaveLength(3);
+        expect(response.body['results'][1]).toMatchObject({
+          transaction: {
+            txInfo: {
+              transferInfo: {
+                tokenAddress: untrustedToken.address,
+              },
+            },
+          },
+        });
+        expect(response.body['results'][2]).toMatchObject({
+          transaction: {
+            txInfo: {
+              transferInfo: {
+                tokenAddress: trustedToken.address,
+              },
+            },
+          },
+        });
       });
   });
 });

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -211,6 +211,8 @@ export class TransactionsController {
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
     timezoneOffset: number,
+    @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
+    trusted: boolean,
   ): Promise<Partial<TransactionItemPage>> {
     return this.transactionsService.getTransactionHistory({
       chainId,
@@ -218,6 +220,7 @@ export class TransactionsController {
       safeAddress,
       paginationData,
       timezoneOffset,
+      onlyTrusted: trusted,
     });
   }
 

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -7,10 +7,10 @@ import { AddConfirmationDto } from '@/domain/transactions/entities/add-confirmat
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
 import { Page } from '@/routes/common/entities/page.entity';
 import {
-  PaginationData,
   buildNextPageURL,
   buildPreviousPageURL,
   cursorUrlFromLimitAndOffset,
+  PaginationData,
 } from '@/routes/common/pagination/pagination.data';
 import {
   MODULE_TRANSACTION_PREFIX,
@@ -360,6 +360,7 @@ export class TransactionsService {
     safeAddress: string;
     paginationData: PaginationData;
     timezoneOffset: number;
+    onlyTrusted: boolean;
   }): Promise<TransactionItemPage> {
     const paginationDataAdjusted = this.getAdjustedPaginationForHistory(
       args.paginationData,
@@ -390,6 +391,7 @@ export class TransactionsService {
       safeInfo,
       args.paginationData.offset,
       args.timezoneOffset,
+      args.onlyTrusted,
     );
 
     return {


### PR DESCRIPTION
- The transaction history endpoint now has a `trusted` query parameter which can be used to filter transfer (incoming/outgoing) depending on the token's trusted status (this status is something that is set on the Safe Transaction Service)
- Adds a feature flag to enable the newly added filtering. The feature can be enabled by setting `FF_TRUSTED_TOKENS` to `true`
- If the filtering is enabled on the endpoint it is then applied to Incoming and Outgoing ERC20 and ERC721 transfers:
  * If `trusted` is present and `true` then the transfer is included.
  * Else (if it's either `false` or we couldn't get the token info) the transfer is excluded.