### PR TITLE
Install devDependencies on build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,17 @@
 #
 FROM node:20.10.0 as base
 ENV NODE_ENV production
+ENV YARN_CACHE_FOLDER /root/.yarn
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
 COPY --chown=node:node .yarn/patches ./.yarn/patches
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
-RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn workspaces focus --production
+RUN --mount=type=cache,target=/root/.yarn yarn
 COPY --chown=node:node assets ./assets
 COPY --chown=node:node src ./src
-RUN yarn run build
+RUN --mount=type=cache,target=/root/.yarn yarn run build \
+    && rm -rf ./node_modules \
+    && yarn workspaces focus --production
 
 #
 # PRODUCTION CONTAINER


### PR DESCRIPTION
**Context**
Before this PR, `devDependencies` were not installed during the first build phase specified on `Dockerfile`. This was blocking us from moving packages needed on the build phase only to `devDependencies` (e.g.: some `@types/...` packages). 

This PR addresses that, by installing all the project dependencies on the build phase container.

Only production dependencies are copied to the production container (this was unchanged).

**Changes:**
- `YARN_CACHE_FOLDER` was extracted to a common `ENV` as it would be used twice.
- The Dockerfile invokes `yarn` two times: the first one installs all the dependencies, and the second one just the production dependencies. A cleaning of `node_modules` is performed between the invocations.