### PR TITLE
feat: add `getSafesByModule` and `clearSafesByModule` to `SafeRepository`

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -150,10 +150,7 @@ export class CacheRouter {
     chainId: string;
     moduleAddress: string;
   }): CacheDir {
-    return new CacheDir(
-      this.getSafesByModuleCacheKey(args), // TODO: Refactor other `CacheDir` keys to use respective key methods
-      '',
-    );
+    return new CacheDir(CacheRouter.getSafesByModuleCacheKey(args), '');
   }
 
   static getSafesByModuleCacheKey(args: {

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -27,7 +27,6 @@ import { Token } from '@/domain/tokens/entities/token.entity';
 import { AddConfirmationDto } from '@/domain/transactions/entities/add-confirmation.dto.entity';
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
 import { Balance } from '@/domain/balances/entities/balance.entity';
-import { SafesByModule } from '@/domain/modules/entities/safes-by-module.entity';
 
 export class TransactionApi implements ITransactionApi {
   private readonly defaultExpirationTimeInSeconds: number;
@@ -443,7 +442,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getSafesByModule(moduleAddress: string): Promise<SafesByModule> {
+  async getSafesByModule(moduleAddress: string): Promise<SafeList> {
     try {
       const cacheDir = CacheRouter.getSafesByModuleCacheDir({
         chainId: this.chainId,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -9,7 +9,6 @@ import { Page } from '@/domain/entities/page.entity';
 import { Estimation } from '@/domain/estimations/entities/estimation.entity';
 import { GetEstimationDto } from '@/domain/estimations/entities/get-estimation.dto.entity';
 import { Message } from '@/domain/messages/entities/message.entity';
-import { SafesByModule } from '@/domain/modules/entities/safes-by-module.entity';
 import { Device } from '@/domain/notifications/entities/device.entity';
 import { CreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
 import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
@@ -112,7 +111,7 @@ export interface ITransactionApi {
     addConfirmationDto: AddConfirmationDto;
   }): Promise<unknown>;
 
-  getSafesByModule(moduleAddress: string): Promise<SafesByModule>;
+  getSafesByModule(moduleAddress: string): Promise<SafeList>;
 
   clearSafesByModule(moduleAddress: string): Promise<void>;
 

--- a/src/domain/modules/entities/safes-by-module.entity.ts
+++ b/src/domain/modules/entities/safes-by-module.entity.ts
@@ -1,3 +1,0 @@
-export interface SafesByModule {
-  safes: string[];
-}

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -181,4 +181,14 @@ export interface ISafeRepository {
     chainId: string;
     safeAddress: string;
   }): Promise<{ currentNonce: number; recommendedNonce: number }>;
+
+  getSafesByModule(args: {
+    chainId: string;
+    moduleAddress: string;
+  }): Promise<SafeList>;
+
+  clearSafesByModule(args: {
+    chainId: string;
+    moduleAddress: string;
+  }): Promise<void>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -402,4 +402,26 @@ export class SafeRepository implements ISafeRepository {
       recommendedNonce: recommendedNonce,
     };
   }
+
+  async getSafesByModule(args: {
+    chainId: string;
+    moduleAddress: string;
+  }): Promise<SafeList> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const safesByModule = await transactionService.getSafesByModule(
+      args.moduleAddress,
+    );
+
+    return this.safeListValidator.validate(safesByModule);
+  }
+
+  async clearSafesByModule(args: {
+    chainId: string;
+    moduleAddress: string;
+  }): Promise<void> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    await transactionService.clearSafesByModule(args.moduleAddress);
+  }
 }

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -768,4 +768,37 @@ describe('Post Hook Events (Unit)', () => {
       webHookExecutionDelayMs,
     );
   });
+
+  it.each([
+    {
+      type: 'MODULE_TRANSACTION',
+      module: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears Safes by module', async (payload) => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+    const moduleAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_module_safes_${moduleAddress}`,
+      '',
+    );
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    const data = {
+      address: safeAddress,
+      chainId: chainId,
+      ...payload,
+    };
+
+    await request(app.getHttpServer())
+      .post(`/hooks/events`)
+      .set('Authorization', `Basic ${authToken}`)
+      .send(data)
+      .expect(202);
+
+    setTimeout(
+      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
+      webHookExecutionDelayMs,
+    );
+  });
 });

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -108,6 +108,10 @@ export class CacheHooksService {
       // - the transaction executed – clear multisig transaction
       // - the safe configuration - clear safe info
       case EventType.EXECUTED_MULTISIG_TRANSACTION:
+        // Important: we should be clearing Safes by module here but we don't have module address
+        // As this is only being used for recovery, whereby our UI deploys new module per Safe
+        // we can assume that the Safes-module relationship does not change for said module
+
         promises.push(
           this.collectiblesRepository.clearCollectibles({
             chainId: event.chainId,
@@ -133,8 +137,6 @@ export class CacheHooksService {
             chainId: event.chainId,
             address: event.address,
           }),
-          // TODO: Need also call clearSafesByModule here but have no access to module address
-          // We must restructure the caching of Safes by module to be Safe <-> Module
         );
         this._logSafeTxEvent(event);
         break;

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -78,6 +78,7 @@ export class CacheHooksService {
       // - the list of all executed transactions for the safe
       // - the list of module transactions for the safe
       // - the safe configuration
+      // - the list of Safes for the module
       case EventType.MODULE_TRANSACTION:
         promises.push(
           this.safeRepository.clearAllExecutedTransactions({
@@ -91,6 +92,10 @@ export class CacheHooksService {
           this.safeRepository.clearSafe({
             chainId: event.chainId,
             address: event.address,
+          }),
+          this.safeRepository.clearSafesByModule({
+            chainId: event.chainId,
+            moduleAddress: event.module,
           }),
         );
         this._logTxEvent(event);

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -133,6 +133,8 @@ export class CacheHooksService {
             chainId: event.chainId,
             address: event.address,
           }),
+          // TODO: Need also call clearSafesByModule here but have no access to module address
+          // We must restructure the caching of Safes by module to be Safe <-> Module
         );
         this._logSafeTxEvent(event);
         break;


### PR DESCRIPTION
This adds the following functionality to the `SafeRepository`, as well as integrating it with the `CacheHooksService`:

  - `getSafesByModule` - fetches and caches endpoint result
  - `clearSafesByModule` - clears existing cache of endpoint result

`clearSafesByModule` is called within the `CacheHooksService` whenever a `EventType.MODULE_TRANSACTION` event occurs.

Depends on https://github.com/safe-global/safe-client-gateway/pull/953.