### PR TITLE
Add missing EMAIL_TEMPLATE_RECOVERY_TX to .env.sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,6 +35,8 @@
 #EMAIL_API_FROM_EMAIL=
 # The email template reference for an unknown recovery transaction notification.
 #EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=
+# The email template reference for a recovery transaction notification.
+#EMAIL_TEMPLATE_RECOVERY_TX=
 # The sender name to be included in the 'from' section of the emails sent.
 # (default is 'Safe' if none is set)
 #EMAIL_API_FROM_NAME=


### PR DESCRIPTION
Changes:
- Missing `EMAIL_TEMPLATE_RECOVERY_TX` was added to `.env.sample` file.