### PR TITLE
refactor: convert `type` properties to use enums

### DIFF
--- a/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
+++ b/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
@@ -6,10 +6,12 @@ import {
   TransferTransactionInfo,
   TransferDirection,
 } from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import { TransactionInfoType } from '@/routes/transactions/entities/transaction-info.entity';
+import { TransferType } from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export function transferTransactionInfoBuilder(): IBuilder<TransferTransactionInfo> {
   return Builder.new<TransferTransactionInfo>()
-    .with('type', 'Transfer')
+    .with('type', TransactionInfoType.Transfer)
     .with('sender', addressInfoBuilder().build())
     .with('recipient', addressInfoBuilder().build())
     .with(
@@ -18,6 +20,6 @@ export function transferTransactionInfoBuilder(): IBuilder<TransferTransactionIn
     )
     .with('transferInfo', {
       ...erc20TransferBuilder().build(),
-      type: 'ERC20_TRANSFER',
+      type: TransferType.Erc20,
     });
 }

--- a/src/routes/transactions/entities/creation-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction-info.entity.ts
@@ -1,6 +1,9 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
+import {
+  TransactionInfo,
+  TransactionInfoType,
+} from '@/routes/transactions/entities/transaction-info.entity';
 
 export class CreationTransactionInfo extends TransactionInfo {
   @ApiProperty()
@@ -18,7 +21,7 @@ export class CreationTransactionInfo extends TransactionInfo {
     implementation: AddressInfo | null,
     factory: AddressInfo | null,
   ) {
-    super('Creation', null, null);
+    super(TransactionInfoType.Creation, null, null);
     this.creator = creator;
     this.transactionHash = transactionHash;
     this.implementation = implementation;

--- a/src/routes/transactions/entities/custom-transaction.entity.ts
+++ b/src/routes/transactions/entities/custom-transaction.entity.ts
@@ -1,7 +1,10 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { RichDecodedInfo } from '@/routes/transactions/entities/human-description.entity';
-import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
+import {
+  TransactionInfo,
+  TransactionInfoType,
+} from '@/routes/transactions/entities/transaction-info.entity';
 
 export class CustomTransactionInfo extends TransactionInfo {
   @ApiProperty()
@@ -27,7 +30,7 @@ export class CustomTransactionInfo extends TransactionInfo {
     humanDescription: string | null,
     richDecodedInfo: RichDecodedInfo | null,
   ) {
-    super('Custom', humanDescription, richDecodedInfo);
+    super(TransactionInfoType.Custom, humanDescription, richDecodedInfo);
     this.to = to;
     this.dataSize = dataSize;
     this.value = value;

--- a/src/routes/transactions/entities/execution-info.entity.ts
+++ b/src/routes/transactions/entities/execution-info.entity.ts
@@ -1,10 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum ExecutionInfoType {
+  Multisig = 'MULTISIG',
+  Module = 'MODULE',
+}
+
 export abstract class ExecutionInfo {
   @ApiProperty()
-  type: string;
+  type: ExecutionInfoType;
 
-  protected constructor(type: string) {
+  protected constructor(type: ExecutionInfoType) {
     this.type = type;
   }
 }

--- a/src/routes/transactions/entities/module-execution-info.entity.ts
+++ b/src/routes/transactions/entities/module-execution-info.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { ExecutionInfo } from '@/routes/transactions/entities/execution-info.entity';
+import {
+  ExecutionInfo,
+  ExecutionInfoType,
+} from '@/routes/transactions/entities/execution-info.entity';
 
 export class ModuleExecutionInfo extends ExecutionInfo {
   @ApiProperty()
   address: AddressInfo;
 
   constructor(address: AddressInfo) {
-    super('MODULE');
+    super(ExecutionInfoType.Module);
     this.address = address;
   }
 }

--- a/src/routes/transactions/entities/multisig-execution-info.entity.ts
+++ b/src/routes/transactions/entities/multisig-execution-info.entity.ts
@@ -1,6 +1,9 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { ExecutionInfo } from '@/routes/transactions/entities/execution-info.entity';
+import {
+  ExecutionInfo,
+  ExecutionInfoType,
+} from '@/routes/transactions/entities/execution-info.entity';
 
 export class MultisigExecutionInfo extends ExecutionInfo {
   @ApiProperty()
@@ -18,7 +21,7 @@ export class MultisigExecutionInfo extends ExecutionInfo {
     confirmationsSubmitted: number,
     missingSigners: AddressInfo[] | null,
   ) {
-    super('MULTISIG');
+    super(ExecutionInfoType.Multisig);
     this.nonce = nonce;
     this.confirmationsRequired = confirmationsRequired;
     this.confirmationsSubmitted = confirmationsSubmitted;

--- a/src/routes/transactions/entities/queued-item.entity.ts
+++ b/src/routes/transactions/entities/queued-item.entity.ts
@@ -1,10 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum QueuedItemType {
+  Label = 'LABEL',
+  Transaction = 'TRANSACTION',
+  ConflictHeader = 'CONFLICT_HEADER',
+}
+
 export class QueuedItem {
   @ApiProperty()
-  type: string;
+  type: QueuedItemType;
 
-  constructor(type: string) {
+  constructor(type: QueuedItemType) {
     this.type = type;
   }
 }

--- a/src/routes/transactions/entities/queued-items/conflict-header-queued-item.entity.ts
+++ b/src/routes/transactions/entities/queued-items/conflict-header-queued-item.entity.ts
@@ -1,12 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { QueuedItem } from '@/routes/transactions/entities/queued-item.entity';
+import {
+  QueuedItem,
+  QueuedItemType,
+} from '@/routes/transactions/entities/queued-item.entity';
 
 export class ConflictHeaderQueuedItem extends QueuedItem {
   @ApiProperty()
   nonce: number;
 
   constructor(nonce: number) {
-    super('CONFLICT_HEADER');
+    super(QueuedItemType.ConflictHeader);
     this.nonce = nonce;
   }
 }

--- a/src/routes/transactions/entities/queued-items/label-queued-item.entity.ts
+++ b/src/routes/transactions/entities/queued-items/label-queued-item.entity.ts
@@ -1,5 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { QueuedItem } from '@/routes/transactions/entities/queued-item.entity';
+import {
+  QueuedItem,
+  QueuedItemType,
+} from '@/routes/transactions/entities/queued-item.entity';
 
 export enum LabelItem {
   Next = 'Next',
@@ -11,7 +14,7 @@ export class LabelQueuedItem extends QueuedItem {
   label: string;
 
   constructor(label: LabelItem) {
-    super('LABEL');
+    super(QueuedItemType.Label);
     this.label = label;
   }
 }

--- a/src/routes/transactions/entities/queued-items/transaction-queued-item.entity.ts
+++ b/src/routes/transactions/entities/queued-items/transaction-queued-item.entity.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ConflictType } from '@/routes/transactions/entities/conflict-type.entity';
-import { QueuedItem } from '@/routes/transactions/entities/queued-item.entity';
+import {
+  QueuedItem,
+  QueuedItemType,
+} from '@/routes/transactions/entities/queued-item.entity';
 import { Transaction } from '@/routes/transactions/entities/transaction.entity';
 
 export class TransactionQueuedItem extends QueuedItem {
@@ -10,7 +13,7 @@ export class TransactionQueuedItem extends QueuedItem {
   conflictType: string;
 
   constructor(transaction: Transaction, conflictType: ConflictType) {
-    super('TRANSACTION');
+    super(QueuedItemType.Transaction);
     this.transaction = transaction;
     this.conflictType = conflictType;
   }

--- a/src/routes/transactions/entities/settings-change-transaction.entity.ts
+++ b/src/routes/transactions/entities/settings-change-transaction.entity.ts
@@ -2,7 +2,10 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
 import { RichDecodedInfo } from '@/routes/transactions/entities/human-description.entity';
 import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
-import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
+import {
+  TransactionInfo,
+  TransactionInfoType,
+} from '@/routes/transactions/entities/transaction-info.entity';
 
 export class SettingsChangeTransaction extends TransactionInfo {
   @ApiProperty()
@@ -16,7 +19,11 @@ export class SettingsChangeTransaction extends TransactionInfo {
     humanDescription: string | null,
     richDecodedInfo: RichDecodedInfo | null,
   ) {
-    super('SettingsChange', humanDescription, richDecodedInfo);
+    super(
+      TransactionInfoType.SettingsChange,
+      humanDescription,
+      richDecodedInfo,
+    );
     this.dataDecoded = dataDecoded;
     this.settingsInfo = settingsInfo;
   }

--- a/src/routes/transactions/entities/settings-changes/add-owner.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/add-owner.entity.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class AddOwner extends SettingsChange {
   @ApiProperty()
@@ -9,7 +12,7 @@ export class AddOwner extends SettingsChange {
   threshold: number;
 
   constructor(owner: AddressInfo, threshold: number) {
-    super('ADD_OWNER');
+    super(SettingsChangeType.AddOwner);
     this.owner = owner;
     this.threshold = threshold;
   }

--- a/src/routes/transactions/entities/settings-changes/change-master-copy.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/change-master-copy.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class ChangeMasterCopy extends SettingsChange {
   @ApiProperty()
   implementation: AddressInfo;
 
   constructor(implementation: AddressInfo) {
-    super('CHANGE_MASTER_COPY');
+    super(SettingsChangeType.ChangeMasterCopy);
     this.implementation = implementation;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/change-threshold.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/change-threshold.entity.ts
@@ -1,12 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class ChangeThreshold extends SettingsChange {
   @ApiProperty()
   threshold: number;
 
   constructor(threshold: number) {
-    super('CHANGE_THRESHOLD');
+    super(SettingsChangeType.ChangeThreshold);
     this.threshold = threshold;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/delete-guard.ts
+++ b/src/routes/transactions/entities/settings-changes/delete-guard.ts
@@ -1,7 +1,10 @@
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class DeleteGuard extends SettingsChange {
   constructor() {
-    super('DELETE_GUARD');
+    super(SettingsChangeType.DeleteGuard);
   }
 }

--- a/src/routes/transactions/entities/settings-changes/disable-module.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/disable-module.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class DisableModule extends SettingsChange {
   @ApiProperty()
   module: AddressInfo;
 
   constructor(module: AddressInfo) {
-    super('DISABLE_MODULE');
+    super(SettingsChangeType.DisableModule);
     this.module = module;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/enable-module.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/enable-module.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class EnableModule extends SettingsChange {
   @ApiProperty()
   module: AddressInfo;
 
   constructor(module: AddressInfo) {
-    super('ENABLE_MODULE');
+    super(SettingsChangeType.EnableModule);
     this.module = module;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/remove-owner.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/remove-owner.entity.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class RemoveOwner extends SettingsChange {
   @ApiProperty()
@@ -9,7 +12,7 @@ export class RemoveOwner extends SettingsChange {
   threshold: number;
 
   constructor(owner: AddressInfo, threshold: number) {
-    super('REMOVE_OWNER');
+    super(SettingsChangeType.RemoveOwner);
     this.owner = owner;
     this.threshold = threshold;
   }

--- a/src/routes/transactions/entities/settings-changes/set-fallback-handler.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/set-fallback-handler.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class SetFallbackHandler extends SettingsChange {
   @ApiProperty()
   handler: AddressInfo;
 
   constructor(handler: AddressInfo) {
-    super('SET_FALLBACK_HANDLER');
+    super(SettingsChangeType.SetFallbackHandler);
     this.handler = handler;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/set-guard.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/set-guard.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class SetGuard extends SettingsChange {
   @ApiProperty()
   guard: AddressInfo;
 
   constructor(guard: AddressInfo) {
-    super('SET_GUARD');
+    super(SettingsChangeType.SetGuard);
     this.guard = guard;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/settings-change.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/settings-change.entity.ts
@@ -1,10 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum SettingsChangeType {
+  AddOwner = 'ADD_OWNER',
+  ChangeMasterCopy = 'CHANGE_MASTER_COPY',
+  ChangeThreshold = 'CHANGE_THRESHOLD',
+  DeleteGuard = 'DELETE_GUARD',
+  DisableModule = 'DISABLE_MODULE',
+  EnableModule = 'ENABLE_MODULE',
+  RemoveOwner = 'REMOVE_OWNER',
+  SetFallbackHandler = 'SET_FALLBACK_HANDLER',
+  SetGuard = 'SET_GUARD',
+  SwapOwner = 'SWAP_OWNER',
+}
+
 export abstract class SettingsChange {
   @ApiProperty()
-  type: string;
+  type: SettingsChangeType;
 
-  protected constructor(type: string) {
+  protected constructor(type: SettingsChangeType) {
     this.type = type;
   }
 }

--- a/src/routes/transactions/entities/settings-changes/swap-owner.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/swap-owner.entity.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import {
+  SettingsChange,
+  SettingsChangeType,
+} from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class SwapOwner extends SettingsChange {
   @ApiProperty()
@@ -9,7 +12,7 @@ export class SwapOwner extends SettingsChange {
   newOwner: AddressInfo;
 
   constructor(oldOwner: AddressInfo, newOwner: AddressInfo) {
-    super('SWAP_OWNER');
+    super(SettingsChangeType.SwapOwner);
     this.oldOwner = oldOwner;
     this.newOwner = newOwner;
   }

--- a/src/routes/transactions/entities/transaction-details/execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/execution-details.entity.ts
@@ -1,10 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum ExecutionDetailsType {
+  Module = 'MODULE',
+  Multisig = 'MULTISIG',
+}
+
 export abstract class ExecutionDetails {
   @ApiProperty()
-  type: string;
+  type: ExecutionDetailsType;
 
-  protected constructor(type: string) {
+  protected constructor(type: ExecutionDetailsType) {
     this.type = type;
   }
 }

--- a/src/routes/transactions/entities/transaction-details/module-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/module-execution-details.entity.ts
@@ -1,13 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { ExecutionDetails } from '@/routes/transactions/entities/transaction-details/execution-details.entity';
+import {
+  ExecutionDetails,
+  ExecutionDetailsType,
+} from '@/routes/transactions/entities/transaction-details/execution-details.entity';
 
 export class ModuleExecutionDetails extends ExecutionDetails {
   @ApiProperty()
   address: AddressInfo;
 
   constructor(address: AddressInfo) {
-    super('MODULE');
+    super(ExecutionDetailsType.Module);
     this.address = address;
   }
 }

--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -1,7 +1,10 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { Token } from '@/routes/balances/entities/token.entity';
-import { ExecutionDetails } from '@/routes/transactions/entities/transaction-details/execution-details.entity';
+import {
+  ExecutionDetails,
+  ExecutionDetailsType,
+} from '@/routes/transactions/entities/transaction-details/execution-details.entity';
 
 export class MultisigConfirmationDetails {
   @ApiProperty()
@@ -71,7 +74,7 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     gasTokenInfo: Token | null,
     trusted: boolean,
   ) {
-    super('MULTISIG');
+    super(ExecutionDetailsType.Multisig);
     this.submittedAt = submittedAt;
     this.nonce = nonce;
     this.safeTxGas = safeTxGas;

--- a/src/routes/transactions/entities/transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transaction-info.entity.ts
@@ -1,9 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RichDecodedInfo } from '@/routes/transactions/entities/human-description.entity';
 
+export enum TransactionInfoType {
+  Creation = 'Creation',
+  Custom = 'Custom',
+  SettingsChange = 'SettingsChange',
+  Transfer = 'Transfer',
+}
+
 export class TransactionInfo {
   @ApiProperty()
-  type: string;
+  type: TransactionInfoType;
   @ApiPropertyOptional({ type: String, nullable: true })
   humanDescription: string | null;
   // TODO: Remove nullable once the feature flag is removed, allow returning an empty array instead
@@ -11,7 +18,7 @@ export class TransactionInfo {
   richDecodedInfo: RichDecodedInfo | null;
 
   protected constructor(
-    type: string,
+    type: TransactionInfoType,
     humanDescription: string | null,
     richDecodedInfo: RichDecodedInfo | null,
   ) {

--- a/src/routes/transactions/entities/transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transfer-transaction-info.entity.ts
@@ -1,7 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { RichDecodedInfo } from '@/routes/transactions/entities/human-description.entity';
-import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
+import {
+  TransactionInfo,
+  TransactionInfoType,
+} from '@/routes/transactions/entities/transaction-info.entity';
 import { Transfer } from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export enum TransferDirection {
@@ -28,7 +31,7 @@ export class TransferTransactionInfo extends TransactionInfo {
     humanDescription: string | null,
     richDecodedInfo: RichDecodedInfo | null,
   ) {
-    super('Transfer', humanDescription, richDecodedInfo);
+    super(TransactionInfoType.Transfer, humanDescription, richDecodedInfo);
     this.sender = sender;
     this.recipient = recipient;
     this.direction = direction;
@@ -39,5 +42,5 @@ export class TransferTransactionInfo extends TransactionInfo {
 export function isTransferTransactionInfo(
   txInfo: TransactionInfo,
 ): txInfo is TransferTransactionInfo {
-  return txInfo.type === 'Transfer';
+  return txInfo.type === TransactionInfoType.Transfer;
 }

--- a/src/routes/transactions/entities/transfers/erc20-transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/erc20-transfer.entity.ts
@@ -1,5 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Transfer } from '@/routes/transactions/entities/transfers/transfer.entity';
+import {
+  Transfer,
+  TransferType,
+} from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export class Erc20Transfer extends Transfer {
   @ApiProperty()
@@ -26,7 +29,7 @@ export class Erc20Transfer extends Transfer {
     decimals: number | null = null,
     trusted: boolean | null = null,
   ) {
-    super('ERC20');
+    super(TransferType.Erc20);
     this.tokenAddress = tokenAddress;
     this.value = value;
     this.tokenName = tokenName;
@@ -38,5 +41,5 @@ export class Erc20Transfer extends Transfer {
 }
 
 export function isErc20Transfer(transfer: Transfer): transfer is Erc20Transfer {
-  return transfer.type === 'ERC20';
+  return transfer.type === TransferType.Erc20;
 }

--- a/src/routes/transactions/entities/transfers/erc721-transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/erc721-transfer.entity.ts
@@ -1,5 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Transfer } from '@/routes/transactions/entities/transfers/transfer.entity';
+import {
+  Transfer,
+  TransferType,
+} from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export class Erc721Transfer extends Transfer {
   @ApiProperty()
@@ -23,7 +26,7 @@ export class Erc721Transfer extends Transfer {
     logoUri: string | null = null,
     trusted: boolean | null = null,
   ) {
-    super('ERC721');
+    super(TransferType.Erc721);
     this.tokenAddress = tokenAddress;
     this.tokenId = tokenId;
     this.tokenName = tokenName;
@@ -36,5 +39,5 @@ export class Erc721Transfer extends Transfer {
 export function isErc721Transfer(
   transfer: Transfer,
 ): transfer is Erc721Transfer {
-  return transfer.type === 'ERC721';
+  return transfer.type === TransferType.Erc721;
 }

--- a/src/routes/transactions/entities/transfers/native-coin-transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/native-coin-transfer.entity.ts
@@ -1,12 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Transfer } from '@/routes/transactions/entities/transfers/transfer.entity';
+import {
+  Transfer,
+  TransferType,
+} from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export class NativeCoinTransfer extends Transfer {
   @ApiProperty()
   value: string;
 
   constructor(value: string) {
-    super('NATIVE_COIN');
+    super(TransferType.NativeCoin);
     this.value = value;
   }
 }

--- a/src/routes/transactions/entities/transfers/transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/transfer.entity.ts
@@ -1,10 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum TransferType {
+  NativeCoin = 'NATIVE_COIN',
+  Erc20 = 'ERC20',
+  Erc721 = 'ERC721',
+}
+
 export abstract class Transfer {
   @ApiProperty()
-  type: string;
+  type: TransferType;
 
-  protected constructor(type: string) {
+  protected constructor(type: TransferType) {
     this.type = type;
   }
 }

--- a/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
+++ b/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
@@ -7,6 +7,7 @@ import {
   MultisigConfirmationDetails,
   MultisigExecutionDetails,
 } from '@/routes/transactions/entities/transaction-details/multisig-execution-details.entity';
+import { ExecutionDetailsType } from '@/routes/transactions/entities/transaction-details/execution-details.entity';
 
 const MIN_SIGNERS = 2;
 const MAX_SIGNERS = 5;
@@ -27,7 +28,7 @@ export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDet
   );
 
   return Builder.new<MultisigExecutionDetails>()
-    .with('type', 'MULTISIG')
+    .with('type', ExecutionDetailsType.Multisig)
     .with('submittedAt', faker.number.int())
     .with('nonce', faker.number.int())
     .with('safeTxGas', faker.string.numeric())

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -19,10 +19,6 @@ import { Transfer } from '@/routes/transactions/entities/transfers/transfer.enti
 
 @Injectable()
 export class TransferInfoMapper {
-  private static readonly ERC20_TRANSFER = 'ERC20_TRANSFER';
-  private static readonly ERC721_TRANSFER = 'ERC721_TRANSFER';
-  private static readonly ETHER_TRANSFER = 'ETHER_TRANSFER';
-
   constructor(
     @Inject(ITokenRepository) private readonly tokenRepository: TokenRepository,
     private readonly addressInfoHelper: AddressInfoHelper,


### PR DESCRIPTION
As mentioned in https://github.com/safe-global/safe-client-gateway/pull/910#discussion_r1415506401, this implements enums and updates tests/builders accordingly for:

- `ExecutionDetails['type']`
- `ExecutionInfo['type']`
- `QueuedItem['type']`
- `SettingsChange['type']`
- `Transfer['type']`
- `TransactionInfo['type']`