### PR TITLE
Add email verification route

### DIFF
--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -44,4 +44,22 @@ export interface IEmailRepository {
     safeAddress: string;
     signer: string;
   }): Promise<void>;
+
+  /**
+   * Verifies an email address with the provided code.
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which we should store the email address
+   * @param args.signer - the owner address to which we should link the email address to
+   * @param args.code - the user-provided code to validate the email verification
+   *
+   * @throws {InvalidVerificationCodeError} - if the verification code does not match the expected one
+   * @throws {InvalidVerificationCodeError} - if the verification code expired
+   */
+  verifyEmailAddress(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+    code: string;
+  }): Promise<any>;
 }

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -18,6 +18,8 @@ import { ApiExcludeController, ApiTags } from '@nestjs/swagger';
 import { ResendVerificationDto } from '@/routes/email/entities/resend-verification-dto.entity';
 import { EmailAlreadyVerifiedExceptionFilter } from '@/routes/email/exception-filters/email-already-verified.exception-filter';
 import { ResendVerificationTimespanExceptionFilter } from '@/routes/email/exception-filters/resend-verification-timespan-error.exception-filter';
+import { VerifyEmailDto } from '@/routes/email/entities/verify-email-dto.entity';
+import { InvalidVerificationCodeExceptionFilter } from '@/routes/email/exception-filters/invalid-verification-code.exception-filter';
 
 @ApiTags('email')
 @Controller({
@@ -62,6 +64,22 @@ export class EmailController {
       chainId,
       safeAddress,
       account: resendVerificationDto.account,
+    });
+  }
+
+  @Put('verify')
+  @UseFilters(InvalidVerificationCodeExceptionFilter)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async verifyEmailAddress(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @Body() verifyEmailDto: VerifyEmailDto,
+  ): Promise<void> {
+    await this.service.verifyEmailAddress({
+      chainId,
+      safeAddress,
+      account: verifyEmailDto.account,
+      code: verifyEmailDto.code,
     });
   }
 }

--- a/src/routes/email/email.controller.verify-email.spec.ts
+++ b/src/routes/email/email.controller.verify-email.spec.ts
@@ -1,0 +1,204 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
+import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { EmailControllerModule } from '@/routes/email/email.controller.module';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { Email, EmailAddress } from '@/domain/email/entities/email.entity';
+
+const resendLockWindowMs = 100;
+const ttlMs = 1000;
+
+describe('Email controller verify email tests', () => {
+  let app;
+  let emailDatasource;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    const defaultTestConfiguration = configuration();
+    const testConfiguration = () => ({
+      ...defaultTestConfiguration,
+      email: {
+        ...defaultTestConfiguration['email'],
+        verificationCode: {
+          resendLockWindowMs: resendLockWindowMs,
+          ttlMs: ttlMs,
+        },
+      },
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(testConfiguration), EmailControllerModule],
+    })
+      .overrideModule(EmailDataSourceModule)
+      .useModule(TestEmailDatasourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    emailDatasource = moduleFixture.get(IEmailDataSource);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('verifies email successfully', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    jest.advanceTimersByTime(ttlMs - 1);
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .send({
+        account: account,
+        code: verificationCode,
+      })
+      .expect(204)
+      .expect({});
+
+    expect(emailDatasource.verifyEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 204 on already verified emails', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: true,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    jest.advanceTimersByTime(ttlMs - 1);
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .send({
+        account: account,
+        code: verificationCode,
+      })
+      .expect(204)
+      .expect({});
+
+    expect(emailDatasource.verifyEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('email verification with expired code returns 400', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    jest.advanceTimersByTime(ttlMs);
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .send({
+        account: account,
+        code: verificationCode,
+      })
+      .expect(400)
+      .expect({
+        message: 'The provided verification code is not valid.',
+        statusCode: 400,
+      });
+
+    expect(emailDatasource.verifyEmail).toHaveBeenCalledTimes(0);
+  });
+
+  it('email verification with wrong code returns 400', async () => {
+    const chain = chainBuilder().build();
+    const account = faker.finance.ethereumAddress();
+    const safe = safeBuilder().with('owners', [account]).build();
+    const emailAddress = faker.internet.email();
+    const verificationCode = faker.string.numeric({ length: 6 });
+    const verificationGeneratedOn = new Date();
+    const verificationSentOn = new Date();
+    emailDatasource.getEmail.mockResolvedValue(<Email>{
+      chainId: chain.chainId,
+      emailAddress: new EmailAddress(emailAddress),
+      isVerified: false,
+      safeAddress: safe.address,
+      signer: account,
+      verificationCode: verificationCode,
+      verificationGeneratedOn: verificationGeneratedOn,
+      verificationSentOn: verificationSentOn,
+    });
+
+    jest.advanceTimersByTime(ttlMs - 1);
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .send({
+        account: account,
+        code: faker.string.numeric({ length: 6 }),
+      })
+      .expect(400)
+      .expect({
+        message: 'The provided verification code is not valid.',
+        statusCode: 400,
+      });
+
+    expect(emailDatasource.verifyEmail).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -26,4 +26,16 @@ export class EmailService {
       signer: args.account,
     });
   }
+
+  async verifyEmailAddress(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+    code: string;
+  }): Promise<any> {
+    return this.repository.verifyEmailAddress({
+      ...args,
+      signer: args.account,
+    });
+  }
 }

--- a/src/routes/email/entities/verify-email-dto.entity.ts
+++ b/src/routes/email/entities/verify-email-dto.entity.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VerifyEmailDto {
+  @ApiProperty()
+  account: string;
+
+  @ApiProperty()
+  code: string;
+}

--- a/src/routes/email/exception-filters/invalid-verification-code.exception-filter.ts
+++ b/src/routes/email/exception-filters/invalid-verification-code.exception-filter.ts
@@ -1,0 +1,21 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-verification-code.error';
+
+@Catch(InvalidVerificationCodeError)
+export class InvalidVerificationCodeExceptionFilter implements ExceptionFilter {
+  catch(exception: InvalidVerificationCodeError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.BAD_REQUEST).json({
+      message: `The provided verification code is not valid.`,
+      statusCode: HttpStatus.BAD_REQUEST,
+    });
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/safe-global/safe-client-gateway/pull/919

- Adds a new route to verify email addresses – `PUT /v1/chains/:chainId/safes/:safeAddress/emails/verify`.
- This route sets an email address as verified if successful.
- This route returns:
  * `204 No Content` – if the request was successful and that the client does not need to navigate away from the current page. This status code is also returned if the email was already verified.
  * `400 Bad Request` – if the code is not valid (wrong or expired code).

 This route accepts the following payload:

 ```javascript
 {
   "account": <string>,
   "code": <string>
 }
 ```