### PR TITLE
fix: change `/alerts` response code to `202`

### DIFF
--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -114,7 +114,7 @@ describe('Alerts (Unit)', () => {
         .set('x-tenderly-signature', signature)
         .set('date', timestamp)
         .send(alert)
-        .expect(200)
+        .expect(202)
         .expect({});
     });
 
@@ -165,7 +165,7 @@ describe('Alerts (Unit)', () => {
         .set('x-tenderly-signature', signature)
         .set('date', timestamp)
         .send(alert)
-        .expect(200)
+        .expect(202)
         .expect({});
 
       const expectedTargetEmailAddresses = verifiedSignerEmails.map(

--- a/src/routes/alerts/alerts.controller.ts
+++ b/src/routes/alerts/alerts.controller.ts
@@ -17,7 +17,7 @@ export class AlertsController {
   @UseGuards(AlertsRouteGuard)
   @UseGuards(TenderlySignatureGuard)
   @Post('/alerts')
-  @HttpCode(200)
+  @HttpCode(202)
   async postAlert(
     @Body(AlertValidationPipe)
     alertPayload: Alert,


### PR DESCRIPTION
As per https://github.com/safe-global/safe-client-gateway/pull/948#issue-2046537653, this changes the response code of the `/alerts` endpoint from `200` to `202` to better reflect the outcome of the route.