### PR TITLE
Decode `multiSend` alerts first and update tests to match module transactions

### DIFF
--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -106,16 +106,32 @@ export class AlertsRepository implements IAlertsRepository {
   }
 
   private _decodeTransactionAdded(data: Hex) {
+    try {
+      return this.multiSendDecoder
+        .mapMultiSendTransactions(data)
+        .flatMap((multiSend) => {
+          return this._decodeRecoveryTransaction(multiSend.data);
+        });
+    } catch {
+      return [this._decodeRecoveryTransaction(data)];
+    }
+  }
+
+  private _decodeRecoveryTransaction(data: Hex) {
     const decoded = this.safeDecoder.decodeFunctionData({ data });
 
-    if (decoded.functionName !== 'execTransaction') {
-      return [decoded];
+    const isRecoveryTransaction = [
+      'addOwnerWithThreshold',
+      'removeOwner',
+      'swapOwner',
+      'changeThreshold',
+    ].includes(decoded.functionName);
+
+    if (!isRecoveryTransaction) {
+      throw new Error('Unknown recovery transaction');
     }
 
-    const execTransactionData = decoded.args[2];
-    return this.multiSendDecoder
-      .mapMultiSendTransactions(execTransactionData)
-      .flatMap(({ data }) => this.safeDecoder.decodeFunctionData({ data }));
+    return decoded;
   }
 
   private async _mapSafeSetup(args: {

--- a/src/domain/alerts/contracts/safe-decoder.helper.ts
+++ b/src/domain/alerts/contracts/safe-decoder.helper.ts
@@ -7,7 +7,6 @@ const OWNER_MANAGER_ABI = parseAbi([
   'function removeOwner(address prevOwner, address owner, uint256 _threshold)',
   'function swapOwner(address prevOwner, address oldOwner, address newOwner)',
   'function changeThreshold(uint256 _threshold)',
-  // Batched owner management transactions are executed via MultiSend
   'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)',
 ]);
 

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -536,15 +536,12 @@ describe('Alerts (Unit)', () => {
           'transactions',
           multiSendTransactions,
         );
-        const execTransaction = execTransactionEncoder()
+        const transactionAddedEvent = transactionAddedEventBuilder()
           .with('data', multiSend.encode())
           .with(
             'to',
             getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress!),
-          );
-        const transactionAddedEvent = transactionAddedEventBuilder()
-          .with('data', execTransaction.encode())
-          .with('to', getAddress(safe.address))
+          )
           .encode();
 
         const alert = alertBuilder()
@@ -1017,15 +1014,12 @@ describe('Alerts (Unit)', () => {
         'transactions',
         multiSendTransactions,
       );
-      const execTransaction = execTransactionEncoder()
+      const transactionAddedEvent = transactionAddedEventBuilder()
         .with('data', multiSend.encode())
         .with(
           'to',
           getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress!),
-        );
-      const transactionAddedEvent = transactionAddedEventBuilder()
-        .with('data', execTransaction.encode())
-        .with('to', getAddress(safe.address))
+        )
         .encode();
 
       const alert = alertBuilder()
@@ -1128,15 +1122,12 @@ describe('Alerts (Unit)', () => {
         'transactions',
         multiSendTransactions,
       );
-      const execTransaction = execTransactionEncoder()
+      const transactionAddedEvent = transactionAddedEventBuilder()
         .with('data', multiSend.encode())
         .with(
           'to',
           getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress!),
-        );
-      const transactionAddedEvent = transactionAddedEventBuilder()
-        .with('data', execTransaction.encode())
-        .with('to', getAddress(safe.address))
+        )
         .encode();
 
       const log = alertLogBuilder()


### PR DESCRIPTION
Recovery transactions are not wrapped in an `execTransaction` as they are executed by a module (see [example](https://sepolia.etherscan.io/tx/0x83eae8585eb068e7de8e641eb1a720c77e4e3d7fa876188d50aab13312a6fa7a#eventlog)). Attempting to decode the incoming alert as an `execTransaction` would fail if it is a `multiSend`-based recovery attempt.

This inverts the associated logic to first try decoding `multiSend` and then Safe transactions. The relevant tests have been updated accordingly.

Changes:

- `AlertsRepository['_decodeTransactionAdded']` tries to decode the `multiSend` call and then Safe methods either within the batch or if the initial decode fails.
- Each Safe method decode attempt is now handled by `AlertsRepository['_decodeRecoveryTransaction']` which checks that the function name matches that expected, otherwise throwing.
- `alerts.controller.spec` mock transactions have been updated to _not_ wrap `multiSend` recoveries in `execTransaction` calls.