### PR TITLE
Fix missing await in test

### DIFF
--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -321,7 +321,7 @@ describe('Email Datasource Tests', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const account = faker.finance.ethereumAddress();
 
-    expect(
+    await expect(
       target.deleteEmail({
         chainId,
         safeAddress,


### PR DESCRIPTION
Adds a missing `await` for the `expect` call which returns a promise.