### PR TITLE
refactor: return `this` from `IBuilder['with']`

### DIFF
--- a/src/__tests__/builder.ts
+++ b/src/__tests__/builder.ts
@@ -1,5 +1,5 @@
 export interface IBuilder<T> {
-  with<K extends keyof T>(key: K, value: T[K]): IBuilder<T>;
+  with<K extends keyof T>(key: K, value: T[K]): this;
 
   build(): T;
 }
@@ -13,9 +13,9 @@ export class Builder<T> implements IBuilder<T> {
    * @param key - the name of the property from T to be set
    * @param value - the value of the property from T to be set
    */
-  with<K extends keyof T>(key: K, value: T[K]): IBuilder<T> {
-    const target: Partial<T> = { ...this.target, [key]: value };
-    return new Builder<T>(target);
+  with<K extends keyof T>(key: K, value: T[K]): this {
+    this.target = { ...this.target, [key]: value };
+    return this;
   }
 
   /**


### PR DESCRIPTION
This adjusts the `ReturnType` of `IBuilder['with']` in preparation for [extending it](https://github.com/safe-global/safe-client-gateway/pull/921/files#r1422237932). Calling `with` currently returns a `Builder` instance, when we should otherwise be returning the potentially extended instance.