### PR TITLE
Remove type assertions

### DIFF
--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -56,7 +56,7 @@ export class EmailDataSource implements IEmailDataSource {
       );
     }
 
-    return <DomainEmail>{
+    return {
       chainId: email.chain_id.toString(),
       emailAddress: new EmailAddress(email.email_address),
       isVerified: email.verified,

--- a/src/datasources/network/axios.network.service.spec.ts
+++ b/src/datasources/network/axios.network.service.spec.ts
@@ -44,7 +44,7 @@ describe('AxiosNetworkService', () => {
 
     it(`get calls axios get with request`, async () => {
       const url = faker.internet.url({ appendSlash: false });
-      const request = <NetworkRequest>{
+      const request: NetworkRequest = {
         params: { some_query_param: 'query_param' },
       };
 
@@ -144,7 +144,7 @@ describe('AxiosNetworkService', () => {
     it(`post calls axios post with request`, async () => {
       const url = faker.internet.url({ appendSlash: false });
       const data = { [faker.word.sample()]: faker.string.alphanumeric() };
-      const request = <NetworkRequest>{
+      const request: NetworkRequest = {
         params: { some_query_param: 'query_param' },
       };
 

--- a/src/domain/alerts/__tests__/delay-modifier.encoder.ts
+++ b/src/domain/alerts/__tests__/delay-modifier.encoder.ts
@@ -35,7 +35,7 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
   static readonly EVENT_SIGNATURE =
     `event TransactionAdded(uint256 indexed queueNonce, bytes32 indexed txHash, ${TransactionAddedEventBuilder.NON_INDEXED_PARAMS})` as const;
 
-  encode() {
+  encode(): TransactionAddedEvent {
     const abi = parseAbi([TransactionAddedEventBuilder.EVENT_SIGNATURE]);
 
     const args = this.build();
@@ -52,9 +52,9 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
         queueNonce: args.queueNonce!,
         txHash: args.txHash!,
       },
-    });
+    }) as TransactionAddedEvent['topics'];
 
-    return <TransactionAddedEvent>{
+    return {
       data,
       topics,
     };

--- a/src/domain/balances/entities/balance.entity.ts
+++ b/src/domain/balances/entities/balance.entity.ts
@@ -1,9 +1,18 @@
 import { BalanceToken } from '@/domain/balances/entities/balance.token.entity';
 
-export interface Balance {
-  tokenAddress: string | null;
-  token: BalanceToken | null;
+interface NativeBalance {
+  tokenAddress: null;
+  token: null;
   balance: string;
+}
+
+interface Erc20Balance {
+  tokenAddress: string;
+  token: BalanceToken;
+  balance: string;
+}
+
+export type Balance = (NativeBalance | Erc20Balance) & {
   fiatBalance: string | null;
   fiatConversion: string | null;
-}
+};

--- a/src/domain/entities/schemas/page.schema.factory.ts
+++ b/src/domain/entities/schemas/page.schema.factory.ts
@@ -1,10 +1,10 @@
-import { Schema, SchemaObject } from 'ajv';
+import { SchemaObject } from 'ajv';
 
 export function buildPageSchema(
   keyRef: string,
   itemSchema: SchemaObject,
-): Schema {
-  return <SchemaObject>{
+): SchemaObject {
+  return {
     $id: keyRef,
     type: 'object',
     properties: {

--- a/src/domain/human-description/entities/human-description-template.entity.ts
+++ b/src/domain/human-description/entities/human-description-template.entity.ts
@@ -65,10 +65,11 @@ export class HumanDescriptionTemplate {
 
     for (const match of this.templateMatches) {
       if ('textToken' in match.groups && match.groups.textToken !== undefined) {
-        fragments.push(<TextFragment>{
+        const textFragment: TextFragment = {
           type: ValueType.Text,
           value: match.groups.textToken,
-        });
+        };
+        fragments.push(textFragment);
       } else if (
         'typeToken' in match.groups &&
         'paramIndex' in match.groups &&

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -40,7 +40,7 @@ export class BalancesService {
       .filter((b) => b.fiatBalance !== null)
       .reduce((acc, b) => acc + Number(b.fiatBalance), 0);
 
-    return <Balances>{
+    return {
       fiatTotal: getNumberString(fiatTotal),
       items: orderBy(balances, (b) => Number(b.fiatBalance), 'desc'),
     };

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -6,7 +6,6 @@ import { NativeCurrency } from '@/domain/chains/entities/native.currency.entity'
 import { Balance } from '@/routes/balances/entities/balance.entity';
 import { Balances } from '@/routes/balances/entities/balances.entity';
 import { TokenType } from '@/routes/balances/entities/token-type.entity';
-import { Token } from '@/routes/balances/entities/token.entity';
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { orderBy } from 'lodash';
 import { IPricesRepository } from '@/domain/prices/prices.repository.interface';
@@ -55,7 +54,7 @@ export class BalancesService {
       tokenAddress === null ? TokenType.NativeToken : TokenType.Erc20;
 
     const tokenMetaData =
-      tokenType === TokenType.NativeToken
+      tokenAddress === null
         ? {
             decimals: nativeCurrency.decimals,
             symbol: nativeCurrency.symbol,
@@ -63,14 +62,14 @@ export class BalancesService {
             logoUri: nativeCurrency.logoUri,
           }
         : {
-            decimals: balance.token?.decimals,
-            symbol: balance.token?.symbol,
-            name: balance.token?.name,
-            logoUri: balance.token?.logoUri,
+            decimals: balance.token.decimals,
+            symbol: balance.token.symbol,
+            name: balance.token.name,
+            logoUri: balance.token.logoUri,
           };
 
-    return <Balance>{
-      tokenInfo: <Token>{
+    return {
+      tokenInfo: {
         type: tokenType,
         address: tokenAddress ?? NULL_ADDRESS,
         ...tokenMetaData,

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -140,9 +140,9 @@ describe('Chains Controller (Unit)', () => {
     });
 
     it('Failure: network service fails', async () => {
-      networkService.get.mockRejectedValueOnce(<NetworkResponseError>{
+      networkService.get.mockRejectedValueOnce({
         status: 500,
-      });
+      } as NetworkResponseError);
 
       await request(app.getHttpServer()).get('/v1/chains').expect(500).expect({
         message: 'An error occurred',
@@ -326,14 +326,14 @@ describe('Chains Controller (Unit)', () => {
         data: domainMasterCopiesResponse,
       });
       const masterCopiesResponse = [
-        <MasterCopy>{
+        {
           address: domainMasterCopiesResponse[0].address,
           version: domainMasterCopiesResponse[0].version,
-        },
-        <MasterCopy>{
+        } as MasterCopy,
+        {
           address: domainMasterCopiesResponse[1].address,
           version: domainMasterCopiesResponse[1].version,
-        },
+        } as MasterCopy,
       ];
 
       await request(app.getHttpServer())

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -3,7 +3,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { IBackboneRepository } from '@/domain/backbone/backbone.repository.interface';
 import { Backbone } from '@/domain/backbone/entities/backbone.entity';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
-import { MasterCopy } from '@/domain/chains/entities/master-copies.entity';
+import { MasterCopy } from '@/routes/chains/entities/master-copy.entity';
 import { Page } from '@/domain/entities/page.entity';
 import { AboutChain } from '@/routes/chains/entities/about-chain.entity';
 import { Chain } from '@/routes/chains/entities/chain.entity';
@@ -105,16 +105,9 @@ export class ChainsService {
   async getMasterCopies(chainId: string): Promise<MasterCopy[]> {
     const result = await this.chainsRepository.getMasterCopies(chainId);
 
-    const masterCopies = Promise.all(
-      result.map(
-        async (masterCopy) =>
-          <MasterCopy>{
-            address: masterCopy.address,
-            version: masterCopy.version,
-          },
-      ),
-    );
-
-    return masterCopies;
+    return result.map((masterCopy) => ({
+      address: masterCopy.address,
+      version: masterCopy.version,
+    }));
   }
 }

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -57,7 +57,7 @@ export class ChainsService {
         ),
     );
 
-    return <Page<Chain>>{
+    return {
       count: result.count,
       next: nextURL?.toString() ?? null,
       previous: previousURL?.toString() ?? null,

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -37,7 +37,7 @@ export class CollectiblesService {
       collectibles.previous,
     );
 
-    return <Page<Collectible>>{
+    return {
       count: collectibles.count,
       next: nextURL?.toString() ?? null,
       previous: previousURL?.toString() ?? null,

--- a/src/routes/delegates/delegates.service.ts
+++ b/src/routes/delegates/delegates.service.ts
@@ -40,7 +40,7 @@ export class DelegatesService {
       delegates.previous,
     );
 
-    return <Page<Delegate>>{
+    return {
       count: delegates.count,
       next: nextURL?.toString() ?? null,
       previous: previousURL?.toString() ?? null,

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -76,7 +76,7 @@ export class MessagesService {
       }),
     );
 
-    return <Page<DateLabel | MessageItem>>{
+    return {
       count: page.count,
       next: nextURL?.toString() ?? null,
       previous: previousURL?.toString() ?? null,

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -44,17 +44,17 @@ export class SafeAppsService {
   ): SafeAppAccessControl {
     switch (domainSafeApp.accessControl.type) {
       case SafeAppAccessControlPolicies.NoRestrictions:
-        return <SafeAppAccessControl>{
+        return {
           type: SafeAppAccessControlPolicies.NoRestrictions,
           value: domainSafeApp.accessControl.value,
         };
       case SafeAppAccessControlPolicies.DomainAllowlist:
-        return <SafeAppAccessControl>{
+        return {
           type: SafeAppAccessControlPolicies.DomainAllowlist,
           value: domainSafeApp.accessControl.value,
         };
       default:
-        return <SafeAppAccessControl>{
+        return {
           type: SafeAppAccessControlPolicies.Unknown,
           value: domainSafeApp.accessControl.value,
         };

--- a/src/routes/transactions/mappers/common/data-decoded-param.helper.spec.ts
+++ b/src/routes/transactions/mappers/common/data-decoded-param.helper.spec.ts
@@ -10,7 +10,7 @@ describe('DataDecoded param helper (Unit)', () => {
 
   describe('getFromParam', () => {
     it('should return the fallback value if null parameters in DataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: null,
       };
@@ -21,7 +21,7 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if empty parameters in DataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [],
       };
@@ -32,12 +32,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if non-string parameters in DataDecoded', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 0,
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam],
       };
@@ -48,12 +48,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "from" param for a transfer method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'value',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transfer',
         parameters: [firstParam],
       };
@@ -64,12 +64,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "from" param for a transferFrom method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'value',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam],
       };
@@ -80,12 +80,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "from" param for a safeTransferFrom method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'value',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'safeTransferFrom',
         parameters: [firstParam],
       };
@@ -96,12 +96,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if method is not "transferFrom"', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'value',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [firstParam],
       };
@@ -114,7 +114,7 @@ describe('DataDecoded param helper (Unit)', () => {
 
   describe('getToParam', () => {
     it('should return the fallback value if null parameters in DataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: null,
       };
@@ -125,7 +125,7 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if empty parameters in DataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [],
       };
@@ -136,12 +136,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if non-string parameters in DataDecoded', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 0,
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam],
       };
@@ -152,18 +152,18 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "to" param for a transfer method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = <DataDecodedParameter>{
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'secondValue',
       };
 
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transfer',
         parameters: [firstParam, secondParam],
       };
@@ -174,15 +174,16 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded fallback for a non-string param', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: faker.number.int(),
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded = {
         method: 'transfer',
         parameters: [firstParam, [firstParam]],
-      };
+        // We cast as it is invalid DataDecoded
+      } as DataDecoded;
 
       const fromParam = helper.getToParam(dataDecoded, 'fallback');
 
@@ -190,18 +191,18 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "to" param for a transferFrom method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = <DataDecodedParameter>{
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'secondValue',
       };
 
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam, secondParam],
       };
@@ -212,17 +213,17 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "to" param for a safeTransferFrom method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = <DataDecodedParameter>{
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'secondValue',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam, secondParam],
       };
@@ -233,12 +234,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if method is not "transferFrom"', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'value',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [firstParam],
       };
@@ -251,7 +252,7 @@ describe('DataDecoded param helper (Unit)', () => {
 
   describe('getValueParam', () => {
     it('should return the fallback value if null parameters in DataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: null,
       };
@@ -262,7 +263,7 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if empty parameters in DataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [],
       };
@@ -273,12 +274,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if non-string parameters in DataDecoded', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: faker.number.int(),
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam],
       };
@@ -289,18 +290,18 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "value" param for a transfer method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = <DataDecodedParameter>{
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'secondValue',
       };
 
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transfer',
         parameters: [firstParam, secondParam],
       };
@@ -311,18 +312,18 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded fallback for a non-string param', () => {
-      const firstParam = {
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = {
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: faker.number.int(),
       };
 
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transfer',
         parameters: [firstParam, secondParam],
       };
@@ -333,22 +334,22 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "value" param for a transferFrom method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = <DataDecodedParameter>{
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'secondValue',
       };
-      const thirdParam = <DataDecodedParameter>{
+      const thirdParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'thirdValue',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam, secondParam, thirdParam],
       };
@@ -359,22 +360,22 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should get the DataDecoded "value" param for a safeTransferFrom method', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'firstValue',
       };
-      const secondParam = <DataDecodedParameter>{
+      const secondParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'secondValue',
       };
-      const thirdParam = <DataDecodedParameter>{
+      const thirdParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'thirdValue',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: 'transferFrom',
         parameters: [firstParam, secondParam, thirdParam],
       };
@@ -385,12 +386,12 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return the fallback value if method is not "transferFrom"', () => {
-      const firstParam = <DataDecodedParameter>{
+      const firstParam: DataDecodedParameter = {
         name: faker.word.sample(),
         type: faker.word.sample(),
         value: 'value',
       };
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [firstParam],
       };
@@ -403,7 +404,7 @@ describe('DataDecoded param helper (Unit)', () => {
 
   describe('hasNestedDelegate', () => {
     it('should return false if the nested data decoded only contains a CALL operation', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [
           {
@@ -439,7 +440,7 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return false if the nested data decoded only contains several CALL operations', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [
           {
@@ -494,15 +495,16 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return false if the nested data decoded does not have parameters', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded = {
         method: faker.word.sample(),
-      };
+        // We cast as it is invalid DataDecoded
+      } as DataDecoded;
 
       expect(helper.hasNestedDelegate(dataDecoded)).toBe(false);
     });
 
     it('should return true if there is one nested DELEGATE operation', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [
           {
@@ -538,7 +540,7 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return true if there is just one nested DELEGATE operation', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [
           {
@@ -593,7 +595,7 @@ describe('DataDecoded param helper (Unit)', () => {
     });
 
     it('should return true if there is one nested DELEGATE operation with no inner dataDecoded', () => {
-      const dataDecoded = <DataDecoded>{
+      const dataDecoded: DataDecoded = {
         method: faker.word.sample(),
         parameters: [
           {

--- a/src/routes/transactions/mappers/common/human-description.mapper.ts
+++ b/src/routes/transactions/mappers/common/human-description.mapper.ts
@@ -157,10 +157,11 @@ export class HumanDescriptionMapper {
       : null;
 
     if (safeAppInfo) {
-      fragments.push(<RichTextFragment>{
+      const fragment: RichTextFragment = {
         type: RichFragmentType.Text,
         value: `via ${safeAppInfo.name}`,
-      });
+      };
+      fragments.push(fragment);
     }
 
     return fragments;

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -123,11 +123,10 @@ export class QueuedItemsMapper {
     transactions: MultisigTransaction[],
   ): TransactionGroup[] {
     return Object.entries(groupBy(transactions, 'nonce')).map(
-      ([nonce, transactions]) =>
-        <TransactionGroup>{
-          nonce: Number(nonce),
-          transactions: transactions,
-        },
+      ([nonce, transactions]): TransactionGroup => ({
+        nonce: Number(nonce),
+        transactions: transactions,
+      }),
     );
   }
 }

--- a/src/routes/transactions/mappers/transaction-preview.mapper.ts
+++ b/src/routes/transactions/mappers/transaction-preview.mapper.ts
@@ -42,14 +42,15 @@ export class TransactionPreviewMapper {
     }
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
       chainId,
-      <MultisigTransaction>{
+      {
         safe: safe.address,
         to: previewTransactionDto.to,
         value: previewTransactionDto.value,
         dataDecoded,
         data: previewTransactionDto.data,
         operation: previewTransactionDto.operation,
-      },
+        // Keep type safety as only the above are available in previewTransactionDto
+      } as MultisigTransaction,
     );
     const txData = await this.transactionDataMapper.mapTransactionData(
       chainId,

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -160,11 +160,11 @@ export class TransactionsHistoryMapper {
           timezoneOffset,
         ).getTime();
       }),
-    ).map(([, transactions]) => {
+    ).map(([, transactions]): TransactionDomainGroup => {
       // The groups respect the timezone offset – this was done for grouping only.
       // The actual value of the group should be in the UTC timezone instead
       // A group should always have at least one transaction.
-      return <TransactionDomainGroup>{
+      return {
         timestamp: this.getTransactionTimestamp(transactions[0]).getTime(),
         transactions: transactions,
       };


### PR DESCRIPTION
This removes type assertions in favour of reliance on return types or variable type definitions. Type assertions "force" a value to be correct and can therefore mean that an incorrect value is valid.

Pleast note: there are two remaining assertions but their removal causes errors. They are fixed in #1040 and #1043.