### PR TITLE
Remove yarn plugins folder from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM node:20.10.0 as base
 ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
-COPY --chown=node:node .yarn/plugins ./.yarn/plugins
 COPY --chown=node:node .yarn/patches ./.yarn/patches
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn workspaces focus --production


### PR DESCRIPTION
Removes the plugins folder from the Docker image. Since the upgrade to Yarn 4 in 758f7b2ee3be402ad7f01922dcfb778b078b3f6b, the workspaces plugin is already bundled with Yarn therefore it was removed.