### PR TITLE
Remove unnecessary `rimraf` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write .",
     "format-check": "prettier --check .",
@@ -43,7 +42,6 @@
     "postgres-shift": "^0.1.0",
     "redis": "^4.6.12",
     "reflect-metadata": "^0.2.1",
-    "rimraf": "^5.0.5",
     "rxjs": "^7.8.1",
     "semver": "^7.5.4",
     "viem": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,7 +4428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:10.3.10, glob@npm:^10.3.7":
+"glob@npm:10.3.10":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -6992,17 +6992,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "rimraf@npm:5.0.5"
-  dependencies:
-    glob: "npm:^10.3.7"
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: a612c7184f96258b7d1328c486b12ca7b60aa30e04229a08bbfa7e964486deb1e9a1b52d917809311bdc39a808a4055c0f950c0280fba194ba0a09e6f0d404f6
-  languageName: node
-  linkType: hard
-
 "run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -7089,7 +7078,6 @@ __metadata:
     prettier: "npm:^3.1.1"
     redis: "npm:^4.6.12"
     reflect-metadata: "npm:^0.2.1"
-    rimraf: "npm:^5.0.5"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.5.4"
     source-map-support: "npm:^0.5.20"


### PR DESCRIPTION
This removes `rimraf` as it is [no longer present in NestJS' `typescript-starter`](https://github.com/nestjs/typescript-starter/commit/ee0923a189627d772250d504274d28a8950972d3) and we do not use the `prebuild` script.