### PR TITLE
Increase minimum number of messages in grouping test

### DIFF
--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -553,7 +553,7 @@ describe('Messages controller', () => {
             .with('safeAppId', null)
             .with('created', messageCreationDate)
             .build(),
-        { count: { min: 0, max: 4 } },
+        { count: { min: 1, max: 4 } },
       );
       const page = pageBuilder()
         .with('previous', null)


### PR DESCRIPTION
This fixes the "should group messages by date" test of the `messages.controller` by ensuring that there is a minimum of of at least 1 message in the builder.