### PR TITLE
Remove static new function from Builder

### DIFF
--- a/src/__tests__/builder.ts
+++ b/src/__tests__/builder.ts
@@ -5,10 +5,10 @@ export interface IBuilder<T> {
 }
 
 export class Builder<T> implements IBuilder<T> {
-  protected constructor(private target: Partial<T>) {}
+  private target: Partial<T> = {};
 
   /**
-   * Returns a new {@link Builder} with the property {@link key} set to {@link value}.
+   * Returns the {@link Builder} with the property {@link key} set to {@link value}.
    *
    * @param key - the name of the property from T to be set
    * @param value - the value of the property from T to be set
@@ -23,9 +23,5 @@ export class Builder<T> implements IBuilder<T> {
    */
   build(): T {
     return this.target as T;
-  }
-
-  public static new<T>(): IBuilder<T> {
-    return new Builder<T>({});
   }
 }

--- a/src/__tests__/encoder-builder.ts
+++ b/src/__tests__/encoder-builder.ts
@@ -1,20 +1,5 @@
 import { Hex } from 'viem';
 
-import { Builder, IBuilder } from '@/__tests__/builder';
-
-export interface IEncoderBuilder<T, E = Hex> extends IBuilder<T> {
+export interface IEncoder<E = Hex> {
   encode(): E;
-}
-
-export class EncoderBuilder<T, E = Hex>
-  extends Builder<T>
-  implements IEncoderBuilder<T, E>
-{
-  encode(): E {
-    throw new Error('Method not implemented.');
-  }
-
-  public static new<T, E = Hex>() {
-    return new this<T, E>({});
-  }
 }

--- a/src/domain/alerts/__tests__/delay-modifier.encoder.ts
+++ b/src/domain/alerts/__tests__/delay-modifier.encoder.ts
@@ -1,13 +1,14 @@
-import { EncoderBuilder, IEncoderBuilder } from '@/__tests__/encoder-builder';
+import { IEncoder } from '@/__tests__/encoder-builder';
 import { faker } from '@faker-js/faker';
 import {
-  Hex,
   encodeAbiParameters,
   encodeEventTopics,
   getAddress,
+  Hex,
   parseAbi,
   parseAbiParameters,
 } from 'viem';
+import { Builder } from '@/__tests__/builder';
 
 // TransactionAdded
 
@@ -25,10 +26,10 @@ type TransactionAddedEvent = {
   topics: [signature: Hex, ...args: Array<Hex>];
 };
 
-class TransactionAddedEventBuilder<
-  T extends TransactionAddedEventArgs,
-  E extends TransactionAddedEvent,
-> extends EncoderBuilder<T, E> {
+class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
+  extends Builder<T>
+  implements IEncoder<TransactionAddedEvent>
+{
   static readonly NON_INDEXED_PARAMS =
     'address to, uint256 value, bytes data, uint8 operation' as const;
   static readonly EVENT_SIGNATURE =
@@ -53,21 +54,15 @@ class TransactionAddedEventBuilder<
       },
     });
 
-    return {
+    return <TransactionAddedEvent>{
       data,
       topics,
-    } as E;
+    };
   }
 }
 
-export function transactionAddedEventBuilder(): IEncoderBuilder<
-  TransactionAddedEventArgs,
-  TransactionAddedEvent
-> {
-  return TransactionAddedEventBuilder.new<
-    TransactionAddedEventArgs,
-    TransactionAddedEvent
-  >()
+export function transactionAddedEventBuilder() {
+  return new TransactionAddedEventBuilder()
     .with('queueNonce', faker.number.bigInt())
     .with('txHash', faker.string.hexadecimal({ length: 64 }) as Hex)
     .with('to', getAddress(faker.finance.ethereumAddress()))

--- a/src/domain/alerts/__tests__/multi-send-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/multi-send-transactions.encoder.ts
@@ -1,14 +1,15 @@
-import { EncoderBuilder, IEncoderBuilder } from '@/__tests__/encoder-builder';
+import { IEncoder } from '@/__tests__/encoder-builder';
 import { faker } from '@faker-js/faker';
 import {
-  Hex,
   concat,
   encodeFunctionData,
   encodePacked,
   getAddress,
+  Hex,
   parseAbi,
   size,
 } from 'viem';
+import { Builder } from '@/__tests__/builder';
 
 // multiSend
 
@@ -16,7 +17,10 @@ type MultiSendArgs = {
   transactions: Hex;
 };
 
-class MultiSendEncoder<T extends MultiSendArgs> extends EncoderBuilder<T> {
+class MultiSendEncoder<T extends MultiSendArgs>
+  extends Builder<T>
+  implements IEncoder
+{
   static readonly FUNCTION_SIGNATURE =
     'function multiSend(bytes memory transactions)' as const;
 
@@ -53,7 +57,7 @@ export function multiSendTransactionsEncoder(
   return concat(encodedTransactions);
 }
 
-export function multiSendEncoder(): IEncoderBuilder<MultiSendArgs> {
+export function multiSendEncoder() {
   const transactions = multiSendTransactionsEncoder([
     {
       operation: 0,
@@ -63,8 +67,5 @@ export function multiSendEncoder(): IEncoderBuilder<MultiSendArgs> {
     },
   ]);
 
-  return MultiSendEncoder.new<MultiSendArgs>().with(
-    'transactions',
-    transactions,
-  );
+  return new MultiSendEncoder().with('transactions', transactions);
 }

--- a/src/domain/alerts/__tests__/safe-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/safe-transactions.encoder.ts
@@ -1,8 +1,9 @@
 import { faker } from '@faker-js/faker';
-import { parseAbi, encodeFunctionData, getAddress, Hex, pad } from 'viem';
+import { encodeFunctionData, getAddress, Hex, pad, parseAbi } from 'viem';
 
 import { Safe } from '@/domain/safe/entities/safe.entity';
-import { EncoderBuilder, IEncoderBuilder } from '@/__tests__/encoder-builder';
+import { IEncoder } from '@/__tests__/encoder-builder';
+import { Builder } from '@/__tests__/builder';
 
 const ZERO_ADDRESS = pad('0x0', { size: 20 });
 const SENTINEL_ADDRESS = pad('0x1', { dir: 'left', size: 20 });
@@ -38,9 +39,10 @@ type ExecTransactionArgs = {
   signatures: Hex;
 };
 
-class ExecTransactionEncoder<
-  T extends ExecTransactionArgs,
-> extends EncoderBuilder<T> {
+class ExecTransactionEncoder<T extends ExecTransactionArgs>
+  extends Builder<T>
+  implements IEncoder
+{
   static readonly FUNCTION_SIGNATURE =
     'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)' as const;
 
@@ -68,8 +70,8 @@ class ExecTransactionEncoder<
   }
 }
 
-export function execTransactionEncoder(): IEncoderBuilder<ExecTransactionArgs> {
-  return ExecTransactionEncoder.new<ExecTransactionArgs>()
+export function execTransactionEncoder() {
+  return new ExecTransactionEncoder()
     .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('value', BigInt(0))
     .with('data', '0x')
@@ -89,9 +91,10 @@ type AddOwnerWithThresholdArgs = {
   threshold: bigint;
 };
 
-class AddOwnerWithThresholdEncoder<
-  T extends AddOwnerWithThresholdArgs,
-> extends EncoderBuilder<T> {
+class AddOwnerWithThresholdEncoder<T extends AddOwnerWithThresholdArgs>
+  extends Builder<T>
+  implements IEncoder
+{
   static readonly FUNCTION_SIGNATURE =
     'function addOwnerWithThreshold(address owner, uint256 _threshold)' as const;
 
@@ -108,8 +111,8 @@ class AddOwnerWithThresholdEncoder<
   }
 }
 
-export function addOwnerWithThresholdEncoder(): IEncoderBuilder<AddOwnerWithThresholdArgs> {
-  return AddOwnerWithThresholdEncoder.new<AddOwnerWithThresholdArgs>()
+export function addOwnerWithThresholdEncoder() {
+  return new AddOwnerWithThresholdEncoder()
     .with('owner', getAddress(faker.finance.ethereumAddress()))
     .with('threshold', faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }));
 }
@@ -122,7 +125,10 @@ type RemoveOwnerArgs = {
   threshold: bigint;
 };
 
-class RemoveOwnerEncoder<T extends RemoveOwnerArgs> extends EncoderBuilder<T> {
+class RemoveOwnerEncoder<T extends RemoveOwnerArgs>
+  extends Builder<T>
+  implements IEncoder
+{
   static readonly FUNCTION_SIGNATURE =
     'function removeOwner(address prevOwner, address owner, uint256 _threshold)';
 
@@ -139,13 +145,11 @@ class RemoveOwnerEncoder<T extends RemoveOwnerArgs> extends EncoderBuilder<T> {
   }
 }
 
-export function removeOwnerEncoder(
-  owners?: Safe['owners'],
-): IEncoderBuilder<RemoveOwnerArgs> {
+export function removeOwnerEncoder(owners?: Safe['owners']) {
   const owner = getAddress(faker.finance.ethereumAddress());
   const prevOwner = getPrevOwner(owner, owners);
 
-  return RemoveOwnerEncoder.new<RemoveOwnerArgs>()
+  return new RemoveOwnerEncoder()
     .with('prevOwner', prevOwner)
     .with('owner', owner)
     .with('threshold', faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }));
@@ -159,7 +163,10 @@ type SwapOwnerArgs = {
   newOwner: Hex;
 };
 
-class SwapOwnerEncoder<T extends SwapOwnerArgs> extends EncoderBuilder<T> {
+class SwapOwnerEncoder<T extends SwapOwnerArgs>
+  extends Builder<T>
+  implements IEncoder
+{
   static readonly FUNCTION_SIGNATURE =
     'function swapOwner(address prevOwner, address oldOwner, address newOwner)';
 
@@ -176,13 +183,11 @@ class SwapOwnerEncoder<T extends SwapOwnerArgs> extends EncoderBuilder<T> {
   }
 }
 
-export function swapOwnerEncoder(
-  owners?: Safe['owners'],
-): IEncoderBuilder<SwapOwnerArgs> {
+export function swapOwnerEncoder(owners?: Safe['owners']) {
   const oldOwner = getAddress(faker.finance.ethereumAddress());
   const prevOwner = getPrevOwner(oldOwner, owners);
 
-  return SwapOwnerEncoder.new<SwapOwnerArgs>()
+  return new SwapOwnerEncoder()
     .with('prevOwner', prevOwner)
     .with('oldOwner', oldOwner)
     .with('newOwner', getAddress(faker.finance.ethereumAddress()));
@@ -194,9 +199,10 @@ type ChangeThresholdArgs = {
   threshold: bigint;
 };
 
-class ChangeThresholdEncoder<
-  T extends ChangeThresholdArgs,
-> extends EncoderBuilder<T> {
+class ChangeThresholdEncoder<T extends ChangeThresholdArgs>
+  extends Builder<T>
+  implements IEncoder
+{
   static readonly FUNCTION_SIGNATURE =
     'function changeThreshold(uint256 _threshold)';
 
@@ -213,8 +219,8 @@ class ChangeThresholdEncoder<
   }
 }
 
-export function changeThresholdEncoder(): IEncoderBuilder<ChangeThresholdArgs> {
-  return ChangeThresholdEncoder.new<ChangeThresholdArgs>().with(
+export function changeThresholdEncoder() {
+  return new ChangeThresholdEncoder().with(
     'threshold',
     faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }),
   );

--- a/src/domain/backbone/entities/__tests__/backbone.builder.ts
+++ b/src/domain/backbone/entities/__tests__/backbone.builder.ts
@@ -4,7 +4,7 @@ import { fakeJson } from '@/__tests__/faker';
 import { Backbone } from '@/domain/backbone/entities/backbone.entity';
 
 export function backboneBuilder(): IBuilder<Backbone> {
-  return Builder.new<Backbone>()
+  return new Builder<Backbone>()
     .with('name', faker.word.sample())
     .with('version', faker.system.semver())
     .with('api_version', faker.system.semver())

--- a/src/domain/balances/entities/__tests__/balance.builder.ts
+++ b/src/domain/balances/entities/__tests__/balance.builder.ts
@@ -4,7 +4,7 @@ import { balanceTokenBuilder } from './balance.token.builder';
 import { Balance } from '@/domain/balances/entities/balance.entity';
 
 export function balanceBuilder(): IBuilder<Balance> {
-  return Builder.new<Balance>()
+  return new Builder<Balance>()
     .with('tokenAddress', faker.finance.ethereumAddress())
     .with('token', balanceTokenBuilder().build())
     .with('balance', faker.string.numeric());

--- a/src/domain/balances/entities/__tests__/balance.token.builder.ts
+++ b/src/domain/balances/entities/__tests__/balance.token.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { BalanceToken } from '@/domain/balances/entities/balance.token.entity';
 
 export function balanceTokenBuilder(): IBuilder<BalanceToken> {
-  return Builder.new<BalanceToken>()
+  return new Builder<BalanceToken>()
     .with('decimals', faker.number.int())
     .with('logoUri', faker.internet.url({ appendSlash: false }))
     .with('name', faker.finance.currencyName())

--- a/src/domain/chains/entities/__tests__/block-explorer-uri-template.builder.ts
+++ b/src/domain/chains/entities/__tests__/block-explorer-uri-template.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { BlockExplorerUriTemplate } from '@/domain/chains/entities/block-explorer-uri-template.entity';
 
 export function blockExplorerUriTemplateBuilder(): IBuilder<BlockExplorerUriTemplate> {
-  return Builder.new<BlockExplorerUriTemplate>()
+  return new Builder<BlockExplorerUriTemplate>()
     .with('address', faker.finance.ethereumAddress())
     .with('txHash', faker.string.hexadecimal())
     .with('api', faker.internet.url({ appendSlash: false }));

--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -10,7 +10,7 @@ import { themeBuilder } from '@/domain/chains/entities/__tests__/theme.builder';
 import { Chain } from '@/domain/chains/entities/chain.entity';
 
 export function chainBuilder(): IBuilder<Chain> {
-  return Builder.new<Chain>()
+  return new Builder<Chain>()
     .with('chainId', faker.string.numeric())
     .with('chainName', faker.company.name())
     .with('description', faker.word.words())

--- a/src/domain/chains/entities/__tests__/gas-price-fixed-eip-1559.builder.ts
+++ b/src/domain/chains/entities/__tests__/gas-price-fixed-eip-1559.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { GasPriceFixedEIP1559 } from '@/domain/chains/entities/gas-price-fixed-eip-1559.entity';
 
 export function gasPriceFixedEIP1559Builder(): IBuilder<GasPriceFixedEIP1559> {
-  return Builder.new<GasPriceFixedEIP1559>()
+  return new Builder<GasPriceFixedEIP1559>()
     .with('type', 'fixed1559')
     .with('maxFeePerGas', faker.string.numeric())
     .with('maxPriorityFeePerGas', faker.string.numeric());

--- a/src/domain/chains/entities/__tests__/gas-price-fixed.builder.ts
+++ b/src/domain/chains/entities/__tests__/gas-price-fixed.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { GasPriceFixed } from '@/domain/chains/entities/gas-price-fixed.entity';
 
 export function gasPriceFixedBuilder(): IBuilder<GasPriceFixed> {
-  return Builder.new<GasPriceFixed>()
+  return new Builder<GasPriceFixed>()
     .with('type', 'fixed')
     .with('weiValue', faker.string.numeric());
 }

--- a/src/domain/chains/entities/__tests__/gas-price-oracle.builder.ts
+++ b/src/domain/chains/entities/__tests__/gas-price-oracle.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { GasPriceOracle } from '@/domain/chains/entities/gas-price-oracle.entity';
 
 export function gasPriceOracleBuilder(): IBuilder<GasPriceOracle> {
-  return Builder.new<GasPriceOracle>()
+  return new Builder<GasPriceOracle>()
     .with('type', 'oracle')
     .with('uri', faker.internet.url({ appendSlash: false }))
     .with('gasParameter', faker.word.sample())

--- a/src/domain/chains/entities/__tests__/master-copy.builder.ts
+++ b/src/domain/chains/entities/__tests__/master-copy.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { MasterCopy } from '@/domain/chains/entities/master-copies.entity';
 
 export function masterCopyBuilder(): IBuilder<MasterCopy> {
-  return Builder.new<MasterCopy>()
+  return new Builder<MasterCopy>()
     .with('address', faker.finance.ethereumAddress())
     .with('version', faker.system.semver())
     .with('deployer', faker.finance.ethereumAddress())

--- a/src/domain/chains/entities/__tests__/native.currency.builder.ts
+++ b/src/domain/chains/entities/__tests__/native.currency.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { NativeCurrency } from '@/domain/chains/entities/native.currency.entity';
 
 export function nativeCurrencyBuilder(): IBuilder<NativeCurrency> {
-  return Builder.new<NativeCurrency>()
+  return new Builder<NativeCurrency>()
     .with('name', faker.finance.currencyName())
     .with('symbol', faker.finance.currencySymbol())
     .with('decimals', 18)

--- a/src/domain/chains/entities/__tests__/rpc-uri.builder.ts
+++ b/src/domain/chains/entities/__tests__/rpc-uri.builder.ts
@@ -4,7 +4,7 @@ import { RpcUri } from '@/domain/chains/entities/rpc-uri.entity';
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
 
 export function rpcUriBuilder(): IBuilder<RpcUri> {
-  return Builder.new<RpcUri>()
+  return new Builder<RpcUri>()
     .with('authentication', RpcUriAuthentication.NoAuthentication)
     .with('value', faker.internet.url({ appendSlash: false }));
 }

--- a/src/domain/chains/entities/__tests__/theme.builder.ts
+++ b/src/domain/chains/entities/__tests__/theme.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Theme } from '@/domain/chains/entities/theme.entity';
 
 export function themeBuilder(): IBuilder<Theme> {
-  return Builder.new<Theme>()
+  return new Builder<Theme>()
     .with('textColor', faker.color.rgb())
     .with('backgroundColor', faker.color.rgb());
 }

--- a/src/domain/collectibles/entities/__tests__/collectible.builder.ts
+++ b/src/domain/collectibles/entities/__tests__/collectible.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
 
 export function collectibleBuilder(): IBuilder<Collectible> {
-  return Builder.new<Collectible>()
+  return new Builder<Collectible>()
     .with('address', faker.finance.ethereumAddress())
     .with('tokenName', faker.company.name())
     .with('tokenSymbol', faker.finance.currencySymbol())

--- a/src/domain/contracts/entities/__tests__/contract.builder.ts
+++ b/src/domain/contracts/entities/__tests__/contract.builder.ts
@@ -4,7 +4,7 @@ import { fakeJson } from '@/__tests__/faker';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
 
 export function contractBuilder(): IBuilder<Contract> {
-  return Builder.new<Contract>()
+  return new Builder<Contract>()
     .with('address', faker.finance.ethereumAddress())
     .with('name', faker.word.sample())
     .with('displayName', faker.word.words())

--- a/src/domain/data-decoder/entities/__tests__/data-decoded.builder.ts
+++ b/src/domain/data-decoder/entities/__tests__/data-decoded.builder.ts
@@ -6,7 +6,7 @@ import {
 } from '@/domain/data-decoder/entities/data-decoded.entity';
 
 export function dataDecodedBuilder(): IBuilder<DataDecoded> {
-  return Builder.new<DataDecoded>()
+  return new Builder<DataDecoded>()
     .with('method', faker.string.alphanumeric())
     .with(
       'parameters',
@@ -17,7 +17,7 @@ export function dataDecodedBuilder(): IBuilder<DataDecoded> {
 }
 
 export function dataDecodedParameterBuilder(): IBuilder<DataDecodedParameter> {
-  return Builder.new<DataDecodedParameter>()
+  return new Builder<DataDecodedParameter>()
     .with('name', faker.string.alphanumeric())
     .with('type', faker.string.alphanumeric())
     .with('value', faker.string.alphanumeric())

--- a/src/domain/delegate/entities/__tests__/delegate.builder.ts
+++ b/src/domain/delegate/entities/__tests__/delegate.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Delegate } from '@/domain/delegate/entities/delegate.entity';
 
 export function delegateBuilder(): IBuilder<Delegate> {
-  return Builder.new<Delegate>()
+  return new Builder<Delegate>()
     .with('safe', faker.finance.ethereumAddress())
     .with('delegate', faker.finance.ethereumAddress())
     .with('delegator', faker.finance.ethereumAddress())

--- a/src/domain/entities/__tests__/page.builder.ts
+++ b/src/domain/entities/__tests__/page.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Page } from '@/domain/entities/page.entity';
 
 export function pageBuilder<T>(): IBuilder<Page<T>> {
-  return Builder.new<Page<T>>()
+  return new Builder<Page<T>>()
     .with('count', faker.number.int())
     .with('next', limitAndOffsetUrlFactory())
     .with('previous', limitAndOffsetUrlFactory())

--- a/src/domain/estimations/entities/__tests__/estimation.builder.ts
+++ b/src/domain/estimations/entities/__tests__/estimation.builder.ts
@@ -3,5 +3,5 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Estimation } from '@/domain/estimations/entities/estimation.entity';
 
 export function estimationBuilder(): IBuilder<Estimation> {
-  return Builder.new<Estimation>().with('safeTxGas', faker.string.numeric(5));
+  return new Builder<Estimation>().with('safeTxGas', faker.string.numeric(5));
 }

--- a/src/domain/messages/entities/__tests__/message-confirmation.builder.ts
+++ b/src/domain/messages/entities/__tests__/message-confirmation.builder.ts
@@ -7,7 +7,7 @@ import {
 } from '@/domain/messages/entities/message-confirmation.entity';
 
 export function messageConfirmationBuilder(): IBuilder<MessageConfirmation> {
-  return Builder.new<MessageConfirmation>()
+  return new Builder<MessageConfirmation>()
     .with('created', faker.date.recent())
     .with('modified', faker.date.recent())
     .with('owner', faker.finance.ethereumAddress())

--- a/src/domain/messages/entities/__tests__/message.builder.ts
+++ b/src/domain/messages/entities/__tests__/message.builder.ts
@@ -8,7 +8,7 @@ import {
 } from '@/domain/messages/entities/__tests__/message-confirmation.builder';
 
 export function messageBuilder(): IBuilder<Message> {
-  return Builder.new<Message>()
+  return new Builder<Message>()
     .with('created', faker.date.recent())
     .with('modified', faker.date.recent())
     .with('safe', faker.finance.ethereumAddress())

--- a/src/domain/safe-apps/entities/__tests__/safe-app-access-control.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-access-control.builder.ts
@@ -7,7 +7,7 @@ import {
 } from '@/domain/safe-apps/entities/safe-app-access-control.entity';
 
 export function safeAppAccessControlBuilder(): IBuilder<SafeAppAccessControl> {
-  return Builder.new<SafeAppAccessControl>()
+  return new Builder<SafeAppAccessControl>()
     .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
     .with(
       'value',

--- a/src/domain/safe-apps/entities/__tests__/safe-app-provider.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-provider.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { SafeAppProvider } from '@/domain/safe-apps/entities/safe-app-provider.entity';
 
 export function safeAppProviderBuilder(): IBuilder<SafeAppProvider> {
-  return Builder.new<SafeAppProvider>()
+  return new Builder<SafeAppProvider>()
     .with('url', faker.internet.url({ appendSlash: false }))
     .with('name', faker.word.sample());
 }

--- a/src/domain/safe-apps/entities/__tests__/safe-app-social-profile.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-social-profile.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { SafeAppSocialProfile } from '@/domain/safe-apps/entities/safe-app-social-profile.entity';
 
 export function safeAppSocialProfileBuilder(): IBuilder<SafeAppSocialProfile> {
-  return Builder.new<SafeAppSocialProfile>()
+  return new Builder<SafeAppSocialProfile>()
     .with('platform', faker.word.sample())
     .with('url', faker.internet.url({ appendSlash: false }));
 }

--- a/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
@@ -7,7 +7,7 @@ import { safeAppSocialProfileBuilder } from '@/domain/safe-apps/entities/__tests
 import { SafeApp } from '@/domain/safe-apps/entities/safe-app.entity';
 
 export function safeAppBuilder(): IBuilder<SafeApp> {
-  return Builder.new<SafeApp>()
+  return new Builder<SafeApp>()
     .with('id', faker.number.int())
     .with('url', faker.internet.url({ appendSlash: false }))
     .with('name', faker.word.sample())

--- a/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
@@ -4,7 +4,7 @@ import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/dat
 import { CreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
 
 export function creationTransactionBuilder(): IBuilder<CreationTransaction> {
-  return Builder.new<CreationTransaction>()
+  return new Builder<CreationTransaction>()
     .with('created', faker.date.recent())
     .with('creator', faker.finance.ethereumAddress())
     .with('transactionHash', faker.string.hexadecimal())

--- a/src/domain/safe/entities/__tests__/erc20-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/erc20-transfer.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { ERC20Transfer } from '@/domain/safe/entities/transfer.entity';
 
 export function erc20TransferBuilder(): IBuilder<ERC20Transfer> {
-  return Builder.new<ERC20Transfer>()
+  return new Builder<ERC20Transfer>()
     .with('blockNumber', faker.number.int())
     .with('executionDate', faker.date.recent())
     .with('from', faker.finance.ethereumAddress())

--- a/src/domain/safe/entities/__tests__/erc721-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/erc721-transfer.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { ERC721Transfer } from '@/domain/safe/entities/transfer.entity';
 
 export function erc721TransferBuilder(): IBuilder<ERC721Transfer> {
-  return Builder.new<ERC721Transfer>()
+  return new Builder<ERC721Transfer>()
     .with('blockNumber', faker.number.int())
     .with('executionDate', faker.date.recent())
     .with('from', faker.finance.ethereumAddress())

--- a/src/domain/safe/entities/__tests__/ethereum-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/ethereum-transaction.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { EthereumTransaction } from '@/domain/safe/entities/ethereum-transaction.entity';
 
 export function ethereumTransactionBuilder(): IBuilder<EthereumTransaction> {
-  return Builder.new<EthereumTransaction>()
+  return new Builder<EthereumTransaction>()
     .with('blockNumber', faker.number.int())
     .with('data', faker.string.hexadecimal())
     .with('executionDate', faker.date.recent())

--- a/src/domain/safe/entities/__tests__/module-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/module-transaction.builder.ts
@@ -4,7 +4,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
 
 export function moduleTransactionBuilder(): IBuilder<ModuleTransaction> {
-  return Builder.new<ModuleTransaction>()
+  return new Builder<ModuleTransaction>()
     .with('blockNumber', faker.number.int())
     .with('created', faker.date.recent())
     .with('data', faker.string.hexadecimal())

--- a/src/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Confirmation } from '@/domain/safe/entities/multisig-transaction.entity';
 
 export function confirmationBuilder(): IBuilder<Confirmation> {
-  return Builder.new<Confirmation>()
+  return new Builder<Confirmation>()
     .with('owner', faker.finance.ethereumAddress())
     .with('signature', faker.string.hexadecimal())
     .with('signatureType', faker.string.sample())

--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -12,7 +12,7 @@ import { Operation } from '@/domain/safe/entities/operation.entity';
 const HASH_LENGTH = 10;
 
 export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
-  return Builder.new<MultisigTransaction>()
+  return new Builder<MultisigTransaction>()
     .with('baseGas', faker.number.int())
     .with('blockNumber', faker.number.int())
     .with(

--- a/src/domain/safe/entities/__tests__/native-token-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/native-token-transfer.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { NativeTokenTransfer } from '@/domain/safe/entities/transfer.entity';
 
 export function nativeTokenTransferBuilder(): IBuilder<NativeTokenTransfer> {
-  return Builder.new<NativeTokenTransfer>()
+  return new Builder<NativeTokenTransfer>()
     .with('blockNumber', faker.number.int())
     .with('executionDate', faker.date.recent())
     .with('from', faker.finance.ethereumAddress())

--- a/src/domain/safe/entities/__tests__/safe.builder.ts
+++ b/src/domain/safe/entities/__tests__/safe.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 
 export function safeBuilder(): IBuilder<Safe> {
-  return Builder.new<Safe>()
+  return new Builder<Safe>()
     .with('address', faker.finance.ethereumAddress())
     .with('nonce', faker.number.int())
     .with('threshold', faker.number.int())

--- a/src/domain/tokens/__tests__/token.builder.ts
+++ b/src/domain/tokens/__tests__/token.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { Token, TokenType } from '@/domain/tokens/entities/token.entity';
 
 export function tokenBuilder(): IBuilder<Token> {
-  return Builder.new<Token>()
+  return new Builder<Token>()
     .with('address', faker.finance.ethereumAddress())
     .with('decimals', faker.number.int())
     .with('logoUri', faker.internet.url({ appendSlash: false }))

--- a/src/routes/alerts/entities/__tests__/alerts.builder.ts
+++ b/src/routes/alerts/entities/__tests__/alerts.builder.ts
@@ -8,7 +8,7 @@ import {
 } from '@/routes/alerts/entities/alert.dto.entity';
 
 export function alertLogBuilder(): IBuilder<AlertLog> {
-  return Builder.new<AlertLog>()
+  return new Builder<AlertLog>()
     .with('address', faker.finance.ethereumAddress())
     .with(
       'topics',
@@ -20,7 +20,7 @@ export function alertLogBuilder(): IBuilder<AlertLog> {
 }
 
 export function alertTransactionBuilder(): IBuilder<AlertTransaction> {
-  return Builder.new<AlertTransaction>()
+  return new Builder<AlertTransaction>()
     .with('network', faker.string.numeric())
     .with('block_hash', faker.string.hexadecimal({ length: 66 }))
     .with('block_number', faker.number.int())
@@ -45,7 +45,7 @@ export function alertTransactionBuilder(): IBuilder<AlertTransaction> {
 }
 
 export function alertBuilder(): IBuilder<Alert> {
-  return Builder.new<Alert>()
+  return new Builder<Alert>()
     .with('id', faker.string.uuid())
     .with('event_type', faker.helpers.enumValue(EventType))
     .with('transaction', alertTransactionBuilder().build());

--- a/src/routes/common/__tests__/entities/address-info.builder.ts
+++ b/src/routes/common/__tests__/entities/address-info.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export function addressInfoBuilder(): IBuilder<AddressInfo> {
-  return Builder.new<AddressInfo>()
+  return new Builder<AddressInfo>()
     .with('value', faker.finance.ethereumAddress())
     .with('name', faker.word.words())
     .with('logoUri', faker.internet.url({ appendSlash: false }));

--- a/src/routes/data-decode/entities/__tests__/get-data-decoded.dto.builder.ts
+++ b/src/routes/data-decode/entities/__tests__/get-data-decoded.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { GetDataDecodedDto } from '@/routes/data-decode/entities/get-data-decoded.dto.entity';
 
 export function getDataDecodedDtoBuilder(): IBuilder<GetDataDecodedDto> {
-  return Builder.new<GetDataDecodedDto>()
+  return new Builder<GetDataDecodedDto>()
     .with('data', faker.string.hexadecimal())
     .with('to', faker.finance.ethereumAddress());
 }

--- a/src/routes/delegates/entities/__tests__/create-delegate.dto.builder.ts
+++ b/src/routes/delegates/entities/__tests__/create-delegate.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { CreateDelegateDto } from '@/routes/delegates/entities/create-delegate.dto.entity';
 
 export function createDelegateDtoBuilder(): IBuilder<CreateDelegateDto> {
-  return Builder.new<CreateDelegateDto>()
+  return new Builder<CreateDelegateDto>()
     .with('safe', faker.finance.ethereumAddress())
     .with('delegate', faker.finance.ethereumAddress())
     .with('delegator', faker.finance.ethereumAddress())

--- a/src/routes/delegates/entities/__tests__/delete-delegate.dto.builder.ts
+++ b/src/routes/delegates/entities/__tests__/delete-delegate.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { DeleteDelegateDto } from '@/routes/delegates/entities/delete-delegate.dto.entity';
 
 export function deleteDelegateDtoBuilder(): IBuilder<DeleteDelegateDto> {
-  return Builder.new<DeleteDelegateDto>()
+  return new Builder<DeleteDelegateDto>()
     .with('delegate', faker.finance.ethereumAddress())
     .with('delegator', faker.finance.ethereumAddress())
     .with('signature', faker.string.hexadecimal({ length: 32 }));

--- a/src/routes/delegates/entities/__tests__/delete-safe-delegate.dto.builder.ts
+++ b/src/routes/delegates/entities/__tests__/delete-safe-delegate.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { DeleteSafeDelegateDto } from '@/routes/delegates/entities/delete-safe-delegate.dto.entity';
 
 export function deleteSafeDelegateDtoBuilder(): IBuilder<DeleteSafeDelegateDto> {
-  return Builder.new<DeleteSafeDelegateDto>()
+  return new Builder<DeleteSafeDelegateDto>()
     .with('delegate', faker.finance.ethereumAddress())
     .with('safe', faker.finance.ethereumAddress())
     .with('signature', faker.string.hexadecimal({ length: 32 }));

--- a/src/routes/flush/entities/__tests__/invalidation-pattern-details.dto.builder.ts
+++ b/src/routes/flush/entities/__tests__/invalidation-pattern-details.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { InvalidationPatternDetails } from '@/routes/flush/entities/invalidation-pattern.dto.entity';
 
 export function invalidationPatternDetailsBuilder(): IBuilder<InvalidationPatternDetails> {
-  return Builder.new<InvalidationPatternDetails>().with(
+  return new Builder<InvalidationPatternDetails>().with(
     'chain_id',
     faker.string.numeric(),
   );

--- a/src/routes/flush/entities/__tests__/invalidation-pattern.dto.builder.ts
+++ b/src/routes/flush/entities/__tests__/invalidation-pattern.dto.builder.ts
@@ -4,7 +4,7 @@ import { invalidationPatternDetailsBuilder } from '@/routes/flush/entities/__tes
 import { InvalidationPatternDto } from '@/routes/flush/entities/invalidation-pattern.dto.entity';
 
 export function invalidationPatternDtoBuilder(): IBuilder<InvalidationPatternDto> {
-  return Builder.new<InvalidationPatternDto>()
+  return new Builder<InvalidationPatternDto>()
     .with('invalidate', faker.word.sample())
     .with('patternDetails', invalidationPatternDetailsBuilder().build());
 }

--- a/src/routes/messages/entities/__tests__/create-message.dto.builder.ts
+++ b/src/routes/messages/entities/__tests__/create-message.dto.builder.ts
@@ -4,7 +4,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { CreateMessageDto } from '@/routes/messages/entities/create-message.dto.entity';
 
 export function createMessageDtoBuilder(): IBuilder<CreateMessageDto> {
-  return Builder.new<CreateMessageDto>()
+  return new Builder<CreateMessageDto>()
     .with('message', faker.word.words(random(1, 5)))
     .with('safeAppId', faker.number.int())
     .with('signature', faker.string.hexadecimal({ length: 32 }));

--- a/src/routes/messages/entities/__tests__/update-message-signature.dto.builder.ts
+++ b/src/routes/messages/entities/__tests__/update-message-signature.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { UpdateMessageSignatureDto } from '@/routes/messages/entities/update-message-signature.entity';
 
 export function updateMessageSignatureDtoBuilder(): IBuilder<UpdateMessageSignatureDto> {
-  return Builder.new<UpdateMessageSignatureDto>().with(
+  return new Builder<UpdateMessageSignatureDto>().with(
     'signature',
     faker.string.hexadecimal({ length: 32 }),
   );

--- a/src/routes/notifications/entities/__tests__/register-device.dto.builder.ts
+++ b/src/routes/notifications/entities/__tests__/register-device.dto.builder.ts
@@ -6,7 +6,7 @@ import { RegisterDeviceDto } from '@/routes/notifications/entities/register-devi
 import { safeRegistrationBuilder } from '@/routes/notifications/entities/__tests__/safe-registration.builder';
 
 export function registerDeviceDtoBuilder(): IBuilder<RegisterDeviceDto> {
-  return Builder.new<RegisterDeviceDto>()
+  return new Builder<RegisterDeviceDto>()
     .with('uuid', faker.string.uuid())
     .with('cloudMessagingToken', faker.string.uuid())
     .with('buildNumber', faker.string.numeric())

--- a/src/routes/notifications/entities/__tests__/safe-registration.builder.ts
+++ b/src/routes/notifications/entities/__tests__/safe-registration.builder.ts
@@ -4,7 +4,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { SafeRegistration } from '@/routes/notifications/entities/safe-registration.entity';
 
 export function safeRegistrationBuilder(): IBuilder<SafeRegistration> {
-  return Builder.new<SafeRegistration>()
+  return new Builder<SafeRegistration>()
     .with('chainId', faker.string.numeric())
     .with(
       'safes',

--- a/src/routes/recovery/entities/__tests__/add-recovery-module.dto.builder.ts
+++ b/src/routes/recovery/entities/__tests__/add-recovery-module.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { AddRecoveryModuleDto } from '@/routes/recovery/entities/add-recovery-module.dto.entity';
 
 export function addRecoveryModuleDtoBuilder(): IBuilder<AddRecoveryModuleDto> {
-  return Builder.new<AddRecoveryModuleDto>().with(
+  return new Builder<AddRecoveryModuleDto>().with(
     'moduleAddress',
     faker.finance.ethereumAddress(),
   );

--- a/src/routes/transactions/__tests__/entities/add-confirmation.dto.builder.ts
+++ b/src/routes/transactions/__tests__/entities/add-confirmation.dto.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { AddConfirmationDto } from '@/routes/transactions/entities/add-confirmation.dto';
 
 export function addConfirmationDtoBuilder(): IBuilder<AddConfirmationDto> {
-  return Builder.new<AddConfirmationDto>().with(
+  return new Builder<AddConfirmationDto>().with(
     'signedSafeTxHash',
     faker.string.hexadecimal({ length: 32 }),
   );

--- a/src/routes/transactions/entities/__tests__/human-description.builder.ts
+++ b/src/routes/transactions/entities/__tests__/human-description.builder.ts
@@ -9,7 +9,7 @@ import {
 import { faker } from '@faker-js/faker';
 
 function richTokenValueFragmentBuilder(): IBuilder<RichTokenValueFragment> {
-  return Builder.new<RichTokenValueFragment>()
+  return new Builder<RichTokenValueFragment>()
     .with('type', RichFragmentType.TokenValue)
     .with('value', faker.string.numeric())
     .with('symbol', faker.finance.currencySymbol())
@@ -17,13 +17,13 @@ function richTokenValueFragmentBuilder(): IBuilder<RichTokenValueFragment> {
 }
 
 function richTextFragmentBuilder(): IBuilder<RichTextFragment> {
-  return Builder.new<RichTextFragment>()
+  return new Builder<RichTextFragment>()
     .with('type', RichFragmentType.Text)
     .with('value', faker.word.words());
 }
 
 function richAddressFragmentBuilder(): IBuilder<RichAddressFragment> {
-  return Builder.new<RichAddressFragment>()
+  return new Builder<RichAddressFragment>()
     .with('type', RichFragmentType.Address)
     .with('value', faker.finance.ethereumAddress());
 }

--- a/src/routes/transactions/entities/__tests__/preview-transaction.dto.builder.ts
+++ b/src/routes/transactions/entities/__tests__/preview-transaction.dto.builder.ts
@@ -4,7 +4,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { PreviewTransactionDto } from '@/routes/transactions/entities/preview-transaction.dto.entity';
 
 export function previewTransactionDtoBuilder(): IBuilder<PreviewTransactionDto> {
-  return Builder.new<PreviewTransactionDto>()
+  return new Builder<PreviewTransactionDto>()
     .with('to', faker.finance.ethereumAddress())
     .with('data', faker.string.hexadecimal({ length: 32 }))
     .with('value', faker.string.numeric())

--- a/src/routes/transactions/entities/__tests__/propose-transaction.dto.builder.ts
+++ b/src/routes/transactions/entities/__tests__/propose-transaction.dto.builder.ts
@@ -4,7 +4,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { ProposeTransactionDto } from '@/routes/transactions/entities/propose-transaction.dto.entity';
 
 export function proposeTransactionDtoBuilder(): IBuilder<ProposeTransactionDto> {
-  return Builder.new<ProposeTransactionDto>()
+  return new Builder<ProposeTransactionDto>()
     .with('to', faker.finance.ethereumAddress())
     .with('value', faker.string.numeric())
     .with('data', faker.string.hexadecimal({ length: 32 }))

--- a/src/routes/transactions/entities/__tests__/safe-app-info.builder.ts
+++ b/src/routes/transactions/entities/__tests__/safe-app-info.builder.ts
@@ -3,7 +3,7 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity';
 
 export function safeAppInfoBuilder(): IBuilder<SafeAppInfo> {
-  return Builder.new<SafeAppInfo>()
+  return new Builder<SafeAppInfo>()
     .with('name', faker.word.words())
     .with('url', faker.internet.url({ appendSlash: false }))
     .with('logoUri', faker.internet.url({ appendSlash: false }));

--- a/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
+++ b/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
@@ -10,7 +10,7 @@ import { TransactionInfoType } from '@/routes/transactions/entities/transaction-
 import { TransferType } from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export function transferTransactionInfoBuilder(): IBuilder<TransferTransactionInfo> {
-  return Builder.new<TransferTransactionInfo>()
+  return new Builder<TransferTransactionInfo>()
     .with('type', TransactionInfoType.Transfer)
     .with('sender', addressInfoBuilder().build())
     .with('recipient', addressInfoBuilder().build())

--- a/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
+++ b/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
@@ -13,7 +13,7 @@ const MIN_SIGNERS = 2;
 const MAX_SIGNERS = 5;
 
 function multisigConfirmationDetailsBuilder(): IBuilder<MultisigConfirmationDetails> {
-  return Builder.new<MultisigConfirmationDetails>()
+  return new Builder<MultisigConfirmationDetails>()
     .with('signer', addressInfoBuilder().build())
     .with('signature', faker.string.hexadecimal())
     .with('submittedAt', faker.number.int());
@@ -27,7 +27,7 @@ export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDet
     multisigConfirmationDetailsBuilder().build(),
   );
 
-  return Builder.new<MultisigExecutionDetails>()
+  return new Builder<MultisigExecutionDetails>()
     .with('type', ExecutionDetailsType.Multisig)
     .with('submittedAt', faker.number.int())
     .with('nonce', faker.number.int())


### PR DESCRIPTION
- We were not taking advantage of the `new` static function of the `Builder` class – it was merely used as syntactic sugar over the constructor.
- With the introduction of new Builders which extend `Builder`, the type of the subclasses was lost because of this static method.
- Even though there are ways to retrieve this type information correctly, using the constructor directly is simpler and more readable as it already returns a `this` type by default.