### PR TITLE
Reduce reliance on `lodash`

### DIFF
--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { get } from 'lodash';
 import {
   CacheService,
   ICacheService,
@@ -55,7 +54,7 @@ export class CacheFirstDataSource {
     try {
       return await this._getFromNetworkAndWriteCache(args);
     } catch (error) {
-      if (get(error, 'status') === 404) {
+      if (error?.status === 404) {
         await this.cacheNotFoundError(
           args.cacheDir,
           new NetworkResponseError(error.status, error),
@@ -75,7 +74,7 @@ export class CacheFirstDataSource {
   ): Promise<T> {
     this.loggingService.debug({ type: 'cache_hit', key, field });
     const cachedData = JSON.parse(cached);
-    if (get(cachedData, 'status') === 404) {
+    if (cachedData?.status === 404) {
       throw new NetworkResponseError(cachedData.status, cachedData.data);
     }
     return cachedData;

--- a/src/datasources/prices-api/coingecko-api.service.ts
+++ b/src/datasources/prices-api/coingecko-api.service.ts
@@ -13,6 +13,7 @@ import {
   NetworkService,
   INetworkService,
 } from '@/datasources/network/network.service.interface';
+import { difference } from 'lodash';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 @Injectable()
@@ -114,9 +115,9 @@ export class CoingeckoApi implements IPricesApi {
     fiatCode: string;
   }): Promise<AssetPrice[]> {
     const pricesFromCache = await this._getTokenPricesFromCache(args);
-    const cachedTokenAddresses = pricesFromCache.flatMap(Object.keys);
-    const notCachedTokenPrices = args.tokenAddresses.filter(
-      (tokenAddress) => !cachedTokenAddresses.includes(tokenAddress),
+    const notCachedTokenPrices = difference(
+      args.tokenAddresses,
+      pricesFromCache.map((assetPrice) => Object.keys(assetPrice)).flat(),
     );
     const pricesFromNetwork = notCachedTokenPrices.length
       ? await this._getTokenPricesFromNetwork({

--- a/src/datasources/prices-api/coingecko-api.service.ts
+++ b/src/datasources/prices-api/coingecko-api.service.ts
@@ -13,7 +13,6 @@ import {
   NetworkService,
   INetworkService,
 } from '@/datasources/network/network.service.interface';
-import { difference } from 'lodash';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 @Injectable()
@@ -115,9 +114,9 @@ export class CoingeckoApi implements IPricesApi {
     fiatCode: string;
   }): Promise<AssetPrice[]> {
     const pricesFromCache = await this._getTokenPricesFromCache(args);
-    const notCachedTokenPrices = difference(
-      args.tokenAddresses,
-      pricesFromCache.map((assetPrice) => Object.keys(assetPrice)).flat(),
+    const cachedTokenAddresses = pricesFromCache.flatMap(Object.keys);
+    const notCachedTokenPrices = args.tokenAddresses.filter(
+      (tokenAddress) => !cachedTokenAddresses.includes(tokenAddress),
     );
     const pricesFromNetwork = notCachedTokenPrices.length
       ? await this._getTokenPricesFromNetwork({

--- a/src/routes/notifications/notifications.service.ts
+++ b/src/routes/notifications/notifications.service.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
-import { inRange } from 'lodash';
 import { Device } from '@/domain/notifications/entities/device.entity';
 import { SafeRegistration as DomainSafeRegistration } from '@/domain/notifications/entities/safe-registration.entity';
 import { INotificationsRepository } from '@/domain/notifications/notifications.repository.interface';
@@ -105,7 +104,9 @@ export class NotificationsService {
     result: PromiseSettledResult<DomainSafeRegistration>,
   ): boolean {
     return (
-      result.status === 'rejected' && inRange(result.reason?.code, 500, 600)
+      result.status === 'rejected' &&
+      result.reason?.code >= 500 &&
+      result.reason?.code < 600
     );
   }
 
@@ -113,7 +114,9 @@ export class NotificationsService {
     result: PromiseSettledResult<DomainSafeRegistration>,
   ): boolean {
     return (
-      result.status === 'rejected' && inRange(result.reason?.code, 400, 500)
+      result.status === 'rejected' &&
+      result.reason?.code >= 400 &&
+      result.reason?.code < 500
     );
   }
 

--- a/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
+++ b/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { isArray } from 'lodash';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { DELEGATE_OPERATION } from '@/domain/safe/entities/operation.entity';
 
@@ -72,7 +71,7 @@ export class DataDecodedParamHelper {
     if (!dataDecoded.parameters) return false;
     return dataDecoded.parameters.some(
       (param) =>
-        isArray(param.valueDecoded) &&
+        Array.isArray(param.valueDecoded) &&
         param.valueDecoded.some(
           (innerParam) => innerParam?.operation === DELEGATE_OPERATION,
         ),

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { isArray, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import {
@@ -110,7 +110,8 @@ export class TransactionDataMapper {
     chainId: string,
     dataDecoded: DataDecoded | null,
   ): Promise<Record<string, AddressInfo>> {
-    if (dataDecoded === null || !isArray(dataDecoded.parameters)) return {};
+    if (dataDecoded === null || !Array.isArray(dataDecoded.parameters))
+      return {};
     const { method, parameters } = dataDecoded;
     const promises: Promise<(AddressInfo | null)[] | AddressInfo | null>[] = [];
 
@@ -148,7 +149,7 @@ export class TransactionDataMapper {
     chainId: string,
     valueDecoded: unknown,
   ): Promise<(AddressInfo | null)[]> {
-    if (!isArray(valueDecoded)) return [];
+    if (!Array.isArray(valueDecoded)) return [];
     const promises: Promise<AddressInfo | null>[] = [];
 
     for (const transaction of valueDecoded) {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -489,7 +489,7 @@ export class TransactionsService {
   private getFirstTransactionNonce(
     page: Page<DomainMultisigTransaction>,
   ): number | null {
-    return page.results[0].nonce ?? null;
+    return page.results[0]?.nonce ?? null;
   }
 
   private getLastTransactionNonce(

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { head, last } from 'lodash';
 import { MultisigTransaction as DomainMultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { SafeRepository } from '@/domain/safe/safe.repository';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
@@ -490,12 +489,12 @@ export class TransactionsService {
   private getFirstTransactionNonce(
     page: Page<DomainMultisigTransaction>,
   ): number | null {
-    return head(page.results)?.nonce ?? null;
+    return page.results[0].nonce ?? null;
   }
 
   private getLastTransactionNonce(
     page: Page<DomainMultisigTransaction>,
   ): number | null {
-    return last(page.results)?.nonce ?? null;
+    return page.results.at(-1)?.nonce ?? null;
   }
 }


### PR DESCRIPTION
This migrates trivial `lodash` functions to their vanilla counterparts, reducing the import cost and lowering the bundle size, e.g. `isArray` which is no longer used:

![image](https://github.com/safe-global/safe-client-gateway/assets/20442784/733b8156-117f-496f-a750-e34624a792eb)

The following functions have been migrated:

- [`get`](https://lodash.com/docs/4.17.15#get) -> accessing property directly with optional chaining
- [`inRange`](https://lodash.com/docs/4.17.15#inRange) -> `>=` and `<`
- [`isArray`](https://lodash.com/docs/4.17.15#isArray) ->`Array.isArray`
- [`flatten`](https://lodash.com/docs/4.17.15#flatten) -> `flat`
- [`head(arr)`](https://lodash.com/docs/4.17.15#head) -> arr[0]
- [`last(arr)`](https://lodash.com/docs/4.17.15#last) -> arr[.at(-1)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at)