### PR TITLE
Add resend email verification route

### DIFF
--- a/src/datasources/email/__tests__/test.email.datasource.module.ts
+++ b/src/datasources/email/__tests__/test.email.datasource.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
 
 const emailDataSource = {
+  getVerifiedSignerEmailsBySafeAddress: jest.fn(),
+  getEmail: jest.fn(),
   saveEmail: jest.fn(),
   setVerificationCode: jest.fn(),
   setVerificationSentDate: jest.fn(),

--- a/src/domain/email/errors/email-already-verified.error.ts
+++ b/src/domain/email/errors/email-already-verified.error.ts
@@ -1,7 +1,10 @@
 export class EmailAlreadyVerifiedError extends Error {
+  readonly signer: string;
+
   constructor(args: { chainId: string; safeAddress: string; signer: string }) {
     super(
       `The email address is already verified. chainId=${args.chainId}, safeAddress=${args.safeAddress}, signer=${args.signer}`,
     );
+    this.signer = args.signer;
   }
 }

--- a/src/routes/email/email.controller.resend-verification.spec.ts
+++ b/src/routes/email/email.controller.resend-verification.spec.ts
@@ -1,0 +1,242 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
+import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { EmailControllerModule } from '@/routes/email/email.controller.module';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { Email, EmailAddress } from '@/domain/email/entities/email.entity';
+
+const resendLockWindowMs = 100;
+const ttlMs = 1000;
+describe('Email controller resend verification tests', () => {
+  let app;
+  let emailDatasource;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    const defaultTestConfiguration = configuration();
+    const testConfiguration = () => ({
+      ...defaultTestConfiguration,
+      email: {
+        ...defaultTestConfiguration['email'],
+        verificationCode: {
+          resendLockWindowMs: resendLockWindowMs,
+          ttlMs: ttlMs,
+        },
+      },
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(testConfiguration), EmailControllerModule],
+    })
+      .overrideModule(EmailDataSourceModule)
+      .useModule(TestEmailDatasourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    emailDatasource = moduleFixture.get(IEmailDataSource);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('resends email verification successfully', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    // Advance timer by the minimum amount of time required to resend email
+    jest.advanceTimersByTime(resendLockWindowMs);
+    await request(app.getHttpServer())
+      .put(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify-resend`,
+      )
+      .send({
+        account: account,
+      })
+      .expect(202)
+      .expect({});
+  });
+
+  it('triggering email resend within lock window returns 429', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    // Advance timer to a time within resendLockWindowMs
+    jest.advanceTimersByTime(resendLockWindowMs - 1);
+    await request(app.getHttpServer())
+      .put(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify-resend`,
+      )
+      .send({
+        account: account,
+      })
+      .expect(429);
+  });
+
+  it('triggering email resend on verified emails throws 409', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: true,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    jest.advanceTimersByTime(resendLockWindowMs);
+    await request(app.getHttpServer())
+      .put(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify-resend`,
+      )
+      .send({
+        account: account,
+      })
+      .expect(409)
+      .expect({
+        message: `Cannot verify the provided email for the provided account ${account}`,
+        statusCode: 409,
+      });
+  });
+
+  it('resend email with new code', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const newVerificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    const email = <Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    };
+    emailDatasource.getEmail.mockResolvedValueOnce(email);
+    emailDatasource.getEmail.mockResolvedValueOnce({
+      ...email,
+      verificationCode: newVerificationCode,
+    });
+
+    // Advance timer so that code is considered as expired
+    jest.advanceTimersByTime(ttlMs);
+    await request(app.getHttpServer())
+      .put(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify-resend`,
+      )
+      .send({
+        account: account,
+      })
+      .expect(202)
+      .expect({});
+
+    // TODO 3rd party mock checking that the new code was sent out (and not the old one)
+  });
+
+  it('null verificationCode should return 500', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    const email = <Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    };
+    emailDatasource.getEmail.mockResolvedValueOnce(email);
+    emailDatasource.getEmail.mockResolvedValueOnce({
+      ...email,
+      verificationCode: null,
+    });
+
+    jest.advanceTimersByTime(resendLockWindowMs);
+    await request(app.getHttpServer())
+      .put(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify-resend`,
+      )
+      .send({
+        account: account,
+      })
+      .expect(500)
+      .expect({ code: 500, message: 'Internal server error' });
+  });
+});

--- a/src/routes/email/email.controller.resend-verification.spec.ts
+++ b/src/routes/email/email.controller.resend-verification.spec.ts
@@ -127,7 +127,11 @@ describe('Email controller resend verification tests', () => {
       .send({
         account: account,
       })
-      .expect(429);
+      .expect(429)
+      .expect({
+        message: 'Verification cannot be resent at this time',
+        statusCode: 429,
+      });
   });
 
   it('triggering email resend on verified emails throws 409', async () => {

--- a/src/routes/email/email.controller.save-email.spec.ts
+++ b/src/routes/email/email.controller.save-email.spec.ts
@@ -21,7 +21,7 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { getAddress } from 'viem';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 
-describe('Email controller tests', () => {
+describe('Email controller save email tests', () => {
   let app;
   let safeConfigUrl;
   let emailDatasource;

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -1,10 +1,23 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
 import { EmailService } from '@/routes/email/email.service';
 import { EmailRegistrationGuard } from '@/routes/email/guards/email-registration.guard';
 import { TimestampGuard } from '@/routes/email/guards/timestamp.guard';
 import { OnlySafeOwnerGuard } from '@/routes/email/guards/only-safe-owner.guard';
 import { SaveEmailDto } from '@/routes/email/entities/save-email-dto.entity';
 import { ApiExcludeController, ApiTags } from '@nestjs/swagger';
+import { ResendVerificationDto } from '@/routes/email/entities/resend-verification-dto.entity';
+import { EmailAlreadyVerifiedExceptionFilter } from '@/routes/email/exception-filters/email-already-verified.exception-filter';
+import { ResendVerificationTimespanExceptionFilter } from '@/routes/email/exception-filters/resend-verification-timespan-error.exception-filter';
 
 @ApiTags('email')
 @Controller({
@@ -31,6 +44,24 @@ export class EmailController {
       emailAddress: saveEmailDto.emailAddress,
       safeAddress,
       account: saveEmailDto.account,
+    });
+  }
+
+  @Put('verify-resend')
+  @UseFilters(
+    EmailAlreadyVerifiedExceptionFilter,
+    ResendVerificationTimespanExceptionFilter,
+  )
+  @HttpCode(HttpStatus.ACCEPTED)
+  async resendVerification(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @Body() resendVerificationDto: ResendVerificationDto,
+  ): Promise<void> {
+    await this.service.resendVerification({
+      chainId,
+      safeAddress,
+      account: resendVerificationDto.account,
     });
   }
 }

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -15,4 +15,15 @@ export class EmailService {
   }): Promise<void> {
     return this.repository.saveEmail(args);
   }
+
+  async resendVerification(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+  }): Promise<void> {
+    return this.repository.resendEmailVerification({
+      ...args,
+      signer: args.account,
+    });
+  }
 }

--- a/src/routes/email/entities/resend-verification-dto.entity.ts
+++ b/src/routes/email/entities/resend-verification-dto.entity.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResendVerificationDto {
+  @ApiProperty()
+  account: string;
+}

--- a/src/routes/email/exception-filters/email-already-verified.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-already-verified.exception-filter.ts
@@ -1,0 +1,21 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { EmailAlreadyVerifiedError } from '@/domain/email/errors/email-already-verified.error';
+import { Response } from 'express';
+
+@Catch(EmailAlreadyVerifiedError)
+export class EmailAlreadyVerifiedExceptionFilter implements ExceptionFilter {
+  catch(exception: EmailAlreadyVerifiedError, host: ArgumentsHost): any {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.CONFLICT).json({
+      message: `Cannot verify the provided email for the provided account ${exception.signer}`,
+      statusCode: HttpStatus.CONFLICT,
+    });
+  }
+}

--- a/src/routes/email/exception-filters/email-already-verified.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-already-verified.exception-filter.ts
@@ -9,7 +9,7 @@ import { Response } from 'express';
 
 @Catch(EmailAlreadyVerifiedError)
 export class EmailAlreadyVerifiedExceptionFilter implements ExceptionFilter {
-  catch(exception: EmailAlreadyVerifiedError, host: ArgumentsHost): any {
+  catch(exception: EmailAlreadyVerifiedError, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/exception-filters/resend-verification-timespan-error.exception-filter.ts
+++ b/src/routes/email/exception-filters/resend-verification-timespan-error.exception-filter.ts
@@ -1,0 +1,23 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { ResendVerificationTimespanError } from '@/domain/email/errors/verification-timeframe.error';
+
+@Catch(ResendVerificationTimespanError)
+export class ResendVerificationTimespanExceptionFilter
+  implements ExceptionFilter
+{
+  catch(exception: ResendVerificationTimespanError, host: ArgumentsHost): any {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.TOO_MANY_REQUESTS).json({
+      message: `Verification cannot be resent at this time`,
+      statusCode: HttpStatus.TOO_MANY_REQUESTS,
+    });
+  }
+}

--- a/src/routes/email/exception-filters/resend-verification-timespan-error.exception-filter.ts
+++ b/src/routes/email/exception-filters/resend-verification-timespan-error.exception-filter.ts
@@ -11,7 +11,7 @@ import { ResendVerificationTimespanError } from '@/domain/email/errors/verificat
 export class ResendVerificationTimespanExceptionFilter
   implements ExceptionFilter
 {
-  catch(exception: ResendVerificationTimespanError, host: ArgumentsHost): any {
+  catch(exception: ResendVerificationTimespanError, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 


### PR DESCRIPTION
- Adds a new route to resend email verifications – `PUT chains/:chainId/safes/:safeAddress/emails/verify-resend`.
- This route returns:
  * `202 Accepted` – if the service accepted the request to resend the verification email.
  * `409 Conflict` – if the account already has a verified email address.
  * `429 Too Many Requests` – if attempting to resend the verification email within the "lock window".
- Renames `email.controller.spec.ts` to `email.controller.save-email.spec.ts` to group the tests targeting different routes in different files.

The expected payload for this route is the `account` (owner) to which we should resend the email verification to:

```javascript
{
  "account": <string>
}
```