### PR TITLE
feat: add `/api/v1/modules/{address}/safes/` to `TransactionApi`

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -14,6 +14,7 @@ export class CacheRouter {
   private static readonly MASTER_COPIES_KEY = 'master_copies';
   private static readonly MESSAGE_KEY = 'message';
   private static readonly MESSAGES_KEY = 'messages';
+  private static readonly MODULES_KEY = 'modules';
   private static readonly MODULE_TRANSACTION_KEY = 'module_transaction';
   private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';
   private static readonly MULTISIG_TRANSACTION_KEY = 'multisig_transaction';
@@ -146,6 +147,23 @@ export class CacheRouter {
 
   static getTransfersCacheKey(args: { chainId: string; safeAddress: string }) {
     return `${args.chainId}_${CacheRouter.TRANSFERS_KEY}_${args.safeAddress}`;
+  }
+
+  static getSafesByModuleCacheDir(args: {
+    chainId: string;
+    moduleAddress: string;
+  }): CacheDir {
+    return new CacheDir(
+      this.getSafesByModuleCacheKey(args), // TODO: Refactor other `CacheDir` keys to use respective key methods
+      '',
+    );
+  }
+
+  static getSafesByModuleCacheKey(args: {
+    chainId: string;
+    moduleAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.MODULES_KEY}_${args.moduleAddress}`;
   }
 
   static getModuleTransactionCacheDir(args: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -14,7 +14,7 @@ export class CacheRouter {
   private static readonly MASTER_COPIES_KEY = 'master_copies';
   private static readonly MESSAGE_KEY = 'message';
   private static readonly MESSAGES_KEY = 'messages';
-  private static readonly MODULES_KEY = 'modules';
+  private static readonly MODULES_SAFES_KEY = 'modules_safes';
   private static readonly MODULE_TRANSACTION_KEY = 'module_transaction';
   private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';
   private static readonly MULTISIG_TRANSACTION_KEY = 'multisig_transaction';
@@ -163,7 +163,7 @@ export class CacheRouter {
     chainId: string;
     moduleAddress: string;
   }): string {
-    return `${args.chainId}_${CacheRouter.MODULES_KEY}_${args.moduleAddress}`;
+    return `${args.chainId}_${CacheRouter.MODULES_SAFES_KEY}_${args.moduleAddress}`;
   }
 
   static getModuleTransactionCacheDir(args: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -14,7 +14,7 @@ export class CacheRouter {
   private static readonly MASTER_COPIES_KEY = 'master_copies';
   private static readonly MESSAGE_KEY = 'message';
   private static readonly MESSAGES_KEY = 'messages';
-  private static readonly MODULES_SAFES_KEY = 'modules_safes';
+  private static readonly MODULE_SAFES_KEY = 'module_safes';
   private static readonly MODULE_TRANSACTION_KEY = 'module_transaction';
   private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';
   private static readonly MULTISIG_TRANSACTION_KEY = 'multisig_transaction';
@@ -163,7 +163,7 @@ export class CacheRouter {
     chainId: string;
     moduleAddress: string;
   }): string {
-    return `${args.chainId}_${CacheRouter.MODULES_SAFES_KEY}_${args.moduleAddress}`;
+    return `${args.chainId}_${CacheRouter.MODULE_SAFES_KEY}_${args.moduleAddress}`;
   }
 
   static getModuleTransactionCacheDir(args: {

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -189,7 +189,7 @@ describe('TransactionApi', () => {
 
       expect(actual).toBe(safesByModule);
       expect(mockDataSource.get).toHaveBeenCalledWith({
-        cacheDir: new CacheDir(`${chainId}_modules_${moduleAddress}`, ''),
+        cacheDir: new CacheDir(`${chainId}_module_safes_${moduleAddress}`, ''),
         url: `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`,
         notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
         expireTimeSeconds: defaultExpirationTimeInSeconds,

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -175,7 +175,7 @@ describe('TransactionApi', () => {
   });
 
   describe('Modules', () => {
-    it('should return Safes with module enables', async () => {
+    it('should return Safes with module enabled', async () => {
       const moduleAddress = faker.finance.ethereumAddress();
       const safesByModule = {
         safes: [

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -173,4 +173,41 @@ describe('TransactionApi', () => {
       expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Modules', () => {
+    it('should return Safes with module enables', async () => {
+      const moduleAddress = faker.finance.ethereumAddress();
+      const safesByModule = {
+        safes: [
+          faker.finance.ethereumAddress(),
+          faker.finance.ethereumAddress(),
+        ],
+      };
+      mockDataSource.get.mockResolvedValueOnce(safesByModule);
+
+      const actual = await service.getSafesByModule(moduleAddress);
+
+      expect(actual).toBe(safesByModule);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir: new CacheDir(`${chainId}_modules_${moduleAddress}`, ''),
+        url: `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+      });
+      expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
+    });
+
+    it('should map error on error', async () => {
+      const moduleAddress = faker.finance.ethereumAddress();
+      const error = new Error('some error');
+      const expected = new DataSourceError('some data source error');
+      mockDataSource.get.mockRejectedValueOnce(error);
+      mockHttpErrorFactory.from.mockReturnValue(expected);
+
+      await expect(service.getSafesByModule(moduleAddress)).rejects.toThrow(
+        expected,
+      );
+      expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -9,6 +9,7 @@ import { Page } from '@/domain/entities/page.entity';
 import { Estimation } from '@/domain/estimations/entities/estimation.entity';
 import { GetEstimationDto } from '@/domain/estimations/entities/get-estimation.dto.entity';
 import { Message } from '@/domain/messages/entities/message.entity';
+import { SafesByModule } from '@/domain/modules/entities/safes-by-module.entity';
 import { Device } from '@/domain/notifications/entities/device.entity';
 import { CreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
 import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
@@ -110,6 +111,10 @@ export interface ITransactionApi {
     safeTxHash: string;
     addConfirmationDto: AddConfirmationDto;
   }): Promise<unknown>;
+
+  getSafesByModule(moduleAddress: string): Promise<SafesByModule>;
+
+  clearSafesByModule(moduleAddress: string): Promise<void>;
 
   getModuleTransaction(moduleTransactionId: string): Promise<ModuleTransaction>;
 

--- a/src/domain/modules/entities/safes-by-module.entity.ts
+++ b/src/domain/modules/entities/safes-by-module.entity.ts
@@ -1,0 +1,3 @@
+export interface SafesByModule {
+  safes: string[];
+}


### PR DESCRIPTION
That extends the `TransactionApi` to support the [`/v1/modules/{address}/safes/` endpoint of the Transaction Service](https://github.com/safe-global/safe-transaction-service/blob/79b1b984c50d127cae8ebf1cb0a38f1484ec72a5/safe_transaction_service/history/views.py#L1202-L1204), adding the following methods:

  - `getSafesByModule` - fetches and caches endpoint result
  - `clearSafesByModule` - clears existing cache of endpoint result

Note: `clearSafesByModule` will be integrated in a follow up PR.