### PR TITLE
Use cache key prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
-    "test:e2e:cov": "jest --coverage --config ./test/jest-e2e.json --runInBand",
-    "test:all": "jest --config ./test/jest-all.json --runInBand",
-    "test:all:cov": "jest --coverage --config ./test/jest-all.json --runInBand"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e:cov": "jest --coverage --config ./test/jest-e2e.json",
+    "test:all": "jest --config ./test/jest-all.json",
+    "test:all:cov": "jest --coverage --config ./test/jest-all.json"
   },
   "dependencies": {
     "@nestjs/cli": "^10.2.1",

--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -5,6 +5,7 @@ import { CacheService } from '@/datasources/cache/cache.service.interface';
 import { RedisCacheService } from '@/datasources/cache/redis.cache.service';
 import { CacheReadiness } from '@/domain/interfaces/cache-readiness.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
 
 export type RedisClientType = ReturnType<typeof createClient>;
 
@@ -34,6 +35,7 @@ async function redisClientFactory(
     },
     { provide: CacheService, useClass: RedisCacheService },
     { provide: CacheReadiness, useExisting: CacheService },
+    { provide: CacheKeyPrefix, useValue: '' },
   ],
   exports: [CacheService, CacheReadiness],
 })

--- a/src/datasources/cache/constants.ts
+++ b/src/datasources/cache/constants.ts
@@ -1,1 +1,10 @@
+/**
+ * The {@link CacheKeyPrefix} is meant to be used whenever a prefix should be added to the keys
+ * registered in the cache.
+ *
+ * This is useful in scenarios like:
+ * - Multiple instances of the service can use the same Redis instance and use the prefix as a "data partition"
+ * - Testing scenario where tests run concurrently – concurrent runs might affect the state of other tests given
+ * that a cache instance might be shared between the tests.
+ */
 export const CacheKeyPrefix = Symbol('CacheKeyPrefix');

--- a/src/datasources/cache/constants.ts
+++ b/src/datasources/cache/constants.ts
@@ -1,0 +1,1 @@
+export const CacheKeyPrefix = Symbol('CacheKeyPrefix');

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -1,0 +1,124 @@
+import { faker } from '@faker-js/faker';
+import { ILoggingService } from '@/logging/logging.interface';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { RedisCacheService } from '@/datasources/cache/redis.cache.service';
+import { RedisClientType } from 'redis';
+import { fakeJson } from '@/__tests__/faker';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import clearAllMocks = jest.clearAllMocks;
+
+const redisClientType = {
+  hGet: jest.fn(),
+  hSet: jest.fn(),
+  hDel: jest.fn(),
+  expire: jest.fn(),
+  unlink: jest.fn(),
+  quit: jest.fn(),
+  scanIterator: jest.fn(),
+} as unknown as RedisClientType;
+const redisClientTypeMock = jest.mocked(redisClientType);
+
+const mockLoggingService = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+} as unknown as ILoggingService;
+
+const configurationService = {
+  getOrThrow: jest.fn(),
+} as unknown as IConfigurationService;
+const mockConfigurationService = jest.mocked(configurationService);
+
+describe('RedisCacheService with a Key Prefix', () => {
+  let redisCacheService: RedisCacheService;
+  let defaultExpirationTimeInSeconds: number;
+  const keyPrefix = faker.string.uuid();
+
+  beforeEach(async () => {
+    clearAllMocks();
+    defaultExpirationTimeInSeconds = faker.number.int();
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'expirationTimeInSeconds.default') {
+        return defaultExpirationTimeInSeconds;
+      }
+      throw Error(`Unexpected key: ${key}`);
+    });
+
+    redisCacheService = new RedisCacheService(
+      redisClientTypeMock,
+      mockLoggingService,
+      mockConfigurationService,
+      keyPrefix,
+    );
+  });
+
+  it('setting a key should set with prefix', async () => {
+    const cacheDir = new CacheDir(
+      faker.string.alphanumeric(),
+      faker.string.sample(),
+    );
+    const value = fakeJson();
+    const expireTime = faker.number.int();
+
+    await redisCacheService.set(cacheDir, value, expireTime);
+
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledWith(
+      `${keyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      value,
+    );
+    expect(redisClientTypeMock.expire).toHaveBeenCalledWith(
+      `${keyPrefix}-${cacheDir.key}`,
+      expireTime,
+    );
+  });
+
+  it('getting a key should get with prefix', async () => {
+    const cacheDir = new CacheDir(
+      faker.string.alphanumeric(),
+      faker.string.sample(),
+    );
+    await redisCacheService.get(cacheDir);
+
+    expect(redisClientTypeMock.hGet).toHaveBeenCalledWith(
+      `${keyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+    );
+  });
+
+  it('deleting a key should unlink with prefix', async () => {
+    jest.useFakeTimers();
+    const now = jest.now();
+    const key = faker.string.alphanumeric();
+
+    await redisCacheService.deleteByKey(key);
+
+    expect(redisClientTypeMock.hSet).toHaveBeenCalledWith(
+      `${keyPrefix}-invalidationTimeMs:${key}`,
+      '',
+      now.toString(),
+    );
+    expect(redisClientTypeMock.expire).toHaveBeenCalledWith(
+      `${keyPrefix}-invalidationTimeMs:${key}`,
+      defaultExpirationTimeInSeconds,
+    );
+    jest.useRealTimers();
+  });
+
+  it('deleting a key by pattern should use the prefix in the pattern', async () => {
+    const matches = [
+      faker.string.alphanumeric(),
+      faker.string.alphanumeric(),
+      faker.string.alphanumeric(),
+    ];
+    redisClientTypeMock.scanIterator = jest.fn().mockReturnValue(matches);
+    const pattern = faker.string.alphanumeric();
+
+    await redisCacheService.deleteByKeyPattern(pattern);
+
+    expect(redisClientTypeMock.scanIterator).toHaveBeenCalledWith({
+      MATCH: `${keyPrefix}-${pattern}`,
+    });
+  });
+});

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -3,9 +3,9 @@ import { ILoggingService } from '@/logging/logging.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { RedisCacheService } from '@/datasources/cache/redis.cache.service';
 import { RedisClientType } from 'redis';
-import clearAllMocks = jest.clearAllMocks;
 import { fakeJson } from '@/__tests__/faker';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import clearAllMocks = jest.clearAllMocks;
 
 const redisClientType = {
   hGet: jest.fn(),
@@ -33,6 +33,7 @@ const mockConfigurationService = jest.mocked(configurationService);
 describe('RedisCacheService', () => {
   let redisCacheService: RedisCacheService;
   let defaultExpirationTimeInSeconds: number;
+  const keyPrefix = '';
 
   beforeEach(async () => {
     clearAllMocks();
@@ -48,6 +49,7 @@ describe('RedisCacheService', () => {
       redisClientTypeMock,
       mockLoggingService,
       mockConfigurationService,
+      keyPrefix,
     );
   });
 

--- a/src/routes/about/__tests__/get-about.e2e-spec.ts
+++ b/src/routes/about/__tests__/get-about.e2e-spec.ts
@@ -4,17 +4,26 @@ import * as request from 'supertest';
 import { AppModule } from '@/app.module';
 import { expect } from '@jest/globals';
 import '@/__tests__/matchers/to-be-string-or-null';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
 
 describe('Get about e2e test', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
+    const cacheKeyPrefix = crypto.randomUUID();
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.register()],
-    }).compile();
+    })
+      .overrideProvider(CacheKeyPrefix)
+      .useValue(cacheKeyPrefix)
+      .compile();
 
     app = moduleRef.createNestApplication();
     await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 
   it('GET /about', async () => {
@@ -30,9 +39,5 @@ describe('Get about e2e test', () => {
           }),
         );
       });
-  });
-
-  afterAll(async () => {
-    await app.close();
   });
 });

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -122,7 +122,7 @@ describe('Get contract e2e test', () => {
       });
 
     const cacheContent = await redisClient.hGet(
-      `${cacheKeyPrefix}${chainId}_contract_${contractAddress}`,
+      `${cacheKeyPrefix}-${chainId}_contract_${contractAddress}`,
       '',
     );
     expect(cacheContent).toEqual(JSON.stringify(expectedResponse));

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -3,16 +3,25 @@ import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from '@/app.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
 
 describe('Get health e2e test', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
+    const cacheKeyPrefix = crypto.randomUUID();
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.register()],
-    }).compile();
+    })
+      .overrideProvider(CacheKeyPrefix)
+      .useValue(cacheKeyPrefix)
+      .compile();
     app = await new TestAppProvider().provide(moduleRef);
     await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 
   it('GET /health/live', async () => {
@@ -22,9 +31,5 @@ describe('Get health e2e test', () => {
       .then(({ body }) => {
         expect(body).toEqual({ status: 'OK' });
       });
-  });
-
-  afterAll(async () => {
-    await app.close();
   });
 });

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -32,7 +32,7 @@ describe('Get safes by owner e2e test', () => {
 
   it('GET /owners/<owner_address>/safes', async () => {
     const ownerAddress = '0xf10E2042ec19747401E5EA174EfB63A0058265E6';
-    const ownerCacheKey = `${cacheKeyPrefix}${chainId}_owner_safes_${ownerAddress}`;
+    const ownerCacheKey = `${cacheKeyPrefix}-${chainId}_owner_safes_${ownerAddress}`;
 
     await request(app.getHttpServer())
       .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -4,29 +4,35 @@ import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '@/app.module';
 import { redisClientFactory } from '@/__tests__/redis-client.factory';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
 
 describe('Get safes by owner e2e test', () => {
   let app: INestApplication;
   let redisClient: RedisClientType;
   const chainId = '5'; // Görli testnet
+  const cacheKeyPrefix = crypto.randomUUID();
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.register()],
-    }).compile();
+    })
+      .overrideProvider(CacheKeyPrefix)
+      .useValue(cacheKeyPrefix)
+      .compile();
 
     app = moduleRef.createNestApplication();
     await app.init();
     redisClient = await redisClientFactory();
   });
 
-  beforeEach(async () => {
-    await redisClient.flushAll();
+  afterAll(async () => {
+    await app.close();
+    await redisClient.quit();
   });
 
   it('GET /owners/<owner_address>/safes', async () => {
     const ownerAddress = '0xf10E2042ec19747401E5EA174EfB63A0058265E6';
-    const ownerCacheKey = `${chainId}_owner_safes_${ownerAddress}`;
+    const ownerCacheKey = `${cacheKeyPrefix}${chainId}_owner_safes_${ownerAddress}`;
 
     await request(app.getHttpServer())
       .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)
@@ -39,11 +45,5 @@ describe('Get safes by owner e2e test', () => {
 
     const cacheContent = await redisClient.hGet(ownerCacheKey, '');
     expect(cacheContent).not.toBeNull();
-  });
-
-  afterAll(async () => {
-    await app.close();
-    await redisClient.flushAll();
-    await redisClient.quit();
   });
 });

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -32,7 +32,7 @@ describe('Get Safe Apps e2e test', () => {
   });
 
   it('GET /chains/<chainId>/safe-apps', async () => {
-    const safeAppsCacheKey = `${cacheKeyPrefix}${chainId}_safe_apps`;
+    const safeAppsCacheKey = `${cacheKeyPrefix}-${chainId}_safe_apps`;
     const safeAppsCacheField = 'undefined_undefined';
 
     await request(app.getHttpServer())
@@ -68,7 +68,7 @@ describe('Get Safe Apps e2e test', () => {
   });
 
   it('GET /chains/<chainId>/safe-apps?url=${transactionBuilderUrl}', async () => {
-    const safeAppsCacheKey = `${cacheKeyPrefix}${chainId}_safe_apps`;
+    const safeAppsCacheKey = `${cacheKeyPrefix}-${chainId}_safe_apps`;
     const transactionBuilderUrl = 'https://safe-apps.dev.5afe.dev/tx-builder';
     const safeAppsCacheField = `undefined_${transactionBuilderUrl}`;
 

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -5,28 +5,34 @@ import * as request from 'supertest';
 import { AppModule } from '@/app.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { redisClientFactory } from '@/__tests__/redis-client.factory';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
 
 describe('Get Safe Apps e2e test', () => {
   let app: INestApplication;
   let redisClient: RedisClientType;
   const chainId = '5'; // Görli testnet
+  const cacheKeyPrefix = crypto.randomUUID();
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.register()],
-    }).compile();
+    })
+      .overrideProvider(CacheKeyPrefix)
+      .useValue(cacheKeyPrefix)
+      .compile();
 
     app = await new TestAppProvider().provide(moduleRef);
     await app.init();
     redisClient = await redisClientFactory();
   });
 
-  beforeEach(async () => {
-    await redisClient.flushAll();
+  afterAll(async () => {
+    await app.close();
+    await redisClient.quit();
   });
 
   it('GET /chains/<chainId>/safe-apps', async () => {
-    const safeAppsCacheKey = `${chainId}_safe_apps`;
+    const safeAppsCacheKey = `${cacheKeyPrefix}${chainId}_safe_apps`;
     const safeAppsCacheField = 'undefined_undefined';
 
     await request(app.getHttpServer())
@@ -62,7 +68,7 @@ describe('Get Safe Apps e2e test', () => {
   });
 
   it('GET /chains/<chainId>/safe-apps?url=${transactionBuilderUrl}', async () => {
-    const safeAppsCacheKey = `${chainId}_safe_apps`;
+    const safeAppsCacheKey = `${cacheKeyPrefix}${chainId}_safe_apps`;
     const transactionBuilderUrl = 'https://safe-apps.dev.5afe.dev/tx-builder';
     const safeAppsCacheField = `undefined_${transactionBuilderUrl}`;
 
@@ -95,11 +101,5 @@ describe('Get Safe Apps e2e test', () => {
       safeAppsCacheField,
     );
     expect(cacheContent).not.toBeNull();
-  });
-
-  afterAll(async () => {
-    await app.close();
-    await redisClient.flushAll();
-    await redisClient.quit();
   });
 });


### PR DESCRIPTION
- Provides a `CacheKeyPrefix` in `CacheModule` – this prefix will be prepended to the cache key being set/read.
- The prefix when running the app (outside a test context) is an empty string.
- Tests that require a Redis instance can now be run in parallel given that they can set a random prefix before running the test suite (e.g.: with `crypto.randomUUID`)

Local testing showed an improvement of around 50% when running the tests concurrently. Note however that E2E tests are bound to networking conditions.