### PR TITLE
Add Email Builder

### DIFF
--- a/src/domain/email/entities/email.builder.ts
+++ b/src/domain/email/entities/email.builder.ts
@@ -1,0 +1,15 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { faker } from '@faker-js/faker';
+import { Email, EmailAddress } from '@/domain/email/entities/email.entity';
+
+export function emailBuilder(): IBuilder<Email> {
+  return new Builder<Email>()
+    .with('chainId', faker.string.numeric())
+    .with('emailAddress', new EmailAddress(faker.internet.email()))
+    .with('isVerified', faker.datatype.boolean())
+    .with('safeAddress', faker.finance.ethereumAddress())
+    .with('account', faker.finance.ethereumAddress())
+    .with('verificationCode', null)
+    .with('verificationGeneratedOn', null)
+    .with('verificationSentOn', null);
+}

--- a/src/routes/email/email.controller.verify-email.spec.ts
+++ b/src/routes/email/email.controller.verify-email.spec.ts
@@ -13,10 +13,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
-import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
-import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
-import { Email, EmailAddress } from '@/domain/email/entities/email.entity';
+import { emailBuilder } from '@/domain/email/entities/email.builder';
 
 const resendLockWindowMs = 100;
 const ttlMs = 1000;
@@ -69,30 +67,22 @@ describe('Email controller verify email tests', () => {
   });
 
   it('verifies email successfully', async () => {
-    const chain = chainBuilder().build();
-    const account = faker.finance.ethereumAddress();
-    const safe = safeBuilder().with('owners', [account]).build();
-    const emailAddress = faker.internet.email();
-    const verificationCode = faker.string.numeric({ length: 6 });
-    const verificationGeneratedOn = new Date();
-    const verificationSentOn = new Date();
-    emailDatasource.getEmail.mockResolvedValue(<Email>{
-      chainId: chain.chainId,
-      emailAddress: new EmailAddress(emailAddress),
-      isVerified: false,
-      safeAddress: safe.address,
-      account: account,
-      verificationCode: verificationCode,
-      verificationGeneratedOn: verificationGeneratedOn,
-      verificationSentOn: verificationSentOn,
-    });
+    const email = emailBuilder()
+      .with('isVerified', false)
+      .with('verificationCode', faker.string.numeric({ length: 6 }))
+      .with('verificationGeneratedOn', new Date())
+      .with('verificationSentOn', new Date())
+      .build();
+    emailDatasource.getEmail.mockResolvedValue(email);
 
     jest.advanceTimersByTime(ttlMs - 1);
     await request(app.getHttpServer())
-      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .put(
+        `/v1/chains/${email.chainId}/safes/${email.safeAddress}/emails/verify`,
+      )
       .send({
-        account: account,
-        code: verificationCode,
+        account: email.account,
+        code: email.verificationCode,
       })
       .expect(204)
       .expect({});
@@ -101,30 +91,21 @@ describe('Email controller verify email tests', () => {
   });
 
   it('returns 204 on already verified emails', async () => {
-    const chain = chainBuilder().build();
-    const account = faker.finance.ethereumAddress();
-    const safe = safeBuilder().with('owners', [account]).build();
-    const emailAddress = faker.internet.email();
-    const verificationCode = faker.string.numeric({ length: 6 });
-    const verificationGeneratedOn = new Date();
-    const verificationSentOn = new Date();
-    emailDatasource.getEmail.mockResolvedValue(<Email>{
-      chainId: chain.chainId,
-      emailAddress: new EmailAddress(emailAddress),
-      isVerified: true,
-      safeAddress: safe.address,
-      account: account,
-      verificationCode: verificationCode,
-      verificationGeneratedOn: verificationGeneratedOn,
-      verificationSentOn: verificationSentOn,
-    });
+    const email = emailBuilder()
+      .with('isVerified', true)
+      .with('verificationGeneratedOn', new Date())
+      .with('verificationCode', faker.string.numeric({ length: 6 }))
+      .build();
+    emailDatasource.getEmail.mockResolvedValueOnce(email);
 
     jest.advanceTimersByTime(ttlMs - 1);
     await request(app.getHttpServer())
-      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .put(
+        `/v1/chains/${email.chainId}/safes/${email.safeAddress}/emails/verify`,
+      )
       .send({
-        account: account,
-        code: verificationCode,
+        account: email.account,
+        code: email.verificationCode,
       })
       .expect(204)
       .expect({});
@@ -133,30 +114,21 @@ describe('Email controller verify email tests', () => {
   });
 
   it('email verification with expired code returns 400', async () => {
-    const chain = chainBuilder().build();
-    const account = faker.finance.ethereumAddress();
-    const safe = safeBuilder().with('owners', [account]).build();
-    const emailAddress = faker.internet.email();
-    const verificationCode = faker.string.numeric({ length: 6 });
-    const verificationGeneratedOn = new Date();
-    const verificationSentOn = new Date();
-    emailDatasource.getEmail.mockResolvedValue(<Email>{
-      chainId: chain.chainId,
-      emailAddress: new EmailAddress(emailAddress),
-      isVerified: false,
-      safeAddress: safe.address,
-      account: account,
-      verificationCode: verificationCode,
-      verificationGeneratedOn: verificationGeneratedOn,
-      verificationSentOn: verificationSentOn,
-    });
+    const email = emailBuilder()
+      .with('isVerified', false)
+      .with('verificationCode', faker.string.numeric({ length: 6 }))
+      .with('verificationGeneratedOn', new Date())
+      .build();
+    emailDatasource.getEmail.mockResolvedValueOnce(email);
 
     jest.advanceTimersByTime(ttlMs);
     await request(app.getHttpServer())
-      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .put(
+        `/v1/chains/${email.chainId}/safes/${email.safeAddress}/emails/verify`,
+      )
       .send({
-        account: account,
-        code: verificationCode,
+        account: email.account,
+        code: email.verificationCode,
       })
       .expect(400)
       .expect({
@@ -168,29 +140,19 @@ describe('Email controller verify email tests', () => {
   });
 
   it('email verification with wrong code returns 400', async () => {
-    const chain = chainBuilder().build();
-    const account = faker.finance.ethereumAddress();
-    const safe = safeBuilder().with('owners', [account]).build();
-    const emailAddress = faker.internet.email();
-    const verificationCode = faker.string.numeric({ length: 6 });
-    const verificationGeneratedOn = new Date();
-    const verificationSentOn = new Date();
-    emailDatasource.getEmail.mockResolvedValue(<Email>{
-      chainId: chain.chainId,
-      emailAddress: new EmailAddress(emailAddress),
-      isVerified: false,
-      safeAddress: safe.address,
-      account: account,
-      verificationCode: verificationCode,
-      verificationGeneratedOn: verificationGeneratedOn,
-      verificationSentOn: verificationSentOn,
-    });
+    const email = emailBuilder()
+      .with('isVerified', false)
+      .with('verificationCode', faker.string.numeric({ length: 6 }))
+      .build();
+    emailDatasource.getEmail.mockResolvedValueOnce(email);
 
     jest.advanceTimersByTime(ttlMs - 1);
     await request(app.getHttpServer())
-      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails/verify`)
+      .put(
+        `/v1/chains/${email.chainId}/safes/${email.safeAddress}/emails/verify`,
+      )
       .send({
-        account: account,
+        account: email.account,
         code: faker.string.numeric({ length: 6 }),
       })
       .expect(400)


### PR DESCRIPTION
Adds an `Email` builder to make the tests less verbose e.g.: when only a subset of the Email properties is required to be set to a certain value.