### PR TITLE
Refactor date label timezone adjustment

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -172,15 +172,10 @@ export class TransactionsHistoryMapper {
    * @param timezoneOffset - Offset of time zone in milliseconds
    */
   private getDayStartForDate(timestamp: Date, timezoneOffset: number): Date {
-    if (timezoneOffset != 0) {
-      timestamp.setUTCMilliseconds(timezoneOffset);
-    }
+    const date = structuredClone(timestamp);
+    date.setTime(date.getTime() + timezoneOffset);
     return new Date(
-      Date.UTC(
-        timestamp.getUTCFullYear(),
-        timestamp.getUTCMonth(),
-        timestamp.getUTCDate(),
-      ),
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
     );
   }
 


### PR DESCRIPTION
Whenever a timezone offset was provided, we would adjust the underlying date directly with `setUTCMilliseconds`.

`setUTCMilliseconds` adjusts the milliseconds in the Date object and expects a value between 0 and 999. However, in the context of timezones, this value is much greater than 999 which is also addressed by the same function by adjusting the other time components (seconds, minutes, etc.). See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds#description

This refactor makes the change clearer by adding/subtracting the amount of millisecond to the date itself. Previously, a condition around the zero value was required so that the number of milliseconds would not reset.

Additionally the function was changing the `Date` object directly which can affect other parts of the code which would use the same object. To solve this, `structuredClone` is used to to a deep clone of the Date object and change that copy instead.