### PR TITLE
Ignore E2E tests in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [
       "index.ts",
-      ".+\\/__tests__\\/.+\\.factory.(t|j)s"
+      ".+\\/__tests__\\/.+\\.factory.(t|j)s",
+      ".e2e.spec.ts"
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "coveragePathIgnorePatterns": [
       "index.ts",
       ".+\\/__tests__\\/.+\\.factory.(t|j)s",
-      ".e2e.spec.ts"
+      ".e2e-spec.ts"
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {


### PR DESCRIPTION
This excludes our `*.e2e.spec.ts` files from our test coverage.