### PR TITLE
Update `blockExplorerUriTemplateBuilder`

### DIFF
--- a/src/domain/chains/entities/__tests__/block-explorer-uri-template.builder.ts
+++ b/src/domain/chains/entities/__tests__/block-explorer-uri-template.builder.ts
@@ -3,8 +3,12 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { BlockExplorerUriTemplate } from '@/domain/chains/entities/block-explorer-uri-template.entity';
 
 export function blockExplorerUriTemplateBuilder(): IBuilder<BlockExplorerUriTemplate> {
+  const explorerUrl = faker.internet.url({ appendSlash: false });
   return new Builder<BlockExplorerUriTemplate>()
-    .with('address', faker.finance.ethereumAddress())
-    .with('txHash', faker.string.hexadecimal())
-    .with('api', faker.internet.url({ appendSlash: false }));
+    .with('address', `${explorerUrl}/address/{{address}}`)
+    .with('txHash', `${explorerUrl}/tx/{{txHash}}`)
+    .with(
+      'api',
+      `${explorerUrl}/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}`,
+    );
 }


### PR DESCRIPTION
This updates the `blockExplorerUriTemplateBuilder` to a) change the `address` and `txHash` to URL templates and b) format the URLs to match that of explorer templates we currently support:

- `address` should be a URL with `{{address}}` present
- `txHash` should be a URL with `{{txHash}}` present
- `api` should match current templates

Note: the updated values match _all_ of the block explorers we currently support.