### PR TITLE
Fix decoded data value on error

### DIFF
--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -259,7 +259,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
         },
         txData: {
           hexData: previewTransactionDto.data,
-          dataDecoded: previewTransactionDto.data,
+          dataDecoded: null,
           to: {
             value: previewTransactionDto.to,
             name: null,

--- a/src/routes/transactions/mappers/transaction-preview.mapper.ts
+++ b/src/routes/transactions/mappers/transaction-preview.mapper.ts
@@ -8,6 +8,7 @@ import { PreviewTransactionDto } from '@/routes/transactions/entities/preview-tr
 import { TransactionPreview } from '@/routes/transactions/entities/transaction-preview.entity';
 import { TransactionDataMapper } from '@/routes/transactions/mappers/common/transaction-data.mapper';
 import { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
+import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 
 @Injectable()
 export class TransactionPreviewMapper {
@@ -25,7 +26,7 @@ export class TransactionPreviewMapper {
     safe: Safe,
     previewTransactionDto: PreviewTransactionDto,
   ): Promise<TransactionPreview> {
-    let dataDecoded;
+    let dataDecoded: DataDecoded | null = null;
     try {
       if (previewTransactionDto.data !== null) {
         dataDecoded = await this.dataDecodedRepository.getDataDecoded({
@@ -38,7 +39,6 @@ export class TransactionPreviewMapper {
       this.loggingService.info(
         `Error trying to decode the input data: ${error.message}`,
       );
-      dataDecoded = previewTransactionDto.data;
     }
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
       chainId,


### PR DESCRIPTION
If an error occurs when getting the decoded data in `POST /v1/chains/:chainId/transactions/:safeAddress/preview`, the value of `dataDecoded` should be `null` and not take the value of the provided transaction data.