### PR TITLE
Remove unused ICacheService.expire function

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -55,8 +55,4 @@ export class FakeCacheService implements ICacheService {
     this.cache[cacheDir.key][cacheDir.field] = value;
     return Promise.resolve();
   }
-
-  expire() {
-    return Promise.resolve();
-  }
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -14,6 +14,4 @@ export interface ICacheService {
   deleteByKey(key: string): Promise<number>;
 
   deleteByKeyPattern(pattern: string): Promise<void>;
-
-  expire(key: string, expireTimeSeconds: number): Promise<void>;
 }

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -53,10 +53,6 @@ export class RedisCacheService
     }
   }
 
-  async expire(key: string, expireTimeSeconds: number): Promise<void> {
-    await this.client.expire(key, expireTimeSeconds);
-  }
-
   /**
    * Closes the connection to Redis when the module associated with this service
    * is destroyed. This tries to gracefully close the connection. If the Redis

--- a/src/datasources/prices-api/coingecko-api.service.spec.ts
+++ b/src/datasources/prices-api/coingecko-api.service.spec.ts
@@ -15,7 +15,6 @@ const mockCacheFirstDataSource = jest.mocked({
 
 const mockCacheService = jest.mocked({
   deleteByKey: jest.fn(),
-  expire: jest.fn(),
   get: jest.fn(),
   set: jest.fn(),
 } as unknown as ICacheService);


### PR DESCRIPTION
**Context**
`ICacheService.expire` function was used briefly to set custom expiration times for cache keys related to token prices. This is not used anymore, since the implementation of https://github.com/safe-global/safe-client-gateway/pull/836.

**Changes**
- `ICacheService.expire` function was removed from the interface and its implementations (`FakeCacheService`, `RedisCacheService`).
