### PR TITLE
Sort supported currency codes 

### DIFF
--- a/src/domain/prices/entities/schemas/fiat-codes.schema.ts
+++ b/src/domain/prices/entities/schemas/fiat-codes.schema.ts
@@ -8,6 +8,10 @@ export const fiatCodesSchema: JSONSchemaType<FiatCodes> = {
   $id: FIAT_CODES_SCHEMA_ID,
   type: 'array',
   items: { type: 'string' },
+  allOf: [
+    { contains: { type: 'string', enum: ['usd'] } },
+    { contains: { type: 'string', enum: ['eur'] } },
+  ],
   minItems: 1,
   uniqueItems: true,
 };

--- a/src/domain/prices/entities/schemas/fiat-codes.schema.ts
+++ b/src/domain/prices/entities/schemas/fiat-codes.schema.ts
@@ -8,10 +8,6 @@ export const fiatCodesSchema: JSONSchemaType<FiatCodes> = {
   $id: FIAT_CODES_SCHEMA_ID,
   type: 'array',
   items: { type: 'string' },
-  allOf: [
-    { contains: { type: 'string', enum: ['usd'] } },
-    { contains: { type: 'string', enum: ['eur'] } },
-  ],
   minItems: 1,
   uniqueItems: true,
 };

--- a/src/domain/prices/prices.repository.interface.ts
+++ b/src/domain/prices/prices.repository.interface.ts
@@ -16,7 +16,7 @@ export interface IPricesRepository {
 
   /**
    * Gets the list of supported fiat codes.
-   * @returns alphabetically ordered list of uppercase strings representing the supported fiat codes.
+   * @returns an alphabetically ordered list of uppercase strings representing the supported fiat codes.
    */
   getFiatCodes(): Promise<string[]>;
 }

--- a/src/domain/prices/prices.repository.interface.ts
+++ b/src/domain/prices/prices.repository.interface.ts
@@ -16,8 +16,7 @@ export interface IPricesRepository {
 
   /**
    * Gets the list of supported fiat codes.
-   * USD and EUR fiat codes are fixed, and should be the first ones in the result list.
-   * @returns ordered list of uppercase strings representing the supported fiat codes.
+   * @returns alphabetically ordered list of uppercase strings representing the supported fiat codes.
    */
   getFiatCodes(): Promise<string[]>;
 }

--- a/src/domain/prices/prices.repository.interface.ts
+++ b/src/domain/prices/prices.repository.interface.ts
@@ -14,5 +14,10 @@ export interface IPricesRepository {
     fiatCode: string;
   }): Promise<AssetPrice[]>;
 
+  /**
+   * Gets the list of supported fiat codes.
+   * USD and EUR fiat codes are fixed, and should be the first ones in the result list.
+   * @returns ordered list of uppercase strings representing the supported fiat codes.
+   */
   getFiatCodes(): Promise<string[]>;
 }

--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -4,11 +4,13 @@ import { IPricesRepository } from './prices.repository.interface';
 import { AssetPriceValidator } from './asset-price.validator';
 import { FiatCodesValidator } from './fiat-codes.validator';
 import { AssetPrice } from '@/domain/prices/entities/asset-price.entity';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 @Injectable()
 export class PricesRepository implements IPricesRepository {
   constructor(
     @Inject(IPricesApi) private readonly coingeckoApi: IPricesApi,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
     private readonly assetPriceValidator: AssetPriceValidator,
     private readonly fiatCodesValidator: FiatCodesValidator,
   ) {}
@@ -50,6 +52,12 @@ export class PricesRepository implements IPricesRepository {
       .map((item) => item.toUpperCase())
       .sort();
 
-    return Array.from(new Set(['USD', 'EUR', ...fiatCodes]));
+    if (!fiatCodes.includes('USD')) {
+      this.loggingService.error(
+        'USD fiat code is not supported by the Prices Provider API',
+      );
+    }
+
+    return fiatCodes;
   }
 }

--- a/src/domain/prices/prices.repository.ts
+++ b/src/domain/prices/prices.repository.ts
@@ -44,6 +44,12 @@ export class PricesRepository implements IPricesRepository {
 
   async getFiatCodes(): Promise<string[]> {
     const result = await this.coingeckoApi.getFiatCodes();
-    return this.fiatCodesValidator.validate(result);
+
+    const fiatCodes = this.fiatCodesValidator
+      .validate(result)
+      .map((item) => item.toUpperCase())
+      .sort();
+
+    return Array.from(new Set(['USD', 'EUR', ...fiatCodes]));
   }
 }

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -568,7 +568,7 @@ describe('Balances Controller (Unit)', () => {
 
   describe('GET /balances/supported-fiat-codes', () => {
     it('should return the ordered list of supported fiat codes', async () => {
-      const pricesProviderFiatCodes = ['chf', 'gbp', 'eur', 'usd', 'eth'];
+      const pricesProviderFiatCodes = ['chf', 'gbp', 'eur', 'eth', 'afn'];
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
@@ -581,7 +581,7 @@ describe('Balances Controller (Unit)', () => {
       await request(app.getHttpServer())
         .get('/v1/balances/supported-fiat-codes')
         .expect(200)
-        .expect(['USD', 'EUR', 'CHF', 'ETH', 'GBP']);
+        .expect(['AFN', 'CHF', 'ETH', 'EUR', 'GBP']);
     });
 
     it('should fail getting fiat currencies data from prices provider', async () => {
@@ -626,48 +626,6 @@ describe('Balances Controller (Unit)', () => {
 
     it('validation error (2) getting fiat currencies data from prices provider', async () => {
       const pricesProviderFiatCodes = 'notAnArray';
-      networkService.get.mockImplementation((url) => {
-        switch (url) {
-          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({ data: pricesProviderFiatCodes });
-          default:
-            return Promise.reject(new Error(`Could not match ${url}`));
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get('/v1/balances/supported-fiat-codes')
-        .expect(500)
-        .expect({
-          message: 'Validation failed',
-          code: 42,
-          arguments: [],
-        });
-    });
-
-    it('validation error when the fiat codes does not include the mandatory EUR code', async () => {
-      const pricesProviderFiatCodes = ['chf', 'gbp', 'usd', 'eth'];
-      networkService.get.mockImplementation((url) => {
-        switch (url) {
-          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({ data: pricesProviderFiatCodes });
-          default:
-            return Promise.reject(new Error(`Could not match ${url}`));
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get('/v1/balances/supported-fiat-codes')
-        .expect(500)
-        .expect({
-          message: 'Validation failed',
-          code: 42,
-          arguments: [],
-        });
-    });
-
-    it('validation error when the fiat codes does not include the mandatory USD code', async () => {
-      const pricesProviderFiatCodes = ['chf', 'gbp', 'eur', 'eth'];
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -568,7 +568,7 @@ describe('Balances Controller (Unit)', () => {
 
   describe('GET /balances/supported-fiat-codes', () => {
     it('should return the ordered list of supported fiat codes', async () => {
-      const pricesProviderFiatCodes = ['chf', 'gbp', 'eur', 'eth', 'afn'];
+      const pricesProviderFiatCodes = ['chf', 'gbp', 'eur', 'usd', 'eth'];
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
@@ -581,7 +581,7 @@ describe('Balances Controller (Unit)', () => {
       await request(app.getHttpServer())
         .get('/v1/balances/supported-fiat-codes')
         .expect(200)
-        .expect(['USD', 'EUR', 'AFN', 'CHF', 'ETH', 'GBP']);
+        .expect(['USD', 'EUR', 'CHF', 'ETH', 'GBP']);
     });
 
     it('should fail getting fiat currencies data from prices provider', async () => {
@@ -626,6 +626,48 @@ describe('Balances Controller (Unit)', () => {
 
     it('validation error (2) getting fiat currencies data from prices provider', async () => {
       const pricesProviderFiatCodes = 'notAnArray';
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
+            return Promise.resolve({ data: pricesProviderFiatCodes });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get('/v1/balances/supported-fiat-codes')
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+
+    it('validation error when the fiat codes does not include the mandatory EUR code', async () => {
+      const pricesProviderFiatCodes = ['chf', 'gbp', 'usd', 'eth'];
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
+            return Promise.resolve({ data: pricesProviderFiatCodes });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get('/v1/balances/supported-fiat-codes')
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+
+    it('validation error when the fiat codes does not include the mandatory USD code', async () => {
+      const pricesProviderFiatCodes = ['chf', 'gbp', 'eur', 'eth'];
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -81,17 +81,7 @@ export class BalancesService {
     };
   }
 
-  /**
-   * Gets the list of supported fiat codes.
-   * USD and EUR fiat codes are fixed, and should be the first ones in the result list.
-   * @returns ordered list of uppercase strings representing the supported fiat codes.
-   */
   async getSupportedFiatCodes(): Promise<string[]> {
-    const pricesProviderFiatCodes = await this.pricesRepository.getFiatCodes();
-    const fiatCodes = pricesProviderFiatCodes
-      .map((item) => item.toUpperCase())
-      .sort();
-
-    return Array.from(new Set(['USD', 'EUR', ...fiatCodes]));
+    return this.pricesRepository.getFiatCodes();
   }
 }


### PR DESCRIPTION
**Context**
This is a follow-up from this comment: https://github.com/safe-global/safe-client-gateway/pull/898#discussion_r1425269639

**Changes**
- Adds a log when the mandatory fiat code (`USD`) is not returned by the provider's supported currencies list.
- Sort the returned codes alphabetically.