### PR TITLE
Use `faker.helpers` instead of `lodash` in tests

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
@@ -60,14 +59,17 @@ describe('FakeCacheService', () => {
     const prefix = faker.word.sample();
     // insert 5 items matching the pattern
     await Promise.all(
-      range(5).map(() =>
-        target.set(new CacheDir(`${prefix}${faker.string.uuid()}`, ''), ''),
+      faker.helpers.multiple(
+        () =>
+          target.set(new CacheDir(`${prefix}${faker.string.uuid()}`, ''), ''),
+        { count: 5 },
       ),
     );
     // insert 4 items not matching the pattern
     await Promise.all(
-      range(4).map(() =>
-        target.set(new CacheDir(`${faker.string.uuid()}`, ''), ''),
+      faker.helpers.multiple(
+        () => target.set(new CacheDir(`${faker.string.uuid()}`, ''), ''),
+        { count: 4 },
       ),
     );
 
@@ -81,17 +83,20 @@ describe('FakeCacheService', () => {
     const suffix = faker.word.sample();
     // insert 5 items matching the pattern
     await Promise.all(
-      range(5).map(() =>
-        target.set(
-          new CacheDir(`${prefix}_${faker.string.uuid()}_${suffix}`, ''),
-          '',
-        ),
+      faker.helpers.multiple(
+        () =>
+          target.set(
+            new CacheDir(`${prefix}_${faker.string.uuid()}_${suffix}`, ''),
+            '',
+          ),
+        { count: 5 },
       ),
     );
     // insert 4 items not matching the pattern
     await Promise.all(
-      range(4).map(() =>
-        target.set(new CacheDir(`${faker.string.uuid()}`, ''), ''),
+      faker.helpers.multiple(
+        () => target.set(new CacheDir(`${faker.string.uuid()}`, ''), ''),
+        { count: 4 },
       ),
     );
 

--- a/src/domain/messages/entities/__tests__/message-confirmation.builder.ts
+++ b/src/domain/messages/entities/__tests__/message-confirmation.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { sample } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import {
   MessageConfirmation,
@@ -12,10 +11,7 @@ export function messageConfirmationBuilder(): IBuilder<MessageConfirmation> {
     .with('modified', faker.date.recent())
     .with('owner', faker.finance.ethereumAddress())
     .with('signature', faker.string.hexadecimal({ length: 32 }))
-    .with(
-      'signatureType',
-      sample(Object.values(SignatureType)) ?? SignatureType.ContractSignature,
-    );
+    .with('signatureType', faker.helpers.objectValue(SignatureType));
 }
 
 export function toJson(confirmation: MessageConfirmation): unknown {

--- a/src/domain/messages/entities/__tests__/message.builder.ts
+++ b/src/domain/messages/entities/__tests__/message.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { Message } from '@/domain/messages/entities/message.entity';
 import {
@@ -12,13 +11,15 @@ export function messageBuilder(): IBuilder<Message> {
     .with('created', faker.date.recent())
     .with('modified', faker.date.recent())
     .with('safe', faker.finance.ethereumAddress())
-    .with('message', faker.word.words(random(1, 5)))
+    .with('message', faker.word.words({ count: { min: 1, max: 5 } }))
     .with('messageHash', faker.string.hexadecimal({ length: 32 }))
     .with('proposedBy', faker.finance.ethereumAddress())
     .with('safeAppId', faker.number.int())
     .with(
       'confirmations',
-      range(random(2, 5)).map(() => messageConfirmationBuilder().build()),
+      faker.helpers.multiple(() => messageConfirmationBuilder().build(), {
+        count: { min: 2, max: 5 },
+      }),
     )
     .with('preparedSignature', faker.string.hexadecimal({ length: 32 }));
 }

--- a/src/domain/safe-apps/entities/__tests__/safe-app-access-control.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-access-control.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import {
   SafeAppAccessControl,
@@ -11,6 +10,8 @@ export function safeAppAccessControlBuilder(): IBuilder<SafeAppAccessControl> {
     .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
     .with(
       'value',
-      range(random(2, 5)).map(() => faker.internet.url({ appendSlash: false })),
+      faker.helpers.multiple(() => faker.internet.url({ appendSlash: false }), {
+        count: { min: 2, max: 5 },
+      }),
     );
 }

--- a/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { safeAppAccessControlBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app-access-control.builder';
 import { safeAppProviderBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app-provider.builder';
@@ -21,6 +20,8 @@ export function safeAppBuilder(): IBuilder<SafeApp> {
     .with('developerWebsite', faker.internet.url({ appendSlash: false }))
     .with(
       'socialProfiles',
-      range(random(5)).map(() => safeAppSocialProfileBuilder().build()),
+      faker.helpers.multiple(() => safeAppSocialProfileBuilder().build(), {
+        count: { min: 0, max: 5 },
+      }),
     );
 }

--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
 import {
@@ -17,7 +16,9 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
     .with('blockNumber', faker.number.int())
     .with(
       'confirmations',
-      range(random(5)).map(() => confirmationBuilder().build()),
+      faker.helpers.multiple(() => confirmationBuilder().build(), {
+        count: { min: 0, max: 5 },
+      }),
     )
     .with('confirmationsRequired', faker.number.int())
     .with('data', faker.string.hexadecimal())

--- a/src/routes/messages/entities/__tests__/create-message.dto.builder.ts
+++ b/src/routes/messages/entities/__tests__/create-message.dto.builder.ts
@@ -1,11 +1,10 @@
 import { faker } from '@faker-js/faker';
-import { random } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { CreateMessageDto } from '@/routes/messages/entities/create-message.dto.entity';
 
 export function createMessageDtoBuilder(): IBuilder<CreateMessageDto> {
   return new Builder<CreateMessageDto>()
-    .with('message', faker.word.words(random(1, 5)))
+    .with('message', faker.word.words({ count: { min: 1, max: 5 } }))
     .with('safeAppId', faker.number.int())
     .with('signature', faker.string.hexadecimal({ length: 32 }));
 }

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { random, range } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
@@ -62,8 +61,9 @@ describe('Messages controller', () => {
     it('Get a confirmed message with no safe app associated', async () => {
       const chain = chainBuilder().build();
       const safeApps = [];
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const message = messageBuilder()
         .with('confirmations', messageConfirmations)
@@ -121,9 +121,12 @@ describe('Messages controller', () => {
 
     it('Get a confirmed message with a safe app associated', async () => {
       const chain = chainBuilder().build();
-      const safeApps = range(random(2, 5)).map(() => safeAppBuilder().build());
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const safeApps = faker.helpers.multiple(() => safeAppBuilder().build(), {
+        count: { min: 2, max: 5 },
+      });
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const message = messageBuilder()
         .with('safeAppId', safeApps[1].id)
@@ -183,8 +186,9 @@ describe('Messages controller', () => {
     it('Get an unconfirmed message with no safe app associated', async () => {
       const chain = chainBuilder().build();
       const safeApps = [];
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const message = messageBuilder()
         .with('confirmations', messageConfirmations)
@@ -242,9 +246,12 @@ describe('Messages controller', () => {
 
     it('Get an unconfirmed message with a safe app associated', async () => {
       const chain = chainBuilder().build();
-      const safeApps = range(random(3, 5)).map(() => safeAppBuilder().build());
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const safeApps = faker.helpers.multiple(() => safeAppBuilder().build(), {
+        count: { min: 3, max: 5 },
+      });
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const message = messageBuilder()
         .with('safeAppId', safeApps[2].id)
@@ -303,8 +310,9 @@ describe('Messages controller', () => {
 
     it('should return null name and logo if the Safe App is not found', async () => {
       const chain = chainBuilder().build();
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const message = messageBuilder()
         .with('safeAppId', faker.number.int())
@@ -363,8 +371,9 @@ describe('Messages controller', () => {
 
     it('should return null name and logo if no safeAppId in the message', async () => {
       const chain = chainBuilder().build();
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const message = messageBuilder()
         .with('safeAppId', null)
@@ -448,8 +457,9 @@ describe('Messages controller', () => {
 
     it('should get a message with a date label', async () => {
       const chain = chainBuilder().build();
-      const messageConfirmations = range(random(2, 5)).map(() =>
-        messageConfirmationBuilder().build(),
+      const messageConfirmations = faker.helpers.multiple(
+        () => messageConfirmationBuilder().build(),
+        { count: { min: 2, max: 5 } },
       );
       const safe = safeBuilder()
         .with(
@@ -537,11 +547,13 @@ describe('Messages controller', () => {
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
       const messageCreationDate = faker.date.recent();
-      const messages = range(4).map(() =>
-        messageBuilder()
-          .with('safeAppId', null)
-          .with('created', messageCreationDate)
-          .build(),
+      const messages = faker.helpers.multiple(
+        () =>
+          messageBuilder()
+            .with('safeAppId', null)
+            .with('created', messageCreationDate)
+            .build(),
+        { count: { min: 0, max: 4 } },
       );
       const page = pageBuilder()
         .with('previous', null)

--- a/src/routes/notifications/entities/__tests__/register-device.dto.builder.ts
+++ b/src/routes/notifications/entities/__tests__/register-device.dto.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range, sample } from 'lodash';
 import { DeviceType } from '@/domain/notifications/entities/device.entity';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { RegisterDeviceDto } from '@/routes/notifications/entities/register-device.dto.entity';
@@ -11,11 +10,13 @@ export function registerDeviceDtoBuilder(): IBuilder<RegisterDeviceDto> {
     .with('cloudMessagingToken', faker.string.uuid())
     .with('buildNumber', faker.string.numeric())
     .with('bundle', faker.internet.domainName())
-    .with('deviceType', sample(Object.values(DeviceType)) ?? DeviceType.Android)
+    .with('deviceType', faker.helpers.objectValue(DeviceType))
     .with('version', faker.system.semver())
     .with('timestamp', faker.date.recent().getTime().toString())
     .with(
       'safeRegistrations',
-      range(random(10)).map(() => safeRegistrationBuilder().build()),
+      faker.helpers.multiple(() => safeRegistrationBuilder().build(), {
+        count: { min: 0, max: 10 },
+      }),
     );
 }

--- a/src/routes/notifications/entities/__tests__/safe-registration.builder.ts
+++ b/src/routes/notifications/entities/__tests__/safe-registration.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { SafeRegistration } from '@/routes/notifications/entities/safe-registration.entity';
 
@@ -8,10 +7,14 @@ export function safeRegistrationBuilder(): IBuilder<SafeRegistration> {
     .with('chainId', faker.string.numeric())
     .with(
       'safes',
-      range(random(5)).map(() => faker.finance.ethereumAddress()),
+      faker.helpers.multiple(() => faker.finance.ethereumAddress(), {
+        count: { min: 0, max: 5 },
+      }),
     )
     .with(
       'signatures',
-      range(random(5)).map(() => faker.string.hexadecimal({ length: 32 })),
+      faker.helpers.multiple(() => faker.string.hexadecimal({ length: 32 }), {
+        count: { min: 0, max: 5 },
+      }),
     );
 }

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { range } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
@@ -54,11 +53,11 @@ describe('Notifications Controller (Unit)', () => {
     registerDeviceDtoBuilder()
       .with(
         'safeRegistrations',
-        range(4)
-          .map((i) => chainBuilder().with('chainId', i.toString()).build())
-          .map((chain) =>
-            safeRegistrationBuilder().with('chainId', chain.chainId).build(),
-          ),
+        Array.from({ length: 4 }).map((_, i) => {
+          return safeRegistrationBuilder()
+            .with('chainId', i.toString())
+            .build();
+        }),
       )
       .build();
 

--- a/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
+++ b/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
@@ -1,4 +1,4 @@
-import { sample } from 'lodash';
+import { faker } from '@faker-js/faker';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { erc20TransferBuilder } from '@/domain/safe/entities/__tests__/erc20-transfer.builder';
 import { addressInfoBuilder } from '@/routes/common/__tests__/entities/address-info.builder';
@@ -14,10 +14,7 @@ export function transferTransactionInfoBuilder(): IBuilder<TransferTransactionIn
     .with('type', TransactionInfoType.Transfer)
     .with('sender', addressInfoBuilder().build())
     .with('recipient', addressInfoBuilder().build())
-    .with(
-      'direction',
-      sample(Object.values(TransferDirection)) ?? TransferDirection.Incoming,
-    )
+    .with('direction', faker.helpers.objectValue(TransferDirection))
     .with('transferInfo', {
       ...erc20TransferBuilder().build(),
       type: TransferType.Erc20,

--- a/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
+++ b/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { random, range, sampleSize } from 'lodash';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { addressInfoBuilder } from '@/routes/common/__tests__/entities/address-info.builder';
@@ -20,11 +19,12 @@ function multisigConfirmationDetailsBuilder(): IBuilder<MultisigConfirmationDeta
 }
 
 export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDetails> {
-  const signers = range(random(MIN_SIGNERS, MAX_SIGNERS)).map(() =>
-    addressInfoBuilder().build(),
-  );
-  const confirmations = range(random(MIN_SIGNERS, MAX_SIGNERS)).map(() =>
-    multisigConfirmationDetailsBuilder().build(),
+  const signers = faker.helpers.multiple(() => addressInfoBuilder().build(), {
+    count: { min: MIN_SIGNERS, max: MAX_SIGNERS },
+  });
+  const confirmations = faker.helpers.multiple(
+    () => multisigConfirmationDetailsBuilder().build(),
+    { count: { min: MIN_SIGNERS, max: MAX_SIGNERS } },
   );
 
   return new Builder<MultisigExecutionDetails>()
@@ -41,7 +41,7 @@ export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDet
     .with('signers', signers)
     .with('confirmationsRequired', faker.number.int({ max: signers.length }))
     .with('confirmations', confirmations)
-    .with('rejectors', sampleSize(signers, MIN_SIGNERS))
+    .with('rejectors', faker.helpers.arrayElements(signers, MIN_SIGNERS))
     .with('gasTokenInfo', tokenBuilder().build())
     .with('trusted', faker.datatype.boolean());
 }

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { sample } from 'lodash';
 import { moduleTransactionBuilder } from '@/domain/safe/entities/__tests__/module-transaction.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { addressInfoBuilder } from '@/routes/common/__tests__/entities/address-info.builder';
@@ -48,8 +47,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
     const transaction = moduleTransactionBuilder()
       .with('safe', safe.address)
       .build();
-    const txStatus =
-      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
     transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
@@ -90,8 +88,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
     const transaction = moduleTransactionBuilder()
       .with('safe', safe.address)
       .build();
-    const txStatus =
-      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
     transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { sample } from 'lodash';
 import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { addressInfoBuilder } from '@/routes/common/__tests__/entities/address-info.builder';
@@ -61,8 +60,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const transaction = multisigTransactionBuilder()
       .with('safe', safe.address)
       .build();
-    const txStatus =
-      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
     transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
@@ -106,8 +104,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const transaction = multisigTransactionBuilder()
       .with('safe', safe.address)
       .build();
-    const txStatus =
-      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
     transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -44,7 +44,6 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { range } from 'lodash';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
 import {
@@ -735,12 +734,13 @@ describe('Transactions History Controller (Unit)', () => {
       .get(IConfigurationService)
       .getOrThrow('mappings.history.maxNestedTransfers');
     const date = new Date();
-    // the amount of transfers is the double of the max value
-    const transfers = range(maxNestedTransfers * 2).map(
+    const transfers = faker.helpers.multiple(
       () =>
         nativeTokenTransferToJson(
           nativeTokenTransferBuilder().with('executionDate', date).build(),
         ) as Transfer,
+      // the amount of transfers is the double of the max value
+      { count: maxNestedTransfers * 2 },
     );
     const transactionHistoryData = {
       count: faker.number.int(),


### PR DESCRIPTION
This removes the usage of `lodash` in favour of the relevant `faker.helpers` in tests and builders. As `faker` is already imported in each of the adjusted files, there is no need to also import `lodash` when `faker` has the required logic.

The following has been changed:

- [`range`](https://lodash.com/docs/4.17.15#range) -> [`faker.helpers.multiple`](https://fakerjs.dev/api/helpers.html#multiple)
- [`sample(Object.values(...))`](https://lodash.com/docs/4.17.15#sample) -> [`faker.helpers.objectValue`](https://fakerjs.dev/api/helpers.html#objectvalue)
- [`sampleSize`](https://lodash.com/docs/4.17.15#sampleSize) -> [`faker.helpers.arrayElements`](https://fakerjs.dev/api/helpers.html#arrayelements)
- [`random`](https://lodash.com/docs/4.17.15#random) -> `options.count` in respective helper