### PR TITLE
Handle DeletedMultisigTransaction event type

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -74,6 +74,11 @@ describe('Post Hook Events (Unit)', () => {
 
   it.each([
     {
+      type: 'DELETED_MULTISIG_TRANSACTION',
+      address: faker.finance.ethereumAddress(),
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
       address: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
@@ -255,6 +260,11 @@ describe('Post Hook Events (Unit)', () => {
       owner: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
+    {
+      type: 'DELETED_MULTISIG_TRANSACTION',
+      address: faker.finance.ethereumAddress(),
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
   ])('$type clears multisig transactions', async (payload) => {
     const safeAddress = faker.finance.ethereumAddress();
     const chainId = faker.string.numeric();
@@ -304,6 +314,11 @@ describe('Post Hook Events (Unit)', () => {
     {
       type: 'NEW_CONFIRMATION',
       owner: faker.finance.ethereumAddress(),
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'DELETED_MULTISIG_TRANSACTION',
+      address: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears multisig transaction', async (payload) => {

--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -23,6 +23,7 @@ import { SafeAppsUpdate } from '@/routes/cache-hooks/entities/safe-apps-update.e
 import { EventValidationPipe } from '@/routes/cache-hooks/pipes/event-validation.pipe';
 import { BasicAuthGuard } from '@/routes/common/auth/basic-auth.guard';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { DeletedMultisigTransaction } from '@/routes/cache-hooks/entities/deleted-multisig-transaction.entity';
 
 @Controller({
   path: '',
@@ -49,6 +50,7 @@ export class CacheHooksController {
     @Body(EventValidationPipe)
     eventPayload:
       | ChainUpdate
+      | DeletedMultisigTransaction
       | ExecutedTransaction
       | IncomingEther
       | IncomingToken


### PR DESCRIPTION
Depends on #980 

Changes:
- Adds the handling logic for a `DeletedMultisigTransaction` event (i.e.: the service will call `clearMultisigTransactions` and `clearMultisigTransaction` when this type of event is received).