### PR TITLE
Change Jest matchers deprecated function calls

### DIFF
--- a/src/config/nest.configuration.service.spec.ts
+++ b/src/config/nest.configuration.service.spec.ts
@@ -23,9 +23,9 @@ describe('NestConfigurationService', () => {
 
     const result = target.get(key);
 
-    expect(configServiceMock.get).toBeCalledTimes(1);
-    expect(configServiceMock.get).toBeCalledWith(key);
-    expect(configServiceMock.getOrThrow).toBeCalledTimes(0);
+    expect(configServiceMock.get).toHaveBeenCalledTimes(1);
+    expect(configServiceMock.get).toHaveBeenCalledWith(key);
+    expect(configServiceMock.getOrThrow).toHaveBeenCalledTimes(0);
     expect(result).toBe(value);
   });
 
@@ -35,9 +35,9 @@ describe('NestConfigurationService', () => {
 
     const result = target.get(key);
 
-    expect(configServiceMock.get).toBeCalledTimes(1);
-    expect(configServiceMock.get).toBeCalledWith(key);
-    expect(configServiceMock.getOrThrow).toBeCalledTimes(0);
+    expect(configServiceMock.get).toHaveBeenCalledTimes(1);
+    expect(configServiceMock.get).toHaveBeenCalledWith(key);
+    expect(configServiceMock.getOrThrow).toHaveBeenCalledTimes(0);
     expect(result).toBe(undefined);
   });
 
@@ -48,9 +48,9 @@ describe('NestConfigurationService', () => {
 
     const result = target.getOrThrow(key);
 
-    expect(configServiceMock.getOrThrow).toBeCalledTimes(1);
-    expect(configServiceMock.getOrThrow).toBeCalledWith(key);
-    expect(configServiceMock.get).toBeCalledTimes(0);
+    expect(configServiceMock.getOrThrow).toHaveBeenCalledTimes(1);
+    expect(configServiceMock.getOrThrow).toHaveBeenCalledWith(key);
+    expect(configServiceMock.get).toHaveBeenCalledTimes(0);
     expect(result).toBe(value);
   });
 
@@ -64,8 +64,8 @@ describe('NestConfigurationService', () => {
       target.getOrThrow(key);
     }).toThrow('some error');
 
-    expect(configServiceMock.getOrThrow).toBeCalledTimes(1);
-    expect(configServiceMock.getOrThrow).toBeCalledWith(key);
-    expect(configServiceMock.get).toBeCalledTimes(0);
+    expect(configServiceMock.getOrThrow).toHaveBeenCalledTimes(1);
+    expect(configServiceMock.getOrThrow).toHaveBeenCalledWith(key);
+    expect(configServiceMock.get).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -87,7 +87,7 @@ describe('TenderlyApi', () => {
 
     await service.addContracts(contracts);
 
-    expect(mockNetworkService.post).toBeCalledWith(
+    expect(mockNetworkService.post).toHaveBeenCalledWith(
       `${tenderlyBaseUri}/api/v2/accounts/${tenderlyAccount}/projects/${tenderlyProject}/contracts`,
       {
         headers: {
@@ -114,7 +114,7 @@ describe('TenderlyApi', () => {
     };
     mockNetworkService.post.mockRejectedValueOnce(error);
 
-    await expect(service.addContracts([])).rejects.toThrowError(
+    await expect(service.addContracts([])).rejects.toThrow(
       new DataSourceError('Unexpected error', status),
     );
 

--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -98,7 +98,7 @@ describe('CacheFirstDataSource', () => {
         url: targetUrl,
         notFoundExpireTimeSeconds,
       }),
-    ).rejects.toThrowError(expectedError);
+    ).rejects.toThrow(expectedError);
 
     expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
     expect(fakeCacheService.keyCount()).toBe(1);
@@ -124,7 +124,7 @@ describe('CacheFirstDataSource', () => {
         url: targetUrl,
         notFoundExpireTimeSeconds,
       }),
-    ).rejects.toThrowError(expectedError);
+    ).rejects.toThrow(expectedError);
 
     await expect(
       cacheFirstDataSource.get({
@@ -132,7 +132,7 @@ describe('CacheFirstDataSource', () => {
         url: targetUrl,
         notFoundExpireTimeSeconds,
       }),
-    ).rejects.toThrowError(expectedError);
+    ).rejects.toThrow(expectedError);
 
     expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
     expect(fakeCacheService.keyCount()).toBe(1);
@@ -171,7 +171,7 @@ describe('CacheFirstDataSource', () => {
         url: targetUrl,
         notFoundExpireTimeSeconds,
       }),
-    ).rejects.toThrowError(expectedError);
+    ).rejects.toThrow(expectedError);
 
     expect(mockCache.set).toHaveBeenCalledWith(
       cacheDir,
@@ -214,7 +214,7 @@ describe('CacheFirstDataSource', () => {
         notFoundExpireTimeSeconds,
         expireTimeSeconds: faker.number.int(),
       }),
-    ).rejects.toThrowError(expectedError);
+    ).rejects.toThrow(expectedError);
 
     expect(mockCache.set).toHaveBeenCalledWith(
       cacheDir,

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -44,11 +44,11 @@ describe('RedisCacheService', () => {
 
     await redisCacheService.set(cacheDir, value, undefined);
 
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.expire).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.expire).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('Setting key with expireTimeSeconds', async () => {
@@ -61,17 +61,20 @@ describe('RedisCacheService', () => {
 
     await redisCacheService.set(cacheDir, value, expireTime);
 
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hSet).toBeCalledWith(
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledWith(
       cacheDir.key,
       cacheDir.field,
       value,
     );
-    expect(redisClientTypeMock.expire).toBeCalledTimes(1);
-    expect(redisClientTypeMock.expire).toBeCalledWith(cacheDir.key, expireTime);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.expire).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.expire).toHaveBeenCalledWith(
+      cacheDir.key,
+      expireTime,
+    );
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('Setting key throws on expire', async () => {
@@ -87,23 +90,23 @@ describe('RedisCacheService', () => {
       redisCacheService.set(cacheDir, value, expireTimeSeconds),
     ).rejects.toThrow('cache error');
 
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hSet).toBeCalledWith(
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledWith(
       cacheDir.key,
       cacheDir.field,
       value,
     );
-    expect(redisClientTypeMock.expire).toBeCalledTimes(1);
-    expect(redisClientTypeMock.expire).toBeCalledWith(
+    expect(redisClientTypeMock.expire).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.expire).toHaveBeenCalledWith(
       cacheDir.key,
       expireTimeSeconds,
     );
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hDel).toBeCalledWith(
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledWith(
       cacheDir.key,
       cacheDir.field,
     );
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('Setting key throws on set', async () => {
@@ -118,19 +121,19 @@ describe('RedisCacheService', () => {
       redisCacheService.set(cacheDir, value, faker.number.int({ min: 5 })),
     ).rejects.toThrow('cache error');
 
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hSet).toBeCalledWith(
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledWith(
       cacheDir.key,
       cacheDir.field,
       value,
     );
-    expect(redisClientTypeMock.expire).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hDel).toBeCalledWith(
+    expect(redisClientTypeMock.expire).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledWith(
       cacheDir.key,
       cacheDir.field,
     );
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('Getting key calls hGet', async () => {
@@ -140,14 +143,14 @@ describe('RedisCacheService', () => {
     );
     await redisCacheService.get(cacheDir);
 
-    expect(redisClientTypeMock.hGet).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hGet).toBeCalledWith(
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledWith(
       cacheDir.key,
       cacheDir.field,
     );
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('Deleting key calls delete', async () => {
@@ -155,11 +158,11 @@ describe('RedisCacheService', () => {
 
     await redisCacheService.deleteByKey(key);
 
-    expect(redisClientTypeMock.unlink).toBeCalledTimes(1);
-    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.unlink).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('Deleting keys by pattern calls scan and unlink', async () => {
@@ -172,20 +175,20 @@ describe('RedisCacheService', () => {
 
     await redisCacheService.deleteByKeyPattern(faker.string.alphanumeric());
 
-    expect(redisClientTypeMock.scanIterator).toBeCalledTimes(1);
-    expect(redisClientTypeMock.unlink).toBeCalledTimes(matches.length);
-    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
-    expect(redisClientTypeMock.quit).toBeCalledTimes(0);
+    expect(redisClientTypeMock.scanIterator).toHaveBeenCalledTimes(1);
+    expect(redisClientTypeMock.unlink).toHaveBeenCalledTimes(matches.length);
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(0);
   });
 
   it('When Module gets destroyed, redis connection is closed', async () => {
     await redisCacheService.onModuleDestroy();
 
-    expect(redisClientTypeMock.hGet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hSet).toBeCalledTimes(0);
-    expect(redisClientTypeMock.hDel).toBeCalledTimes(0);
-    expect(redisClientTypeMock.quit).toBeCalledTimes(1);
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.hDel).toHaveBeenCalledTimes(0);
+    expect(redisClientTypeMock.quit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -76,15 +76,15 @@ describe('ConfigApi', () => {
     const actual = await service.getChains({});
 
     expect(actual).toBe(data);
-    expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith({
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir('chains', 'undefined_undefined'),
       url: `${baseUri}/api/v1/chains`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: { params: { limit: undefined, offset: undefined } },
       expireTimeSeconds: expirationTimeInSeconds,
     });
-    expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
   it('should return the chain retrieved', async () => {
@@ -94,14 +94,14 @@ describe('ConfigApi', () => {
     const actual = await service.getChain(data.chainId);
 
     expect(actual).toBe(data);
-    expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith({
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(`${data.chainId}_chain`, ''),
       url: `${baseUri}/api/v1/chains/${data.chainId}`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       expireTimeSeconds: expirationTimeInSeconds,
     });
-    expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
   it('should return the safe apps retrieved by chainId', async () => {
@@ -112,8 +112,8 @@ describe('ConfigApi', () => {
     const actual = await service.getSafeApps({ chainId });
 
     expect(actual).toBe(data);
-    expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith({
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(`${chainId}_safe_apps`, 'undefined_undefined'),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
@@ -122,7 +122,7 @@ describe('ConfigApi', () => {
       },
       expireTimeSeconds: expirationTimeInSeconds,
     });
-    expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
   it('should return the safe apps retrieved by chainId and url', async () => {
@@ -134,15 +134,15 @@ describe('ConfigApi', () => {
     const actual = await service.getSafeApps({ chainId, url });
 
     expect(actual).toBe(data);
-    expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith({
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(`${chainId}_safe_apps`, `undefined_${url}`),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: { params: { chainId, clientUrl: undefined, url } },
       expireTimeSeconds: expirationTimeInSeconds,
     });
-    expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
   it('should return the safe apps retrieved by chainId and clientUrl', async () => {
@@ -154,15 +154,15 @@ describe('ConfigApi', () => {
     const actual = await service.getSafeApps({ chainId, clientUrl });
 
     expect(actual).toBe(data);
-    expect(mockDataSource.get).toBeCalledTimes(1);
-    expect(mockDataSource.get).toBeCalledWith({
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: { params: { chainId, clientUrl, url: undefined } },
       expireTimeSeconds: expirationTimeInSeconds,
     });
-    expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
   it('should forward error', async () => {
@@ -170,26 +170,28 @@ describe('ConfigApi', () => {
     mockHttpErrorFactory.from.mockReturnValue(expected);
     mockDataSource.get.mockRejectedValueOnce(new Error('Some error'));
 
-    await expect(service.getChains({})).rejects.toThrowError(expected);
+    await expect(service.getChains({})).rejects.toThrow(expected);
 
     expect(mockDataSource.get).toHaveBeenCalledTimes(1);
-    expect(mockHttpErrorFactory.from).toBeCalledTimes(1);
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(1);
   });
 
   it('clear chains should trigger delete on cache service', async () => {
     await service.clearChains();
 
-    expect(mockCacheService.deleteByKey).toBeCalledWith('chains');
-    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_chain');
-    expect(mockCacheService.deleteByKey).toBeCalledTimes(1);
-    expect(mockCacheService.deleteByKeyPattern).toBeCalledTimes(1);
+    expect(mockCacheService.deleteByKey).toHaveBeenCalledWith('chains');
+    expect(mockCacheService.deleteByKeyPattern).toHaveBeenCalledWith('*_chain');
+    expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.deleteByKeyPattern).toHaveBeenCalledTimes(1);
   });
 
   it('clear safe apps should trigger delete on cache service', async () => {
     await service.clearSafeApps();
 
-    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_safe_apps');
-    expect(mockCacheService.deleteByKeyPattern).toBeCalledTimes(1);
-    expect(mockCacheService.deleteByKey).toBeCalledTimes(0);
+    expect(mockCacheService.deleteByKeyPattern).toHaveBeenCalledWith(
+      '*_safe_apps',
+    );
+    expect(mockCacheService.deleteByKeyPattern).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/datasources/email-api/pushwoosh-api.service.spec.ts
+++ b/src/datasources/email-api/pushwoosh-api.service.spec.ts
@@ -84,7 +84,7 @@ describe('PushwooshApi', () => {
 
       await expect(
         service.createMessage(createEmailMessageDto),
-      ).rejects.toThrowError(new DataSourceError('Unexpected error', status));
+      ).rejects.toThrow(new DataSourceError('Unexpected error', status));
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
     });
@@ -179,7 +179,7 @@ describe('PushwooshApi', () => {
 
       await expect(
         service.deleteEmailAddress({ emailAddress: faker.internet.email() }),
-      ).rejects.toThrowError(new DataSourceError('Unexpected error', status));
+      ).rejects.toThrow(new DataSourceError('Unexpected error', status));
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
     });

--- a/src/datasources/exchange-api/exchange-api.service.spec.ts
+++ b/src/datasources/exchange-api/exchange-api.service.spec.ts
@@ -83,7 +83,7 @@ describe('ExchangeApi', () => {
 
     await target.getFiatCodes();
 
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir('exchange_fiat_codes', ''),
       url: `${exchangeBaseUri}/symbols?access_key=${exchangeApiKey}`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
@@ -125,7 +125,7 @@ describe('ExchangeApi', () => {
 
     await target.getRates();
 
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir('exchange_rates', ''),
       url: `${exchangeBaseUri}/latest?access_key=${exchangeApiKey}`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,

--- a/src/datasources/network/axios.network.service.spec.ts
+++ b/src/datasources/network/axios.network.service.spec.ts
@@ -38,8 +38,8 @@ describe('AxiosNetworkService', () => {
 
       await target.get(url);
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(url, undefined);
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+      expect(axiosMock.get).toHaveBeenCalledWith(url, undefined);
     });
 
     it(`get calls axios get with request`, async () => {
@@ -50,20 +50,20 @@ describe('AxiosNetworkService', () => {
 
       await target.get(url, request);
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(url, request);
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+      expect(axiosMock.get).toHaveBeenCalledWith(url, request);
     });
 
     it(`get forwards unknown error as NetworkOtherError`, async () => {
       const url = faker.internet.url({ appendSlash: false });
       (axiosMock.get as any).mockRejectedValueOnce(new Error('Axios error'));
 
-      await expect(target.get(url)).rejects.toThrowError(
+      await expect(target.get(url)).rejects.toThrow(
         new NetworkOtherError('Axios error'),
       );
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(url, undefined);
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+      expect(axiosMock.get).toHaveBeenCalledWith(url, undefined);
     });
 
     it(`get forwards response error as NetworkResponseError`, async () => {
@@ -74,12 +74,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.get as any).mockRejectedValueOnce(error);
 
-      await expect(target.get(url)).rejects.toThrowError(
+      await expect(target.get(url)).rejects.toThrow(
         new NetworkResponseError(error.response.data, error.response.status),
       );
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(url, undefined);
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+      expect(axiosMock.get).toHaveBeenCalledWith(url, undefined);
     });
 
     it(`get forwards response error as NetworkRequestError`, async () => {
@@ -89,12 +89,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.get as any).mockRejectedValueOnce(error);
 
-      await expect(target.get(url)).rejects.toThrowError(
+      await expect(target.get(url)).rejects.toThrow(
         new NetworkRequestError(error.request),
       );
 
-      expect(axiosMock.get).toBeCalledTimes(1);
-      expect(axiosMock.get).toBeCalledWith(url, undefined);
+      expect(axiosMock.get).toHaveBeenCalledTimes(1);
+      expect(axiosMock.get).toHaveBeenCalledWith(url, undefined);
     });
 
     it(`get logs response error`, async () => {
@@ -113,12 +113,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.get as any).mockRejectedValueOnce(error);
 
-      await expect(target.get(url)).rejects.toThrowError(
+      await expect(target.get(url)).rejects.toThrow(
         new NetworkRequestError(error.request),
       );
 
-      expect(loggingService.debug).toBeCalledTimes(1);
-      expect(loggingService.debug).toBeCalledWith({
+      expect(loggingService.debug).toHaveBeenCalledTimes(1);
+      expect(loggingService.debug).toHaveBeenCalledWith({
         type: 'external_request',
         protocol: error.request.protocol,
         target_host: error.request.host,
@@ -137,8 +137,8 @@ describe('AxiosNetworkService', () => {
 
       await target.post(url, data);
 
-      expect(axiosMock.post).toBeCalledTimes(1);
-      expect(axiosMock.post).toBeCalledWith(url, data, undefined);
+      expect(axiosMock.post).toHaveBeenCalledTimes(1);
+      expect(axiosMock.post).toHaveBeenCalledWith(url, data, undefined);
     });
 
     it(`post calls axios post with request`, async () => {
@@ -150,8 +150,8 @@ describe('AxiosNetworkService', () => {
 
       await target.post(url, data, request);
 
-      expect(axiosMock.post).toBeCalledTimes(1);
-      expect(axiosMock.post).toBeCalledWith(url, data, request);
+      expect(axiosMock.post).toHaveBeenCalledTimes(1);
+      expect(axiosMock.post).toHaveBeenCalledWith(url, data, request);
     });
 
     it(`post forwards unknown error as NetworkOtherError`, async () => {
@@ -159,12 +159,12 @@ describe('AxiosNetworkService', () => {
       const data = { [faker.word.sample()]: faker.string.alphanumeric() };
       (axiosMock.post as any).mockRejectedValueOnce(new Error('Axios error'));
 
-      await expect(target.post(url, data)).rejects.toThrowError(
+      await expect(target.post(url, data)).rejects.toThrow(
         new NetworkOtherError('Axios error'),
       );
 
-      expect(axiosMock.post).toBeCalledTimes(1);
-      expect(axiosMock.post).toBeCalledWith(url, data, undefined);
+      expect(axiosMock.post).toHaveBeenCalledTimes(1);
+      expect(axiosMock.post).toHaveBeenCalledWith(url, data, undefined);
     });
 
     it(`post forwards response error as NetworkResponseError`, async () => {
@@ -176,12 +176,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.post as any).mockRejectedValueOnce(error);
 
-      await expect(target.post(url, data)).rejects.toThrowError(
+      await expect(target.post(url, data)).rejects.toThrow(
         new NetworkResponseError(error.response.data, error.response.status),
       );
 
-      expect(axiosMock.post).toBeCalledTimes(1);
-      expect(axiosMock.post).toBeCalledWith(url, data, undefined);
+      expect(axiosMock.post).toHaveBeenCalledTimes(1);
+      expect(axiosMock.post).toHaveBeenCalledWith(url, data, undefined);
     });
 
     it(`post forwards response error as NetworkRequestError`, async () => {
@@ -192,12 +192,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.post as any).mockRejectedValueOnce(error);
 
-      await expect(target.post(url, data)).rejects.toThrowError(
+      await expect(target.post(url, data)).rejects.toThrow(
         new NetworkRequestError(error.request),
       );
 
-      expect(axiosMock.post).toBeCalledTimes(1);
-      expect(axiosMock.post).toBeCalledWith(url, data, undefined);
+      expect(axiosMock.post).toHaveBeenCalledTimes(1);
+      expect(axiosMock.post).toHaveBeenCalledWith(url, data, undefined);
     });
 
     it(`post logs response error`, async () => {
@@ -216,12 +216,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.post as any).mockRejectedValueOnce(error);
 
-      await expect(target.post(url, {})).rejects.toThrowError(
+      await expect(target.post(url, {})).rejects.toThrow(
         new NetworkRequestError(error.request),
       );
 
-      expect(loggingService.debug).toBeCalledTimes(1);
-      expect(loggingService.debug).toBeCalledWith({
+      expect(loggingService.debug).toHaveBeenCalledTimes(1);
+      expect(loggingService.debug).toHaveBeenCalledWith({
         type: 'external_request',
         protocol: error.request.protocol,
         target_host: error.request.host,
@@ -240,8 +240,8 @@ describe('AxiosNetworkService', () => {
 
       await target.delete(url, data);
 
-      expect(axiosMock.delete).toBeCalledTimes(1);
-      expect(axiosMock.delete).toBeCalledWith(url, { data: data });
+      expect(axiosMock.delete).toHaveBeenCalledTimes(1);
+      expect(axiosMock.delete).toHaveBeenCalledWith(url, { data: data });
     });
 
     it(`delete forwards unknown error as NetworkOtherError`, async () => {
@@ -249,12 +249,12 @@ describe('AxiosNetworkService', () => {
       const data = { some_data: 'some_data' };
       axiosMock.delete.mockRejectedValueOnce(new Error('Axios error'));
 
-      await expect(target.delete(url, data)).rejects.toThrowError(
+      await expect(target.delete(url, data)).rejects.toThrow(
         new NetworkOtherError('Axios error'),
       );
 
-      expect(axiosMock.delete).toBeCalledTimes(1);
-      expect(axiosMock.delete).toBeCalledWith(url, { data: data });
+      expect(axiosMock.delete).toHaveBeenCalledTimes(1);
+      expect(axiosMock.delete).toHaveBeenCalledWith(url, { data: data });
     });
 
     it(`delete forwards response error as NetworkResponseError`, async () => {
@@ -266,12 +266,12 @@ describe('AxiosNetworkService', () => {
       };
       axiosMock.delete.mockRejectedValueOnce(error);
 
-      await expect(target.delete(url, data)).rejects.toThrowError(
+      await expect(target.delete(url, data)).rejects.toThrow(
         new NetworkResponseError(error.response.data, error.response.status),
       );
 
-      expect(axiosMock.delete).toBeCalledTimes(1);
-      expect(axiosMock.delete).toBeCalledWith(url, { data: data });
+      expect(axiosMock.delete).toHaveBeenCalledTimes(1);
+      expect(axiosMock.delete).toHaveBeenCalledWith(url, { data: data });
     });
 
     it(`delete forwards response error as NetworkRequestError`, async () => {
@@ -282,12 +282,12 @@ describe('AxiosNetworkService', () => {
       };
       axiosMock.delete.mockRejectedValueOnce(error);
 
-      await expect(target.delete(url, data)).rejects.toThrowError(
+      await expect(target.delete(url, data)).rejects.toThrow(
         new NetworkRequestError(error.request),
       );
 
-      expect(axiosMock.delete).toBeCalledTimes(1);
-      expect(axiosMock.delete).toBeCalledWith(url, { data: data });
+      expect(axiosMock.delete).toHaveBeenCalledTimes(1);
+      expect(axiosMock.delete).toHaveBeenCalledWith(url, { data: data });
     });
 
     it(`delete logs response error`, async () => {
@@ -306,12 +306,12 @@ describe('AxiosNetworkService', () => {
       };
       (axiosMock.delete as any).mockRejectedValueOnce(error);
 
-      await expect(target.delete(url)).rejects.toThrowError(
+      await expect(target.delete(url)).rejects.toThrow(
         new NetworkRequestError(error.request),
       );
 
-      expect(loggingService.debug).toBeCalledTimes(1);
-      expect(loggingService.debug).toBeCalledWith({
+      expect(loggingService.debug).toHaveBeenCalledTimes(1);
+      expect(loggingService.debug).toHaveBeenCalledWith({
         type: 'external_request',
         protocol: error.request.protocol,
         target_host: error.request.host,

--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -90,7 +90,7 @@ describe('CoingeckoAPI', () => {
     const fiatCodes = await service.getFiatCodes();
 
     expect(fiatCodes).toBe(expectedFiatCodes);
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir('fiat_codes', ''),
       url: `${coingeckoBaseUri}/simple/supported_vs_currencies`,
       networkRequest: {
@@ -118,7 +118,7 @@ describe('CoingeckoAPI', () => {
     const fiatCodes = await service.getFiatCodes();
 
     expect(fiatCodes).toBe(expectedFiatCodes);
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir('fiat_codes', ''),
       url: `${coingeckoBaseUri}/simple/supported_vs_currencies`,
       networkRequest: {},
@@ -149,7 +149,7 @@ describe('CoingeckoAPI', () => {
       '',
     );
     expect(assetPrice).toEqual([{ [tokenAddress]: { [fiatCode]: price } }]);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(mockNetworkService.get).toHaveBeenCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
         headers: {
@@ -201,7 +201,7 @@ describe('CoingeckoAPI', () => {
       '',
     );
     expect(assetPrice).toEqual([{ [tokenAddress]: { [fiatCode]: price } }]);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(mockNetworkService.get).toHaveBeenCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
         params: {
@@ -252,7 +252,7 @@ describe('CoingeckoAPI', () => {
       { [secondTokenAddress]: { [fiatCode]: secondPrice } },
       { [thirdTokenAddress]: { [fiatCode]: thirdPrice } },
     ]);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(mockNetworkService.get).toHaveBeenCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
         headers: {
@@ -354,7 +354,7 @@ describe('CoingeckoAPI', () => {
         (i) => Object.keys(i)[0],
       ),
     );
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(mockNetworkService.get).toHaveBeenCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
         headers: {
@@ -446,7 +446,7 @@ describe('CoingeckoAPI', () => {
         (i) => Object.keys(i)[0],
       ),
     );
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(mockNetworkService.get).toHaveBeenCalledWith(
       `${coingeckoBaseUri}/simple/token_price/${chainName}`,
       {
         headers: {
@@ -501,7 +501,7 @@ describe('CoingeckoAPI', () => {
 
     await service.getNativeCoinPrice({ nativeCoinId, fiatCode });
 
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
         `${nativeCoinId}_native_coin_price_${fiatCode}`,
         '',
@@ -537,7 +537,7 @@ describe('CoingeckoAPI', () => {
 
     await service.getNativeCoinPrice({ nativeCoinId, fiatCode });
 
-    expect(mockCacheFirstDataSource.get).toBeCalledWith({
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
         `${nativeCoinId}_native_coin_price_${fiatCode}`,
         '',

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -79,7 +79,7 @@ describe('Transaction API Manager Tests', () => {
     const transactionApi = await target.getTransactionApi(chain.chainId);
     await transactionApi.getBackbone();
 
-    expect(dataSourceMock.get).toBeCalledWith({
+    expect(dataSourceMock.get).toHaveBeenCalledWith({
       cacheDir: expect.anything(),
       url: `${expectedUrl}/api/v1/about`,
       notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -86,7 +86,7 @@ describe('TransactionApi', () => {
       });
 
       expect(actual).toBe(data);
-      expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
     });
 
     it('should forward error', async () => {
@@ -100,10 +100,10 @@ describe('TransactionApi', () => {
           trusted: true,
           excludeSpam: true,
         }),
-      ).rejects.toThrowError(expected);
+      ).rejects.toThrow(expected);
 
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
-      expect(mockHttpErrorFactory.from).toBeCalledTimes(1);
+      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -115,7 +115,7 @@ describe('TransactionApi', () => {
       const actual = await service.getBackbone();
 
       expect(actual).toBe(data);
-      expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
     });
 
     it('should forward error', async () => {
@@ -123,10 +123,10 @@ describe('TransactionApi', () => {
       mockHttpErrorFactory.from.mockReturnValue(expected);
       mockDataSource.get.mockRejectedValueOnce(new Error('testErr'));
 
-      await expect(service.getBackbone()).rejects.toThrowError(expected);
+      await expect(service.getBackbone()).rejects.toThrow(expected);
 
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
-      expect(mockHttpErrorFactory.from).toBeCalledTimes(1);
+      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -137,11 +137,11 @@ describe('TransactionApi', () => {
 
       await service.clearLocalBalances(safeAddress);
 
-      expect(mockCacheService.deleteByKey).toBeCalledTimes(2);
-      expect(mockCacheService.deleteByKey).toBeCalledWith(
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(2);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
         `${chainId}_balances_${safeAddress}`,
       );
-      expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
+      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -153,7 +153,7 @@ describe('TransactionApi', () => {
       const actual = await service.getSafe(safe.address);
 
       expect(actual).toBe(safe);
-      expect(mockDataSource.get).toBeCalledWith({
+      expect(mockDataSource.get).toHaveBeenCalledWith({
         cacheDir: new CacheDir(`${chainId}_safe_${safe.address}`, ''),
         url: `${baseUrl}/api/v1/safes/${safe.address}`,
         notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
@@ -169,9 +169,7 @@ describe('TransactionApi', () => {
       mockDataSource.get.mockRejectedValueOnce(error);
       mockHttpErrorFactory.from.mockReturnValue(expected);
 
-      await expect(service.getSafe(safe.address)).rejects.toThrowError(
-        expected,
-      );
+      await expect(service.getSafe(safe.address)).rejects.toThrow(expected);
       expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -127,8 +127,8 @@ describe('Chains Controller (Unit)', () => {
           ],
         });
 
-      expect(networkService.get).toBeCalledTimes(1);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains`,
         {
           params: {
@@ -149,8 +149,8 @@ describe('Chains Controller (Unit)', () => {
         code: 500,
       });
 
-      expect(networkService.get).toBeCalledTimes(1);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains`,
         {
           params: {
@@ -175,8 +175,8 @@ describe('Chains Controller (Unit)', () => {
         arguments: [],
       });
 
-      expect(networkService.get).toBeCalledTimes(1);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains`,
         {
           params: {
@@ -260,7 +260,7 @@ describe('Chains Controller (Unit)', () => {
         .expect(200)
         .expect(backboneResponse);
 
-      expect(networkService.get).toBeCalledTimes(2);
+      expect(networkService.get).toHaveBeenCalledTimes(2);
       expect(networkService.get.mock.calls[0][0]).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
@@ -283,8 +283,8 @@ describe('Chains Controller (Unit)', () => {
           code: 400,
         });
 
-      expect(networkService.get).toBeCalledTimes(1);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains/1`,
         undefined,
       );
@@ -304,7 +304,7 @@ describe('Chains Controller (Unit)', () => {
           code: 502,
         });
 
-      expect(networkService.get).toBeCalledTimes(2);
+      expect(networkService.get).toHaveBeenCalledTimes(2);
       expect(networkService.get.mock.calls[0][0]).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
@@ -341,7 +341,7 @@ describe('Chains Controller (Unit)', () => {
         .expect(200)
         .expect(masterCopiesResponse);
 
-      expect(networkService.get).toBeCalledTimes(2);
+      expect(networkService.get).toHaveBeenCalledTimes(2);
       expect(networkService.get.mock.calls[0][0]).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
@@ -364,8 +364,8 @@ describe('Chains Controller (Unit)', () => {
           code: 400,
         });
 
-      expect(networkService.get).toBeCalledTimes(1);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains/1`,
         undefined,
       );
@@ -385,7 +385,7 @@ describe('Chains Controller (Unit)', () => {
           code: 502,
         });
 
-      expect(networkService.get).toBeCalledTimes(2);
+      expect(networkService.get).toHaveBeenCalledTimes(2);
       expect(networkService.get.mock.calls[0][0]).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -77,8 +77,8 @@ describe('RouteLoggerInterceptor tests', () => {
   it('500 error triggers error level', async () => {
     await request(app.getHttpServer()).get('/test/server-error').expect(500);
 
-    expect(mockLoggingService.error).toBeCalledTimes(1);
-    expect(mockLoggingService.error).toBeCalledWith({
+    expect(mockLoggingService.error).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.error).toHaveBeenCalledWith({
       chain_id: null,
       client_ip: null,
       detail: 'Some 500 error',
@@ -89,9 +89,9 @@ describe('RouteLoggerInterceptor tests', () => {
       safe_app_user_agent: null,
       status_code: 500,
     });
-    expect(mockLoggingService.info).not.toBeCalled();
-    expect(mockLoggingService.debug).not.toBeCalled();
-    expect(mockLoggingService.warn).not.toBeCalled();
+    expect(mockLoggingService.info).not.toHaveBeenCalled();
+    expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    expect(mockLoggingService.warn).not.toHaveBeenCalled();
   });
 
   it('500 Datasource error triggers error level', async () => {
@@ -104,8 +104,8 @@ describe('RouteLoggerInterceptor tests', () => {
       // (see expects below)
       .expect(500);
 
-    expect(mockLoggingService.error).toBeCalledTimes(1);
-    expect(mockLoggingService.error).toBeCalledWith({
+    expect(mockLoggingService.error).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.error).toHaveBeenCalledWith({
       chain_id: null,
       client_ip: null,
       detail: 'Some DataSource error',
@@ -116,16 +116,16 @@ describe('RouteLoggerInterceptor tests', () => {
       safe_app_user_agent: null,
       status_code: 501,
     });
-    expect(mockLoggingService.info).not.toBeCalled();
-    expect(mockLoggingService.debug).not.toBeCalled();
-    expect(mockLoggingService.warn).not.toBeCalled();
+    expect(mockLoggingService.info).not.toHaveBeenCalled();
+    expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    expect(mockLoggingService.warn).not.toHaveBeenCalled();
   });
 
   it('400 error triggers info level', async () => {
     await request(app.getHttpServer()).get('/test/client-error').expect(405);
 
-    expect(mockLoggingService.info).toBeCalledTimes(1);
-    expect(mockLoggingService.info).toBeCalledWith({
+    expect(mockLoggingService.info).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.info).toHaveBeenCalledWith({
       chain_id: null,
       client_ip: null,
       detail: 'Some 400 error',
@@ -136,16 +136,16 @@ describe('RouteLoggerInterceptor tests', () => {
       safe_app_user_agent: null,
       status_code: 405,
     });
-    expect(mockLoggingService.error).not.toBeCalled();
-    expect(mockLoggingService.debug).not.toBeCalled();
-    expect(mockLoggingService.warn).not.toBeCalled();
+    expect(mockLoggingService.error).not.toHaveBeenCalled();
+    expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    expect(mockLoggingService.warn).not.toHaveBeenCalled();
   });
 
   it('200 triggers info level', async () => {
     await request(app.getHttpServer()).get('/test/success').expect(200);
 
-    expect(mockLoggingService.info).toBeCalledTimes(1);
-    expect(mockLoggingService.info).toBeCalledWith({
+    expect(mockLoggingService.info).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.info).toHaveBeenCalledWith({
       chain_id: null,
       client_ip: null,
       detail: null,
@@ -156,9 +156,9 @@ describe('RouteLoggerInterceptor tests', () => {
       safe_app_user_agent: null,
       status_code: 200,
     });
-    expect(mockLoggingService.error).not.toBeCalled();
-    expect(mockLoggingService.debug).not.toBeCalled();
-    expect(mockLoggingService.warn).not.toBeCalled();
+    expect(mockLoggingService.error).not.toHaveBeenCalled();
+    expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    expect(mockLoggingService.warn).not.toHaveBeenCalled();
   });
 
   it('200 with chainId logs chain id', async () => {
@@ -167,8 +167,8 @@ describe('RouteLoggerInterceptor tests', () => {
       .get(`/test/success/${chainId}`)
       .expect(200);
 
-    expect(mockLoggingService.info).toBeCalledTimes(1);
-    expect(mockLoggingService.info).toBeCalledWith({
+    expect(mockLoggingService.info).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.info).toHaveBeenCalledWith({
       chain_id: chainId,
       client_ip: null,
       detail: null,
@@ -179,9 +179,9 @@ describe('RouteLoggerInterceptor tests', () => {
       safe_app_user_agent: null,
       status_code: 200,
     });
-    expect(mockLoggingService.error).not.toBeCalled();
-    expect(mockLoggingService.debug).not.toBeCalled();
-    expect(mockLoggingService.warn).not.toBeCalled();
+    expect(mockLoggingService.error).not.toHaveBeenCalled();
+    expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    expect(mockLoggingService.warn).not.toHaveBeenCalled();
   });
 
   it('non http error triggers error level', async () => {
@@ -189,8 +189,8 @@ describe('RouteLoggerInterceptor tests', () => {
       .get('/test/server-error-non-http')
       .expect(500);
 
-    expect(mockLoggingService.error).toBeCalledTimes(1);
-    expect(mockLoggingService.error).toBeCalledWith({
+    expect(mockLoggingService.error).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.error).toHaveBeenCalledWith({
       chain_id: null,
       client_ip: null,
       detail: 'Some random error',
@@ -201,9 +201,9 @@ describe('RouteLoggerInterceptor tests', () => {
       safe_app_user_agent: null,
       status_code: 500,
     });
-    expect(mockLoggingService.info).not.toBeCalled();
-    expect(mockLoggingService.debug).not.toBeCalled();
-    expect(mockLoggingService.warn).not.toBeCalled();
+    expect(mockLoggingService.info).not.toHaveBeenCalled();
+    expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    expect(mockLoggingService.warn).not.toHaveBeenCalled();
   });
 
   it('Logs Safe-App-User-Agent header', async () => {
@@ -214,7 +214,7 @@ describe('RouteLoggerInterceptor tests', () => {
       .set('Safe-App-User-Agent', safeAppUserAgentHeader)
       .expect(200);
 
-    expect(mockLoggingService.info).toBeCalledWith({
+    expect(mockLoggingService.info).toHaveBeenCalledWith({
       chain_id: null,
       client_ip: null,
       detail: null,

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -252,8 +252,8 @@ describe('Notifications Controller (Unit)', () => {
         .delete(`/v1/chains/${chain.chainId}/notifications/devices/${uuid}`)
         .expect(200)
         .expect({});
-      expect(networkService.delete).toBeCalledTimes(1);
-      expect(networkService.delete).toBeCalledWith(expectedProviderURL);
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(expectedProviderURL);
     });
 
     it('Failure: Config API fails', async () => {
@@ -268,7 +268,7 @@ describe('Notifications Controller (Unit)', () => {
       await request(app.getHttpServer())
         .delete(`/v1/chains/${chainId}/notifications/devices/${uuid}`)
         .expect(503);
-      expect(networkService.delete).toBeCalledTimes(0);
+      expect(networkService.delete).toHaveBeenCalledTimes(0);
     });
 
     it('Failure: Transaction API fails', async () => {
@@ -289,7 +289,7 @@ describe('Notifications Controller (Unit)', () => {
       await request(app.getHttpServer())
         .delete(`/v1/chains/${chain.chainId}/notifications/devices/${uuid}`)
         .expect(503);
-      expect(networkService.delete).toBeCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -314,8 +314,8 @@ describe('Notifications Controller (Unit)', () => {
         )
         .expect(200)
         .expect({});
-      expect(networkService.delete).toBeCalledTimes(1);
-      expect(networkService.delete).toBeCalledWith(expectedProviderURL);
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(expectedProviderURL);
     });
 
     it('Failure: Config API fails', async () => {
@@ -333,7 +333,7 @@ describe('Notifications Controller (Unit)', () => {
           `/v1/chains/${chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(503);
-      expect(networkService.delete).toBeCalledTimes(0);
+      expect(networkService.delete).toHaveBeenCalledTimes(0);
     });
 
     it('Failure: Transaction API fails', async () => {
@@ -357,7 +357,7 @@ describe('Notifications Controller (Unit)', () => {
           `/v1/chains/${chain.chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(503);
-      expect(networkService.delete).toBeCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -88,8 +88,8 @@ describe('Owners Controller (Unit)', () => {
           code: 500,
         });
 
-      expect(networkService.get).toBeCalledTimes(1);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains/${chainId}`,
         undefined,
       );
@@ -112,12 +112,12 @@ describe('Owners Controller (Unit)', () => {
           code: 500,
         });
 
-      expect(networkService.get).toBeCalledTimes(2);
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledTimes(2);
+      expect(networkService.get).toHaveBeenCalledWith(
         `${safeConfigUrl}/api/v1/chains/${chainId}`,
         undefined,
       );
-      expect(networkService.get).toBeCalledWith(
+      expect(networkService.get).toHaveBeenCalledWith(
         `${chainResponse.transactionService}/api/v1/owners/${ownerAddress}/safes/`,
         undefined,
       );

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -87,8 +87,8 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(1);
-    expect(networkService.get).toBeCalledWith(getChainUrl, undefined);
+    expect(networkService.get).toHaveBeenCalledTimes(1);
+    expect(networkService.get).toHaveBeenCalledWith(getChainUrl, undefined);
   });
 
   it('Failure: Transaction API fails', async () => {
@@ -118,9 +118,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(2);
-    expect(networkService.get).toBeCalledWith(getChainUrl, undefined);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(2);
+    expect(networkService.get).toHaveBeenCalledWith(getChainUrl, undefined);
+    expect(networkService.get).toHaveBeenCalledWith(
       getModuleTransactionUrl,
       undefined,
     );

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -81,8 +81,8 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(1);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(1);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -109,12 +109,12 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(2);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(2);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledWith(
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`,
       expect.objectContaining({
         params: expect.objectContaining({ offset, limit }),

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -71,8 +71,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(1);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(1);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -95,8 +95,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(2);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(2);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -139,8 +139,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 404,
       });
 
-    expect(networkService.get).toBeCalledTimes(2);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(2);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -80,8 +80,8 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(1);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(1);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -104,12 +104,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(2);
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledTimes(2);
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledWith(
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`,
       expect.objectContaining({
         params: expect.objectContaining({

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -661,11 +661,11 @@ describe('Transactions History Controller (Unit)', () => {
         expect(body.previous).toContain(clientPreviousCursor);
       });
 
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
-    expect(networkService.get).toBeCalledWith(
+    expect(networkService.get).toHaveBeenCalledWith(
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`,
       {
         params: {


### PR DESCRIPTION
Test-related changes only:
- `toBeCalled` matcher function is deprecated, it was changed by `toHaveBeenCalled`.
- `toBeCalledTimes` matcher function is deprecated, it was changed by `toHaveBeenCalledTimes`.
- `toBeCalledWith` matcher function is deprecated, it was changed by `toHaveBeenCalledWith`.
- `toThrowError` matcher function is deprecated, it was changed by `toThrow`.