### PR TITLE
Add timezone_offset query param to transaction routes

### DIFF
--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
@@ -61,7 +61,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       trustedDelegateCallTarget,
     );
 
-    const actual = await mapper.mapDetails(chainId, transaction);
+    const actual = await mapper.mapDetails(chainId, transaction, 0);
 
     expect(actual).toEqual({
       safeAddress: safe.address,
@@ -109,7 +109,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       trustedDelegateCallTarget,
     );
 
-    const actual = await mapper.mapDetails(chainId, transaction);
+    const actual = await mapper.mapDetails(chainId, transaction, 0);
 
     expect(actual).toEqual({
       safeAddress: safe.address,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
@@ -25,6 +25,7 @@ export class ModuleTransactionDetailsMapper {
   async mapDetails(
     chainId: string,
     transaction: ModuleTransaction,
+    timezoneOffsetMs: number,
   ): Promise<TransactionDetails> {
     const [moduleAddress, txInfo, txData] = await Promise.all([
       this.addressInfoHelper.getOrDefault(chainId, transaction.module, [
@@ -34,10 +35,13 @@ export class ModuleTransactionDetailsMapper {
       this.mapTransactionData(chainId, transaction),
     ]);
 
+    const date = structuredClone(transaction.executionDate);
+    date.setTime(date.getTime() + timezoneOffsetMs);
+
     return {
       safeAddress: transaction.safe,
       txId: `${MODULE_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${transaction.safe}${TRANSACTION_ID_SEPARATOR}${transaction.moduleTransactionId}`,
-      executedAt: transaction.executionDate?.getTime() ?? null,
+      executedAt: date.getTime(),
       txStatus: this.statusMapper.mapTransactionStatus(transaction),
       txInfo,
       txData,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -77,7 +77,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const to = addressInfoBuilder().build();
     addressInfoHelper.getOrDefault.mockResolvedValue(to);
 
-    const actual = await mapper.mapDetails(chainId, transaction, safe);
+    const actual = await mapper.mapDetails(chainId, transaction, safe, 0);
 
     expect(actual).toEqual({
       safeAddress: safe.address,
@@ -128,7 +128,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const to = addressInfoBuilder().build();
     addressInfoHelper.getOrDefault.mockResolvedValue(to);
 
-    const actual = await mapper.mapDetails(chainId, transaction, safe);
+    const actual = await mapper.mapDetails(chainId, transaction, safe, 0);
 
     expect(actual).toEqual({
       safeAddress: safe.address,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -31,6 +31,7 @@ export class MultisigTransactionDetailsMapper {
     chainId: string,
     transaction: MultisigTransaction,
     safe: Safe,
+    timezoneOffsetMs: number,
   ): Promise<TransactionDetails> {
     const txStatus = this.statusMapper.mapTransactionStatus(transaction, safe);
     const [
@@ -57,14 +58,18 @@ export class MultisigTransactionDetailsMapper {
         chainId,
         transaction,
         safe,
+        timezoneOffsetMs,
       ),
       this._getRecipientAddressInfo(chainId, transaction.to),
     ]);
 
+    const date = structuredClone(transaction.executionDate);
+    date?.setTime(date?.getTime() + timezoneOffsetMs);
+
     return {
       safeAddress: safe.address,
       txId: `${MULTISIG_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${safe.address}${TRANSACTION_ID_SEPARATOR}${transaction.safeTxHash}`,
-      executedAt: transaction.executionDate?.getTime() ?? null,
+      executedAt: date?.getTime() ?? null,
       txStatus,
       txInfo,
       txData: new TransactionData(

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -63,6 +63,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
       chainId,
       transaction,
       safe,
+      0,
     );
 
     expect(actual).toEqual(
@@ -126,6 +127,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
       chainId,
       transaction,
       safe,
+      0,
     );
 
     expect(actual).toEqual(
@@ -191,6 +193,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
       chainId,
       transaction,
       safe,
+      0,
     );
 
     expect(actual).toEqual(

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -10,8 +10,8 @@ import { AddressInfoHelper } from '@/routes/common/address-info/address-info.hel
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import {
-  MultisigExecutionDetails,
   MultisigConfirmationDetails,
+  MultisigExecutionDetails,
 } from '@/routes/transactions/entities/transaction-details/multisig-execution-details.entity';
 
 @Injectable()
@@ -27,6 +27,7 @@ export class MultisigTransactionExecutionDetailsMapper {
     chainId: string,
     transaction: MultisigTransaction,
     safe: Safe,
+    timezoneOffsetMs: number,
   ): Promise<MultisigExecutionDetails> {
     const signers = safe.owners.map((owner) => new AddressInfo(owner));
     const gasToken = transaction.gasToken ?? NULL_ADDRESS;
@@ -61,8 +62,11 @@ export class MultisigTransactionExecutionDetailsMapper {
         this._getRejectors(chainId, transaction),
       ]);
 
+    const date = structuredClone(transaction.submissionDate);
+    date.setTime(date.getTime() + timezoneOffsetMs);
+
     return new MultisigExecutionDetails(
-      transaction.submissionDate.getTime(),
+      date.getTime(),
       transaction.nonce,
       transaction.safeTxGas?.toString() ?? '0',
       transaction.baseGas?.toString() ?? '0',

--- a/src/routes/transactions/mappers/transfers/transfer-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-details.mapper.spec.ts
@@ -24,7 +24,7 @@ describe('TransferDetails mapper (Unit)', () => {
     const transferInfo = transferTransactionInfoBuilder().build();
     transferInfoMapper.mapTransferInfo.mockResolvedValue(transferInfo);
 
-    const actual = await mapper.mapDetails(chainId, transfer, safe);
+    const actual = await mapper.mapDetails(chainId, transfer, safe, 0);
 
     expect(actual).toEqual({
       safeAddress: safe.address,

--- a/src/routes/transactions/mappers/transfers/transfer-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-details.mapper.spec.ts
@@ -38,4 +38,29 @@ describe('TransferDetails mapper (Unit)', () => {
       safeAppInfo: null,
     });
   });
+
+  it('should return an execution date with a timezone offset', async () => {
+    const chainId = faker.string.numeric();
+    const transfer = erc20TransferBuilder().build();
+    const safe = safeBuilder().build();
+    const transferInfo = transferTransactionInfoBuilder().build();
+    transferInfoMapper.mapTransferInfo.mockResolvedValue(transferInfo);
+    const timezoneOffset = faker.number.int({
+      min: -12 * 60 * 60 * 1000,
+      max: 12 * 60 * 60 * 1000,
+    }); // range from -12 hours to +12 hours
+
+    const actual = await mapper.mapDetails(
+      chainId,
+      transfer,
+      safe,
+      timezoneOffset,
+    );
+
+    const expectedExecutionDate =
+      transfer.executionDate.getTime() + timezoneOffset;
+    expect(actual).toMatchObject({
+      executedAt: expectedExecutionDate,
+    });
+  });
 });

--- a/src/routes/transactions/mappers/transfers/transfer-details.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-details.mapper.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import { Transfer } from '@/domain/safe/entities/transfer.entity';
 import {
-  TRANSFER_PREFIX,
   TRANSACTION_ID_SEPARATOR,
+  TRANSFER_PREFIX,
 } from '@/routes/transactions/constants';
 import { TransactionDetails } from '@/routes/transactions/entities/transaction-details/transaction-details.entity';
 import { TransactionStatus } from '@/routes/transactions/entities/transaction-status.entity';
@@ -17,11 +17,15 @@ export class TransferDetailsMapper {
     chainId: string,
     transfer: Transfer,
     safe: Safe,
+    timezoneOffsetMs: number,
   ): Promise<TransactionDetails> {
+    const date = structuredClone(transfer.executionDate);
+    date.setTime(date.getTime() + timezoneOffsetMs);
+
     return {
       safeAddress: safe.address,
       txId: `${TRANSFER_PREFIX}${TRANSACTION_ID_SEPARATOR}${safe.address}${TRANSACTION_ID_SEPARATOR}${transfer.transferId}`,
-      executedAt: transfer.executionDate?.getTime() ?? null,
+      executedAt: date.getTime(),
       txStatus: TransactionStatus.Success,
       txInfo: await this.transferInfoMapper.mapTransferInfo(
         chainId,

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -48,12 +48,19 @@ export class TransactionsController {
   async getTransactionById(
     @Param('chainId') chainId: string,
     @Param('id') id: string,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffsetMs: number,
   ): Promise<TransactionDetails> {
-    return this.transactionsService.getById({ chainId, txId: id });
+    return this.transactionsService.getById({
+      chainId,
+      txId: id,
+      timezoneOffsetMs,
+    });
   }
 
   @ApiOkResponse({ type: MultisigTransactionPage })
   @Get('chains/:chainId/safes/:safeAddress/multisig-transactions')
+  @ApiQuery({ name: 'timezone_offset', required: false, type: Number })
   @ApiQuery({ name: 'execution_date__gte', required: false, type: String })
   @ApiQuery({ name: 'execution_date__lte', required: false, type: String })
   @ApiQuery({ name: 'to', required: false, type: String })
@@ -66,6 +73,8 @@ export class TransactionsController {
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Param('safeAddress') safeAddress: string,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffsetMs: number,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
     @Query('to') to?: string,
@@ -85,11 +94,13 @@ export class TransactionsController {
       value,
       nonce,
       executed,
+      timezoneOffsetMs,
     });
   }
 
   @ApiOkResponse({ type: ModuleTransactionPage })
   @Get('chains/:chainId/safes/:safeAddress/module-transactions')
+  @ApiQuery({ name: 'timezone_offset', required: false, type: Number })
   @ApiQuery({ name: 'to', required: false, type: String })
   @ApiQuery({ name: 'module', required: false, type: String })
   @ApiQuery({ name: 'cursor', required: false, type: String })
@@ -98,6 +109,8 @@ export class TransactionsController {
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Param('safeAddress') safeAddress: string,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffsetMs: number,
     @Query('to') to?: string,
     @Query('module') module?: string,
   ): Promise<Page<ModuleTransaction>> {
@@ -108,6 +121,7 @@ export class TransactionsController {
       to,
       module,
       paginationData,
+      timezoneOffsetMs,
     });
   }
 
@@ -117,6 +131,8 @@ export class TransactionsController {
   async addConfirmation(
     @Param('chainId') chainId: string,
     @Param('safeTxHash') safeTxHash: string,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffsetMs: number,
     @Body(AddConfirmationDtoValidationPipe)
     addConfirmationDto: AddConfirmationDto,
   ): Promise<TransactionDetails> {
@@ -124,11 +140,13 @@ export class TransactionsController {
       chainId,
       safeTxHash,
       addConfirmationDto,
+      timezoneOffsetMs,
     });
   }
 
   @ApiOkResponse({ type: IncomingTransferPage })
   @Get('chains/:chainId/safes/:safeAddress/incoming-transfers')
+  @ApiQuery({ name: 'timezone_offset', required: false, type: Number })
   @ApiQuery({ name: 'execution_date__gte', required: false, type: String })
   @ApiQuery({ name: 'execution_date__lte', required: false, type: String })
   @ApiQuery({ name: 'to', required: false, type: String })
@@ -140,6 +158,8 @@ export class TransactionsController {
     @RouteUrlDecorator() routeUrl: URL,
     @Param('safeAddress') safeAddress: string,
     @PaginationDataDecorator() paginationData: PaginationData,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffsetMs: number,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
     @Query('to') to?: string,
@@ -156,6 +176,7 @@ export class TransactionsController {
       value,
       tokenAddress,
       paginationData,
+      timezoneOffsetMs,
     });
   }
 
@@ -210,7 +231,7 @@ export class TransactionsController {
     @Param('safeAddress') safeAddress: string,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
-    timezoneOffset: number,
+    timezoneOffsetMs: number,
     @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
     trusted: boolean,
   ): Promise<Partial<TransactionItemPage>> {
@@ -219,7 +240,7 @@ export class TransactionsController {
       routeUrl,
       safeAddress,
       paginationData,
-      timezoneOffset,
+      timezoneOffsetMs,
       onlyTrusted: trusted,
     });
   }
@@ -230,6 +251,8 @@ export class TransactionsController {
   async proposeTransaction(
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
+    @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
+    timezoneOffsetMs: number,
     @Body(ProposeTransactionDtoValidationPipe)
     proposeTransactionDto: ProposeTransactionDto,
   ): Promise<TransactionDetails> {
@@ -237,6 +260,7 @@ export class TransactionsController {
       chainId,
       safeAddress,
       proposeTransactionDto,
+      timezoneOffsetMs,
     });
   }
 }

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -55,6 +55,7 @@ export class TransactionsService {
   async getById(args: {
     chainId: string;
     txId: string;
+    timezoneOffsetMs: number;
   }): Promise<TransactionDetails> {
     const [txType, safeAddress, id] = args.txId.split(TRANSACTION_ID_SEPARATOR);
 
@@ -66,7 +67,11 @@ export class TransactionsService {
             moduleTransactionId: id,
           }),
         ]);
-        return this.moduleTransactionDetailsMapper.mapDetails(args.chainId, tx);
+        return this.moduleTransactionDetailsMapper.mapDetails(
+          args.chainId,
+          tx,
+          args.timezoneOffsetMs,
+        );
       }
 
       case TRANSFER_PREFIX: {
@@ -84,6 +89,7 @@ export class TransactionsService {
           args.chainId,
           transfer,
           safe,
+          args.timezoneOffsetMs,
         );
       }
 
@@ -102,6 +108,7 @@ export class TransactionsService {
           args.chainId,
           tx,
           safe,
+          args.timezoneOffsetMs,
         );
       }
 
@@ -119,6 +126,7 @@ export class TransactionsService {
           args.chainId,
           tx,
           safe,
+          args.timezoneOffsetMs,
         );
       }
     }
@@ -135,6 +143,7 @@ export class TransactionsService {
     value?: string;
     nonce?: string;
     executed?: boolean;
+    timezoneOffsetMs: number;
   }): Promise<Partial<Page<MultisigTransaction>>> {
     const domainTransactions =
       await this.safeRepository.getMultisigTransactions({
@@ -155,7 +164,7 @@ export class TransactionsService {
               args.chainId,
               domainTransaction,
               safeInfo,
-              0, // TODO add timezone offset query parameter
+              args.timezoneOffsetMs,
             ),
             ConflictType.None,
           ),
@@ -181,6 +190,7 @@ export class TransactionsService {
     chainId: string;
     safeTxHash: string;
     addConfirmationDto: AddConfirmationDto;
+    timezoneOffsetMs: number;
   }): Promise<TransactionDetails> {
     await this.safeRepository.addConfirmation(args);
     const transaction = await this.safeRepository.getMultiSigTransaction({
@@ -196,6 +206,7 @@ export class TransactionsService {
       args.chainId,
       transaction,
       safe,
+      args.timezoneOffsetMs,
     );
   }
 
@@ -206,6 +217,7 @@ export class TransactionsService {
     to?: string;
     module?: string;
     paginationData?: PaginationData;
+    timezoneOffsetMs: number;
   }): Promise<Page<ModuleTransaction>> {
     const domainTransactions = await this.safeRepository.getModuleTransactions({
       ...args,
@@ -220,7 +232,7 @@ export class TransactionsService {
             await this.moduleTransactionMapper.mapTransaction(
               args.chainId,
               domainTransaction,
-              0, // TODO add timezone offset query parameter
+              args.timezoneOffsetMs,
             ),
           ),
       ),
@@ -251,6 +263,7 @@ export class TransactionsService {
     value?: string;
     tokenAddress?: string;
     paginationData?: PaginationData;
+    timezoneOffsetMs: number;
   }): Promise<Partial<Page<IncomingTransfer>>> {
     const transfers = await this.safeRepository.getIncomingTransfers({
       ...args,
@@ -270,7 +283,7 @@ export class TransactionsService {
               args.chainId,
               transfer,
               safeInfo,
-              0, // TODO add timezone offset query parameter
+              args.timezoneOffsetMs,
             ),
           ),
       ),
@@ -362,7 +375,7 @@ export class TransactionsService {
     routeUrl: Readonly<URL>;
     safeAddress: string;
     paginationData: PaginationData;
-    timezoneOffset: number;
+    timezoneOffsetMs: number;
     onlyTrusted: boolean;
   }): Promise<TransactionItemPage> {
     const paginationDataAdjusted = this.getAdjustedPaginationForHistory(
@@ -393,7 +406,7 @@ export class TransactionsService {
       domainTransactions.results,
       safeInfo,
       args.paginationData.offset,
-      args.timezoneOffset,
+      args.timezoneOffsetMs,
       args.onlyTrusted,
     );
 
@@ -409,6 +422,7 @@ export class TransactionsService {
     chainId: string;
     safeAddress: string;
     proposeTransactionDto: ProposeTransactionDto;
+    timezoneOffsetMs: number;
   }): Promise<TransactionDetails> {
     await this.safeRepository.proposeTransaction(args);
 
@@ -425,6 +439,7 @@ export class TransactionsService {
       args.chainId,
       domainTransaction,
       safe,
+      args.timezoneOffsetMs,
     );
   }
 


### PR DESCRIPTION
Adds a `timezone_offset` query parameter to the following routes:
- `GET /v1/chains/:chainId/transactions/:id`
- `GET /v1/chains/:chainId/safes/:safeAddress/multisig-transactions`
- `GET /v1/chains/:chainId/safes/:safeAddress/module-transactions`
- `POST /v1/chains/:chainId/transactions/:safeTxHash/confirmations`
- `GET /v1/chains/:chainId/safes/:safeAddress/incoming-transfers`
- `POST /v1/chains/:chainId/transactions/:safeAddress/propose`

The `timezone_offset` functions in the same way as the Transaction History and Transaction Queue endpoints – given a `timezone_offset` in milliseconds, it will shift the results by that number of milliseconds.