### PR TITLE
Remove unused symbol

### DIFF
--- a/src/domain/collectibles/collectibles.repository.interface.ts
+++ b/src/domain/collectibles/collectibles.repository.interface.ts
@@ -1,8 +1,6 @@
 import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
 import { Page } from '@/domain/entities/page.entity';
 
-export const IChainsRepository = Symbol('IChainsRepository');
-
 export const ICollectiblesRepository = Symbol('ICollectiblesRepository');
 
 export interface ICollectiblesRepository {


### PR DESCRIPTION
Removes unused `IChainsRepository` which was declared in collectibles.repository.interface