### PR TITLE
Send verification code email message

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -37,6 +37,8 @@
 #EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=
 # The email template reference for a recovery transaction notification.
 #EMAIL_TEMPLATE_RECOVERY_TX=
+# The email template reference for a verification code sent.
+#EMAIL_TEMPLATE_VERIFICATION_CODE=
 # The sender name to be included in the 'from' section of the emails sent.
 # (default is 'Safe' if none is set)
 #EMAIL_API_FROM_NAME=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-changeme@example.com}
       EMAIL_API_KEY: ${EMAIL_API_KEY-example_api_key}
       EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: ${EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX-example_template_unknown_recovery_tx}
+      EMAIL_TEMPLATE_RECOVERY_TX: ${EMAIL_TEMPLATE_RECOVERY_TX-example_template_recovery_tx}
+      EMAIL_TEMPLATE_VERIFICATION_CODE: ${EMAIL_TEMPLATE_VERIFICATION_CODE-example_template_verification_code}
     depends_on:
       - redis
       - db

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -16,6 +16,7 @@ describe('Configuration validator', () => {
     EMAIL_API_KEY: faker.string.uuid(),
     EMAIL_TEMPLATE_RECOVERY_TX: faker.string.alphanumeric(),
     EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
+    EMAIL_TEMPLATE_VERIFICATION_CODE: faker.string.alphanumeric(),
   };
 
   it('should bypass this validation on test environment', () => {
@@ -42,6 +43,7 @@ describe('Configuration validator', () => {
     { key: 'EMAIL_API_KEY' },
     { key: 'EMAIL_TEMPLATE_RECOVERY_TX' },
     { key: 'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX' },
+    { key: 'EMAIL_TEMPLATE_VERIFICATION_CODE' },
   ])(
     'should detect that $key is missing in the configuration in production environment',
     ({ key }) => {
@@ -67,6 +69,7 @@ describe('Configuration validator', () => {
         EMAIL_API_KEY: faker.string.uuid(),
         EMAIL_TEMPLATE_RECOVERY_TX: faker.string.alphanumeric(),
         EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
+        EMAIL_TEMPLATE_VERIFICATION_CODE: faker.string.alphanumeric(),
       }),
     ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
   });

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -18,6 +18,7 @@ const configurationSchema: Schema = {
     EMAIL_API_KEY: { type: 'string' },
     EMAIL_TEMPLATE_RECOVERY_TX: { type: 'string' },
     EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: { type: 'string' },
+    EMAIL_TEMPLATE_VERIFICATION_CODE: { type: 'string' },
   },
   required: [
     'AUTH_TOKEN',
@@ -30,6 +31,7 @@ const configurationSchema: Schema = {
     'EMAIL_API_KEY',
     'EMAIL_TEMPLATE_RECOVERY_TX',
     'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX',
+    'EMAIL_TEMPLATE_VERIFICATION_CODE',
   ],
 };
 

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -36,6 +36,7 @@ export default (): ReturnType<typeof configuration> => ({
     templates: {
       recoveryTx: faker.string.alphanumeric(),
       unknownRecoveryTx: faker.string.alphanumeric(),
+      verificationCode: faker.string.alphanumeric(),
     },
     verificationCode: {
       resendLockWindowMs: faker.number.int(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -34,6 +34,7 @@ export default () => ({
     templates: {
       recoveryTx: process.env.EMAIL_TEMPLATE_RECOVERY_TX,
       unknownRecoveryTx: process.env.EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX,
+      verificationCode: process.env.EMAIL_TEMPLATE_VERIFICATION_CODE,
     },
     verificationCode: {
       resendLockWindowMs: parseInt(


### PR DESCRIPTION
This PR implements verification codes email sending when a new email account is registered for a given Safe owner.

Changes:
- Adds `email.templates.verificationCode` configuration key, filled by the mandatory environment variable `EMAIL_TEMPLATE_VERIFICATION_CODE`, which holds the template reference identification in the email provider system.
- Implements verification codes sending in `EmailRepository`, and adds associated test functions.