### PR TITLE
Remove webhooks execution delay

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -145,5 +145,4 @@ export default (): ReturnType<typeof configuration> => ({
   safeTransaction: {
     useVpcUrl: false,
   },
-  webHookExecutionDelayMs: faker.number.int({ min: 1, max: 10 }),
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -130,7 +130,4 @@ export default () => ({
   safeTransaction: {
     useVpcUrl: process.env.USE_TX_SERVICE_VPC_URL?.toLowerCase() === 'true',
   },
-  webHookExecutionDelayMs: parseInt(
-    process.env.WEB_HOOK_EXECUTION_DELAY_MS ?? `${5_000}`,
-  ),
 });

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -25,11 +25,9 @@ describe('Post Hook Events (Unit)', () => {
   let safeConfigUrl;
   let fakeCacheService: FakeCacheService;
   let networkService;
-  let webHookExecutionDelayMs;
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule.register(configuration)],
@@ -49,16 +47,9 @@ describe('Post Hook Events (Unit)', () => {
     const configurationService = moduleFixture.get(IConfigurationService);
     authToken = configurationService.get('auth.token');
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
-    webHookExecutionDelayMs = configurationService.get(
-      'webHookExecutionDelayMs',
-    );
     networkService = moduleFixture.get(NetworkService);
 
     await app.init();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   afterAll(async () => {
@@ -239,10 +230,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -262,7 +250,6 @@ describe('Post Hook Events (Unit)', () => {
     },
     {
       type: 'DELETED_MULTISIG_TRANSACTION',
-      address: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears multisig transactions', async (payload) => {
@@ -295,10 +282,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -318,7 +302,6 @@ describe('Post Hook Events (Unit)', () => {
     },
     {
       type: 'DELETED_MULTISIG_TRANSACTION',
-      address: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears multisig transaction', async (payload) => {
@@ -351,10 +334,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -398,10 +378,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -450,10 +427,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -502,10 +476,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -549,10 +520,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -591,10 +559,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -658,10 +623,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -703,10 +665,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -728,10 +687,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -753,10 +709,7 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -778,9 +731,6 @@ describe('Post Hook Events (Unit)', () => {
       .send(data)
       .expect(202);
 
-    setTimeout(
-      () => expect(fakeCacheService.get(cacheDir)).resolves.toBeNull(),
-      webHookExecutionDelayMs,
-    );
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
 });

--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Body,
-  Controller,
-  HttpCode,
-  Inject,
-  Post,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { CacheHooksService } from '@/routes/cache-hooks/cache-hooks.service';
 import { ChainUpdate } from '@/routes/cache-hooks/entities/chain-update.entity';
@@ -22,7 +15,6 @@ import { PendingTransaction } from '@/routes/cache-hooks/entities/pending-transa
 import { SafeAppsUpdate } from '@/routes/cache-hooks/entities/safe-apps-update.entity';
 import { EventValidationPipe } from '@/routes/cache-hooks/pipes/event-validation.pipe';
 import { BasicAuthGuard } from '@/routes/common/auth/basic-auth.guard';
-import { IConfigurationService } from '@/config/configuration.service.interface';
 import { DeletedMultisigTransaction } from '@/routes/cache-hooks/entities/deleted-multisig-transaction.entity';
 
 @Controller({
@@ -31,17 +23,7 @@ import { DeletedMultisigTransaction } from '@/routes/cache-hooks/entities/delete
 })
 @ApiExcludeController()
 export class CacheHooksController {
-  private readonly webHookExecutionDelayMs: number;
-
-  constructor(
-    private readonly service: CacheHooksService,
-    @Inject(IConfigurationService)
-    private readonly configurationService: IConfigurationService,
-  ) {
-    this.webHookExecutionDelayMs = this.configurationService.getOrThrow<number>(
-      'webHookExecutionDelayMs',
-    );
-  }
+  constructor(private readonly service: CacheHooksService) {}
 
   @UseGuards(BasicAuthGuard)
   @Post('/hooks/events')
@@ -63,9 +45,6 @@ export class CacheHooksController {
       | PendingTransaction
       | SafeAppsUpdate,
   ): Promise<void> {
-    setTimeout(
-      () => this.service.onEvent(eventPayload),
-      this.webHookExecutionDelayMs,
-    );
+    await this.service.onEvent(eventPayload);
   }
 }


### PR DESCRIPTION
This PR is a follow-up from https://github.com/safe-global/safe-client-gateway/pull/970

Depends on https://github.com/safe-global/safe-client-gateway/pull/970

Changes:
- Removes the webhook execution delay, since is not needed anymore after the implementation of https://github.com/safe-global/safe-client-gateway/pull/970