### PR TITLE
Rename all references of "update" to "edit" regarding emails

### DIFF
--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -77,14 +77,14 @@ export interface IEmailRepository {
   }): Promise<void>;
 
   /**
-   * Updates an email entry.
+   * Edits an email entry.
    *
    * @param args.chainId - the chain id of where the Safe is deployed
    * @param args.safeAddress - the Safe address to which we should store the email address
    * @param args.emailAddress - the email address to store
    * @param args.account - the owner address to which we should link the email address to
    */
-  updateEmail(args: {
+  editEmail(args: {
     chainId: string;
     safeAddress: string;
     emailAddress: string;

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -8,7 +8,7 @@ import { ResendVerificationTimespanError } from '@/domain/email/errors/verificat
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { EmailAlreadyVerifiedError } from '@/domain/email/errors/email-already-verified.error';
 import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-verification-code.error';
-import { EmailUpdateMatchesError } from '@/domain/email/errors/email-update-matches.error';
+import { EmailEditMatchesError } from '@/domain/email/errors/email-edit-matches.error';
 
 @Injectable()
 export class EmailRepository implements IEmailRepository {
@@ -165,7 +165,7 @@ export class EmailRepository implements IEmailRepository {
     const currentEmail = await this.emailDataSource.getEmail(args);
 
     if (newEmail.value === currentEmail.emailAddress.value) {
-      throw new EmailUpdateMatchesError(args);
+      throw new EmailEditMatchesError(args);
     }
 
     const verificationCode = this._generateCode();

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -155,7 +155,7 @@ export class EmailRepository implements IEmailRepository {
     return this.emailDataSource.deleteEmail(args);
   }
 
-  async updateEmail(args: {
+  async editEmail(args: {
     chainId: string;
     safeAddress: string;
     emailAddress: string;

--- a/src/domain/email/errors/email-edit-matches.error.ts
+++ b/src/domain/email/errors/email-edit-matches.error.ts
@@ -1,4 +1,4 @@
-export class EmailUpdateMatchesError extends Error {
+export class EmailEditMatchesError extends Error {
   constructor(args: { chainId: string; safeAddress: string; account: string }) {
     super(
       `The provided email address matches that set for the Safe owner. chainId=${args.chainId}, safeAddress=${args.safeAddress}, account=${args.account}`,

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -24,7 +24,7 @@ import { VerifyEmailDto } from '@/routes/email/entities/verify-email-dto.entity'
 import { InvalidVerificationCodeExceptionFilter } from '@/routes/email/exception-filters/invalid-verification-code.exception-filter';
 import { DeleteEmailDto } from '@/routes/email/entities/delete-email-dto.entity';
 import { EmailAddressDoesNotExistExceptionFilter } from '@/routes/email/exception-filters/email-does-not-exist.exception-filter';
-import { UpdateEmailDto } from '@/routes/email/entities/update-email-dto.entity';
+import { EditEmailDto } from '@/routes/email/entities/edit-email-dto.entity';
 import { EmailEditGuard } from '@/routes/email/guards/email-edit.guard';
 import { EmailEditMatchesExceptionFilter } from '@/routes/email/exception-filters/email-edit-matches.exception-filter';
 
@@ -121,16 +121,16 @@ export class EmailController {
     EmailAddressDoesNotExistExceptionFilter,
   )
   @HttpCode(HttpStatus.ACCEPTED)
-  async updateEmail(
+  async editEmail(
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
-    @Body() updateEmailDto: UpdateEmailDto,
+    @Body() editEmailDto: EditEmailDto,
   ): Promise<void> {
-    await this.service.updateEmail({
+    await this.service.editEmail({
       chainId,
       safeAddress,
-      account: updateEmailDto.account,
-      emailAddress: updateEmailDto.emailAddress,
+      account: editEmailDto.account,
+      emailAddress: editEmailDto.emailAddress,
     });
   }
 }

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -25,8 +25,8 @@ import { InvalidVerificationCodeExceptionFilter } from '@/routes/email/exception
 import { DeleteEmailDto } from '@/routes/email/entities/delete-email-dto.entity';
 import { EmailAddressDoesNotExistExceptionFilter } from '@/routes/email/exception-filters/email-does-not-exist.exception-filter';
 import { UpdateEmailDto } from '@/routes/email/entities/update-email-dto.entity';
-import { EmailUpdateGuard } from '@/routes/email/guards/email-update.guard';
-import { EmailUpdateMatchesExceptionFilter } from '@/routes/email/exception-filters/email-update-matches.exception-filter';
+import { EmailEditGuard } from '@/routes/email/guards/email-edit.guard';
+import { EmailEditMatchesExceptionFilter } from '@/routes/email/exception-filters/email-edit-matches.exception-filter';
 
 @ApiTags('email')
 @Controller({
@@ -112,12 +112,12 @@ export class EmailController {
 
   @Put('')
   @UseGuards(
-    EmailUpdateGuard,
+    EmailEditGuard,
     TimestampGuard(5 * 60 * 1000), // 5 minutes
     OnlySafeOwnerGuard,
   )
   @UseFilters(
-    EmailUpdateMatchesExceptionFilter,
+    EmailEditMatchesExceptionFilter,
     EmailAddressDoesNotExistExceptionFilter,
   )
   @HttpCode(HttpStatus.ACCEPTED)

--- a/src/routes/email/email.controller.update-email.spec.ts
+++ b/src/routes/email/email.controller.update-email.spec.ts
@@ -77,7 +77,7 @@ describe('Email controller update email tests', () => {
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
@@ -119,7 +119,7 @@ describe('Email controller update email tests', () => {
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
@@ -164,7 +164,7 @@ describe('Email controller update email tests', () => {
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
@@ -214,7 +214,7 @@ describe('Email controller update email tests', () => {
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
@@ -259,7 +259,7 @@ describe('Email controller update email tests', () => {
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
 
     jest.advanceTimersByTime(5 * 60 * 1000);
@@ -324,7 +324,7 @@ describe('Email controller update email tests', () => {
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-update-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -41,12 +41,12 @@ export class EmailService {
     return this.repository.deleteEmail(args);
   }
 
-  async updateEmail(args: {
+  async editEmail(args: {
     chainId: string;
     safeAddress: string;
     account: string;
     emailAddress: string;
   }): Promise<void> {
-    return this.repository.updateEmail(args);
+    return this.repository.editEmail(args);
   }
 }

--- a/src/routes/email/entities/edit-email-dto.entity.ts
+++ b/src/routes/email/entities/edit-email-dto.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class UpdateEmailDto {
+export class EditEmailDto {
   @ApiProperty()
   emailAddress: string;
 

--- a/src/routes/email/exception-filters/email-edit-matches.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-edit-matches.exception-filter.ts
@@ -5,11 +5,11 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Response } from 'express';
-import { EmailUpdateMatchesError } from '@/domain/email/errors/email-update-matches.error';
+import { EmailEditMatchesError } from '@/domain/email/errors/email-edit-matches.error';
 
-@Catch(EmailUpdateMatchesError)
-export class EmailUpdateMatchesExceptionFilter implements ExceptionFilter {
-  catch(exception: EmailUpdateMatchesError, host: ArgumentsHost) {
+@Catch(EmailEditMatchesError)
+export class EmailEditMatchesExceptionFilter implements ExceptionFilter {
+  catch(exception: EmailEditMatchesError, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/guards/email-edit.guard.spec.ts
+++ b/src/routes/email/guards/email-edit.guard.spec.ts
@@ -8,27 +8,27 @@ import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { Hash } from 'viem';
-import { EmailUpdateGuard } from '@/routes/email/guards/email-update.guard';
+import { EmailEditGuard } from '@/routes/email/guards/email-edit.guard';
 
 @Controller()
 class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
-  @UseGuards(EmailUpdateGuard)
+  @UseGuards(EmailEditGuard)
   async validRoute() {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
-  @UseGuards(EmailUpdateGuard)
+  @UseGuards(EmailEditGuard)
   async invalidRouteWithChainId() {}
 
   @Post('test/invalid/safes/:safeAddress')
   @HttpCode(200)
-  @UseGuards(EmailUpdateGuard)
+  @UseGuards(EmailEditGuard)
   async invalidRouteWithSafeAddress() {}
 }
 
-describe('EmailUpdate guard tests', () => {
+describe('EmailEdit guard tests', () => {
   let app;
 
   const chainId = faker.string.numeric();
@@ -41,7 +41,7 @@ describe('EmailUpdate guard tests', () => {
   let signature: Hash;
 
   beforeAll(async () => {
-    const message = `email-update-${chainId}-${safe}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const message = `email-edit-${chainId}-${safe}-${emailAddress}-${accountAddress}-${timestamp}`;
     signature = await account.signMessage({ message });
   });
 

--- a/src/routes/email/guards/email-edit.guard.ts
+++ b/src/routes/email/guards/email-edit.guard.ts
@@ -8,13 +8,13 @@ import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { verifyMessage } from 'viem';
 
 /**
- * The EmailUpdateGuard guard should be used on routes that require
+ * The EmailEditGuard guard should be used on routes that require
  * authenticated actions on updating email addresses.
  *
  * This guard therefore validates if the message came from the specified account.
  *
  * The following message should be signed:
- * email-update-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}
+ * email-edit-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}
  *
  * (where ${} represents placeholder values for the respective data)
  *
@@ -27,12 +27,12 @@ import { verifyMessage } from 'viem';
  * - the 'timestamp' as part of the JSON body (top level)
  */
 @Injectable()
-export class EmailUpdateGuard implements CanActivate {
+export class EmailEditGuard implements CanActivate {
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
-  private static readonly ACTION_PREFIX = 'email-update';
+  private static readonly ACTION_PREFIX = 'email-edit';
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -55,7 +55,7 @@ export class EmailUpdateGuard implements CanActivate {
     )
       return false;
 
-    const message = `${EmailUpdateGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}`;
+    const message = `${EmailEditGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}`;
 
     try {
       return await verifyMessage({


### PR DESCRIPTION
All instances of "update" have been renamed to "edit" with regards to emails across files and their contents:

- `EmailUpdateGuard` -> `EmailEditGuard`
- `email-update-*` signature prefix for updating emails -> `email-edit-*`
- `updateEmail` in `EmailController` -> `editEmail`
- `UpdateEmailDto` -> `EditEmailDto`
- `updateEmail` in `EmailRepository` and relevant interface-> `editEmail`
- `EmailUpdateMatchesError` -> `EmailEditMatchesError`
- `EmailUpdateMatchesExceptionFilter` -> `EmailEditMatchesExceptionFilter`

Note: the data source was not changed as it fits the database changes.