### PR TITLE
Exclude first pattern when testing `deleteByKeyPattern`

### DIFF
--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -143,7 +143,7 @@ describe('RedisCacheService', () => {
       `${pattern}${faker.string.alphanumeric()}`,
       `${pattern}${faker.string.alphanumeric()}`,
     ];
-    const anotherPattern = faker.string.alphanumeric();
+    const anotherPattern = faker.string.alphanumeric({ exclude: pattern });
     const value = fakeJson();
     await redisClient.hSet(anotherPattern, '', value);
     for (const key of matches) {


### PR DESCRIPTION
When testing `deleteByKeyPattern`, we set two patterned-keys. The test was brittle as the two test patterns could match and therefore make the test fail. This makes sure that the two test patterns are never the same.