### PR TITLE
Update (unknown) recovery email subject and substituions

### DIFF
--- a/src/datasources/email-template/email-template.module.ts
+++ b/src/datasources/email-template/email-template.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PushwooshTemplate } from '@/datasources/email-template/pushwoosh-template.service';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { IEmailTemplate } from '@/domain/interfaces/email-template.interface';
+
+@Module({
+  providers: [
+    HttpErrorFactory,
+    { provide: IEmailTemplate, useClass: PushwooshTemplate },
+  ],
+  exports: [IEmailTemplate],
+})
+export class EmailTemplateModule {}

--- a/src/datasources/email-template/email-template.module.ts
+++ b/src/datasources/email-template/email-template.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
-import { PushwooshTemplate } from '@/datasources/email-template/pushwoosh-template.service';
+import { PushWooshTemplate } from '@/datasources/email-template/pushwoosh-template.service';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IEmailTemplate } from '@/domain/interfaces/email-template.interface';
 
 @Module({
   providers: [
     HttpErrorFactory,
-    { provide: IEmailTemplate, useClass: PushwooshTemplate },
+    { provide: IEmailTemplate, useClass: PushWooshTemplate },
   ],
   exports: [IEmailTemplate],
 })

--- a/src/datasources/email-template/pushwood-template.service.spec.ts
+++ b/src/datasources/email-template/pushwood-template.service.spec.ts
@@ -1,0 +1,46 @@
+import { PushwooshTemplate } from '@/datasources/email-template/pushwoosh-template.service';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+describe('PushwoodTemplate', () => {
+  const service = new PushwooshTemplate();
+
+  describe('addressToHtml', () => {
+    it('should return an element with a checksummed address', () => {
+      const address = faker.finance.ethereumAddress();
+      const checksummedAddress = getAddress(address);
+
+      const start = checksummedAddress.slice(0, 6);
+      const center = checksummedAddress.slice(6, -4);
+      const end = checksummedAddress.slice(-4);
+
+      const expected = `${start}<span id="address-center">${center}</span>${end}`;
+
+      expect(service.addressToHtml(address)).toEqual(expected);
+    });
+  });
+
+  describe('addressListToHtml', () => {
+    it('should return a list element with checksummed addresses', () => {
+      const addresses = [
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+      ];
+      const checksummedAddresses = addresses.map((address) => {
+        return getAddress(address);
+      });
+
+      const expected = `<ul>${checksummedAddresses
+        .map((checmsummedAddress) => {
+          const start = checmsummedAddress.slice(0, 6);
+          const center = checmsummedAddress.slice(6, -4);
+          const end = checmsummedAddress.slice(-4);
+
+          return `<li>${start}<span id="address-center">${center}</span>${end}</li>`;
+        })
+        .join('')}</ul>`;
+
+      expect(service.addressListToHtml(addresses)).toEqual(expected);
+    });
+  });
+});

--- a/src/datasources/email-template/pushwoosh-template.service.spec.ts
+++ b/src/datasources/email-template/pushwoosh-template.service.spec.ts
@@ -1,9 +1,9 @@
-import { PushwooshTemplate } from '@/datasources/email-template/pushwoosh-template.service';
+import { PushWooshTemplate } from '@/datasources/email-template/pushwoosh-template.service';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 
-describe('PushwoodTemplate', () => {
-  const service = new PushwooshTemplate();
+describe('PushWoodshTemplate', () => {
+  const service = new PushWooshTemplate();
 
   describe('addressToHtml', () => {
     it('should return an element with a checksummed address', () => {
@@ -26,15 +26,14 @@ describe('PushwoodTemplate', () => {
         faker.finance.ethereumAddress(),
         faker.finance.ethereumAddress(),
       ];
-      const checksummedAddresses = addresses.map((address) => {
-        return getAddress(address);
-      });
 
-      const expected = `<ul>${checksummedAddresses
-        .map((checmsummedAddress) => {
-          const start = checmsummedAddress.slice(0, 6);
-          const center = checmsummedAddress.slice(6, -4);
-          const end = checmsummedAddress.slice(-4);
+      const expected = `<ul>${addresses
+        .map((address) => {
+          const checksummedAddress = getAddress(address);
+
+          const start = checksummedAddress.slice(0, 6);
+          const center = checksummedAddress.slice(6, -4);
+          const end = checksummedAddress.slice(-4);
 
           return `<li>${start}<span id="address-center">${center}</span>${end}</li>`;
         })

--- a/src/datasources/email-template/pushwoosh-template.service.ts
+++ b/src/datasources/email-template/pushwoosh-template.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { getAddress } from 'viem';
+import { IEmailTemplate } from '@/domain/interfaces/email-template.interface';
+
+@Injectable()
+export class PushwooshTemplate implements IEmailTemplate {
+  addressToHtml(address: string): string {
+    const CSS_ID = 'address-center';
+
+    const checksummedAddress = getAddress(address);
+
+    const start = checksummedAddress.slice(0, 6);
+    const center = checksummedAddress.slice(6, -4);
+    const end = checksummedAddress.slice(-4);
+
+    return `${start}<span id="${CSS_ID}">${center}</span>${end}`;
+  }
+
+  addressListToHtml(addresses: Array<string>): string {
+    return `<ul>${addresses.map(
+      (owner) => `<li>${this.addressToHtml(owner)}</li>`,
+    )}</ul>`;
+  }
+}

--- a/src/datasources/email-template/pushwoosh-template.service.ts
+++ b/src/datasources/email-template/pushwoosh-template.service.ts
@@ -3,7 +3,7 @@ import { getAddress } from 'viem';
 import { IEmailTemplate } from '@/domain/interfaces/email-template.interface';
 
 @Injectable()
-export class PushwooshTemplate implements IEmailTemplate {
+export class PushWooshTemplate implements IEmailTemplate {
   addressToHtml(address: string): string {
     const CSS_ID = 'address-center';
 

--- a/src/datasources/email-template/pushwoosh-template.service.ts
+++ b/src/datasources/email-template/pushwoosh-template.service.ts
@@ -17,8 +17,8 @@ export class PushwooshTemplate implements IEmailTemplate {
   }
 
   addressListToHtml(addresses: Array<string>): string {
-    return `<ul>${addresses.map(
-      (owner) => `<li>${this.addressToHtml(owner)}</li>`,
-    )}</ul>`;
+    return `<ul>${addresses
+      .map((owner) => `<li>${this.addressToHtml(owner)}</li>`)
+      .join('')}</ul>`;
   }
 }

--- a/src/domain/alerts/alerts.domain.module.ts
+++ b/src/domain/alerts/alerts.domain.module.ts
@@ -5,6 +5,7 @@ import { IAlertsRepository } from '@/domain/alerts/alerts.repository.interface';
 import { AlertsDecodersModule } from '@/domain/alerts/alerts-decoders.module';
 import { EmailApiModule } from '@/datasources/email-api/email-api.module';
 import { EmailDomainModule } from '@/domain/email/email.domain.module';
+import { EmailTemplateModule } from '@/datasources/email-template/email-template.module';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { EmailDomainModule } from '@/domain/email/email.domain.module';
     AlertsDecodersModule,
     EmailApiModule,
     EmailDomainModule,
+    EmailTemplateModule,
   ],
   providers: [{ provide: IAlertsRepository, useClass: AlertsRepository }],
   exports: [IAlertsRepository],

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Hex, getAddress } from 'viem';
+import { Hex } from 'viem';
 import { IAlertsRepository } from '@/domain/alerts/alerts.repository.interface';
 import { IAlertsApi } from '@/domain/interfaces/alerts-api.interface';
 import { AlertsRegistration } from '@/domain/alerts/entities/alerts.entity';

--- a/src/domain/interfaces/email-template.interface.ts
+++ b/src/domain/interfaces/email-template.interface.ts
@@ -1,7 +1,7 @@
 export const IEmailTemplate = Symbol('IEmailTemplate');
 
 /**
- * Templates are required (but used sparingly) as PushWoosh doesn't support
+ * Templates are required (but used sparingly) as some providers don't support
  * JavaScript or arrays passed as substitution variables
  */
 export interface IEmailTemplate {

--- a/src/domain/interfaces/email-template.interface.ts
+++ b/src/domain/interfaces/email-template.interface.ts
@@ -1,0 +1,19 @@
+export const IEmailTemplate = Symbol('IEmailTemplate');
+
+/**
+ * Templates are required (but used sparingly) as PushWoosh doesn't support
+ * JavaScript or arrays passed as substitution variables
+ */
+export interface IEmailTemplate {
+  /**
+   * Checksums and formats address to be displayed in email
+   * @param address - address to be converted
+   */
+  addressToHtml(address: string): string;
+
+  /**
+   * Checksums and formats addresses to be displayed in email as list
+   * @param addresses - addresses to be converted
+   */
+  addressListToHtml(addresses: Array<string>): string;
+}

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -65,6 +65,18 @@ function fakeTenderlySignature(args: {
   return hmac.digest('hex');
 }
 
+function formatAddress(address: string): string {
+  const CSS_ID = 'address-center';
+
+  const checksummedAddress = getAddress(address);
+
+  const start = checksummedAddress.slice(0, 6);
+  const center = checksummedAddress.slice(6, -4);
+  const end = checksummedAddress.slice(-4);
+
+  return `${start}<span id="${CSS_ID}">${center}</span>${end}`;
+}
+
 describe('Alerts (Unit)', () => {
   let configurationService;
   let emailApi;
@@ -205,7 +217,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([...safe.owners, owner]),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[...safe.owners, owner].map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -294,7 +310,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([owners[0], owners[2]]),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[owners[0], owners[2]].map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -382,7 +402,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([owners[0], newOwner, owners[2]]),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[owners[0], newOwner, owners[2]].map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: safe.threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -460,7 +484,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify(safe.owners),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${safe.owners.map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -572,11 +600,13 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[
               owners[1],
               owners[2],
               addOwnerWithThreshold.build().owner,
-            ]),
+            ].map((owner) => `<li>${formatAddress(owner)}</li>`)}</ul>`,
             threshold: removeOwner.build().threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -653,7 +683,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([...safe.owners, owner]),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[...safe.owners, owner].map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -664,7 +698,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(2, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([...safe.owners, owner]),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[...safe.owners, owner].map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -745,7 +783,11 @@ describe('Alerts (Unit)', () => {
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
           subject: 'Recovery attempt',
           substitutions: {
-            owners: JSON.stringify([...safe.owners, owner]),
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+            owners: `<ul>${[...safe.owners, owner].map(
+              (owner) => `<li>${formatAddress(owner)}</li>`,
+            )}</ul>`,
             threshold: threshold.toString(),
           },
           template: configurationService.getOrThrow(
@@ -821,8 +863,11 @@ describe('Alerts (Unit)', () => {
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
-          subject: 'Unknown transaction attempt',
-          substitutions: {},
+          subject: 'Malicious transaction',
+          substitutions: {
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+          },
           template: configurationService.getOrThrow(
             'email.templates.unknownRecoveryTx',
           ),
@@ -893,16 +938,22 @@ describe('Alerts (Unit)', () => {
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(2);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
-          subject: 'Unknown transaction attempt',
-          substitutions: {},
+          subject: 'Malicious transaction',
+          substitutions: {
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+          },
           template: configurationService.getOrThrow(
             'email.templates.unknownRecoveryTx',
           ),
           to: expectedTargetEmailAddresses,
         });
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(2, {
-          subject: 'Unknown transaction attempt',
-          substitutions: {},
+          subject: 'Malicious transaction',
+          substitutions: {
+            chainId: chain.chainId,
+            safeAddress: formatAddress(safe.address),
+          },
           template: configurationService.getOrThrow(
             'email.templates.unknownRecoveryTx',
           ),
@@ -1008,8 +1059,11 @@ describe('Alerts (Unit)', () => {
       );
       expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
-        subject: 'Unknown transaction attempt',
-        substitutions: {},
+        subject: 'Malicious transaction',
+        substitutions: {
+          chainId: chain.chainId,
+          safeAddress: formatAddress(safe.address),
+        },
         template: configurationService.getOrThrow(
           'email.templates.unknownRecoveryTx',
         ),
@@ -1113,16 +1167,22 @@ describe('Alerts (Unit)', () => {
       );
       expect(emailApi.createMessage).toHaveBeenCalledTimes(2);
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
-        subject: 'Unknown transaction attempt',
-        substitutions: {},
+        subject: 'Malicious transaction',
+        substitutions: {
+          chainId: chain.chainId,
+          safeAddress: formatAddress(safe.address),
+        },
         template: configurationService.getOrThrow(
           'email.templates.unknownRecoveryTx',
         ),
         to: expectedTargetEmailAddresses,
       });
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(2, {
-        subject: 'Unknown transaction attempt',
-        substitutions: {},
+        subject: 'Malicious transaction',
+        substitutions: {
+          chainId: chain.chainId,
+          safeAddress: formatAddress(safe.address),
+        },
         template: configurationService.getOrThrow(
           'email.templates.unknownRecoveryTx',
         ),
@@ -1202,7 +1262,11 @@ describe('Alerts (Unit)', () => {
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
         subject: 'Recovery attempt',
         substitutions: {
-          owners: JSON.stringify([...safe.owners, owner]),
+          chainId: chain.chainId,
+          safeAddress: formatAddress(safe.address),
+          owners: `<ul>${[...safe.owners, owner].map(
+            (owner) => `<li>${formatAddress(owner)}</li>`,
+          )}</ul>`,
           threshold: threshold.toString(),
         },
         template: configurationService.getOrThrow('email.templates.recoveryTx'),


### PR DESCRIPTION
This updates the `subject` and `substitutions` provided when sending (unknown) recovery emails.

The subject of unknown recovery transaction emails have been aligned with the client implementation:

- "Unknown transaction attempt" -> "Malicious transaction"

A new `IEmailTemplate` service has been created, namely a provider specific `PushwoodTemplate` for creating substitute-specific HTML elements.

(Unknown) recovery attempts now both receive the following:

- `chainId`
- `safeAddress` - pre-formatted as our provider does not allow JavaScript. We want to colour the centre of the address.

Recovery attempts also have the following for the new Safe setup:

- `owners` - pre-formatted as our provider does not allow mapping over arrays in templates, as well as formatting of the addresses explained above for `safeAddress`.
- `threshold`

Note: the above is subject to change after consultation with design and I am also in contact with out provider regarding the mapping of `owners`.