### PR TITLE
Set Jest timezone to UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "testEnvironment": "node",
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/../src/$1"
-    }
+    },
+    "globalSetup": "<rootDir>/../test/global-setup.ts"
   },
   "main": "main.ts",
   "repository": "https://github.com/5afe/safe-client-gateway-nest.git",

--- a/src/__tests__/timezone.spec.ts
+++ b/src/__tests__/timezone.spec.ts
@@ -1,0 +1,5 @@
+describe('Jest timezone test', () => {
+  it('should have a UTC timezone', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0);
+  });
+});

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,0 +1,3 @@
+export default async () => {
+  process.env.TZ = 'UTC';
+};


### PR DESCRIPTION
This sets the timezone of Jest to UTC via a [`globalSetup`](https://jestjs.io/docs/configuration#globalsetup-string) file. It cannot be set via our `e2e-setup` file as it needs run once before everything.