### PR TITLE
Add email subscription cancellation routes

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { RootModule } from '@/routes/root/root.module';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { AlertsControllerModule } from '@/routes/alerts/alerts.controller.module';
 import { RecoveryModule } from '@/routes/recovery/recovery.module';
+import { SubscriptionControllerModule } from '@/routes/subscriptions/subscription.module';
 
 @Module({})
 export class AppModule implements NestModule {
@@ -62,7 +63,12 @@ export class AppModule implements NestModule {
         DataDecodedModule,
         DelegatesModule,
         ...(isEmailFeatureEnabled
-          ? [AlertsControllerModule, EmailControllerModule, RecoveryModule]
+          ? [
+              AlertsControllerModule,
+              EmailControllerModule,
+              RecoveryModule,
+              SubscriptionControllerModule,
+            ]
           : []),
         EstimationsModule,
         HealthModule,

--- a/src/datasources/account/__tests__/test.account.datasource.module.ts
+++ b/src/datasources/account/__tests__/test.account.datasource.module.ts
@@ -10,6 +10,10 @@ const accountDataSource = {
   verifyEmail: jest.fn(),
   deleteAccount: jest.fn(),
   updateAccountEmail: jest.fn(),
+  getSubscriptions: jest.fn(),
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn(),
+  unsubscribeAll: jest.fn(),
 } as jest.MockedObjectDeep<IAccountDataSource>;
 
 @Module({

--- a/src/domain/account/account.domain.module.ts
+++ b/src/domain/account/account.domain.module.ts
@@ -3,10 +3,18 @@ import { AccountDataSourceModule } from '@/datasources/account/account.datasourc
 import { IAccountRepository } from '@/domain/account/account.repository.interface';
 import { AccountRepository } from '@/domain/account/account-repository.service';
 import { EmailApiModule } from '@/datasources/email-api/email-api.module';
+import { ISubscriptionRepository } from '@/domain/subscriptions/subscription.repository.interface';
+import { SubscriptionRepository } from '@/domain/subscriptions/subscription.repository';
 
 @Module({
   imports: [AccountDataSourceModule, EmailApiModule],
-  providers: [{ provide: IAccountRepository, useClass: AccountRepository }],
+  providers: [
+    { provide: IAccountRepository, useClass: AccountRepository },
+    {
+      provide: ISubscriptionRepository,
+      useClass: SubscriptionRepository,
+    },
+  ],
   exports: [IAccountRepository],
 })
 export class AccountDomainModule {}

--- a/src/domain/subscriptions/subscription.domain.module.ts
+++ b/src/domain/subscriptions/subscription.domain.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { EmailApiModule } from '@/datasources/email-api/email-api.module';
+import { ISubscriptionRepository } from '@/domain/subscriptions/subscription.repository.interface';
+import { SubscriptionRepository } from '@/domain/subscriptions/subscription.repository';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+
+@Module({
+  imports: [AccountDataSourceModule, EmailApiModule],
+  providers: [
+    { provide: ISubscriptionRepository, useClass: SubscriptionRepository },
+  ],
+  exports: [ISubscriptionRepository],
+})
+export class SubscriptionDomainModule {}

--- a/src/domain/subscriptions/subscription.repository.interface.ts
+++ b/src/domain/subscriptions/subscription.repository.interface.ts
@@ -1,0 +1,19 @@
+import { Subscription } from '@/domain/account/entities/subscription.entity';
+
+export const ISubscriptionRepository = Symbol('ISubscriptionRepository');
+
+export interface ISubscriptionRepository {
+  subscribe(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+    notificationTypeKey: string;
+  }): Promise<Subscription[]>;
+
+  unsubscribe(args: {
+    notificationTypeKey: string;
+    token: string;
+  }): Promise<Subscription[]>;
+
+  unsubscribeAll(args: { token: string }): Promise<Subscription[]>;
+}

--- a/src/domain/subscriptions/subscription.repository.ts
+++ b/src/domain/subscriptions/subscription.repository.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
+import { ISubscriptionRepository } from '@/domain/subscriptions/subscription.repository.interface';
+import { Subscription } from '@/domain/account/entities/subscription.entity';
+
+@Injectable()
+export class SubscriptionRepository implements ISubscriptionRepository {
+  public static CATEGORY_ACCOUNT_RECOVERY = 'account_recovery';
+
+  constructor(
+    @Inject(IAccountDataSource)
+    private readonly accountDataSource: IAccountDataSource,
+  ) {}
+
+  subscribe(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+    notificationTypeKey: string;
+  }): Promise<Subscription[]> {
+    return this.accountDataSource.subscribe(args);
+  }
+
+  unsubscribe(args: {
+    notificationTypeKey: string;
+    token: string;
+  }): Promise<Subscription[]> {
+    return this.accountDataSource.unsubscribe(args);
+  }
+
+  unsubscribeAll(args: { token: string }): Promise<Subscription[]> {
+    return this.accountDataSource.unsubscribeAll(args);
+  }
+}

--- a/src/routes/email/email.controller.save-email.spec.ts
+++ b/src/routes/email/email.controller.save-email.spec.ts
@@ -99,6 +99,12 @@ describe('Email controller save email tests', () => {
       }
     });
     accountDataSource.createAccount.mockResolvedValue();
+    accountDataSource.subscribe.mockResolvedValue([
+      {
+        key: faker.word.sample(),
+        name: faker.word.words(2),
+      },
+    ]);
 
     await request(app.getHttpServer())
       .post(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
@@ -119,6 +125,12 @@ describe('Email controller save email tests', () => {
         'email.templates.verificationCode',
       ),
       to: [emailAddress],
+    });
+    expect(accountDataSource.subscribe).toHaveBeenCalledWith({
+      chainId: chain.chainId,
+      safeAddress: safe.address,
+      signer: signerAddress,
+      notificationTypeKey: 'account_recovery',
     });
   });
 

--- a/src/routes/subscriptions/subscription.controller.spec.ts
+++ b/src/routes/subscriptions/subscription.controller.spec.ts
@@ -52,7 +52,7 @@ describe('Subscription Controller tests', () => {
     await app.close();
   });
 
-  it('deletes category successfully', async () => {
+  it('unsubscribes from a category successfully', async () => {
     const subscriptionKey = faker.word.sample();
     const subscriptionName = faker.word.sample(2);
     const token = faker.string.uuid();

--- a/src/routes/subscriptions/subscription.controller.spec.ts
+++ b/src/routes/subscriptions/subscription.controller.spec.ts
@@ -1,0 +1,168 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { EmailControllerModule } from '@/routes/email/email.controller.module';
+import { EmailApiModule } from '@/datasources/email-api/email-api.module';
+import { TestEmailApiModule } from '@/datasources/email-api/__tests__/test.email-api.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { Subscription } from '@/domain/account/entities/subscription.entity';
+import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
+import { INestApplication } from '@nestjs/common';
+
+describe('Subscription Controller tests', () => {
+  let app: INestApplication;
+  let accountDataSource: jest.MockedObjectDeep<IAccountDataSource>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration), EmailControllerModule],
+    })
+      .overrideModule(EmailApiModule)
+      .useModule(TestEmailApiModule)
+      .overrideModule(AccountDataSourceModule)
+      .useModule(TestAccountDataSourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    accountDataSource = moduleFixture.get(IAccountDataSource);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('deletes category successfully', async () => {
+    const subscriptionKey = faker.word.sample();
+    const subscriptionName = faker.word.sample(2);
+    const token = faker.string.uuid();
+    const subscriptions = [
+      {
+        key: subscriptionKey,
+        name: subscriptionName,
+      },
+    ] as Subscription[];
+    accountDataSource.unsubscribe.mockResolvedValueOnce(subscriptions);
+
+    await request(app.getHttpServer())
+      .delete(`/v1/subscriptions/?category=${subscriptionKey}&token=${token}`)
+      .expect(200)
+      .expect({});
+
+    expect(accountDataSource.unsubscribe).toHaveBeenCalledWith({
+      notificationTypeKey: subscriptionKey,
+      token: token,
+    });
+    expect(accountDataSource.unsubscribeAll).toHaveBeenCalledTimes(0);
+  });
+
+  it('validates uuid format when deleting category', async () => {
+    const subscriptionKey = faker.word.sample();
+    const token = faker.string.hexadecimal();
+
+    await request(app.getHttpServer())
+      .delete(`/v1/subscriptions/?category=${subscriptionKey}&token=${token}`)
+      .expect(400)
+      .expect({
+        message: 'Validation failed (uuid is expected)',
+        error: 'Bad Request',
+        statusCode: 400,
+      });
+
+    expect(accountDataSource.unsubscribe).toHaveBeenCalledTimes(0);
+    expect(accountDataSource.unsubscribeAll).toHaveBeenCalledTimes(0);
+  });
+
+  it('deleting category is not successful', async () => {
+    const subscriptionKey = faker.word.sample();
+    const token = faker.string.uuid();
+    accountDataSource.unsubscribe.mockRejectedValueOnce(
+      new Error('some error'),
+    );
+
+    await request(app.getHttpServer())
+      .delete(`/v1/subscriptions/?category=${subscriptionKey}&token=${token}`)
+      .expect(500)
+      .expect({ code: 500, message: 'Internal server error' });
+  });
+
+  it('deletes all categories successfully', async () => {
+    const subscriptionKey = faker.word.sample();
+    const subscriptionName = faker.word.sample(2);
+    const token = faker.string.uuid();
+    const subscriptions = [
+      {
+        key: subscriptionKey,
+        name: subscriptionName,
+      },
+    ] as Subscription[];
+    accountDataSource.unsubscribeAll.mockResolvedValueOnce(subscriptions);
+
+    await request(app.getHttpServer())
+      .delete(`/v1/subscriptions/all?token=${token}`)
+      .expect(200)
+      .expect({});
+
+    expect(accountDataSource.unsubscribeAll).toHaveBeenCalledWith({
+      token: token,
+    });
+    expect(accountDataSource.unsubscribe).toHaveBeenCalledTimes(0);
+  });
+
+  it('validates uuid format when deleting all categories', async () => {
+    const subscriptionKey = faker.word.sample();
+    const subscriptionName = faker.word.sample(2);
+    const token = faker.string.hexadecimal();
+    const subscriptions = [
+      {
+        key: subscriptionKey,
+        name: subscriptionName,
+      },
+    ] as Subscription[];
+    accountDataSource.unsubscribe.mockResolvedValueOnce(subscriptions);
+
+    await request(app.getHttpServer())
+      .delete(`/v1/subscriptions/all?token=${token}`)
+      .expect(400)
+      .expect({
+        message: 'Validation failed (uuid is expected)',
+        error: 'Bad Request',
+        statusCode: 400,
+      });
+
+    expect(accountDataSource.unsubscribe).toHaveBeenCalledTimes(0);
+    expect(accountDataSource.unsubscribeAll).toHaveBeenCalledTimes(0);
+  });
+
+  it('deleting all categories is not successful', async () => {
+    const token = faker.string.uuid();
+    accountDataSource.unsubscribeAll.mockRejectedValueOnce(
+      new Error('some error'),
+    );
+
+    await request(app.getHttpServer())
+      .delete(`/v1/subscriptions/all?token=${token}`)
+      .expect(500)
+      .expect({ code: 500, message: 'Internal server error' });
+  });
+});

--- a/src/routes/subscriptions/subscription.controller.ts
+++ b/src/routes/subscriptions/subscription.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Delete, ParseUUIDPipe, Query } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { SubscriptionService } from '@/routes/subscriptions/subscription.service';
+
+@Controller({
+  path: 'subscriptions',
+  version: '1',
+})
+@ApiExcludeController()
+export class SubscriptionController {
+  constructor(private readonly service: SubscriptionService) {}
+
+  @Delete()
+  async unsubscribe(
+    @Query('category') category: string,
+    @Query('token', new ParseUUIDPipe()) token: string,
+  ): Promise<void> {
+    return this.service.unsubscribe({ notificationTypeKey: category, token });
+  }
+
+  @Delete('all')
+  async unsubscribeAll(
+    @Query('token', new ParseUUIDPipe()) token: string,
+  ): Promise<void> {
+    return this.service.unsubscribeAll({ token });
+  }
+}

--- a/src/routes/subscriptions/subscription.module.ts
+++ b/src/routes/subscriptions/subscription.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SubscriptionDomainModule } from '@/domain/subscriptions/subscription.domain.module';
+import { SubscriptionService } from '@/routes/subscriptions/subscription.service';
+import { SubscriptionController } from '@/routes/subscriptions/subscription.controller';
+
+@Module({
+  imports: [SubscriptionDomainModule],
+  providers: [SubscriptionService],
+  controllers: [SubscriptionController],
+})
+export class SubscriptionControllerModule {}

--- a/src/routes/subscriptions/subscription.service.ts
+++ b/src/routes/subscriptions/subscription.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { SubscriptionRepository } from '@/domain/subscriptions/subscription.repository';
+import { ISubscriptionRepository } from '@/domain/subscriptions/subscription.repository.interface';
+
+@Injectable()
+export class SubscriptionService {
+  constructor(
+    @Inject(ISubscriptionRepository)
+    private readonly repository: SubscriptionRepository,
+  ) {}
+
+  async unsubscribe(args: {
+    notificationTypeKey: string;
+    token: string;
+  }): Promise<void> {
+    await this.repository.unsubscribe(args);
+  }
+
+  async unsubscribeAll(args: { token: string }): Promise<void> {
+    await this.repository.unsubscribeAll(args);
+  }
+}


### PR DESCRIPTION
- Adds `DELETE /v1/subscriptions?category=<string>&token=<string>`
  * This endpoint deletes the subscription of the given `category`, if a valid token is provided.
  * The token must be a UUID. A `400` is returned otherwise.
- Adds `DELETE /v1/subscriptions/all?token=<string>`
  * This endpoint deletes all subscriptions of an account with the associated `token`.
  * The token must be a UUID. A `400` is returned otherwise.
- Saving a new email with `EmailRepository` now subscribes to the Account Recovery category – this is a default subscription for all new accounts registered.

An indication of the token's existence is not returned to the client i.e. if an invalid token is provided the response is still successful. This was done while considering that the endpoint is unauthenticated and the link should be _private_ to the email owner. Therefore, no feedback is given regarding the validity of said token.