### PR TITLE
fix: remove Safes by modules caching

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -14,7 +14,6 @@ export class CacheRouter {
   private static readonly MASTER_COPIES_KEY = 'master_copies';
   private static readonly MESSAGE_KEY = 'message';
   private static readonly MESSAGES_KEY = 'messages';
-  private static readonly MODULE_SAFES_KEY = 'module_safes';
   private static readonly MODULE_TRANSACTION_KEY = 'module_transaction';
   private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';
   private static readonly MULTISIG_TRANSACTION_KEY = 'multisig_transaction';
@@ -144,20 +143,6 @@ export class CacheRouter {
 
   static getTransfersCacheKey(args: { chainId: string; safeAddress: string }) {
     return `${args.chainId}_${CacheRouter.TRANSFERS_KEY}_${args.safeAddress}`;
-  }
-
-  static getSafesByModuleCacheDir(args: {
-    chainId: string;
-    moduleAddress: string;
-  }): CacheDir {
-    return new CacheDir(CacheRouter.getSafesByModuleCacheKey(args), '');
-  }
-
-  static getSafesByModuleCacheKey(args: {
-    chainId: string;
-    moduleAddress: string;
-  }): string {
-    return `${args.chainId}_${CacheRouter.MODULE_SAFES_KEY}_${args.moduleAddress}`;
   }
 
   static getModuleTransactionCacheDir(args: {

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -173,41 +173,4 @@ describe('TransactionApi', () => {
       expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
     });
   });
-
-  describe('Modules', () => {
-    it('should return Safes with module enabled', async () => {
-      const moduleAddress = faker.finance.ethereumAddress();
-      const safesByModule = {
-        safes: [
-          faker.finance.ethereumAddress(),
-          faker.finance.ethereumAddress(),
-        ],
-      };
-      mockDataSource.get.mockResolvedValueOnce(safesByModule);
-
-      const actual = await service.getSafesByModule(moduleAddress);
-
-      expect(actual).toBe(safesByModule);
-      expect(mockDataSource.get).toHaveBeenCalledWith({
-        cacheDir: new CacheDir(`${chainId}_module_safes_${moduleAddress}`, ''),
-        url: `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`,
-        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
-        expireTimeSeconds: defaultExpirationTimeInSeconds,
-      });
-      expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
-    });
-
-    it('should map error on error', async () => {
-      const moduleAddress = faker.finance.ethereumAddress();
-      const error = new Error('some error');
-      const expected = new DataSourceError('some data source error');
-      mockDataSource.get.mockRejectedValueOnce(error);
-      mockHttpErrorFactory.from.mockReturnValue(expected);
-
-      await expect(service.getSafesByModule(moduleAddress)).rejects.toThrow(
-        expected,
-      );
-      expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -32,8 +32,10 @@ const httpErrorFactory = {
 const mockHttpErrorFactory = jest.mocked(httpErrorFactory);
 
 const networkService = jest.mocked({
+  get: jest.fn(),
   post: jest.fn(),
 }) as unknown as INetworkService;
+const mockNetworkService = jest.mocked(networkService);
 
 describe('TransactionApi', () => {
   const chainId = '1';
@@ -70,7 +72,7 @@ describe('TransactionApi', () => {
       mockCacheService,
       mockConfigurationService,
       mockHttpErrorFactory,
-      networkService,
+      mockNetworkService,
     );
   });
 
@@ -146,31 +148,67 @@ describe('TransactionApi', () => {
   });
 
   describe('Safe', () => {
-    it('should return retrieved safe', async () => {
-      const safe = safeBuilder().build();
-      mockDataSource.get.mockResolvedValueOnce(safe);
+    describe('getSafe', () => {
+      it('should return retrieved safe', async () => {
+        const safe = safeBuilder().build();
+        mockDataSource.get.mockResolvedValueOnce(safe);
 
-      const actual = await service.getSafe(safe.address);
+        const actual = await service.getSafe(safe.address);
 
-      expect(actual).toBe(safe);
-      expect(mockDataSource.get).toHaveBeenCalledWith({
-        cacheDir: new CacheDir(`${chainId}_safe_${safe.address}`, ''),
-        url: `${baseUrl}/api/v1/safes/${safe.address}`,
-        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
-        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        expect(actual).toBe(safe);
+        expect(mockDataSource.get).toHaveBeenCalledWith({
+          cacheDir: new CacheDir(`${chainId}_safe_${safe.address}`, ''),
+          url: `${baseUrl}/api/v1/safes/${safe.address}`,
+          notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+          expireTimeSeconds: defaultExpirationTimeInSeconds,
+        });
+        expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
       });
-      expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
+
+      it('should map error on error', async () => {
+        const safe = safeBuilder().build();
+        const error = new Error('some error');
+        const expected = new DataSourceError('some data source error');
+        mockDataSource.get.mockRejectedValueOnce(error);
+        mockHttpErrorFactory.from.mockReturnValue(expected);
+
+        await expect(service.getSafe(safe.address)).rejects.toThrow(expected);
+        expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it('should map error on error', async () => {
-      const safe = safeBuilder().build();
-      const error = new Error('some error');
-      const expected = new DataSourceError('some data source error');
-      mockDataSource.get.mockRejectedValueOnce(error);
-      mockHttpErrorFactory.from.mockReturnValue(expected);
+    describe('getSafesByModules', () => {
+      it('should return Safes with module enabled', async () => {
+        const moduleAddress = faker.finance.ethereumAddress();
+        const safesByModule = {
+          safes: [
+            faker.finance.ethereumAddress(),
+            faker.finance.ethereumAddress(),
+          ],
+        };
+        mockNetworkService.get.mockResolvedValueOnce(safesByModule);
 
-      await expect(service.getSafe(safe.address)).rejects.toThrow(expected);
-      expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
+        const actual = await service.getSafesByModule(moduleAddress);
+
+        expect(actual).toBe(safesByModule);
+        expect(mockNetworkService.get).toHaveBeenCalledWith(
+          `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`,
+        );
+        expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
+      });
+
+      it('should map error on error', async () => {
+        const moduleAddress = faker.finance.ethereumAddress();
+        const error = new Error('some error');
+        const expected = new DataSourceError('some data source error');
+        mockNetworkService.get.mockRejectedValueOnce(error);
+        mockHttpErrorFactory.from.mockReturnValue(expected);
+
+        await expect(service.getSafesByModule(moduleAddress)).rejects.toThrow(
+          expected,
+        );
+        expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -186,7 +186,7 @@ describe('TransactionApi', () => {
             faker.finance.ethereumAddress(),
           ],
         };
-        mockNetworkService.get.mockResolvedValueOnce(safesByModule);
+        mockNetworkService.get.mockResolvedValueOnce({ data: safesByModule });
 
         const actual = await service.getSafesByModule(moduleAddress);
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -445,7 +445,8 @@ export class TransactionApi implements ITransactionApi {
   async getSafesByModule(moduleAddress: string): Promise<SafeList> {
     try {
       const url = `${this.baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
-      return await this.networkService.get(url);
+      const { data } = await this.networkService.get(url);
+      return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -444,28 +444,11 @@ export class TransactionApi implements ITransactionApi {
 
   async getSafesByModule(moduleAddress: string): Promise<SafeList> {
     try {
-      const cacheDir = CacheRouter.getSafesByModuleCacheDir({
-        chainId: this.chainId,
-        moduleAddress,
-      });
       const url = `${this.baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
-      return await this.dataSource.get({
-        cacheDir,
-        url,
-        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
-        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
-      });
+      return await this.networkService.get(url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
-  }
-
-  async clearSafesByModule(moduleAddress: string): Promise<void> {
-    const key = CacheRouter.getSafesByModuleCacheKey({
-      chainId: this.chainId,
-      moduleAddress,
-    });
-    await this.cacheService.deleteByKey(key);
   }
 
   // Important: there is no hook which invalidates this endpoint,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -113,8 +113,6 @@ export interface ITransactionApi {
 
   getSafesByModule(moduleAddress: string): Promise<SafeList>;
 
-  clearSafesByModule(moduleAddress: string): Promise<void>;
-
   getModuleTransaction(moduleTransactionId: string): Promise<ModuleTransaction>;
 
   getModuleTransactions(args: {

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -186,9 +186,4 @@ export interface ISafeRepository {
     chainId: string;
     moduleAddress: string;
   }): Promise<SafeList>;
-
-  clearSafesByModule(args: {
-    chainId: string;
-    moduleAddress: string;
-  }): Promise<void>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -415,13 +415,4 @@ export class SafeRepository implements ISafeRepository {
 
     return this.safeListValidator.validate(safesByModule);
   }
-
-  async clearSafesByModule(args: {
-    chainId: string;
-    moduleAddress: string;
-  }): Promise<void> {
-    const transactionService =
-      await this.transactionApiManager.getTransactionApi(args.chainId);
-    await transactionService.clearSafesByModule(args.moduleAddress);
-  }
 }

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -178,11 +178,12 @@ describe('Alerts (Unit)', () => {
         );
 
         networkService.get.mockImplementation((url) => {
+          console.log(url);
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -271,7 +272,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -359,7 +360,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -437,7 +438,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -549,7 +550,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -630,7 +631,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -722,7 +723,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -800,7 +801,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -872,7 +873,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({ safes: [safe.address] });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -987,7 +988,7 @@ describe('Alerts (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ data: { safes: [safe.address] } });
+            return Promise.resolve({ safes: [safe.address] });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
@@ -1092,7 +1093,7 @@ describe('Alerts (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ data: { safes: [safe.address] } });
+            return Promise.resolve({ safes: [safe.address] });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
@@ -1179,7 +1180,7 @@ describe('Alerts (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ data: { safes: [safe.address] } });
+            return Promise.resolve({ safes: [safe.address] });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -182,7 +182,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -271,7 +271,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -359,7 +359,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -437,7 +437,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -549,7 +549,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -630,7 +630,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -722,7 +722,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -800,7 +800,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -872,7 +872,7 @@ describe('Alerts (Unit)', () => {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ safes: [safe.address] });
+              return Promise.resolve({ data: { safes: [safe.address] } });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({ data: safe });
             default:
@@ -987,7 +987,7 @@ describe('Alerts (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ safes: [safe.address] });
+            return Promise.resolve({ data: { safes: [safe.address] } });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
@@ -1092,7 +1092,7 @@ describe('Alerts (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ safes: [safe.address] });
+            return Promise.resolve({ data: { safes: [safe.address] } });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:
@@ -1179,7 +1179,7 @@ describe('Alerts (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ safes: [safe.address] });
+            return Promise.resolve({ data: { safes: [safe.address] } });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: safe });
           default:

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -178,7 +178,6 @@ describe('Alerts (Unit)', () => {
         );
 
         networkService.get.mockImplementation((url) => {
-          console.log(url);
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain });

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -768,37 +768,4 @@ describe('Post Hook Events (Unit)', () => {
       webHookExecutionDelayMs,
     );
   });
-
-  it.each([
-    {
-      type: 'MODULE_TRANSACTION',
-      module: faker.finance.ethereumAddress(),
-      txHash: faker.string.hexadecimal({ length: 32 }),
-    },
-  ])('$type clears Safes by module', async (payload) => {
-    const chainId = faker.string.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-    const moduleAddress = faker.finance.ethereumAddress();
-    const cacheDir = new CacheDir(
-      `${chainId}_module_safes_${moduleAddress}`,
-      '',
-    );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
-    const data = {
-      address: safeAddress,
-      chainId: chainId,
-      ...payload,
-    };
-
-    await request(app.getHttpServer())
-      .post(`/hooks/events`)
-      .set('Authorization', `Basic ${authToken}`)
-      .send(data)
-      .expect(202);
-
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
-  });
 });

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -78,7 +78,6 @@ export class CacheHooksService {
       // - the list of all executed transactions for the safe
       // - the list of module transactions for the safe
       // - the safe configuration
-      // - the list of Safes for the module
       case EventType.MODULE_TRANSACTION:
         promises.push(
           this.safeRepository.clearAllExecutedTransactions({
@@ -93,10 +92,6 @@ export class CacheHooksService {
             chainId: event.chainId,
             address: event.address,
           }),
-          this.safeRepository.clearSafesByModule({
-            chainId: event.chainId,
-            moduleAddress: event.module,
-          }),
         );
         this._logTxEvent(event);
         break;
@@ -108,10 +103,6 @@ export class CacheHooksService {
       // - the transaction executed – clear multisig transaction
       // - the safe configuration - clear safe info
       case EventType.EXECUTED_MULTISIG_TRANSACTION:
-        // Important: we should be clearing Safes by module here but we don't have module address
-        // As this is only being used for recovery, whereby our UI deploys new module per Safe
-        // we can assume that the Safes-module relationship does not change for said module
-
         promises.push(
           this.collectiblesRepository.clearCollectibles({
             chainId: event.chainId,


### PR DESCRIPTION
Depends on #961

This removes caching of Safes by modules as it was deemed an unnecessary optimisation that we will revisit later if necessary.