### PR TITLE
feat: add blockchain data source

### DIFF
--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -15,6 +15,7 @@ describe('Configuration validator', () => {
     EMAIL_API_FROM_EMAIL: faker.internet.email(),
     EMAIL_API_KEY: faker.string.uuid(),
     EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
+    INFURA_TOKEN: faker.string.alphanumeric(),
   };
 
   it('should bypass this validation on test environment', () => {
@@ -40,6 +41,7 @@ describe('Configuration validator', () => {
     { key: 'EMAIL_API_FROM_EMAIL' },
     { key: 'EMAIL_API_KEY' },
     { key: 'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX' },
+    { key: 'INFURA_TOKEN' },
   ])(
     'should detect that $key is missing in the configuration in production environment',
     ({ key }) => {
@@ -64,6 +66,7 @@ describe('Configuration validator', () => {
         EMAIL_API_FROM_EMAIL: faker.internet.email(),
         EMAIL_API_KEY: faker.string.uuid(),
         EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
+        INFURA_TOKEN: faker.string.alphanumeric(),
       }),
     ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
   });

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -28,6 +28,7 @@ const configurationSchema: Schema = {
     'EMAIL_API_FROM_EMAIL',
     'EMAIL_API_KEY',
     'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX',
+    'INFURA_TOKEN',
   ],
 };
 

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -18,6 +18,9 @@ export default (): ReturnType<typeof configuration> => ({
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),
   },
+  blockchain: {
+    infuraToken: faker.string.alphanumeric(),
+  },
   db: {
     postgres: {
       host: process.env.POSTGRES_TEST_HOST || 'localhost',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -16,6 +16,9 @@ export default () => ({
   auth: {
     token: process.env.AUTH_TOKEN,
   },
+  blockchain: {
+    infuraToken: process.env.INFURA_TOKEN,
+  },
   db: {
     postgres: {
       host: process.env.POSTGRES_HOST || 'localhost',

--- a/src/datasources/blockchain/blockchain.datasource.module.ts
+++ b/src/datasources/blockchain/blockchain.datasource.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { createPublicClient } from 'viem';
+import { BlockchainDataSource } from '@/datasources/blockchain/blockchain.datasource';
+import { IBlockchainDataSource } from '@/domain/interfaces/blockchain.datasource.interface';
+
+@Module({
+  providers: [
+    {
+      provide: 'createPublicClient',
+      useFactory: createPublicClient,
+    },
+    { provide: IBlockchainDataSource, useClass: BlockchainDataSource },
+  ],
+  exports: [IBlockchainDataSource],
+})
+export class BlockchainDataSourceModule {}

--- a/src/datasources/blockchain/blockchain.datasource.spec.ts
+++ b/src/datasources/blockchain/blockchain.datasource.spec.ts
@@ -1,0 +1,106 @@
+import { faker } from '@faker-js/faker';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { BlockchainDataSource } from '@/datasources/blockchain/blockchain.datasource';
+import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
+
+const chainsRepository = {
+  getChain: jest.fn(),
+} as unknown as IChainsRepository;
+const chainsRepositoryMock = jest.mocked(chainsRepository);
+
+const createPublicClient = jest.fn();
+const createPublicClientMock = jest.mocked(createPublicClient);
+
+describe('BlockchainDataSource', () => {
+  let fakeConfigurationService: FakeConfigurationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    fakeConfigurationService = new FakeConfigurationService();
+  });
+
+  it('returns a public client without authentication', async () => {
+    const chain = chainBuilder()
+      .with('rpcUri', {
+        authentication: RpcUriAuthentication.NoAuthentication,
+        value: faker.internet.url(),
+      })
+      .build();
+    chainsRepositoryMock.getChain.mockResolvedValue(chain);
+
+    const target = new BlockchainDataSource(
+      chainsRepositoryMock,
+      fakeConfigurationService,
+      createPublicClientMock,
+    );
+
+    await target.getPublicClient(chain.chainId);
+
+    expect(createPublicClientMock).toHaveBeenCalledWith({
+      chain: {
+        id: Number(chain.chainId),
+        name: chain.chainName,
+        network: chain.chainName.toLowerCase(),
+        nativeCurrency: {
+          name: chain.nativeCurrency.name,
+          symbol: chain.nativeCurrency.symbol,
+          decimals: chain.nativeCurrency.decimals,
+        },
+        rpcUrls: {
+          default: {
+            http: [chain.rpcUri.value],
+          },
+          public: {
+            http: [chain.rpcUri.value],
+          },
+        },
+      },
+      transport: expect.any(Function),
+    });
+  });
+
+  it('returns a public client with authentication', async () => {
+    const chain = chainBuilder()
+      .with('rpcUri', {
+        authentication: RpcUriAuthentication.ApiKeyPath,
+        value: faker.internet.url(),
+      })
+      .build();
+    chainsRepositoryMock.getChain.mockResolvedValue(chain);
+    const apiKey = faker.string.alphanumeric();
+    fakeConfigurationService.set('blockchain.infuraToken', apiKey);
+
+    const target = new BlockchainDataSource(
+      chainsRepositoryMock,
+      fakeConfigurationService,
+      createPublicClientMock,
+    );
+
+    await target.getPublicClient(chain.chainId);
+
+    expect(createPublicClientMock).toHaveBeenCalledWith({
+      chain: {
+        id: Number(chain.chainId),
+        name: chain.chainName,
+        network: chain.chainName.toLowerCase(),
+        nativeCurrency: {
+          name: chain.nativeCurrency.name,
+          symbol: chain.nativeCurrency.symbol,
+          decimals: chain.nativeCurrency.decimals,
+        },
+        rpcUrls: {
+          default: {
+            http: [chain.rpcUri.value + apiKey],
+          },
+          public: {
+            http: [chain.rpcUri.value + apiKey],
+          },
+        },
+      },
+      transport: expect.any(Function),
+    });
+  });
+});

--- a/src/datasources/blockchain/blockchain.datasource.ts
+++ b/src/datasources/blockchain/blockchain.datasource.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  Chain,
+  PublicClient,
+  createPublicClient as _createPublicClient,
+  http,
+} from 'viem';
+import { IBlockchainDataSource } from '@/domain/interfaces/blockchain.datasource.interface';
+import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
+import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+
+@Injectable()
+export class BlockchainDataSource implements IBlockchainDataSource {
+  private readonly infuraToken: string | undefined;
+
+  constructor(
+    @Inject(IChainsRepository)
+    private readonly chainsRepository: IChainsRepository,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject('createPublicClient')
+    private readonly createPublicClient: typeof _createPublicClient,
+  ) {
+    this.infuraToken = this.configurationService.get('blockchain.infuraToken');
+  }
+
+  async getPublicClient(chainId: string): Promise<PublicClient> {
+    const chain = await this.chainsRepository.getChain(chainId);
+
+    const rpcUrl =
+      chain.rpcUri.authentication === RpcUriAuthentication.ApiKeyPath &&
+      this.infuraToken
+        ? chain.rpcUri.value + this.infuraToken
+        : chain.rpcUri.value;
+
+    const chainConfig: Chain = {
+      id: Number(chain.chainId),
+      name: chain.chainName,
+      network: chain.chainName.toLowerCase(),
+      nativeCurrency: {
+        name: chain.nativeCurrency.name,
+        symbol: chain.nativeCurrency.symbol,
+        decimals: chain.nativeCurrency.decimals,
+      },
+      rpcUrls: {
+        default: { http: [rpcUrl] },
+        public: { http: [rpcUrl] },
+      },
+    };
+
+    return this.createPublicClient({
+      chain: chainConfig,
+      transport: http(),
+    });
+  }
+}

--- a/src/domain/interfaces/blockchain.datasource.interface.ts
+++ b/src/domain/interfaces/blockchain.datasource.interface.ts
@@ -1,0 +1,7 @@
+import { PublicClient } from 'viem';
+
+export const IBlockchainDataSource = Symbol('IBlockchainDataSource');
+
+export interface IBlockchainDataSource {
+  getPublicClient(chainId: string): Promise<PublicClient>;
+}


### PR DESCRIPTION
In preparation for retrieving [Safe addresses via recovery modules](https://github.com/safe-global/safe-client-gateway/pull/923#discussion_r1430128476), this adds a `IBlockchainDataSource` for retrieval of the viem `PublicClient`. The following functionality is avaialable:

- `getPublicClient` - returns a viem `PublicClient` for interfacing with the given chain.

`createPublicClient` of `viem` is injected directly within the `BlockchainDataSourceModule` instead of a wrapped version as we already have "viem-opinionated" code in the codebase and would otherwise need create a vast interface.