### PR TITLE
Throttle email edits according to verification code TTL

### DIFF
--- a/src/domain/email/email.repository.interface.ts
+++ b/src/domain/email/email.repository.interface.ts
@@ -83,6 +83,9 @@ export interface IEmailRepository {
    * @param args.safeAddress - the Safe address to which we should store the email address
    * @param args.emailAddress - the email address to store
    * @param args.account - the owner address to which we should link the email address to
+   *
+   * @throws {EditTimeframeError} - if trying to edit again within email.verificationCode.resendLockWindowMs
+   * @throws {EmailEditMatchesError} - if trying to apply edit with same email address as current one
    */
   editEmail(args: {
     chainId: string;

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -171,6 +171,7 @@ export class EmailRepository implements IEmailRepository {
     const newEmail = new EmailAddress(args.emailAddress);
     const currentEmail = await this.emailDataSource.getEmail(args);
 
+    // Prevent subsequent edit if verification code still valid
     if (
       currentEmail.verificationGeneratedOn &&
       this._isEmailVerificationCodeValid(currentEmail)

--- a/src/domain/email/errors/email-timespan.error.ts
+++ b/src/domain/email/errors/email-timespan.error.ts
@@ -1,0 +1,13 @@
+export class EditTimespanError extends Error {
+  constructor(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+    timespanMs: number;
+    lockWindowMs: number;
+  }) {
+    super(
+      `Email cannot be edited at this time. ${args.timespanMs} ms have elapsed out of ${args.lockWindowMs} ms for account=${args.account}, safe=${args.safeAddress}, chainId=${args.chainId}`,
+    );
+  }
+}

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -27,6 +27,7 @@ import { EmailAddressDoesNotExistExceptionFilter } from '@/routes/email/exceptio
 import { EditEmailDto } from '@/routes/email/entities/edit-email-dto.entity';
 import { EmailEditGuard } from '@/routes/email/guards/email-edit.guard';
 import { EmailEditMatchesExceptionFilter } from '@/routes/email/exception-filters/email-edit-matches.exception-filter';
+import { EmailEditTimespanExceptionFilter } from '@/routes/email/exception-filters/email-edit-timespan.exception-filter';
 
 @ApiTags('email')
 @Controller({
@@ -117,6 +118,7 @@ export class EmailController {
     OnlySafeOwnerGuard,
   )
   @UseFilters(
+    EmailEditTimespanExceptionFilter,
     EmailEditMatchesExceptionFilter,
     EmailAddressDoesNotExistExceptionFilter,
   )

--- a/src/routes/email/email.controller.update-email.spec.ts
+++ b/src/routes/email/email.controller.update-email.spec.ts
@@ -23,9 +23,12 @@ import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { EmailAddressDoesNotExistError } from '@/datasources/email/errors/email-address-does-not-exist.error';
 import { EmailAddress } from '@/domain/email/entities/email.entity';
 
+const verificationCodeTtlMs = 100;
+
 describe('Email controller update email tests', () => {
   let app;
   let safeConfigUrl;
+  let verificationCodeResendLockWindowMs;
   let emailDatasource;
   let networkService;
 
@@ -33,8 +36,23 @@ describe('Email controller update email tests', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
 
+    const defaultConfiguration = configuration();
+
+    function testConfiguration() {
+      return {
+        ...defaultConfiguration,
+        email: {
+          ...defaultConfiguration.email,
+          verificationCode: {
+            ...defaultConfiguration.email.verificationCode,
+            ttlMs: verificationCodeTtlMs,
+          },
+        },
+      };
+    }
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration), EmailControllerModule],
+      imports: [AppModule.register(testConfiguration), EmailControllerModule],
     })
       .overrideModule(EmailDataSourceModule)
       .useModule(TestEmailDatasourceModule)
@@ -50,6 +68,9 @@ describe('Email controller update email tests', () => {
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
     emailDatasource = moduleFixture.get(IEmailDataSource);
     networkService = moduleFixture.get(NetworkService);
+    verificationCodeResendLockWindowMs = configurationService.get(
+      'email.verificationCode.resendLockWindowMs',
+    );
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -104,6 +125,57 @@ describe('Email controller update email tests', () => {
       })
       .expect(202)
       .expect({});
+  });
+
+  it('should return 429 if trying to update email too often', async () => {
+    const verificationGeneratedOn = faker.date.anytime();
+    // Verification code is still valid as it is currently the same time it was generated
+    jest.setSystemTime(verificationGeneratedOn.getTime());
+
+    const chain = chainBuilder().build();
+    const prevEmailAddress = faker.internet.email();
+    const emailAddress = faker.internet.email();
+    const timestamp = jest.now();
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const accountAddress = account.address;
+    // Signer is owner of safe
+    const safe = safeBuilder()
+      .with('owners', [accountAddress])
+      // Faker generates non-checksum addresses only
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
+    const signature = await account.signMessage({ message });
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+          return Promise.resolve({ data: safe });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    emailDatasource.getEmail.mockResolvedValue({
+      emailAddress: new EmailAddress(prevEmailAddress),
+      verificationGeneratedOn: verificationGeneratedOn,
+    });
+    emailDatasource.updateEmail.mockResolvedValue();
+
+    await request(app.getHttpServer())
+      .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
+      .send({
+        emailAddress,
+        account: account.address,
+        timestamp,
+        signature,
+      })
+      .expect(429)
+      .expect({
+        statusCode: 429,
+        message: 'Cannot edit at this time',
+      });
   });
 
   it('should return 409 if trying to update with the same email', async () => {

--- a/src/routes/email/email.controller.update-email.spec.ts
+++ b/src/routes/email/email.controller.update-email.spec.ts
@@ -67,9 +67,6 @@ describe('Email controller update email tests', () => {
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
     emailDatasource = moduleFixture.get(IEmailDataSource);
     networkService = moduleFixture.get(NetworkService);
-    verificationCodeResendLockWindowMs = configurationService.get(
-      'email.verificationCode.resendLockWindowMs',
-    );
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();

--- a/src/routes/email/email.controller.update-email.spec.ts
+++ b/src/routes/email/email.controller.update-email.spec.ts
@@ -28,7 +28,6 @@ const verificationCodeTtlMs = 100;
 describe('Email controller update email tests', () => {
   let app;
   let safeConfigUrl;
-  let verificationCodeResendLockWindowMs;
   let emailDatasource;
   let networkService;
 

--- a/src/routes/email/exception-filters/email-edit-timespan.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-edit-timespan.exception-filter.ts
@@ -1,0 +1,21 @@
+import { EditTimespanError } from '@/domain/email/errors/email-timespan.error';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(EditTimespanError)
+export class EmailEditTimespanExceptionFilter implements ExceptionFilter {
+  catch(exception: EditTimespanError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.TOO_MANY_REQUESTS).json({
+      message: 'Cannot edit at this time',
+      statusCode: HttpStatus.TOO_MANY_REQUESTS,
+    });
+  }
+}


### PR DESCRIPTION
This throttle email edit requests according to the TTL of verification codes. If an edit request occurs again within the TTL of the generated verification occurs, a `429` is returned.

- `EmailRepository['editEmail']` now includes a condition checking the presence of `verificationGeneratedOn` for the current email, then checking whether the current request is before or after the TTL and throwing accordingly.
- `EditTimespanError` error and associated `EmailEditTimespanExceptionFilter` exception filter have been included.
- Associated test coverage added.