### PR TITLE
fix: retrieve Safe address via recovery module address

### DIFF
--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -10,7 +10,6 @@ import { MultiSendDecoder } from '@/domain/alerts/contracts/multi-send-decoder.h
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
 import { IEmailRepository } from '@/domain/email/email.repository.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { IModulesRepository } from '@/domain/modules/modules.repository.interface';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 import { Safe } from '@/domain/safe/entities/safe.entity';
@@ -33,8 +32,6 @@ export class AlertsRepository implements IAlertsRepository {
     private readonly configurationService: IConfigurationService,
     @Inject(ISafeRepository)
     private readonly safeRepository: ISafeRepository,
-    @Inject(IModulesRepository)
-    private readonly modulesRepository: IModulesRepository,
   ) {}
 
   async addContracts(contracts: Array<AlertsRegistration>): Promise<void> {

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -10,6 +10,7 @@ import { MultiSendDecoder } from '@/domain/alerts/contracts/multi-send-decoder.h
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
 import { IEmailRepository } from '@/domain/email/email.repository.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { IModulesRepository } from '@/domain/modules/modules.repository.interface';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 import { Safe } from '@/domain/safe/entities/safe.entity';
@@ -32,6 +33,8 @@ export class AlertsRepository implements IAlertsRepository {
     private readonly configurationService: IConfigurationService,
     @Inject(ISafeRepository)
     private readonly safeRepository: ISafeRepository,
+    @Inject(IModulesRepository)
+    private readonly modulesRepository: IModulesRepository,
   ) {}
 
   async addContracts(contracts: Array<AlertsRegistration>): Promise<void> {
@@ -39,70 +42,74 @@ export class AlertsRepository implements IAlertsRepository {
   }
 
   async handleAlertLog(chainId: string, log: AlertLog): Promise<void> {
-    const emails = await this.emailRepository.getVerifiedEmailsBySafeAddress({
+    const moduleAddress = log.address;
+
+    const { safes } = await this.modulesRepository.getSafesByModule({
       chainId,
-      // TODO: This is the address of the module, _not_ the Safe
-      // Discussion in https://github.com/safe-global/safe-client-gateway/pull/923
-      safeAddress: log.address,
+      moduleAddress,
     });
 
-    if (emails.length === 0) {
+    if (safes.length === 0) {
       this.loggingService.debug(
-        `An alert for a Safe with no associated emails was received. safeAddress=${log.address}`,
+        `An alert for a module that is not activated on a Safe was received. moduleAddress=${moduleAddress}`,
       );
       return;
     }
 
-    const decodedEvent = this.delayModifierDecoder.decodeEventLog({
-      data: log.data as Hex,
-      topics: log.topics as [Hex, Hex, Hex],
+    // Recovery module is deployed per Safe so we can assume that it is only enabled on one
+    const safeAddress = safes[0];
+
+    const emails = await this.emailRepository.getVerifiedEmailsBySafeAddress({
+      chainId,
+      safeAddress,
     });
 
-    const decodedTransactions = this._decodeTransactionAdded(
-      decodedEvent.args.data,
-    );
-
-    if (!decodedTransactions) {
-      return this._notifyUnknownTransaction(emails);
+    if (emails.length === 0) {
+      this.loggingService.debug(
+        `An alert for a Safe with no associated emails was received. moduleAddress=${moduleAddress}, safeAddress=${safeAddress}`,
+      );
+      return;
     }
 
     try {
-      const safeAddress = decodedEvent.args.to;
-
       const safe = await this.safeRepository.getSafe({
         chainId,
         address: safeAddress,
       });
+
+      const decodedEvent = this.delayModifierDecoder.decodeEventLog({
+        data: log.data as Hex,
+        topics: log.topics as [Hex, Hex, Hex],
+      });
+      const decodedTransactions = this._decodeTransactionAdded(
+        decodedEvent.args.data,
+      );
 
       const newSafeState = await this._mapSafeSetup({
         safe,
         decodedTransactions,
       });
 
-      return this._notifySafeSetup({
+      this._notifySafeSetup({
         chainId,
         newSafeState,
       });
     } catch {
-      return this._notifyUnknownTransaction(emails);
+      this._notifyUnknownTransaction(emails);
     }
   }
 
   private _decodeTransactionAdded(data: Hex) {
-    try {
-      const decoded = this.safeDecoder.decodeFunctionData({ data });
+    const decoded = this.safeDecoder.decodeFunctionData({ data });
 
-      if (decoded.functionName !== 'execTransaction') {
-        return [decoded];
-      }
-
-      const execTransactionData = decoded.args[2];
-      return this.multiSendDecoder
-        .mapMultiSendTransactions(execTransactionData)
-        .flatMap(({ data }) => this.safeDecoder.decodeFunctionData({ data }));
-    } catch {
-      return null;
+    if (decoded.functionName !== 'execTransaction') {
+      return [decoded];
     }
+
+    const execTransactionData = decoded.args[2];
+    return this.multiSendDecoder
+      .mapMultiSendTransactions(execTransactionData)
+      .flatMap(({ data }) => this.safeDecoder.decodeFunctionData({ data }));
   }
 
   private async _mapSafeSetup(args: {

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -41,7 +41,7 @@ export class AlertsRepository implements IAlertsRepository {
   async handleAlertLog(chainId: string, log: AlertLog): Promise<void> {
     const moduleAddress = log.address;
 
-    const { safes } = await this.modulesRepository.getSafesByModule({
+    const { safes } = await this.safeRepository.getSafesByModule({
       chainId,
       moduleAddress,
     });

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -181,9 +181,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -270,9 +270,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -358,9 +358,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -436,9 +436,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -548,9 +548,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -608,7 +608,6 @@ describe('Alerts (Unit)', () => {
             'transaction',
             alertTransactionBuilder()
               .with('to', delayModifier)
-
               .with('logs', [log, log]) // Multiple logs
               .with('network', chain.chainId)
               .build(),
@@ -630,9 +629,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -722,9 +721,9 @@ describe('Alerts (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
-            case `${chain.transactionService}/api/v1/safes/${getAddress(
-              safe.address,
-            )}`:
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
@@ -759,6 +758,7 @@ describe('Alerts (Unit)', () => {
 
     describe('it notifies about an invalid transaction attempt', () => {
       it('notifies about an invalid transaction attempt', async () => {
+        const chain = chainBuilder().build();
         const delayModifier = faker.finance.ethereumAddress();
         const safe = safeBuilder().with('modules', [delayModifier]).build();
         const transactionAddedEvent = transactionAddedEventBuilder()
@@ -779,6 +779,7 @@ describe('Alerts (Unit)', () => {
                   .with('topics', transactionAddedEvent.topics)
                   .build(),
               ])
+              .with('network', chain.chainId)
               .build(),
           )
           .with('event_type', EventType.ALERT)
@@ -793,6 +794,19 @@ describe('Alerts (Unit)', () => {
         emailDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
           verifiedSignerEmails,
         );
+
+        networkService.get.mockImplementation((url) => {
+          switch (url) {
+            case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+              return Promise.resolve({ data: chain });
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+              return Promise.resolve({ data: safe });
+            default:
+              return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        });
 
         await request(app.getHttpServer())
           .post('/v1/alerts')
@@ -817,6 +831,7 @@ describe('Alerts (Unit)', () => {
       });
 
       it('notifies about alerts with multiple logs', async () => {
+        const chain = chainBuilder().build();
         const delayModifier = faker.finance.ethereumAddress();
         const safe = safeBuilder().with('modules', [delayModifier]).build();
         const transactionAddedEvent = transactionAddedEventBuilder()
@@ -836,6 +851,7 @@ describe('Alerts (Unit)', () => {
             alertTransactionBuilder()
               .with('to', delayModifier)
               .with('logs', [log, log]) // Multiple logs
+              .with('network', chain.chainId)
               .build(),
           )
           .with('event_type', EventType.ALERT)
@@ -850,6 +866,19 @@ describe('Alerts (Unit)', () => {
         emailDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
           verifiedSignerEmails,
         );
+
+        networkService.get.mockImplementation((url) => {
+          switch (url) {
+            case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+              return Promise.resolve({ data: chain });
+            case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+              return Promise.resolve({ data: { safes: [safe.address] } });
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+              return Promise.resolve({ data: safe });
+            default:
+              return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        });
 
         await request(app.getHttpServer())
           .post('/v1/alerts')
@@ -957,9 +986,9 @@ describe('Alerts (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
-          case `${chain.transactionService}/api/v1/safes/${getAddress(
-            safe.address,
-          )}`:
+          case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+            return Promise.resolve({ data: { safes: [safe.address] } });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -1062,9 +1091,9 @@ describe('Alerts (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
-          case `${chain.transactionService}/api/v1/safes/${getAddress(
-            safe.address,
-          )}`:
+          case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+            return Promise.resolve({ data: { safes: [safe.address] } });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -1149,9 +1178,9 @@ describe('Alerts (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
-          case `${chain.transactionService}/api/v1/safes/${getAddress(
-            safe.address,
-          )}`:
+          case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
+            return Promise.resolve({ data: { safes: [safe.address] } });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);


### PR DESCRIPTION
This adjusts recovery alerts to fetch the Safe address via the module address of the alert as well as adjusting test coverage accordingly.


Depends on https://github.com/safe-global/safe-client-gateway/pull/953 then https://github.com/safe-global/safe-client-gateway/pull/954.