### PR TITLE
Add missing interface declaration

### DIFF
--- a/src/domain/backbone/backbone.repository.ts
+++ b/src/domain/backbone/backbone.repository.ts
@@ -2,9 +2,10 @@ import { Inject, Injectable } from '@nestjs/common';
 import { BackboneValidator } from '@/domain/backbone/backbone.validator';
 import { Backbone } from '@/domain/backbone/entities/backbone.entity';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import { IBackboneRepository } from '@/domain/backbone/backbone.repository.interface';
 
 @Injectable()
-export class BackboneRepository {
+export class BackboneRepository implements IBackboneRepository {
   constructor(
     @Inject(ITransactionApiManager)
     private readonly transactionApiManager: ITransactionApiManager,


### PR DESCRIPTION
`BackboneRepository` should implement `IBackboneRepository`. The mapping is already being done in the `DomainModule`.