### PR TITLE
Fix transaction history timezone mapping

### DIFF
--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -602,7 +602,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const timezoneOffsetSubmissionDates = transactions.map(
       ({ submissionDate }) => {
         const dateObj = new Date(submissionDate);
-        dateObj.setUTCMilliseconds(timezoneOffset);
+        dateObj.setTime(dateObj.getTime() + timezoneOffset);
         return dateObj.getTime();
       },
     );

--- a/src/routes/transactions/mappers/creation-transaction/creation-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/creation-transaction/creation-transaction.mapper.ts
@@ -16,6 +16,7 @@ export class CreationTransactionMapper {
     chainId: string,
     transaction: CreationTransaction,
     safe: Safe,
+    timezoneOffsetMs: number,
   ): Promise<Transaction> {
     const creator = await this.addressInfoHelper.getOrDefault(
       chainId,
@@ -40,9 +41,13 @@ export class CreationTransactionMapper {
       implementation,
       factory,
     );
+
+    const date = structuredClone(transaction.created);
+    date.setTime(date.getTime() + timezoneOffsetMs);
+
     return new Transaction(
       `${CreationTransactionMapper.TRANSACTION_TYPE}_${safe.address}`,
-      transaction.created.getTime(),
+      date.getTime(),
       TransactionStatus.Success,
       txInfo,
       null,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -21,6 +21,7 @@ export class ModuleTransactionMapper {
   async mapTransaction(
     chainId: string,
     transaction: ModuleTransaction,
+    timezoneOffsetMs: number,
   ): Promise<Transaction> {
     const txStatus = this.statusMapper.mapTransactionStatus(transaction);
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
@@ -32,9 +33,13 @@ export class ModuleTransactionMapper {
         'CONTRACT',
       ]),
     );
+
+    const date = structuredClone(transaction.executionDate);
+    date.setTime(date.getTime() + timezoneOffsetMs);
+
     return new Transaction(
       `${MODULE_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${transaction.safe}${TRANSACTION_ID_SEPARATOR}${transaction.moduleTransactionId}`,
-      transaction.executionDate.getTime(),
+      date.getTime(),
       txStatus,
       txInfo,
       executionInfo,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -24,6 +24,7 @@ export class MultisigTransactionMapper {
     chainId: string,
     transaction: MultisigTransaction,
     safe: Safe,
+    timezoneOffsetMs: number,
   ): Promise<Transaction> {
     const txStatus = this.statusMapper.mapTransactionStatus(transaction, safe);
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
@@ -39,11 +40,14 @@ export class MultisigTransactionMapper {
       chainId,
       transaction,
     );
-    const timestamp = transaction.executionDate ?? transaction.submissionDate;
+    const date = structuredClone(
+      transaction.executionDate ?? transaction.submissionDate,
+    );
+    date.setTime(date.getTime() + timezoneOffsetMs);
 
     return new Transaction(
       `${MULTISIG_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${transaction.safe}${TRANSACTION_ID_SEPARATOR}${transaction.safeTxHash}`,
-      timestamp?.getTime() ?? null,
+      date.getTime(),
       txStatus,
       txInfo,
       executionInfo,

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -96,6 +96,7 @@ export class TransactionsHistoryMapper {
             chainId,
             safe,
             onlyTrusted,
+            timezoneOffset,
           )
         )
           .filter(<T>(x: T | undefined): x is T => x != null)
@@ -189,6 +190,7 @@ export class TransactionsHistoryMapper {
     chainId: string,
     safe: Safe,
     onlyTrusted: boolean,
+    timezoneOffsetMs: number,
   ): Promise<TransactionItem[]> {
     const limitedTransfers = transfers.slice(0, this.maxNestedTransfers);
     const result: TransactionItem[] = [];
@@ -198,6 +200,7 @@ export class TransactionsHistoryMapper {
         chainId,
         transfer,
         safe,
+        timezoneOffsetMs,
       );
 
       const transferWithValue = this.mapZeroValueTransfer(nestedTransaction);
@@ -248,6 +251,7 @@ export class TransactionsHistoryMapper {
     chainId: string,
     safe: Safe,
     onlyTrusted: boolean,
+    timezoneOffsetMs: number,
   ): Promise<(TransactionItem | TransactionItem[] | undefined)[]> {
     return Promise.all(
       transactionGroup.transactions.map(async (transaction) => {
@@ -257,6 +261,7 @@ export class TransactionsHistoryMapper {
               chainId,
               transaction,
               safe,
+              timezoneOffsetMs,
             ),
           );
         } else if (isModuleTransaction(transaction)) {
@@ -264,6 +269,7 @@ export class TransactionsHistoryMapper {
             await this.moduleTransactionMapper.mapTransaction(
               chainId,
               transaction,
+              timezoneOffsetMs,
             ),
           );
         } else if (isEthereumTransaction(transaction)) {
@@ -274,6 +280,7 @@ export class TransactionsHistoryMapper {
               chainId,
               safe,
               onlyTrusted,
+              timezoneOffsetMs,
             );
           }
         } else if (isCreationTransaction(transaction)) {
@@ -282,6 +289,7 @@ export class TransactionsHistoryMapper {
               chainId,
               transaction,
               safe,
+              timezoneOffsetMs,
             ),
           );
         } else {

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import { Transfer } from '@/domain/safe/entities/transfer.entity';
 import {
-  TRANSFER_PREFIX,
   TRANSACTION_ID_SEPARATOR,
+  TRANSFER_PREFIX,
 } from '@/routes/transactions/constants';
 import { TransactionStatus } from '@/routes/transactions/entities/transaction-status.entity';
 import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/transfer-info.mapper';
@@ -17,10 +17,14 @@ export class TransferMapper {
     chainId: string,
     transfer: Transfer,
     safe: Safe,
+    timezoneOffsetMs: number,
   ): Promise<Transaction> {
+    const date = structuredClone(transfer.executionDate);
+    date.setTime(date.getTime() + timezoneOffsetMs);
+
     return new Transaction(
       `${TRANSFER_PREFIX}${TRANSACTION_ID_SEPARATOR}${safe.address}${TRANSACTION_ID_SEPARATOR}${transfer.transferId}`,
-      transfer.executionDate.getTime(),
+      date.getTime(),
       TransactionStatus.Success,
       await this.transferInfoMapper.mapTransferInfo(chainId, transfer, safe),
       null,

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -186,7 +186,7 @@ export class TransactionsController {
     @Param('safeAddress') safeAddress: string,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
-    timezoneOffset: number,
+    timezoneOffsetMs: number,
     @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
     trusted: boolean,
   ): Promise<Partial<Page<QueuedItem>>> {
@@ -196,7 +196,7 @@ export class TransactionsController {
       safeAddress,
       paginationData,
       trusted,
-      timezoneOffset,
+      timezoneOffsetMs,
     });
   }
 

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -155,6 +155,7 @@ export class TransactionsService {
               args.chainId,
               domainTransaction,
               safeInfo,
+              0, // TODO add timezone offset query parameter
             ),
             ConflictType.None,
           ),
@@ -219,6 +220,7 @@ export class TransactionsService {
             await this.moduleTransactionMapper.mapTransaction(
               args.chainId,
               domainTransaction,
+              0, // TODO add timezone offset query parameter
             ),
           ),
       ),
@@ -268,6 +270,7 @@ export class TransactionsService {
               args.chainId,
               transfer,
               safeInfo,
+              0, // TODO add timezone offset query parameter
             ),
           ),
       ),
@@ -308,7 +311,7 @@ export class TransactionsService {
     safeAddress: string;
     paginationData: PaginationData;
     trusted?: boolean;
-    timezoneOffset: number;
+    timezoneOffsetMs: number;
   }): Promise<Page<QueuedItem>> {
     const pagination = this.getAdjustedPaginationForQueue(args.paginationData);
     const safeInfo = await this.safeRepository.getSafe({
@@ -331,7 +334,7 @@ export class TransactionsService {
       args.chainId,
       this.getPreviousPageLastNonce(transactions, args.paginationData),
       this.getNextPageFirstNonce(transactions),
-      args.timezoneOffset,
+      args.timezoneOffsetMs,
     );
 
     return {


### PR DESCRIPTION
Closes #924 

- Applies the timezone offset to the transactions returned by the Transaction History endpoint
- Since mappers are shared between multiple routes, a default of `0` was set for the routes which do not take into consideration any timezone information. This will be tackled by separately as this would be a new feature.