### PR TITLE
Add trusted field to Token

### DIFF
--- a/src/domain/tokens/__tests__/token.builder.ts
+++ b/src/domain/tokens/__tests__/token.builder.ts
@@ -9,5 +9,6 @@ export function tokenBuilder(): IBuilder<Token> {
     .with('logoUri', faker.internet.url({ appendSlash: false }))
     .with('name', faker.word.sample())
     .with('symbol', faker.finance.currencySymbol())
-    .with('type', faker.helpers.arrayElement(Object.values(TokenType)));
+    .with('type', faker.helpers.arrayElement(Object.values(TokenType)))
+    .with('trusted', faker.datatype.boolean());
 }

--- a/src/domain/tokens/entities/schemas/token.schema.ts
+++ b/src/domain/tokens/entities/schemas/token.schema.ts
@@ -15,7 +15,9 @@ export const tokenSchema: JSONSchemaType<Token> = {
     name: { type: 'string' },
     symbol: { type: 'string' },
     type: { type: 'string', enum: Object.values(TokenType) },
+    trusted: { type: 'boolean' },
   },
+  // TODO: trusted should be required. Add to required fields once features.trustedTokens is removed
   required: ['address', 'decimals', 'logoUri', 'name', 'symbol', 'type'],
 };
 

--- a/src/domain/tokens/entities/token.entity.ts
+++ b/src/domain/tokens/entities/token.entity.ts
@@ -11,4 +11,6 @@ export interface Token {
   name: string;
   symbol: string;
   type: TokenType;
+  // TODO: trusted should be non-null. Remove null type once features.trustedTokens is removed
+  trusted: boolean | null;
 }


### PR DESCRIPTION
The `Token` entity now has a `trusted` field which can be used for filter operations depending on the trustworthiness status of said token.

The field is currently optional to support the rollout of the feature.