### PR TITLE
Return early if email is verified

### DIFF
--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -130,6 +130,11 @@ export class EmailRepository implements IEmailRepository {
   }): Promise<void> {
     const email = await this.emailDataSource.getEmail(args);
 
+    if (email.isVerified) {
+      // email is already verified, so we don't need to perform further checks
+      return;
+    }
+
     if (email.verificationCode !== args.code) {
       throw new InvalidVerificationCodeError(args);
     }

--- a/src/routes/email/email.controller.verify-email.spec.ts
+++ b/src/routes/email/email.controller.verify-email.spec.ts
@@ -91,11 +91,7 @@ describe('Email controller verify email tests', () => {
   });
 
   it('returns 204 on already verified emails', async () => {
-    const email = emailBuilder()
-      .with('isVerified', true)
-      .with('verificationGeneratedOn', new Date())
-      .with('verificationCode', faker.string.numeric({ length: 6 }))
-      .build();
+    const email = emailBuilder().with('isVerified', true).build();
     emailDatasource.getEmail.mockResolvedValueOnce(email);
 
     jest.advanceTimersByTime(ttlMs - 1);
@@ -110,7 +106,7 @@ describe('Email controller verify email tests', () => {
       .expect(204)
       .expect({});
 
-    expect(emailDatasource.verifyEmail).toHaveBeenCalledTimes(1);
+    expect(emailDatasource.verifyEmail).toHaveBeenCalledTimes(0);
   });
 
   it('email verification with expired code returns 400', async () => {


### PR DESCRIPTION
If an email is already verified and `PUT /v1/chains/:chainId/safes/:safeAddress/emails/verify` is triggered, then we can return early successfully.

Since the action is considered to be idempotent – calling `/verify` on a verified email should not change the underlying email state and return 204.