### PR TITLE
fix: batched recovery proposal decoding

### DIFF
--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -79,15 +79,21 @@ export class AlertsRepository implements IAlertsRepository {
 
   private decodeTransactionAdded(data: Hex) {
     try {
-      return this.multiSendDecoder
-        .mapMultiSendTransactions(data)
-        .map(this.safeDecoder.decodeFunctionData);
-    } catch {
-      try {
-        return [this.safeDecoder.decodeFunctionData({ data })];
-      } catch {
-        return null;
+      const decoded = this.safeDecoder.decodeFunctionData({ data });
+
+      if (decoded.functionName !== 'execTransaction') {
+        return [decoded];
       }
+
+      // TODO: Check "validity" of multiSend transaction:
+      // - calling official deployment
+      // - all transactions are to current Safe
+      // - all transactions are owner management
+      return this.multiSendDecoder
+        .mapMultiSendTransactions(decoded.args[2])
+        .flatMap(({ data }) => this.safeDecoder.decodeFunctionData({ data }));
+    } catch {
+      return null;
     }
   }
 

--- a/src/domain/alerts/contracts/safe-decoder.helper.ts
+++ b/src/domain/alerts/contracts/safe-decoder.helper.ts
@@ -7,6 +7,8 @@ const OWNER_MANAGER_ABI = parseAbi([
   'function removeOwner(address prevOwner, address owner, uint256 _threshold)',
   'function swapOwner(address prevOwner, address oldOwner, address newOwner)',
   'function changeThreshold(uint256 _threshold)',
+  // Batched owner management transactions are executed via MultiSend
+  'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)',
 ]);
 
 @Injectable()


### PR DESCRIPTION
This adjusts the decoding logic for recovery proposals, taking into account the MultiSend contract is called via an `execTransaction` call, not directly.

Note: test coverage for this first requires the merge of #916 and will be completed in a separate PR.