### PR TITLE
Remove assertions from token type mapping

### DIFF
--- a/src/domain/human-description/entities/human-description-template.entity.ts
+++ b/src/domain/human-description/entities/human-description-template.entity.ts
@@ -1,10 +1,7 @@
-import { decodeFunctionData, parseAbi } from 'viem';
+import { decodeFunctionData, isHex, parseAbi } from 'viem';
 import {
-  AddressFragment,
   HumanDescriptionFragment,
-  NumberFragment,
   TextFragment,
-  TokenValueFragment,
   ValueType,
 } from '@/domain/human-description/entities/human-description.entity';
 
@@ -101,24 +98,48 @@ export class HumanDescriptionTemplate {
     index: number,
     args: readonly unknown[],
   ): HumanDescriptionFragment {
+    const value = args[index];
+
     switch (tokenType) {
-      case ValueType.TokenValue:
-        return <TokenValueFragment>{
+      case ValueType.TokenValue: {
+        if (typeof value !== 'bigint') {
+          throw Error(
+            `Invalid token type amount. tokenType=${tokenType}, amount=${value}`,
+          );
+        }
+
+        return {
           type: ValueType.TokenValue,
-          value: { amount: args[index], address: to },
+          value: { amount: value, address: to },
         };
-      case ValueType.Address:
-        return <AddressFragment>{
+      }
+      case ValueType.Address: {
+        if (!isHex(value)) {
+          throw Error(
+            `Invalid token type value. tokenType=${tokenType}, address=${value}`,
+          );
+        }
+
+        return {
           type: ValueType.Address,
-          value: args[index],
+          value,
         };
-      case ValueType.Number:
-        return <NumberFragment>{
+      }
+      case ValueType.Number: {
+        if (typeof value !== 'bigint') {
+          throw Error(
+            `Invalid token type value. tokenType=${tokenType}, address=${value}`,
+          );
+        }
+
+        return {
           type: ValueType.Number,
-          value: args[index],
+          value,
         };
-      default:
+      }
+      default: {
         throw Error(`Unknown token type ${tokenType}`);
+      }
     }
   }
 }


### PR DESCRIPTION
This removes the assertions from human readable token type types. As the types are no longer asserted, associated error handling for invalid types had to be added as well.