### PR TITLE
Fix EMAIL_API_FROM_EMAIL default value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       ALERTS_PROVIDER_ACCOUNT: ${ALERTS_PROVIDER_ACCOUNT-example_account}
       ALERTS_PROVIDER_PROJECT: ${ALERTS_PROVIDER_PROJECT-example_project}
       EMAIL_API_APPLICATION_CODE: ${EMAIL_API_APPLICATION_CODE-example_application_code}
-      EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-ch@nge.me}
+      EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-changeme@example.com}
       EMAIL_API_KEY: ${EMAIL_API_KEY-example_api_key}
       EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: ${EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX-example_template_unknown_recovery_tx}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       ALERTS_PROVIDER_ACCOUNT: ${ALERTS_PROVIDER_ACCOUNT-example_account}
       ALERTS_PROVIDER_PROJECT: ${ALERTS_PROVIDER_PROJECT-example_project}
       EMAIL_API_APPLICATION_CODE: ${EMAIL_API_APPLICATION_CODE-example_application_code}
-      EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-example_from_email}
+      EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-ch@nge.me}
       EMAIL_API_KEY: ${EMAIL_API_KEY-example_api_key}
       EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: ${EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX-example_template_unknown_recovery_tx}
     depends_on:

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -6,7 +6,7 @@ process.env.ALERTS_PROVIDER_API_KEY = 'fake-api-key';
 process.env.ALERTS_PROVIDER_ACCOUNT = 'fake-account';
 process.env.ALERTS_PROVIDER_PROJECT = 'fake-project';
 process.env.EMAIL_API_APPLICATION_CODE = 'fake-application-code';
-process.env.EMAIL_API_FROM_EMAIL = 'fake-from-email';
+process.env.EMAIL_API_FROM_EMAIL = 'ch@nge.me';
 process.env.EMAIL_API_KEY = 'fake-api-key';
 
 // For E2E tests, connect to the test database

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -6,7 +6,7 @@ process.env.ALERTS_PROVIDER_API_KEY = 'fake-api-key';
 process.env.ALERTS_PROVIDER_ACCOUNT = 'fake-account';
 process.env.ALERTS_PROVIDER_PROJECT = 'fake-project';
 process.env.EMAIL_API_APPLICATION_CODE = 'fake-application-code';
-process.env.EMAIL_API_FROM_EMAIL = 'ch@nge.me';
+process.env.EMAIL_API_FROM_EMAIL = 'changeme@example.com';
 process.env.EMAIL_API_KEY = 'fake-api-key';
 
 // For E2E tests, connect to the test database


### PR DESCRIPTION
Changes:
- Changes the `docker-compose.yml` default value for `EMAIL_API_FROM_EMAIL`.
- Changes the `test/e2e-setup.ts` default value for `EMAIL_API_FROM_EMAIL`.

Otherwise the following error would happen when running the container without providing a value via environment variable:
```
Error: Configuration is invalid: /EMAIL_API_FROM_EMAIL must match format "email"
```
