### PR TITLE
Use same global setup in all Jest configs

### DIFF
--- a/test/jest-all.json
+++ b/test/jest-all.json
@@ -12,5 +12,6 @@
   "coverageDirectory": "./coverage",
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1"
-  }
+  },
+  "globalSetup": "<rootDir>/test/global-setup.ts"
 }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -12,5 +12,6 @@
   "coverageDirectory": "./coverage",
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1"
-  }
+  },
+  "globalSetup": "<rootDir>/test/global-setup.ts"
 }


### PR DESCRIPTION
This updates our custom Jest configurations (`jest-all.json` and `jest-e2e.json`) to use the same global setup as our standard tests (setting the timezone of tests to UTC).