### PR TITLE
Add email subscriptions datasource

### DIFF
--- a/migrations/00001_initial/index.sql
+++ b/migrations/00001_initial/index.sql
@@ -13,5 +13,28 @@ CREATE table emails.account_emails
     verification_code              text,
     verification_code_generated_on timestamp with time zone,
     verification_sent_on           timestamp with time zone,
+    unsubscription_token           uuid                  NOT NULL,
     UNIQUE (chain_id, safe_address, account)
 );
+
+DROP TABLE IF EXISTS emails.subscriptions CASCADE;
+CREATE TABLE emails.subscriptions
+(
+    id   SERIAL PRIMARY KEY,
+    key  TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL
+);
+
+-- Add the default subscription type: account_recovery
+INSERT INTO emails.subscriptions (key, name)
+VALUES ('account_recovery', 'Account Recovery');
+
+DROP TABLE IF EXISTS emails.account_subscriptions CASCADE;
+CREATE TABLE emails.account_subscriptions
+(
+    account_id      INT,
+    subscription_id INT,
+    FOREIGN KEY (account_id) REFERENCES emails.account_emails (id) ON DELETE CASCADE,
+    FOREIGN KEY (subscription_id) REFERENCES emails.subscriptions (id) ON DELETE CASCADE,
+    UNIQUE (account_id, subscription_id)
+)

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -541,7 +541,7 @@ describe('Email Datasource Tests', () => {
     expect(subscriptions).toContainEqual(subscription);
   });
 
-  it('unsubscribes to a category successfully', async () => {
+  it('unsubscribes from a category successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
     const safeAddress = faker.finance.ethereumAddress();
     const emailAddress = new EmailAddress(faker.internet.email());

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -600,7 +600,7 @@ describe('Email Datasource Tests', () => {
     expect(currentSubscriptions).not.toContainEqual(subscriptions[0]);
   });
 
-  it('unsubscribes to non existent category', async () => {
+  it('unsubscribes from a non-existent category', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
     const safeAddress = faker.finance.ethereumAddress();
     const emailAddress = new EmailAddress(faker.internet.email());

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -661,7 +661,7 @@ describe('Email Datasource Tests', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('unsubscribes to all categories successfully', async () => {
+  it('unsubscribes from all categories successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
     const safeAddress = faker.finance.ethereumAddress();
     const emailAddress = new EmailAddress(faker.internet.email());

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -598,6 +598,7 @@ describe('Email Datasource Tests', () => {
     });
     expect(result).toContainEqual(subscriptions[0]);
     expect(currentSubscriptions).not.toContainEqual(subscriptions[0]);
+    expect(currentSubscriptions).toContainEqual(subscriptions[1]);
   });
 
   it('unsubscribes from a non-existent category', async () => {
@@ -658,7 +659,14 @@ describe('Email Datasource Tests', () => {
       token: faker.string.uuid(),
     });
 
+    const currentSubscriptions = await target.getSubscriptions({
+      chainId,
+      safeAddress,
+      account,
+    });
     expect(result).toHaveLength(0);
+    // Length of 1 since there is a default subscription
+    expect(currentSubscriptions).toHaveLength(1);
   });
 
   it('unsubscribes from all categories successfully', async () => {
@@ -705,8 +713,7 @@ describe('Email Datasource Tests', () => {
       categoryKey: subscriptions[1].key,
     });
 
-    // Unsubscribe from one category
-    await target.unsubscribeAll({
+    const result = await target.unsubscribeAll({
       token: unsubscriptionToken,
     });
 
@@ -716,5 +723,8 @@ describe('Email Datasource Tests', () => {
       account,
     });
     expect(currentSubscriptions).toHaveLength(0);
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual(subscriptions[0]);
+    expect(result).toContainEqual(subscriptions[1]);
   });
 });

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -31,7 +31,7 @@ describe('Email Datasource Tests', () => {
   });
 
   afterEach(async () => {
-    await sql`TRUNCATE emails.account_emails CASCADE`;
+    await sql`TRUNCATE TABLE emails.account_emails, emails.account_subscriptions CASCADE`;
   });
 
   afterAll(async () => {
@@ -45,6 +45,7 @@ describe('Email Datasource Tests', () => {
     const account = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -53,6 +54,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     });
     const email = await target.getEmail({
       chainId: chainId.toString(),
@@ -78,6 +80,7 @@ describe('Email Datasource Tests', () => {
     const account = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -86,6 +89,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     });
 
     await expect(
@@ -96,6 +100,7 @@ describe('Email Datasource Tests', () => {
         account,
         code,
         codeGenerationDate,
+        unsubscriptionToken,
       }),
     ).rejects.toThrow(PostgresError);
   });
@@ -109,6 +114,7 @@ describe('Email Datasource Tests', () => {
     const codeGenerationDate = faker.date.recent();
     const newCode = code + 1;
     const newCodeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -117,6 +123,7 @@ describe('Email Datasource Tests', () => {
       account,
       code: code.toString(),
       codeGenerationDate,
+      unsubscriptionToken,
     });
     const savedEmail = await target.getEmail({
       chainId: chainId.toString(),
@@ -149,6 +156,7 @@ describe('Email Datasource Tests', () => {
     const sentOn = faker.date.recent();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId: chainId.toString(),
@@ -157,6 +165,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     });
     await target.setVerificationSentDate({
       chainId: chainId.toString(),
@@ -215,12 +224,14 @@ describe('Email Datasource Tests', () => {
         account: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
         codeGenerationDate: faker.date.recent(),
+        unsubscriptionToken: faker.string.uuid(),
       },
       {
         emailAddress: new EmailAddress(faker.internet.email()),
         account: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
         codeGenerationDate: faker.date.recent(),
+        unsubscriptionToken: faker.string.uuid(),
       },
     ];
     const nonVerifiedAccounts = [
@@ -229,12 +240,14 @@ describe('Email Datasource Tests', () => {
         account: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
         codeGenerationDate: faker.date.recent(),
+        unsubscriptionToken: faker.string.uuid(),
       },
       {
         emailAddress: new EmailAddress(faker.internet.email()),
         account: faker.finance.ethereumAddress(),
         code: faker.number.int({ max: 999998 }).toString(),
         codeGenerationDate: faker.date.recent(),
+        unsubscriptionToken: faker.string.uuid(),
       },
     ];
     for (const {
@@ -242,6 +255,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     } of verifiedAccounts) {
       await target.saveEmail({
         chainId,
@@ -250,6 +264,7 @@ describe('Email Datasource Tests', () => {
         account,
         code,
         codeGenerationDate,
+        unsubscriptionToken,
       });
       await target.verifyEmail({
         chainId: chainId,
@@ -262,6 +277,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     } of nonVerifiedAccounts) {
       await target.saveEmail({
         chainId,
@@ -270,6 +286,7 @@ describe('Email Datasource Tests', () => {
         account,
         code,
         codeGenerationDate,
+        unsubscriptionToken,
       });
     }
 
@@ -292,6 +309,7 @@ describe('Email Datasource Tests', () => {
     const account = faker.finance.ethereumAddress();
     const code = faker.number.int({ max: 999998 }).toString();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId,
@@ -300,6 +318,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     });
     await target.deleteEmail({
       chainId,
@@ -338,6 +357,7 @@ describe('Email Datasource Tests', () => {
     const account = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId,
@@ -346,6 +366,7 @@ describe('Email Datasource Tests', () => {
       account,
       code: faker.string.numeric(),
       codeGenerationDate: faker.date.recent(),
+      unsubscriptionToken,
     });
 
     await target.updateEmail({
@@ -355,6 +376,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     });
 
     const email = await target.getEmail({
@@ -382,6 +404,7 @@ describe('Email Datasource Tests', () => {
     const account = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await target.saveEmail({
       chainId,
@@ -390,6 +413,7 @@ describe('Email Datasource Tests', () => {
       account,
       code: faker.string.numeric(),
       codeGenerationDate: faker.date.recent(),
+      unsubscriptionToken,
     });
 
     await target.verifyEmail({
@@ -405,6 +429,7 @@ describe('Email Datasource Tests', () => {
       account,
       code,
       codeGenerationDate,
+      unsubscriptionToken,
     });
 
     const email = await target.getEmail({
@@ -431,6 +456,7 @@ describe('Email Datasource Tests', () => {
     const account = faker.finance.ethereumAddress();
     const code = faker.string.numeric();
     const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
 
     await expect(
       target.updateEmail({
@@ -440,7 +466,255 @@ describe('Email Datasource Tests', () => {
         account,
         code,
         codeGenerationDate,
+        unsubscriptionToken,
       }),
     ).rejects.toThrow(EmailAddressDoesNotExistError);
+  });
+
+  it('subscribes to account_recovery upon registration', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
+
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+      unsubscriptionToken,
+    });
+
+    const actual = await target.getSubscriptions({
+      chainId,
+      safeAddress,
+      account,
+    });
+
+    expect(actual).toContainEqual({
+      key: 'account_recovery',
+      name: 'Account Recovery',
+    });
+  });
+
+  it('subscribes to category', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
+    const subscription = {
+      key: faker.word.sample(),
+      name: faker.word.words(2),
+    };
+    await sql`INSERT INTO emails.subscriptions (key, name)
+              VALUES (${subscription.key}, ${subscription.name})`;
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+      unsubscriptionToken,
+    });
+
+    await target.subscribe({
+      chainId,
+      safeAddress,
+      account,
+      categoryKey: subscription.key,
+    });
+
+    const subscriptions = await target.getSubscriptions({
+      chainId,
+      safeAddress,
+      account,
+    });
+    expect(subscriptions).toContainEqual(subscription);
+  });
+
+  it('unsubscribes to a category successfully', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
+    const subscriptions = [
+      {
+        key: faker.word.sample(),
+        name: faker.word.words(2),
+      },
+      {
+        key: faker.word.sample(),
+        name: faker.word.words(2),
+      },
+    ];
+    await sql`INSERT INTO emails.subscriptions (key, name)
+              VALUES (${subscriptions[0].key}, ${subscriptions[0].name}),
+                     (${subscriptions[1].key}, ${subscriptions[1].name})`;
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+      unsubscriptionToken,
+    });
+    // Subscribe to two categories
+    await target.subscribe({
+      chainId,
+      safeAddress,
+      account,
+      categoryKey: subscriptions[0].key,
+    });
+    await target.subscribe({
+      chainId,
+      safeAddress,
+      account,
+      categoryKey: subscriptions[1].key,
+    });
+
+    // Unsubscribe from one category
+    const result = await target.unsubscribe({
+      categoryKey: subscriptions[0].key,
+      token: unsubscriptionToken,
+    });
+
+    const currentSubscriptions = await target.getSubscriptions({
+      chainId,
+      safeAddress,
+      account,
+    });
+    expect(result).toContainEqual(subscriptions[0]);
+    expect(currentSubscriptions).not.toContainEqual(subscriptions[0]);
+  });
+
+  it('unsubscribes to non existent category', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
+    const nonExistentCategory = faker.word.sample();
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+      unsubscriptionToken,
+    });
+
+    // Unsubscribe from one category
+    const result = await target.unsubscribe({
+      categoryKey: nonExistentCategory,
+      token: unsubscriptionToken,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('unsubscribes with wrong token', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
+    const subscriptions = [
+      {
+        key: faker.word.sample(),
+        name: faker.word.words(2),
+      },
+    ];
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+      unsubscriptionToken,
+    });
+
+    // Unsubscribe from one category
+    const result = await target.unsubscribe({
+      categoryKey: subscriptions[0].key,
+      token: faker.string.uuid(),
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('unsubscribes to all categories successfully', async () => {
+    const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
+    const safeAddress = faker.finance.ethereumAddress();
+    const emailAddress = new EmailAddress(faker.internet.email());
+    const account = faker.finance.ethereumAddress();
+    const code = faker.string.numeric();
+    const codeGenerationDate = faker.date.recent();
+    const unsubscriptionToken = faker.string.uuid();
+    const subscriptions = [
+      {
+        key: faker.word.sample(),
+        name: faker.word.words(2),
+      },
+      {
+        key: faker.word.sample(),
+        name: faker.word.words(2),
+      },
+    ];
+    await sql`INSERT INTO emails.subscriptions (key, name)
+              VALUES (${subscriptions[0].key}, ${subscriptions[0].name}),
+                     (${subscriptions[1].key}, ${subscriptions[1].name})`;
+    await target.saveEmail({
+      chainId,
+      safeAddress,
+      emailAddress,
+      account,
+      code,
+      codeGenerationDate,
+      unsubscriptionToken,
+    });
+    // Subscribe to two categories
+    await target.subscribe({
+      chainId,
+      safeAddress,
+      account,
+      categoryKey: subscriptions[0].key,
+    });
+    await target.subscribe({
+      chainId,
+      safeAddress,
+      account,
+      categoryKey: subscriptions[1].key,
+    });
+
+    // Unsubscribe from one category
+    await target.unsubscribeAll({
+      token: unsubscriptionToken,
+    });
+
+    const currentSubscriptions = await target.getSubscriptions({
+      chainId,
+      safeAddress,
+      account,
+    });
+    expect(currentSubscriptions).toHaveLength(0);
   });
 });

--- a/src/datasources/email/email.datasource.spec.ts
+++ b/src/datasources/email/email.datasource.spec.ts
@@ -471,7 +471,7 @@ describe('Email Datasource Tests', () => {
     ).rejects.toThrow(EmailAddressDoesNotExistError);
   });
 
-  it('subscribes to account_recovery upon registration', async () => {
+  it('Has zero subscriptions when saving new email', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
     const safeAddress = faker.finance.ethereumAddress();
     const emailAddress = new EmailAddress(faker.internet.email());
@@ -495,11 +495,7 @@ describe('Email Datasource Tests', () => {
       safeAddress,
       account,
     });
-
-    expect(actual).toContainEqual({
-      key: 'account_recovery',
-      name: 'Account Recovery',
-    });
+    expect(actual).toHaveLength(0);
   });
 
   it('subscribes to category', async () => {
@@ -665,8 +661,7 @@ describe('Email Datasource Tests', () => {
       account,
     });
     expect(result).toHaveLength(0);
-    // Length of 1 since there is a default subscription
-    expect(currentSubscriptions).toHaveLength(1);
+    expect(currentSubscriptions).toHaveLength(0);
   });
 
   it('unsubscribes from all categories successfully', async () => {
@@ -723,7 +718,7 @@ describe('Email Datasource Tests', () => {
       account,
     });
     expect(currentSubscriptions).toHaveLength(0);
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(2);
     expect(result).toContainEqual(subscriptions[0]);
     expect(result).toContainEqual(subscriptions[1]);
   });

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -242,14 +242,14 @@ export class EmailDataSource implements IEmailDataSource {
   }): Promise<DomainSubscription[]> {
     const subscriptions = await this
       .sql`INSERT INTO emails.account_subscriptions (account_id, subscription_id)
-           SELECT account_emails.id AS account_id,
-                  subscriptions.id  AS subscription_id
-           FROM emails.account_emails
-                    CROSS JOIN emails.subscriptions
-           WHERE account_emails.chain_id = ${args.chainId}
-             AND account_emails.safe_address = ${args.safeAddress}
-             AND account_emails.account = ${args.account}
-             AND subscriptions.key = ${args.categoryKey}
+               (SELECT account_emails.id AS account_id,
+                       subscriptions.id  AS subscription_id
+                FROM emails.account_emails
+                         CROSS JOIN emails.subscriptions
+                WHERE account_emails.chain_id = ${args.chainId}
+                  AND account_emails.safe_address = ${args.safeAddress}
+                  AND account_emails.account = ${args.account}
+                  AND subscriptions.key = ${args.categoryKey})
            RETURNING *`;
 
     return subscriptions.map(

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -6,6 +6,7 @@ import {
   Email as DomainEmail,
   EmailAddress,
 } from '@/domain/email/entities/email.entity';
+import { Subscription as DomainSubscription } from '@/domain/email/entities/subscription.entity';
 
 interface Email {
   id: number;
@@ -17,6 +18,13 @@ interface Email {
   verification_code: string | null;
   verification_code_generated_on: Date | null;
   verification_sent_on: Date | null;
+  unsubscription_token: string;
+}
+
+interface Subscription {
+  id: number;
+  key: string;
+  name: string;
 }
 
 @Injectable()
@@ -75,12 +83,24 @@ export class EmailDataSource implements IEmailDataSource {
     account: string;
     code: string;
     codeGenerationDate: Date;
+    unsubscriptionToken: string;
   }): Promise<void> {
-    await this.sql<Email[]>`
+    const [email] = await this.sql<Email[]>`
         INSERT INTO emails.account_emails (chain_id, email_address, safe_address, account, verification_code,
-                                           verification_code_generated_on)
+                                           verification_code_generated_on, unsubscription_token)
         VALUES (${args.chainId}, ${args.emailAddress.value}, ${args.safeAddress}, ${args.account}, ${args.code},
-                ${args.codeGenerationDate})
+                ${args.codeGenerationDate}, ${args.unsubscriptionToken})
+        RETURNING *
+    `;
+
+    // When registering a new email address, the account_recovery subscription should be enabled by default
+    await this.sql`
+        INSERT INTO emails.account_subscriptions (account_id, subscription_id)
+        SELECT ae.id, s.id
+        FROM emails.subscriptions s
+                 CROSS JOIN emails.account_emails ae
+        WHERE s.key = 'account_recovery'
+          AND ae.id = ${email.id};
     `;
   }
 
@@ -180,12 +200,14 @@ export class EmailDataSource implements IEmailDataSource {
     account: string;
     code: string;
     codeGenerationDate: Date;
+    unsubscriptionToken: string;
   }): Promise<void> {
     const [email] = await this.sql<Email[]>`UPDATE emails.account_emails
                                             SET email_address                  = ${args.emailAddress.value},
                                                 verified                       = false,
                                                 verification_code              = ${args.code},
-                                                verification_code_generated_on = ${args.codeGenerationDate}
+                                                verification_code_generated_on = ${args.codeGenerationDate},
+                                                unsubscription_token           = ${args.unsubscriptionToken}
                                             WHERE chain_id = ${args.chainId}
                                               AND safe_address = ${args.safeAddress}
                                               AND account = ${args.account}
@@ -198,5 +220,88 @@ export class EmailDataSource implements IEmailDataSource {
         args.account,
       );
     }
+  }
+
+  async getSubscriptions(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+  }): Promise<DomainSubscription[]> {
+    const subscriptions = await this.sql`SELECT key, name
+                                         FROM emails.subscriptions
+                                                  INNER JOIN emails.account_subscriptions subs
+                                                             on subscriptions.id = subs.subscription_id
+                                                  INNER JOIN emails.account_emails emails on emails.id = subs.account_id
+                                         WHERE chain_id = ${args.chainId}
+                                           AND safe_address = ${args.safeAddress}
+                                           AND account = ${args.account}`;
+    return subscriptions.map(
+      (subscription) =>
+        <DomainSubscription>{
+          key: subscription.key,
+          name: subscription.name,
+        },
+    );
+  }
+
+  async subscribe(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+    categoryKey: string;
+  }): Promise<DomainSubscription[]> {
+    const subscriptions = await this
+      .sql`INSERT INTO emails.account_subscriptions (account_id, subscription_id)
+           SELECT ae.id AS account_id,
+                  s.id  AS subscription_id
+           FROM emails.account_emails ae
+                    CROSS JOIN emails.subscriptions s
+           WHERE ae.chain_id = ${args.chainId}
+             AND ae.safe_address = ${args.safeAddress}
+             AND ae.account = ${args.account}
+             AND s.key = ${args.categoryKey}
+           RETURNING *`;
+
+    return subscriptions.map(
+      (s) =>
+        <DomainSubscription>{
+          key: s.key,
+          name: s.name,
+        },
+    );
+  }
+
+  async unsubscribe(args: {
+    categoryKey: string;
+    token: string;
+  }): Promise<DomainSubscription[]> {
+    const subscriptions = await this.sql<Subscription[]>`DELETE
+                                                         FROM emails.account_subscriptions
+                                                             USING emails.account_emails, emails.subscriptions
+                                                         WHERE emails.subscriptions.key = ${args.categoryKey}
+                                                           AND emails.account_emails.unsubscription_token = ${args.token}
+                                                         RETURNING *`;
+    return subscriptions.map(
+      (s) =>
+        <DomainSubscription>{
+          key: s.key,
+          name: s.name,
+        },
+    );
+  }
+
+  async unsubscribeAll(args: { token: string }): Promise<DomainSubscription[]> {
+    const subscriptions = await this.sql`DELETE
+                                         FROM emails.account_subscriptions
+                                             USING emails.account_emails
+                                         WHERE emails.account_emails.unsubscription_token = ${args.token}`;
+
+    return subscriptions.map(
+      (s) =>
+        <DomainSubscription>{
+          key: s.key,
+          name: s.name,
+        },
+    );
   }
 }

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -10,6 +10,7 @@ import { EmailAlreadyVerifiedError } from '@/domain/email/errors/email-already-v
 import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-verification-code.error';
 import { EmailEditMatchesError } from '@/domain/email/errors/email-edit-matches.error';
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
+import * as crypto from 'crypto';
 import { EditTimespanError } from '@/domain/email/errors/email-timespan.error';
 
 @Injectable()
@@ -59,6 +60,7 @@ export class EmailRepository implements IEmailRepository {
         safeAddress: args.safeAddress,
         account: args.account,
         codeGenerationDate: new Date(),
+        unsubscriptionToken: crypto.randomUUID(),
       });
       await this._sendEmailVerification({
         ...args,
@@ -200,6 +202,7 @@ export class EmailRepository implements IEmailRepository {
       safeAddress: args.safeAddress,
       account: args.account,
       codeGenerationDate: new Date(),
+      unsubscriptionToken: crypto.randomUUID(),
     });
     await this._sendEmailVerification({
       ...args,

--- a/src/domain/email/entities/subscription.entity.ts
+++ b/src/domain/email/entities/subscription.entity.ts
@@ -1,0 +1,4 @@
+export interface Subscription {
+  key: string;
+  name: string;
+}

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -1,4 +1,5 @@
 import { Email, EmailAddress } from '@/domain/email/entities/email.entity';
+import { Subscription } from '@/domain/email/entities/subscription.entity';
 
 export const IEmailDataSource = Symbol('IEmailDataSource');
 
@@ -44,6 +45,7 @@ export interface IEmailDataSource {
     account: string;
     code: string;
     codeGenerationDate: Date;
+    unsubscriptionToken: string;
   }): Promise<void>;
 
   /**
@@ -123,5 +125,63 @@ export interface IEmailDataSource {
     account: string;
     code: string;
     codeGenerationDate: Date;
+    unsubscriptionToken: string;
   }): Promise<void>;
+
+  /**
+   * Gets all the subscriptions for the account on chainId, with the specified safeAddress
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which the email address is linked to
+   * @param args.account - the owner address to which we the email address is linked to
+   */
+  getSubscriptions(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+  }): Promise<Subscription[]>;
+
+  /**
+   * Subscribes the account on chainId, with the safeAddress to a category
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address to which the email address is linked to
+   * @param args.account - the owner address to which we the email address is linked to
+   * @param args.categoryKey - the category key to subscribe to
+   *
+   * @returns The Subscriptions that were successfully subscribed to
+   */
+  subscribe(args: {
+    chainId: string;
+    safeAddress: string;
+    account: string;
+    categoryKey: string;
+  }): Promise<Subscription[]>;
+
+  /**
+   * Unsubscribes from the notification category with the provided category key.
+   *
+   * If the category key or the token are incorrect, no subscriptions are returned from this call.
+   *
+   * @param args.categoryKey - the category key to unsubscribe
+   * @param args.token - the unsubscription token (tied to a single account)
+   *
+   * @returns The Subscriptions that were successfully unsubscribed.
+   */
+  unsubscribe(args: {
+    categoryKey: string;
+    token: string;
+  }): Promise<Subscription[]>;
+
+  /**
+   * Unsubscribes from all notification categories.
+   *
+   * If the category key or the token are incorrect, no subscriptions are returned from this call.
+   *
+   * @param args.categoryKey - the category key to unsubscribe
+   * @param args.token - the unsubscription token (tied to a single account)
+   *
+   * @returns The Subscriptions that were successfully unsubscribed.
+   */
+  unsubscribeAll(args: { token: string }): Promise<Subscription[]>;
 }

--- a/src/domain/interfaces/email.datasource.interface.ts
+++ b/src/domain/interfaces/email.datasource.interface.ts
@@ -133,7 +133,7 @@ export interface IEmailDataSource {
    *
    * @param args.chainId - the chain id of where the Safe is deployed
    * @param args.safeAddress - the Safe address to which the email address is linked to
-   * @param args.account - the owner address to which we the email address is linked to
+   * @param args.account - the owner address to which the email address is linked to
    */
   getSubscriptions(args: {
     chainId: string;
@@ -146,7 +146,7 @@ export interface IEmailDataSource {
    *
    * @param args.chainId - the chain id of where the Safe is deployed
    * @param args.safeAddress - the Safe address to which the email address is linked to
-   * @param args.account - the owner address to which we the email address is linked to
+   * @param args.account - the owner address to which we email address is linked to
    * @param args.categoryKey - the category key to subscribe to
    *
    * @returns The Subscriptions that were successfully subscribed to


### PR DESCRIPTION
Adds two new tables: `subscriptions` and `account_subscriptions`.

The `subscriptions` table holds a collection of subscription types:

|         id         |         key          |     name      |
|:------------------:|:--------------------:|:-------------:|
| SERIAL PRIMARY KEY | TEXT NOT NULL UNIQUE | TEXT NOT NULL |

The `key` should be used to reference the category in a human-readable format. The `name` should be used for rendering purposes.

A default entry is added with `migrations/000001_initial`: `key='account_recovery' name='Account Recovery'`. (Note: migration was edited directly because there's no deployment yet).

The `account_subscriptions` table holds the data on the account subscriptions which are active (i.e., if there is a row, then there is a subscription).

| account_id | subscription_id |
|:----------:|:---------------:|
| FOREIGN KEY (emails.account_emails) | FOREIGN KEY (emails.subscriptions) |

---
The following functionality was added to `IEmailDataSource`:
- `getSubscriptions` – Gets all the subscriptions for the account on chain id, with the specified Safe address.
- `subscribe` – Subscribes the account on chain id, with the Safe address to a category.
- `unsubscribe` – Unsubscribes from the notification category with the provided category key.
- `unsubscribeAll` – Unsubscribes from all notification categories.