### PR TITLE
Remove humanDescription feature flag

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -57,7 +57,7 @@ export default (): ReturnType<typeof configuration> => ({
   express: { jsonLimit: '1mb' },
   features: {
     pricesProviderChainIds: ['10'],
-    humanDescription: true,
+    richFragments: true,
     email: true,
     trustedTokens: true,
   },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -77,8 +77,7 @@ export default () => ({
   features: {
     pricesProviderChainIds:
       process.env.FF_PRICES_PROVIDER_CHAIN_IDS?.split(',') ?? [],
-    humanDescription:
-      process.env.FF_HUMAN_DESCRIPTION?.toLowerCase() === 'true',
+    richFragments: process.env.FF_RICH_FRAGMENTS?.toLowerCase() === 'true',
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
     trustedTokens: process.env.FF_TRUSTED_TOKENS?.toLowerCase() === 'true',
   },

--- a/src/routes/transactions/entities/custom-transaction.entity.ts
+++ b/src/routes/transactions/entities/custom-transaction.entity.ts
@@ -28,7 +28,7 @@ export class CustomTransactionInfo extends TransactionInfo {
     actionCount: number | null,
     isCancellation: boolean,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ) {
     super(TransactionInfoType.Custom, humanDescription, richDecodedInfo);
     this.to = to;

--- a/src/routes/transactions/entities/settings-change-transaction.entity.ts
+++ b/src/routes/transactions/entities/settings-change-transaction.entity.ts
@@ -17,7 +17,7 @@ export class SettingsChangeTransaction extends TransactionInfo {
     dataDecoded: DataDecoded,
     settingsInfo: SettingsChange | null,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ) {
     super(
       TransactionInfoType.SettingsChange,

--- a/src/routes/transactions/entities/transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transaction-info.entity.ts
@@ -15,12 +15,12 @@ export class TransactionInfo {
   humanDescription: string | null;
   // TODO: Remove nullable once the feature flag is removed, allow returning an empty array instead
   @ApiPropertyOptional({ type: RichDecodedInfo, nullable: true })
-  richDecodedInfo: RichDecodedInfo | null;
+  richDecodedInfo: RichDecodedInfo | null | undefined;
 
   protected constructor(
     type: TransactionInfoType,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ) {
     this.type = type;
     this.humanDescription = humanDescription;

--- a/src/routes/transactions/entities/transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transfer-transaction-info.entity.ts
@@ -29,7 +29,7 @@ export class TransferTransactionInfo extends TransactionInfo {
     direction: string,
     transferInfo: Transfer,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ) {
     super(TransactionInfoType.Transfer, humanDescription, richDecodedInfo);
     this.sender = sender;

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
@@ -20,7 +20,7 @@ export class CustomTransactionMapper {
     dataSize: number,
     chainId: string,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ): Promise<CustomTransactionInfo> {
     const toAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,

--- a/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
@@ -22,7 +22,7 @@ export class Erc20TransferMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ): Promise<TransferTransactionInfo> {
     const { dataDecoded } = transaction;
     const sender = this.dataDecodedParamHelper.getFromParam(

--- a/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
@@ -22,7 +22,7 @@ export class Erc721TransferMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ): Promise<TransferTransactionInfo> {
     const { dataDecoded } = transaction;
     const sender = this.dataDecodedParamHelper.getFromParam(

--- a/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
@@ -18,7 +18,7 @@ export class NativeCoinTransferMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
     humanDescription: string | null,
-    richDecodedInfo: RichDecodedInfo | null,
+    richDecodedInfo: RichDecodedInfo | null | undefined,
   ): Promise<TransferTransactionInfo> {
     const recipient = await this.addressInfoHelper.getOrDefault(
       chainId,

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -65,15 +65,20 @@ export class MultisigTransactionInfoMapper {
     const dataSize =
       dataByteLength >= 2 ? Math.floor((dataByteLength - 2) / 2) : 0;
 
-    const richDecodedInfo = this.isRichFragmentsEnabled
-      ? await this.humanDescriptionMapper.mapRichDecodedInfo(
-          transaction,
-          chainId,
-        )
-      : null;
+    const richDecodedInfo =
+      await this.humanDescriptionMapper.mapRichDecodedInfo(
+        transaction,
+        chainId,
+      );
 
     const humanDescription =
       this.humanDescriptionMapper.mapHumanDescription(richDecodedInfo);
+
+    // If the rich fragment feature is disabled, we set it as undefined.
+    // Undefined properties are not rendered on the response
+    const richDecodedInfoApiProperty = this.isRichFragmentsEnabled
+      ? richDecodedInfo
+      : undefined;
 
     if (this.isCustomTransaction(value, dataSize, transaction.operation)) {
       return await this.customTransactionMapper.mapCustomTransaction(
@@ -81,7 +86,7 @@ export class MultisigTransactionInfoMapper {
         dataSize,
         chainId,
         humanDescription,
-        richDecodedInfo,
+        richDecodedInfoApiProperty,
       );
     }
 
@@ -90,7 +95,7 @@ export class MultisigTransactionInfoMapper {
         chainId,
         transaction,
         humanDescription,
-        richDecodedInfo,
+        richDecodedInfoApiProperty,
       );
     }
 
@@ -121,7 +126,7 @@ export class MultisigTransactionInfoMapper {
         new DataDecoded(transaction.dataDecoded.method, dataDecodedParameters),
         settingsInfo,
         humanDescription,
-        richDecodedInfo,
+        richDecodedInfoApiProperty,
       );
     }
 
@@ -137,7 +142,7 @@ export class MultisigTransactionInfoMapper {
             chainId,
             transaction,
             humanDescription,
-            richDecodedInfo,
+            richDecodedInfoApiProperty,
           );
         case TokenType.Erc721:
           return this.erc721TransferMapper.mapErc721Transfer(
@@ -145,7 +150,7 @@ export class MultisigTransactionInfoMapper {
             chainId,
             transaction,
             humanDescription,
-            richDecodedInfo,
+            richDecodedInfoApiProperty,
           );
       }
     }
@@ -155,7 +160,7 @@ export class MultisigTransactionInfoMapper {
       dataSize,
       chainId,
       humanDescription,
-      richDecodedInfo,
+      richDecodedInfoApiProperty,
     );
   }
 

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -23,7 +23,7 @@ export class MultisigTransactionInfoMapper {
   private readonly TRANSFER_METHOD = 'transfer';
   private readonly TRANSFER_FROM_METHOD = 'transferFrom';
   private readonly SAFE_TRANSFER_FROM_METHOD = 'safeTransferFrom';
-  private readonly isHumanDescriptionEnabled: boolean;
+  private readonly isRichFragmentsEnabled: boolean;
 
   private readonly ERC20_TRANSFER_METHODS = [
     this.TRANSFER_METHOD,
@@ -48,8 +48,8 @@ export class MultisigTransactionInfoMapper {
     private readonly erc721TransferMapper: Erc721TransferMapper,
     private readonly humanDescriptionMapper: HumanDescriptionMapper,
   ) {
-    this.isHumanDescriptionEnabled = this.configurationService.getOrThrow(
-      'features.humanDescription',
+    this.isRichFragmentsEnabled = this.configurationService.getOrThrow(
+      'features.richFragments',
     );
   }
 
@@ -65,16 +65,15 @@ export class MultisigTransactionInfoMapper {
     const dataSize =
       dataByteLength >= 2 ? Math.floor((dataByteLength - 2) / 2) : 0;
 
-    const richDecodedInfo = this.isHumanDescriptionEnabled
+    const richDecodedInfo = this.isRichFragmentsEnabled
       ? await this.humanDescriptionMapper.mapRichDecodedInfo(
           transaction,
           chainId,
         )
       : null;
 
-    const humanDescription = this.isHumanDescriptionEnabled
-      ? this.humanDescriptionMapper.mapHumanDescription(richDecodedInfo)
-      : null;
+    const humanDescription =
+      this.humanDescriptionMapper.mapHumanDescription(richDecodedInfo);
 
     if (this.isCustomTransaction(value, dataSize, transaction.operation)) {
       return await this.customTransactionMapper.mapCustomTransaction(


### PR DESCRIPTION
- Removes `features.humanDescription` – this feature is considered stable and is now officially part of the provided API.
- Adds a new feature flag for "rich fragments" – rich fragments are currently under development and are considered to be a separate feature to human-readable descriptions.
- This feature flag can be enabled via `FF_RICH_FRAGMENTS`