### PR TITLE
Add email update functionality

### DIFF
--- a/src/datasources/email/__tests__/test.email.datasource.module.ts
+++ b/src/datasources/email/__tests__/test.email.datasource.module.ts
@@ -9,6 +9,7 @@ const emailDataSource = {
   setVerificationSentDate: jest.fn(),
   verifyEmail: jest.fn(),
   deleteEmail: jest.fn(),
+  updateEmail: jest.fn(),
 } as unknown as IEmailDataSource;
 
 @Module({

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -329,4 +329,67 @@ describe('Email Datasource Tests', () => {
       }),
     ).rejects.toThrow(EmailAddressDoesNotExistError);
   });
+
+  it('updates emails successfully', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+
+    await target.saveEmail({
+      chainId: chainId.toString(),
+      safeAddress,
+      emailAddress: new EmailAddress(faker.internet.email()),
+      account,
+      code: faker.string.numeric(),
+      codeGenerationDate: faker.date.recent(),
+    });
+
+    await target.updateEmail({
+      chainId: chainId.toString(),
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+    });
+
+    const email = await target.getEmail({
+      chainId: chainId.toString(),
+      safeAddress,
+      account,
+    });
+
+    expect(email).toMatchObject({
+      chainId: chainId.toString(),
+      emailAddress,
+      isVerified: false,
+      safeAddress,
+      account,
+      verificationCode: code,
+      verificationSentOn: null,
+    });
+  });
+
+  it('updating a non-existent email throws', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+
+    await expect(
+      target.updateEmail({
+        chainId: chainId.toString(),
+        safeAddress,
+        emailAddress,
+        account,
+        code,
+        codeGenerationDate,
+      }),
+    ).rejects.toThrow(EmailAddressDoesNotExistError);
+  });
 });

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -331,24 +331,31 @@ describe('Email Datasource Tests', () => {
   });
 
   it('updates emails successfully', async () => {
-    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
     const safeAddress = faker.finance.ethereumAddress();
+    const prevEmailAddress = new EmailAddress(faker.internet.email());
     const emailAddress = new EmailAddress(faker.internet.email());
     const account = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
 
     await target.saveEmail({
-      chainId: chainId.toString(),
+      chainId,
       safeAddress,
-      emailAddress: new EmailAddress(faker.internet.email()),
+      emailAddress: prevEmailAddress,
       account,
       code: faker.string.numeric(),
       codeGenerationDate: faker.date.recent(),
     });
 
+    await target.verifyEmail({
+      chainId,
+      safeAddress,
+      account,
+    });
+
     await target.updateEmail({
-      chainId: chainId.toString(),
+      chainId,
       safeAddress,
       emailAddress,
       account,
@@ -357,13 +364,13 @@ describe('Email Datasource Tests', () => {
     });
 
     const email = await target.getEmail({
-      chainId: chainId.toString(),
+      chainId,
       safeAddress,
       account,
     });
 
     expect(email).toMatchObject({
-      chainId: chainId.toString(),
+      chainId,
       emailAddress,
       isVerified: false,
       safeAddress,

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -330,7 +330,51 @@ describe('Email Datasource Tests', () => {
     ).rejects.toThrow(EmailAddressDoesNotExistError);
   });
 
-  it('updates emails successfully', async () => {
+  it('update from previously unverified emails successfully', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const prevEmailAddress = new EmailAddress(faker.internet.email());
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress: prevEmailAddress,
+      account,
+      code: faker.string.numeric(),
+      codeGenerationDate: faker.date.recent(),
+    });
+
+    await target.updateEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+    });
+
+    const email = await target.getEmail({
+      chainId,
+      safeAddress,
+      account,
+    });
+
+    expect(email).toMatchObject({
+      chainId,
+      emailAddress,
+      isVerified: false,
+      safeAddress,
+      account,
+      verificationCode: code,
+      verificationSentOn: null,
+    });
+  });
+
+  it('update from previously verified emails successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
     const safeAddress = faker.finance.ethereumAddress();
     const prevEmailAddress = new EmailAddress(faker.internet.email());

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -186,6 +186,7 @@ export class EmailDataSource implements IEmailDataSource {
   }): Promise<void> {
     const [email] = await this.sql<Email[]>`UPDATE emails.account_emails
                                             SET email_address                  = ${args.emailAddress.value},
+                                                verified                       = false,
                                                 verification_code              = ${args.code},
                                                 verification_code_generated_on = ${args.codeGenerationDate}
                                             WHERE chain_id = ${args.chainId}

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -175,4 +175,30 @@ export class EmailDataSource implements IEmailDataSource {
       );
     }
   }
+
+  async updateEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    emailAddress: EmailAddress;
+    account: string;
+    code: string;
+    codeGenerationDate: Date;
+  }): Promise<void> {
+    const [email] = await this.sql<Email[]>`UPDATE emails.account_emails
+                                            SET email_address                  = ${args.emailAddress.value},
+                                                verification_code              = ${args.code},
+                                                verification_code_generated_on = ${args.codeGenerationDate}
+                                            WHERE chain_id = ${args.chainId}
+                                              AND safe_address = ${args.safeAddress}
+                                              AND account = ${args.account}
+                                            RETURNING *`;
+
+    if (!email) {
+      throw new EmailAddressDoesNotExistError(
+        args.chainId,
+        args.safeAddress,
+        args.account,
+      );
+    }
+  }
 }

--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -75,4 +75,19 @@ export interface IEmailRepository {
     safeAddress: string;
     account: string;
   }): Promise<void>;
+
+  /**
+   * Updates an email entry.
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which we should store the email address
+   * @param args.emailAddress - the email address to store
+   * @param args.account - the owner address to which we should link the email address to
+   */
+  updateEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    emailAddress: string;
+    account: string;
+  }): Promise<void>;
 }

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -8,6 +8,7 @@ import { ResendVerificationTimespanError } from '@/domain/email/errors/verificat
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { EmailAlreadyVerifiedError } from '@/domain/email/errors/email-already-verified.error';
 import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-verification-code.error';
+import { EmailUpdateError } from '@/domain/email/errors/email-update.error';
 
 @Injectable()
 export class EmailRepository implements IEmailRepository {
@@ -147,6 +148,33 @@ export class EmailRepository implements IEmailRepository {
     account: string;
   }): Promise<void> {
     return this.emailDataSource.deleteEmail(args);
+  }
+
+  async updateEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    emailAddress: string;
+    account: string;
+  }): Promise<void> {
+    const email = new EmailAddress(args.emailAddress);
+    const verificationCode = this._generateCode();
+
+    try {
+      await this.emailDataSource.updateEmail({
+        chainId: args.chainId,
+        code: verificationCode,
+        emailAddress: email,
+        safeAddress: args.safeAddress,
+        account: args.account,
+        codeGenerationDate: new Date(),
+      });
+      await this._sendEmailVerification({
+        ...args,
+        code: verificationCode,
+      });
+    } catch (e) {
+      throw new EmailUpdateError(args);
+    }
   }
 
   private _isEmailVerificationCodeValid(email: Email) {

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -8,7 +8,6 @@ import { ResendVerificationTimespanError } from '@/domain/email/errors/verificat
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { EmailAlreadyVerifiedError } from '@/domain/email/errors/email-already-verified.error';
 import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-verification-code.error';
-import { EmailUpdateError } from '@/domain/email/errors/email-update.error';
 import { EmailUpdateMatchesError } from '@/domain/email/errors/email-update-matches.error';
 
 @Injectable()
@@ -166,22 +165,18 @@ export class EmailRepository implements IEmailRepository {
 
     const verificationCode = this._generateCode();
 
-    try {
-      await this.emailDataSource.updateEmail({
-        chainId: args.chainId,
-        code: verificationCode,
-        emailAddress: newEmail,
-        safeAddress: args.safeAddress,
-        account: args.account,
-        codeGenerationDate: new Date(),
-      });
-      await this._sendEmailVerification({
-        ...args,
-        code: verificationCode,
-      });
-    } catch (e) {
-      throw new EmailUpdateError(args);
-    }
+    await this.emailDataSource.updateEmail({
+      chainId: args.chainId,
+      code: verificationCode,
+      emailAddress: newEmail,
+      safeAddress: args.safeAddress,
+      account: args.account,
+      codeGenerationDate: new Date(),
+    });
+    await this._sendEmailVerification({
+      ...args,
+      code: verificationCode,
+    });
   }
 
   private _isEmailVerificationCodeValid(email: Email) {

--- a/src/domain/email/errors/email-update-matches.error.ts
+++ b/src/domain/email/errors/email-update-matches.error.ts
@@ -1,0 +1,7 @@
+export class EmailUpdateMatchesError extends Error {
+  constructor(args: { chainId: string; safeAddress: string; account: string }) {
+    super(
+      `The provided email address matches that set for the Safe owner. chainId=${args.chainId}, safeAddress=${args.safeAddress}, account=${args.account}`,
+    );
+  }
+}

--- a/src/domain/email/errors/email-update.error.ts
+++ b/src/domain/email/errors/email-update.error.ts
@@ -1,7 +1,0 @@
-export class EmailUpdateError extends Error {
-  constructor(args: { chainId: string; safeAddress: string; account: string }) {
-    super(
-      `Error while updating email of provided Safe owner. chainId=${args.chainId}, safeAddress=${args.safeAddress}, account=${args.account}`,
-    );
-  }
-}

--- a/src/domain/email/errors/email-update.error.ts
+++ b/src/domain/email/errors/email-update.error.ts
@@ -1,0 +1,7 @@
+export class EmailUpdateError extends Error {
+  constructor(args: { chainId: string; safeAddress: string; account: string }) {
+    super(
+      `Error while updating email of provided Safe owner. chainId=${args.chainId}, safeAddress=${args.safeAddress}, account=${args.account}`,
+    );
+  }
+}

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -105,4 +105,23 @@ export interface IEmailDataSource {
     safeAddress: string;
     account: string;
   }): Promise<void>;
+
+  /**
+   * Updates an email entry in the respective data source.
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which we should store the email address
+   * @param args.emailAddress - the email address to store
+   * @param args.account - the owner address to which we should link the email address to
+   * @param args.code - the generated code to be used to verify this email address
+   * @param args.verificationGeneratedOn – the date which represents when the code was generated
+   */
+  updateEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    emailAddress: EmailAddress;
+    account: string;
+    code: string;
+    codeGenerationDate: Date;
+  }): Promise<void>;
 }

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -24,6 +24,8 @@ import { VerifyEmailDto } from '@/routes/email/entities/verify-email-dto.entity'
 import { InvalidVerificationCodeExceptionFilter } from '@/routes/email/exception-filters/invalid-verification-code.exception-filter';
 import { DeleteEmailDto } from '@/routes/email/entities/delete-email-dto.entity';
 import { EmailAddressDoesNotExistExceptionFilter } from '@/routes/email/exception-filters/email-does-not-exist.exception-filter';
+import { UpdateEmailDto } from '@/routes/email/entities/update-email-dto.entity';
+import { EmailUpdateGuard } from '@/routes/email/guards/email-update.guard';
 
 @ApiTags('email')
 @Controller({
@@ -104,6 +106,27 @@ export class EmailController {
       chainId,
       safeAddress,
       account: deleteEmailDto.account,
+    });
+  }
+
+  @Put('')
+  @UseGuards(
+    EmailUpdateGuard,
+    TimestampGuard(5 * 60 * 1000), // 5 minutes
+    OnlySafeOwnerGuard,
+  )
+  @UseFilters(EmailAddressDoesNotExistExceptionFilter)
+  @HttpCode(HttpStatus.ACCEPTED)
+  async updateEmail(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @Body() updateEmailDto: UpdateEmailDto,
+  ): Promise<void> {
+    await this.service.updateEmail({
+      chainId,
+      safeAddress,
+      account: updateEmailDto.account,
+      emailAddress: updateEmailDto.emailAddress,
     });
   }
 }

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -26,6 +26,7 @@ import { DeleteEmailDto } from '@/routes/email/entities/delete-email-dto.entity'
 import { EmailAddressDoesNotExistExceptionFilter } from '@/routes/email/exception-filters/email-does-not-exist.exception-filter';
 import { UpdateEmailDto } from '@/routes/email/entities/update-email-dto.entity';
 import { EmailUpdateGuard } from '@/routes/email/guards/email-update.guard';
+import { EmailUpdateMatchesExceptionFilter } from '@/routes/email/exception-filters/email-update-matches.exception-filter';
 
 @ApiTags('email')
 @Controller({
@@ -115,7 +116,10 @@ export class EmailController {
     TimestampGuard(5 * 60 * 1000), // 5 minutes
     OnlySafeOwnerGuard,
   )
-  @UseFilters(EmailAddressDoesNotExistExceptionFilter)
+  @UseFilters(
+    EmailUpdateMatchesExceptionFilter,
+    EmailAddressDoesNotExistExceptionFilter,
+  )
   @HttpCode(HttpStatus.ACCEPTED)
   async updateEmail(
     @Param('chainId') chainId: string,

--- a/src/routes/email/email.controller.update-email.spec.ts
+++ b/src/routes/email/email.controller.update-email.spec.ts
@@ -1,0 +1,212 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
+import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { getAddress } from 'viem';
+import { EmailControllerModule } from '@/routes/email/email.controller.module';
+
+describe('Email controller update email tests', () => {
+  let app;
+  let safeConfigUrl;
+  let emailDatasource;
+  let networkService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration), EmailControllerModule],
+    })
+      .overrideModule(EmailDataSourceModule)
+      .useModule(TestEmailDatasourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    const configurationService = moduleFixture.get(IConfigurationService);
+    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    emailDatasource = moduleFixture.get(IEmailDataSource);
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('updates email successfully', async () => {
+    const chain = chainBuilder().build();
+    const emailAddress = faker.internet.email();
+    const timestamp = jest.now();
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const accountAddress = account.address;
+    // Signer is owner of safe
+    const safe = safeBuilder()
+      .with('owners', [accountAddress])
+      // Faker generates non-checksum addresses only
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const signature = await account.signMessage({ message });
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+          return Promise.resolve({ data: safe });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    emailDatasource.updateEmail.mockResolvedValue({
+      email: emailAddress,
+      verificationCode: faker.string.numeric(),
+    });
+
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
+      .send({
+        emailAddress,
+        account: account.address,
+        timestamp,
+        signature,
+      })
+      .expect(202)
+      .expect({});
+  });
+
+  it('returns 403 is message was signed with a timestamp older than 5 minutes', async () => {
+    const chain = chainBuilder().build();
+    const emailAddress = faker.internet.email();
+    const timestamp = jest.now();
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const accountAddress = account.address;
+    // Signer is owner of safe
+    const safe = safeBuilder()
+      .with('owners', [accountAddress])
+      // Faker generates non-checksum addresses only
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const signature = await account.signMessage({ message });
+
+    jest.advanceTimersByTime(5 * 60 * 1000);
+
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
+      .send({
+        emailAddress,
+        account: account.address,
+        timestamp,
+        signature,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on wrong message signature', async () => {
+    const chain = chainBuilder().build();
+    const emailAddress = faker.internet.email();
+    const timestamp = jest.now();
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const accountAddress = account.address;
+    // Signer is owner of safe
+    const safe = safeBuilder()
+      .with('owners', [accountAddress])
+      // Faker generates non-checksum addresses only
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+    const message = `some-action-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const signature = await account.signMessage({ message });
+
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
+      .send({
+        emailAddress,
+        account: account.address,
+        timestamp,
+        signature,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if message not signed by owner', async () => {
+    const chain = chainBuilder().build();
+    const emailAddress = faker.internet.email();
+    const timestamp = jest.now();
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const accountAddress = account.address;
+    // Signer is owner of safe
+    const safe = safeBuilder()
+      // Faker generates non-checksum addresses only
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const signature = await account.signMessage({ message });
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+          return Promise.resolve({ data: safe });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
+      .send({
+        emailAddress,
+        account: account.address,
+        timestamp,
+        signature,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+});

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -40,4 +40,13 @@ export class EmailService {
   }): Promise<void> {
     return this.repository.deleteEmail(args);
   }
+
+  async updateEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+    emailAddress: string;
+  }): Promise<void> {
+    return this.repository.updateEmail(args);
+  }
 }

--- a/src/routes/email/entities/update-email-dto.entity.ts
+++ b/src/routes/email/entities/update-email-dto.entity.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateEmailDto {
+  @ApiProperty()
+  emailAddress: string;
+
+  @ApiProperty()
+  account: string;
+
+  @ApiProperty()
+  timestamp: number;
+
+  @ApiProperty()
+  signature: string;
+}

--- a/src/routes/email/exception-filters/email-update-matches.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-update-matches.exception-filter.ts
@@ -1,0 +1,21 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { EmailUpdateMatchesError } from '@/domain/email/errors/email-update-matches.error';
+
+@Catch(EmailUpdateMatchesError)
+export class EmailUpdateMatchesExceptionFilter implements ExceptionFilter {
+  catch(exception: EmailUpdateMatchesError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.CONFLICT).json({
+      message: 'Email address matches that of the Safe owner.',
+      statusCode: HttpStatus.CONFLICT,
+    });
+  }
+}

--- a/src/routes/email/guards/email-update.guard.spec.ts
+++ b/src/routes/email/guards/email-update.guard.spec.ts
@@ -1,0 +1,205 @@
+import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { Hash } from 'viem';
+import { EmailUpdateGuard } from '@/routes/email/guards/email-update.guard';
+
+@Controller()
+class TestController {
+  @Post('test/:chainId/:safeAddress')
+  @HttpCode(200)
+  @UseGuards(EmailUpdateGuard)
+  async validRoute() {}
+
+  @Post('test/invalid/chains/:chainId')
+  @HttpCode(200)
+  @UseGuards(EmailUpdateGuard)
+  async invalidRouteWithChainId() {}
+
+  @Post('test/invalid/safes/:safeAddress')
+  @HttpCode(200)
+  @UseGuards(EmailUpdateGuard)
+  async invalidRouteWithSafeAddress() {}
+}
+
+describe('EmailUpdate guard tests', () => {
+  let app;
+
+  const chainId = faker.string.numeric();
+  const safe = faker.finance.ethereumAddress();
+  const emailAddress = faker.internet.email();
+  const timestamp = faker.date.recent().getTime();
+  const privateKey = generatePrivateKey();
+  const account = privateKeyToAccount(privateKey);
+  const accountAddress = account.address;
+  let signature: Hash;
+
+  beforeAll(async () => {
+    const message = `email-update-${chainId}-${safe}-${emailAddress}-${accountAddress}-${timestamp}`;
+    signature = await account.signMessage({ message });
+  });
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 403 on empty body', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 200 on a valid signature', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(200);
+  });
+
+  it('returns 403 on an invalid signature', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress: faker.internet.email(), // different email should have different signature
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the email address is missing from payload', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the account is missing from payload', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the signature is missing from payload', async () => {
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safe}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if the timestamp is missing from payload', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/${chainId}/${safeAddress}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without safe address', async () => {
+    const chainId = faker.string.numeric();
+
+    await request(app.getHttpServer())
+      .post(`/test/invalid/chains/${chainId}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without chain id', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .post(`/test/invalid/safes/${safeAddress}`)
+      .send({
+        emailAddress,
+        account: accountAddress,
+        signature,
+        timestamp,
+      })
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+});


### PR DESCRIPTION
The adds the following methods to the `EmailDataSource`:

- `updateEmail` - updates an entry for the given Safe/account, setting it as unverified.

When calling the above method, the `EmailService` sets the provided email as unverified and dispatches a verification email.

This functionality is propagated to the `chains/:chainId/safes/:safeAddress/emails` endpoint via a [new `PUT` method](https://www.notion.so/safe-global/Technical-Specification-Email-Registration-1b897da501d541ce973cd846bbca4763?pvs=4#b266ad747d624e1da3b514556bffd575). It is guarded by timestamp, owner and signature (prefixed with `email-update-`) guards.