### PR TITLE
feat: add transaction encoders for recovery alerts

### DIFF
--- a/src/domain/alerts/__tests__/delay-modifier.encoder.ts
+++ b/src/domain/alerts/__tests__/delay-modifier.encoder.ts
@@ -1,0 +1,78 @@
+import { faker } from '@faker-js/faker';
+import {
+  Hex,
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  parseAbi,
+  parseAbiParameters,
+} from 'viem';
+
+// TransactionAdded
+
+type TransactionAddedEventArgs = {
+  queueNonce: bigint;
+  txHash: string;
+  to: string;
+  value: bigint;
+  data: string;
+  operation: 0 | 1;
+};
+
+class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs> {
+  static readonly NON_INDEXED_PARAMS =
+    'address to, uint256 value, bytes data, uint8 operation' as const;
+  static readonly EVENT_SIGNATURE =
+    `event TransactionAdded(uint256 indexed queueNonce, bytes32 indexed txHash, ${TransactionAddedEventBuilder.NON_INDEXED_PARAMS})` as const;
+
+  private constructor(private args: Partial<T>) {}
+
+  public static new<
+    T extends TransactionAddedEventArgs,
+  >(): TransactionAddedEventBuilder<T> {
+    return new TransactionAddedEventBuilder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new TransactionAddedEventBuilder(args);
+  }
+
+  build() {
+    const abi = parseAbi([TransactionAddedEventBuilder.EVENT_SIGNATURE]);
+
+    const data = encodeAbiParameters(
+      parseAbiParameters(TransactionAddedEventBuilder.NON_INDEXED_PARAMS),
+      [
+        getAddress(this.args.to!),
+        this.args.value!,
+        this.args.data as Hex,
+        this.args.operation!,
+      ],
+    );
+
+    const topics = encodeEventTopics({
+      abi,
+      eventName: 'TransactionAdded',
+      args: {
+        queueNonce: this.args.queueNonce!,
+        txHash: this.args.txHash! as Hex,
+      },
+    });
+
+    return {
+      data,
+      topics,
+    };
+  }
+}
+
+export function transactionAddedEventBuilder() {
+  return TransactionAddedEventBuilder.new<TransactionAddedEventArgs>()
+    .with('queueNonce', faker.number.bigInt())
+    .with('txHash', faker.string.hexadecimal({ length: 64 }))
+    .with('to', faker.finance.ethereumAddress())
+    .with('value', BigInt(0))
+    .with('data', '0x')
+    .with('operation', 0);
+}

--- a/src/domain/alerts/__tests__/multisend-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/multisend-transactions.encoder.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import {
   Hex,
   concat,
@@ -8,27 +9,68 @@ import {
   size,
 } from 'viem';
 
-export function multiSendEncoder(
+// multiSend
+
+type MultiSendArgs = {
   transactions: Array<{
     operation: number;
     to: string;
     value: bigint;
-    data: Hex;
-  }>,
-): Hex {
-  const abi = parseAbi(['function multiSend(bytes memory transactions)']);
+    data: string;
+  }>;
+};
 
-  const encodedTransactions = transactions.map(
-    ({ operation, to, value, data }) =>
-      encodePacked(
-        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
-        [operation, getAddress(to), value, BigInt(size(data)), data],
-      ),
-  );
+class MultiSendEncoder<T extends MultiSendArgs> {
+  static readonly FUNCTION_SIGNATURE =
+    'function multiSend(bytes memory transactions)' as const;
 
-  return encodeFunctionData({
-    abi,
-    functionName: 'multiSend',
-    args: [concat(encodedTransactions)],
-  });
+  private constructor(private args: Partial<T>) {}
+
+  public static new<T extends MultiSendArgs>(): MultiSendEncoder<T> {
+    return new MultiSendEncoder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new MultiSendEncoder(args);
+  }
+
+  build() {
+    const encodedTransactions = this.args.transactions!.map(
+      ({ operation, to, value, data }) => {
+        const _data = data as Hex;
+        return encodePacked(
+          ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+          [operation, getAddress(to), value, BigInt(size(_data)), _data],
+        );
+      },
+    );
+
+    return {
+      transactions: concat(encodedTransactions),
+    };
+  }
+
+  encode(): Hex {
+    const abi = parseAbi([MultiSendEncoder.FUNCTION_SIGNATURE]);
+
+    const { transactions } = this.build();
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'multiSend',
+      args: [transactions],
+    });
+  }
+}
+
+export function multiSendEncoder() {
+  return MultiSendEncoder.new<MultiSendArgs>().with('transactions', [
+    {
+      operation: 0,
+      to: faker.finance.ethereumAddress(),
+      value: BigInt(0),
+      data: '0x',
+    },
+  ]);
 }

--- a/src/domain/alerts/__tests__/safe-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/safe-transactions.encoder.ts
@@ -1,95 +1,322 @@
 import { faker } from '@faker-js/faker';
-import { parseAbi, encodeFunctionData, getAddress, Hex } from 'viem';
+import { parseAbi, encodeFunctionData, getAddress, Hex, pad } from 'viem';
 
-export function addOwnerWithThresholdEncoder(
-  {
-    owner = faker.finance.ethereumAddress(),
-    _threshold = faker.number.bigInt(),
-  }: {
-    owner: string;
-    _threshold: bigint;
-  } = {
-    owner: faker.finance.ethereumAddress(),
-    _threshold: faker.number.bigInt(),
-  },
-): Hex {
-  const abi = parseAbi([
-    'function addOwnerWithThreshold(address owner, uint256 _threshold)',
-  ]);
+import { Safe } from '@/domain/safe/entities/safe.entity';
 
-  return encodeFunctionData({
-    abi,
-    functionName: 'addOwnerWithThreshold',
-    args: [getAddress(owner), _threshold],
-  });
+const ZERO_ADDRESS = pad('0x0', { size: 20 });
+const SENTINEL_ADDRESS = pad('0x1', { dir: 'left', size: 20 });
+
+const MAX_THRESHOLD = 10;
+
+// execTransaction
+
+type ExecTransactionArgs = {
+  to: string;
+  value: bigint;
+  data: string;
+  operation: 0 | 1;
+  safeTxGas: bigint;
+  baseGas: bigint;
+  gasPrice: bigint;
+  gasToken: string;
+  refundReceiver: string;
+  signatures: string;
+};
+
+class ExecTransactionEncoder<T extends ExecTransactionArgs> {
+  static readonly FUNCTION_SIGNATURE =
+    'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)' as const;
+
+  private constructor(private args: Partial<T>) {}
+
+  public static new<
+    T extends ExecTransactionArgs,
+  >(): ExecTransactionEncoder<T> {
+    return new ExecTransactionEncoder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new ExecTransactionEncoder(args);
+  }
+
+  build() {
+    return {
+      to: getAddress(this.args.to!),
+      value: this.args.value!,
+      data: this.args.data as Hex,
+      operation: this.args.operation!,
+      safeTxGas: this.args.safeTxGas!,
+      baseGas: this.args.baseGas!,
+      gasPrice: this.args.gasPrice!,
+      gasToken: getAddress(this.args.gasToken!),
+      refundReceiver: getAddress(this.args.refundReceiver!),
+      signatures: this.args.signatures as Hex,
+    };
+  }
+
+  encode(): Hex {
+    const abi = parseAbi([ExecTransactionEncoder.FUNCTION_SIGNATURE]);
+
+    const {
+      to,
+      value,
+      data,
+      operation,
+      safeTxGas,
+      baseGas,
+      gasPrice,
+      gasToken,
+      refundReceiver,
+      signatures,
+    } = this.build();
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'execTransaction',
+      args: [
+        to,
+        value,
+        data,
+        operation,
+        safeTxGas,
+        baseGas,
+        gasPrice,
+        gasToken,
+        refundReceiver,
+        signatures,
+      ],
+    });
+  }
 }
 
-export function removeOwnerEncoder(
-  {
-    prevOwner = faker.finance.ethereumAddress(),
-    owner = faker.finance.ethereumAddress(),
-    _threshold = faker.number.bigInt(),
-  }: {
-    prevOwner: string;
-    owner: string;
-    _threshold: bigint;
-  } = {
-    prevOwner: faker.finance.ethereumAddress(),
-    owner: faker.finance.ethereumAddress(),
-    _threshold: faker.number.bigInt(),
-  },
-): Hex {
-  const ABI = parseAbi([
-    'function removeOwner(address prevOwner, address owner, uint256 _threshold)',
-  ]);
-
-  return encodeFunctionData({
-    abi: ABI,
-    functionName: 'removeOwner',
-    args: [getAddress(prevOwner), getAddress(owner), _threshold],
-  });
+export function execTransactionEncoder() {
+  return ExecTransactionEncoder.new()
+    .with('to', faker.finance.ethereumAddress())
+    .with('value', BigInt(0))
+    .with('data', '0x')
+    .with('operation', 0)
+    .with('safeTxGas', BigInt(0))
+    .with('baseGas', BigInt(0))
+    .with('gasPrice', BigInt(0))
+    .with('gasToken', ZERO_ADDRESS)
+    .with('refundReceiver', ZERO_ADDRESS)
+    .with('signatures', '0x');
 }
 
-export function swapOwnerEncoder(
-  {
-    prevOwner = faker.finance.ethereumAddress(),
-    oldOwner = faker.finance.ethereumAddress(),
-    newOwner = faker.finance.ethereumAddress(),
-  }: {
-    prevOwner: string;
-    oldOwner: string;
-    newOwner: string;
-  } = {
-    prevOwner: faker.finance.ethereumAddress(),
-    oldOwner: faker.finance.ethereumAddress(),
-    newOwner: faker.finance.ethereumAddress(),
-  },
-): Hex {
-  const ABI = parseAbi([
-    'function swapOwner(address prevOwner, address oldOwner, address newOwner)',
-  ]);
+// addOwnerWithThreshold
 
-  return encodeFunctionData({
-    abi: ABI,
-    functionName: 'swapOwner',
-    args: [getAddress(prevOwner), getAddress(oldOwner), getAddress(newOwner)],
-  });
+type AddOwnerWithThresholdArgs = {
+  owner: string;
+  threshold: bigint;
+};
+
+class AddOwnerWithThresholdEncoder<T extends AddOwnerWithThresholdArgs> {
+  static readonly FUNCTION_SIGNATURE =
+    'function addOwnerWithThreshold(address owner, uint256 _threshold)' as const;
+
+  private constructor(private args: Partial<T>) {}
+
+  public static new<
+    T extends AddOwnerWithThresholdArgs,
+  >(): AddOwnerWithThresholdEncoder<T> {
+    return new AddOwnerWithThresholdEncoder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new AddOwnerWithThresholdEncoder(args);
+  }
+
+  build() {
+    return {
+      owner: getAddress(this.args.owner!),
+      threshold: this.args.threshold!,
+    };
+  }
+
+  encode(): Hex {
+    const abi = parseAbi([AddOwnerWithThresholdEncoder.FUNCTION_SIGNATURE]);
+
+    const { owner, threshold } = this.build();
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'addOwnerWithThreshold',
+      args: [owner, threshold],
+    });
+  }
 }
 
-export function changeThresholdEncoder(
-  {
-    _threshold = faker.number.bigInt(),
-  }: {
-    _threshold: bigint;
-  } = {
-    _threshold: faker.number.bigInt(),
-  },
-): Hex {
-  const ABI = parseAbi(['function changeThreshold(uint256 _threshold)']);
+export function addOwnerWithThresholdEncoder() {
+  return AddOwnerWithThresholdEncoder.new()
+    .with('owner', faker.finance.ethereumAddress())
+    .with('threshold', faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }));
+}
 
-  return encodeFunctionData({
-    abi: ABI,
-    functionName: 'changeThreshold',
-    args: [_threshold],
-  });
+// removeOwner
+
+type RemoveOwnerArgs = {
+  owner: string;
+  threshold: bigint;
+};
+
+class RemoveOwnerEncoder<T extends RemoveOwnerArgs> {
+  static readonly FUNCTION_SIGNATURE =
+    'function removeOwner(address prevOwner, address owner, uint256 _threshold)';
+
+  private constructor(private args: Partial<T>) {}
+
+  public static new<T extends RemoveOwnerArgs>(): RemoveOwnerEncoder<T> {
+    return new RemoveOwnerEncoder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new RemoveOwnerEncoder(args);
+  }
+
+  build(owners: Safe['owners']) {
+    const prevOwner = (() => {
+      const ownerIndex = owners.findIndex((owners) => {
+        return getAddress(owners) === getAddress(this.args.owner!);
+      });
+
+      return ownerIndex <= 0
+        ? SENTINEL_ADDRESS
+        : getAddress(owners[ownerIndex - 1]);
+    })();
+
+    return {
+      prevOwner,
+      owner: getAddress(this.args.owner!),
+      threshold: this.args.threshold!,
+    };
+  }
+
+  encode(owners: Safe['owners']): Hex {
+    const abi = parseAbi([RemoveOwnerEncoder.FUNCTION_SIGNATURE]);
+
+    const { prevOwner, owner, threshold } = this.build(owners);
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'removeOwner',
+      args: [prevOwner, owner, threshold],
+    });
+  }
+}
+
+export function removeOwnerEncoder() {
+  return RemoveOwnerEncoder.new()
+    .with('owner', faker.finance.ethereumAddress())
+    .with('threshold', faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }));
+}
+
+// swapOwner
+
+type SwapOwnerArgs = {
+  oldOwner: string;
+  newOwner: string;
+};
+
+class SwapOwnerEncoder<T extends SwapOwnerArgs> {
+  static readonly FUNCTION_SIGNATURE =
+    'function swapOwner(address prevOwner, address oldOwner, address newOwner)';
+
+  private constructor(private args: Partial<T>) {}
+
+  public static new<T extends SwapOwnerArgs>(): SwapOwnerEncoder<T> {
+    return new SwapOwnerEncoder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new SwapOwnerEncoder(args);
+  }
+
+  build(owners: Safe['owners']) {
+    const prevOwner = (() => {
+      const ownerIndex = owners.findIndex((owners) => {
+        return getAddress(owners) === getAddress(this.args.oldOwner!);
+      });
+
+      return ownerIndex <= 0
+        ? SENTINEL_ADDRESS
+        : getAddress(owners[ownerIndex - 1]);
+    })();
+
+    return {
+      prevOwner,
+      oldOwner: getAddress(this.args.oldOwner!),
+      newOwner: getAddress(this.args.newOwner!),
+    };
+  }
+
+  encode(owners: Safe['owners']): Hex {
+    const abi = parseAbi([SwapOwnerEncoder.FUNCTION_SIGNATURE]);
+
+    const { prevOwner, oldOwner, newOwner } = this.build(owners);
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'swapOwner',
+      args: [prevOwner, oldOwner, newOwner],
+    });
+  }
+}
+
+export function swapOwnerEncoder() {
+  return SwapOwnerEncoder.new()
+    .with('oldOwner', faker.finance.ethereumAddress())
+    .with('newOwner', faker.finance.ethereumAddress());
+}
+
+// changeThreshold
+
+type ChangeThresholdArgs = {
+  threshold: bigint;
+};
+
+class ChangeThresholdEncoder<T extends ChangeThresholdArgs> {
+  static readonly FUNCTION_SIGNATURE =
+    'function changeThreshold(uint256 _threshold)';
+
+  private constructor(private args: Partial<T>) {}
+
+  public static new<
+    T extends ChangeThresholdArgs,
+  >(): ChangeThresholdEncoder<T> {
+    return new ChangeThresholdEncoder<T>({});
+  }
+
+  with<K extends keyof T>(key: K, value: T[K]) {
+    const args: Partial<T> = { ...this.args, [key]: value };
+    return new ChangeThresholdEncoder(args);
+  }
+
+  build() {
+    return {
+      threshold: this.args.threshold!,
+    };
+  }
+
+  encode(): Hex {
+    const abi = parseAbi([ChangeThresholdEncoder.FUNCTION_SIGNATURE]);
+
+    const { threshold } = this.build();
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'changeThreshold',
+      args: [threshold],
+    });
+  }
+}
+
+export function changeThresholdEncoder() {
+  return ChangeThresholdEncoder.new().with(
+    'threshold',
+    faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }),
+  );
 }

--- a/src/domain/alerts/__tests__/safe-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/safe-transactions.encoder.ts
@@ -165,26 +165,35 @@ class RemoveOwnerEncoder<T extends RemoveOwnerArgs> {
   static readonly FUNCTION_SIGNATURE =
     'function removeOwner(address prevOwner, address owner, uint256 _threshold)';
 
-  private constructor(private args: Partial<T>) {}
+  private constructor(
+    private args: Partial<T>,
+    private owners?: Safe['owners'],
+  ) {}
 
-  public static new<T extends RemoveOwnerArgs>(): RemoveOwnerEncoder<T> {
-    return new RemoveOwnerEncoder<T>({});
+  public static new<T extends RemoveOwnerArgs>(
+    owners?: Safe['owners'],
+  ): RemoveOwnerEncoder<T> {
+    return new RemoveOwnerEncoder<T>({}, owners);
   }
 
   with<K extends keyof T>(key: K, value: T[K]) {
     const args: Partial<T> = { ...this.args, [key]: value };
-    return new RemoveOwnerEncoder(args);
+    return new RemoveOwnerEncoder(args, this.owners);
   }
 
-  build(owners: Safe['owners']) {
+  build() {
     const prevOwner = (() => {
-      const ownerIndex = owners.findIndex((owners) => {
-        return getAddress(owners) === getAddress(this.args.owner!);
+      if (!this.owners) {
+        return SENTINEL_ADDRESS;
+      }
+
+      const ownerIndex = this.owners.findIndex((owner) => {
+        return getAddress(owner) === getAddress(this.args.owner!);
       });
 
       return ownerIndex <= 0
         ? SENTINEL_ADDRESS
-        : getAddress(owners[ownerIndex - 1]);
+        : getAddress(this.owners[ownerIndex - 1]);
     })();
 
     return {
@@ -194,10 +203,10 @@ class RemoveOwnerEncoder<T extends RemoveOwnerArgs> {
     };
   }
 
-  encode(owners: Safe['owners']): Hex {
+  encode(): Hex {
     const abi = parseAbi([RemoveOwnerEncoder.FUNCTION_SIGNATURE]);
 
-    const { prevOwner, owner, threshold } = this.build(owners);
+    const { prevOwner, owner, threshold } = this.build();
 
     return encodeFunctionData({
       abi,
@@ -207,8 +216,8 @@ class RemoveOwnerEncoder<T extends RemoveOwnerArgs> {
   }
 }
 
-export function removeOwnerEncoder() {
-  return RemoveOwnerEncoder.new()
+export function removeOwnerEncoder(owners?: Safe['owners']) {
+  return RemoveOwnerEncoder.new(owners)
     .with('owner', faker.finance.ethereumAddress())
     .with('threshold', faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }));
 }
@@ -224,26 +233,35 @@ class SwapOwnerEncoder<T extends SwapOwnerArgs> {
   static readonly FUNCTION_SIGNATURE =
     'function swapOwner(address prevOwner, address oldOwner, address newOwner)';
 
-  private constructor(private args: Partial<T>) {}
+  private constructor(
+    private args: Partial<T>,
+    private owners?: Safe['owners'],
+  ) {}
 
-  public static new<T extends SwapOwnerArgs>(): SwapOwnerEncoder<T> {
-    return new SwapOwnerEncoder<T>({});
+  public static new<T extends SwapOwnerArgs>(
+    owners?: Safe['owners'],
+  ): SwapOwnerEncoder<T> {
+    return new SwapOwnerEncoder<T>({}, owners);
   }
 
   with<K extends keyof T>(key: K, value: T[K]) {
     const args: Partial<T> = { ...this.args, [key]: value };
-    return new SwapOwnerEncoder(args);
+    return new SwapOwnerEncoder(args, this.owners);
   }
 
-  build(owners: Safe['owners']) {
+  build() {
     const prevOwner = (() => {
-      const ownerIndex = owners.findIndex((owners) => {
-        return getAddress(owners) === getAddress(this.args.oldOwner!);
+      if (!this.owners) {
+        return SENTINEL_ADDRESS;
+      }
+
+      const ownerIndex = this.owners.findIndex((owner) => {
+        return getAddress(owner) === getAddress(this.args.oldOwner!);
       });
 
       return ownerIndex <= 0
         ? SENTINEL_ADDRESS
-        : getAddress(owners[ownerIndex - 1]);
+        : getAddress(this.owners[ownerIndex - 1]);
     })();
 
     return {
@@ -253,10 +271,10 @@ class SwapOwnerEncoder<T extends SwapOwnerArgs> {
     };
   }
 
-  encode(owners: Safe['owners']): Hex {
+  encode(): Hex {
     const abi = parseAbi([SwapOwnerEncoder.FUNCTION_SIGNATURE]);
 
-    const { prevOwner, oldOwner, newOwner } = this.build(owners);
+    const { prevOwner, oldOwner, newOwner } = this.build();
 
     return encodeFunctionData({
       abi,
@@ -266,8 +284,8 @@ class SwapOwnerEncoder<T extends SwapOwnerArgs> {
   }
 }
 
-export function swapOwnerEncoder() {
-  return SwapOwnerEncoder.new()
+export function swapOwnerEncoder(owners?: Safe['owners']) {
+  return SwapOwnerEncoder.new(owners)
     .with('oldOwner', faker.finance.ethereumAddress())
     .with('newOwner', faker.finance.ethereumAddress());
 }

--- a/src/domain/alerts/contracts/multi-send-decoder.helper.spec.ts
+++ b/src/domain/alerts/contracts/multi-send-decoder.helper.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
 
 import { MultiSendDecoder } from '@/domain/alerts/contracts/multi-send-decoder.helper';
 import {
@@ -29,7 +30,7 @@ describe('MultiSendDecoder', () => {
         operation: faker.number.int({ min: 0, max: 1 }),
         data,
         // Normally static (0/0) but more robust if we generate random values
-        to: safe.address,
+        to: getAddress(safe.address),
         value: faker.number.bigInt(),
       }));
 


### PR DESCRIPTION
In anticipation of test coverage for recovery alert log decoding, this adds custom transaction/event encoders for recovery-related transactions. This will later be merged into #894 and #895 to avoid mocking decoders.

The following MultiSend methods are covered:

- `multiSend`

The following Safe methods are covered:

- `execTransaction` (batched owner management is handled by the MultiSend contract and thus needs to be executed)
- `addOwner`
- `removeOwner`
- `swapOwner`
- `changeThreshold`

The following Delay Modifier events are covered:

- [`TransactionAdded`](https://github.com/gnosis/zodiac-modifier-delay/blob/515737f67bb704d0ce14d45cd6f7cc8e6b4655d1/contracts/Delay.sol#L16-L23) (emitted upon recovery proposal attempts)

Note: there room for refactoring but due to type complexity this proved difficult and was postponed. We should consider revisiting this in the future.

