### PR TITLE
Add linting to enforce return types and assertion consistency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,9 +15,13 @@ module.exports = {
   ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/consistent-type-assertions': [
+      'warn',
+      { assertionStyle: 'as' },
+    ],
   },
 };

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -114,7 +114,7 @@ export class AppModule implements NestModule {
     };
   }
 
-  configure(consumer: MiddlewareConsumer) {
+  configure(consumer: MiddlewareConsumer): void {
     consumer
       // The ClsMiddleware needs to be applied before the LoggerMiddleware
       // in order to generate the request ids that will be logged afterward

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -4,17 +4,17 @@ import { NestFactory } from '@nestjs/core';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { json } from 'express';
 
-function configureVersioning(app: INestApplication) {
+function configureVersioning(app: INestApplication): void {
   app.enableVersioning({
     type: VersioningType.URI,
   });
 }
 
-export function configureShutdownHooks(app: INestApplication) {
+export function configureShutdownHooks(app: INestApplication): void {
   app.enableShutdownHooks();
 }
 
-function configureSwagger(app: INestApplication) {
+function configureSwagger(app: INestApplication): void {
   const configurationService = app.get<IConfigurationService>(
     IConfigurationService,
   );
@@ -32,7 +32,7 @@ function configureSwagger(app: INestApplication) {
   });
 }
 
-function configureRequestBodyLimit(app: INestApplication) {
+function configureRequestBodyLimit(app: INestApplication): void {
   const configurationService = app.get<IConfigurationService>(
     IConfigurationService,
   );

--- a/src/config/__tests__/fake.configuration.service.spec.ts
+++ b/src/config/__tests__/fake.configuration.service.spec.ts
@@ -27,7 +27,7 @@ describe('FakeConfigurationService', () => {
   it(`Retrieving unknown key should throw`, async () => {
     configurationService.set('aaa', 'bbb');
 
-    const result = () => {
+    const result = (): void => {
       configurationService.getOrThrow('unknown_key');
     };
 

--- a/src/config/__tests__/fake.configuration.service.ts
+++ b/src/config/__tests__/fake.configuration.service.ts
@@ -3,7 +3,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 export class FakeConfigurationService implements IConfigurationService {
   private configuration: Record<string, any> = {};
 
-  set(key: string, value: any) {
+  set(key: string, value: any): void {
     this.configuration[key] = value;
   }
 

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -1,3 +1,5 @@
+// Custom configuration for the application
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default () => ({
   about: {
     name: 'safe-client-gateway',

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -9,7 +9,7 @@ export class FakeCacheService implements ICacheService {
     return this.isReady ? Promise.resolve() : Promise.reject();
   }
 
-  setReadyState(isReady: boolean) {
+  setReadyState(isReady: boolean): void {
     this.isReady = isReady;
   }
 
@@ -17,7 +17,7 @@ export class FakeCacheService implements ICacheService {
     return Object.keys(this.cache).length;
   }
 
-  clear() {
+  clear(): void {
     this.cache = {};
   }
 

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -98,7 +98,10 @@ export class CacheRouter {
     );
   }
 
-  static getCollectiblesKey(args: { chainId: string; safeAddress: string }) {
+  static getCollectiblesKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
     return `${args.chainId}_${CacheRouter.COLLECTIBLES_KEY}_${args.safeAddress}`;
   }
 
@@ -141,7 +144,10 @@ export class CacheRouter {
     );
   }
 
-  static getTransfersCacheKey(args: { chainId: string; safeAddress: string }) {
+  static getTransfersCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
     return `${args.chainId}_${CacheRouter.TRANSFERS_KEY}_${args.safeAddress}`;
   }
 

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -115,7 +115,7 @@ export class RedisCacheService
   /**
    * Forces the closing of the Redis connection associated with this service.
    */
-  private async forceQuit() {
+  private async forceQuit(): Promise<void> {
     this.loggingService.warn('Forcing Redis connection close');
     await this.client.disconnect();
     this.loggingService.warn('Redis connection closed');

--- a/src/datasources/db/postgres-database.migration.hook.ts
+++ b/src/datasources/db/postgres-database.migration.hook.ts
@@ -19,7 +19,7 @@ export class PostgresDatabaseMigrationHook implements OnModuleInit {
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
-  async onModuleInit() {
+  async onModuleInit(): Promise<void> {
     this.loggingService.info('Checking migrations');
     try {
       // Acquire lock to perform a migration.

--- a/src/datasources/db/postgres-database.shutdown.hook.ts
+++ b/src/datasources/db/postgres-database.shutdown.hook.ts
@@ -11,7 +11,7 @@ export class PostgresDatabaseShutdownHook implements OnModuleDestroy {
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
-  async onModuleDestroy() {
+  async onModuleDestroy(): Promise<void> {
     this.loggingService.info('Closing database connection');
     // Resolves when all queries are finished and the underlying connections are closed
     await this.db.end({

--- a/src/datasources/email-api/__tests__/test.email-api.module.ts
+++ b/src/datasources/email-api/__tests__/test.email-api.module.ts
@@ -12,7 +12,7 @@ const emailApi = {
     HttpErrorFactory,
     {
       provide: IEmailApi,
-      useFactory: () => jest.mocked(emailApi),
+      useFactory: (): any => jest.mocked(emailApi),
     },
   ],
   exports: [IEmailApi],

--- a/src/datasources/email/__tests__/test.email.datasource.module.ts
+++ b/src/datasources/email/__tests__/test.email.datasource.module.ts
@@ -16,7 +16,7 @@ const emailDataSource = {
   providers: [
     {
       provide: IEmailDataSource,
-      useFactory: () => {
+      useFactory: (): any => {
         return jest.mocked(emailDataSource);
       },
     },

--- a/src/datasources/email/email.datasource.ts
+++ b/src/datasources/email/email.datasource.ts
@@ -225,13 +225,10 @@ export class EmailDataSource implements IEmailDataSource {
                                          WHERE chain_id = ${args.chainId}
                                            AND safe_address = ${args.safeAddress}
                                            AND account = ${args.account}`;
-    return subscriptions.map(
-      (subscription) =>
-        <DomainSubscription>{
-          key: subscription.key,
-          name: subscription.name,
-        },
-    );
+    return subscriptions.map((subscription) => ({
+      key: subscription.key,
+      name: subscription.name,
+    }));
   }
 
   async subscribe(args: {
@@ -252,13 +249,10 @@ export class EmailDataSource implements IEmailDataSource {
                   AND subscriptions.key = ${args.categoryKey})
            RETURNING *`;
 
-    return subscriptions.map(
-      (s) =>
-        <DomainSubscription>{
-          key: s.key,
-          name: s.name,
-        },
-    );
+    return subscriptions.map((s) => ({
+      key: s.key,
+      name: s.name,
+    }));
   }
 
   async unsubscribe(args: {
@@ -273,13 +267,10 @@ export class EmailDataSource implements IEmailDataSource {
                                                            AND account_subscriptions.account_id = account_emails.id
                                                            AND account_subscriptions.subscription_id = subscriptions.id
                                                          RETURNING subscriptions.key, subscriptions.name`;
-    return subscriptions.map(
-      (s) =>
-        <DomainSubscription>{
-          key: s.key,
-          name: s.name,
-        },
-    );
+    return subscriptions.map((s) => ({
+      key: s.key,
+      name: s.name,
+    }));
   }
 
   async unsubscribeAll(args: { token: string }): Promise<DomainSubscription[]> {
@@ -295,12 +286,9 @@ export class EmailDataSource implements IEmailDataSource {
                  JOIN deleted_subscriptions deleted_subs ON subs.id = deleted_subs.subscription_id;;
     `;
 
-    return subscriptions.map(
-      (s) =>
-        <DomainSubscription>{
-          key: s.key,
-          name: s.name,
-        },
-    );
+    return subscriptions.map((s) => ({
+      key: s.key,
+      name: s.name,
+    }));
   }
 }

--- a/src/datasources/network/__tests__/test.network.module.ts
+++ b/src/datasources/network/__tests__/test.network.module.ts
@@ -25,7 +25,7 @@ const networkService: INetworkService = {
   providers: [
     {
       provide: NetworkService,
-      useFactory: () => {
+      useFactory: (): any => {
         return jest.mocked(networkService);
       },
     },

--- a/src/datasources/network/axios.network.service.ts
+++ b/src/datasources/network/axios.network.service.ts
@@ -72,7 +72,7 @@ export class AxiosNetworkService implements INetworkService {
     }
   }
 
-  private logErrorResponse(error, responseTimeMs) {
+  private logErrorResponse(error, responseTimeMs): void {
     this.loggingService.debug({
       type: 'external_request',
       protocol: error.request.protocol,

--- a/src/datasources/prices-api/coingecko-api.service.ts
+++ b/src/datasources/prices-api/coingecko-api.service.ts
@@ -252,7 +252,7 @@ export class CoingeckoApi implements IPricesApi {
    * Gets a random integer value between (notFoundPriceTtlSeconds - notFoundTtlRangeSeconds)
    * and (notFoundPriceTtlSeconds + notFoundTtlRangeSeconds).
    */
-  private _getRandomNotFoundTokenPriceTtl() {
+  private _getRandomNotFoundTokenPriceTtl(): number {
     const min =
       this.notFoundPriceTtlSeconds - CoingeckoApi.notFoundTtlRangeSeconds;
     const max =

--- a/src/domain/alerts/__tests__/delay-modifier.encoder.ts
+++ b/src/domain/alerts/__tests__/delay-modifier.encoder.ts
@@ -61,7 +61,7 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
   }
 }
 
-export function transactionAddedEventBuilder() {
+export function transactionAddedEventBuilder(): TransactionAddedEventBuilder<TransactionAddedEventArgs> {
   return new TransactionAddedEventBuilder()
     .with('queueNonce', faker.number.bigInt())
     .with('txHash', faker.string.hexadecimal({ length: 64 }) as Hex)

--- a/src/domain/alerts/__tests__/multi-send-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/multi-send-transactions.encoder.ts
@@ -24,7 +24,7 @@ class MultiSendEncoder<T extends MultiSendArgs>
   static readonly FUNCTION_SIGNATURE =
     'function multiSend(bytes memory transactions)' as const;
 
-  encode() {
+  encode(): Hex {
     const abi = parseAbi([MultiSendEncoder.FUNCTION_SIGNATURE]);
 
     const args = this.build();
@@ -57,7 +57,7 @@ export function multiSendTransactionsEncoder(
   return concat(encodedTransactions);
 }
 
-export function multiSendEncoder() {
+export function multiSendEncoder(): MultiSendEncoder<MultiSendArgs> {
   const transactions = multiSendTransactionsEncoder([
     {
       operation: 0,

--- a/src/domain/alerts/__tests__/safe-transactions.encoder.ts
+++ b/src/domain/alerts/__tests__/safe-transactions.encoder.ts
@@ -46,7 +46,7 @@ class ExecTransactionEncoder<T extends ExecTransactionArgs>
   static readonly FUNCTION_SIGNATURE =
     'function execTransaction(address to, uint256 value, bytes calldata data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)' as const;
 
-  encode() {
+  encode(): Hex {
     const abi = parseAbi([ExecTransactionEncoder.FUNCTION_SIGNATURE]);
 
     const args = this.build();
@@ -70,7 +70,7 @@ class ExecTransactionEncoder<T extends ExecTransactionArgs>
   }
 }
 
-export function execTransactionEncoder() {
+export function execTransactionEncoder(): ExecTransactionEncoder<ExecTransactionArgs> {
   return new ExecTransactionEncoder()
     .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('value', BigInt(0))
@@ -98,7 +98,7 @@ class AddOwnerWithThresholdEncoder<T extends AddOwnerWithThresholdArgs>
   static readonly FUNCTION_SIGNATURE =
     'function addOwnerWithThreshold(address owner, uint256 _threshold)' as const;
 
-  encode() {
+  encode(): Hex {
     const abi = parseAbi([AddOwnerWithThresholdEncoder.FUNCTION_SIGNATURE]);
 
     const args = this.build();
@@ -111,7 +111,7 @@ class AddOwnerWithThresholdEncoder<T extends AddOwnerWithThresholdArgs>
   }
 }
 
-export function addOwnerWithThresholdEncoder() {
+export function addOwnerWithThresholdEncoder(): AddOwnerWithThresholdEncoder<AddOwnerWithThresholdArgs> {
   return new AddOwnerWithThresholdEncoder()
     .with('owner', getAddress(faker.finance.ethereumAddress()))
     .with('threshold', faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }));
@@ -132,7 +132,7 @@ class RemoveOwnerEncoder<T extends RemoveOwnerArgs>
   static readonly FUNCTION_SIGNATURE =
     'function removeOwner(address prevOwner, address owner, uint256 _threshold)';
 
-  encode() {
+  encode(): Hex {
     const abi = parseAbi([RemoveOwnerEncoder.FUNCTION_SIGNATURE]);
 
     const args = this.build();
@@ -145,7 +145,9 @@ class RemoveOwnerEncoder<T extends RemoveOwnerArgs>
   }
 }
 
-export function removeOwnerEncoder(owners?: Safe['owners']) {
+export function removeOwnerEncoder(
+  owners?: Safe['owners'],
+): RemoveOwnerEncoder<RemoveOwnerArgs> {
   const owner = getAddress(faker.finance.ethereumAddress());
   const prevOwner = getPrevOwner(owner, owners);
 
@@ -170,7 +172,7 @@ class SwapOwnerEncoder<T extends SwapOwnerArgs>
   static readonly FUNCTION_SIGNATURE =
     'function swapOwner(address prevOwner, address oldOwner, address newOwner)';
 
-  encode() {
+  encode(): Hex {
     const abi = parseAbi([SwapOwnerEncoder.FUNCTION_SIGNATURE]);
 
     const args = this.build();
@@ -183,7 +185,9 @@ class SwapOwnerEncoder<T extends SwapOwnerArgs>
   }
 }
 
-export function swapOwnerEncoder(owners?: Safe['owners']) {
+export function swapOwnerEncoder(
+  owners?: Safe['owners'],
+): SwapOwnerEncoder<SwapOwnerArgs> {
   const oldOwner = getAddress(faker.finance.ethereumAddress());
   const prevOwner = getPrevOwner(oldOwner, owners);
 
@@ -206,7 +210,7 @@ class ChangeThresholdEncoder<T extends ChangeThresholdArgs>
   static readonly FUNCTION_SIGNATURE =
     'function changeThreshold(uint256 _threshold)';
 
-  encode() {
+  encode(): Hex {
     const abi = parseAbi([ChangeThresholdEncoder.FUNCTION_SIGNATURE]);
 
     const args = this.build();
@@ -219,7 +223,7 @@ class ChangeThresholdEncoder<T extends ChangeThresholdArgs>
   }
 }
 
-export function changeThresholdEncoder() {
+export function changeThresholdEncoder(): ChangeThresholdEncoder<ChangeThresholdArgs> {
   return new ChangeThresholdEncoder().with(
     'threshold',
     faker.number.bigInt({ min: 1, max: MAX_THRESHOLD }),

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -104,7 +104,9 @@ export class AlertsRepository implements IAlertsRepository {
     }
   }
 
-  private _decodeTransactionAdded(data: Hex) {
+  private _decodeTransactionAdded(
+    data: Hex,
+  ): Array<ReturnType<typeof this._decodeRecoveryTransaction>> {
     try {
       return this.multiSendDecoder
         .mapMultiSendTransactions(data)
@@ -116,7 +118,9 @@ export class AlertsRepository implements IAlertsRepository {
     }
   }
 
-  private _decodeRecoveryTransaction(data: Hex) {
+  private _decodeRecoveryTransaction(
+    data: Hex,
+  ): ReturnType<typeof this.safeDecoder.decodeFunctionData> {
     const decoded = this.safeDecoder.decodeFunctionData({ data });
 
     const isRecoveryTransaction = [

--- a/src/domain/alerts/contracts/abi-decoder.helper.ts
+++ b/src/domain/alerts/contracts/abi-decoder.helper.ts
@@ -11,6 +11,8 @@ import {
 export abstract class AbiDecoder<TAbi extends Abi | readonly unknown[]> {
   protected constructor(private readonly abi: TAbi) {}
 
+  // Use inferred types from viem
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   decodeEventLog<
     const abi extends Abi | readonly unknown[],
     eventName extends ContractEventName<abi> | undefined = undefined,
@@ -29,6 +31,8 @@ export abstract class AbiDecoder<TAbi extends Abi | readonly unknown[]> {
     });
   }
 
+  // Use inferred types from viem
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   decodeFunctionData<TAbi extends Abi | readonly unknown[]>(
     args: Omit<DecodeFunctionDataParameters<TAbi>, 'abi'>,
   ) {

--- a/src/domain/email/email.repository.ts
+++ b/src/domain/email/email.repository.ts
@@ -35,7 +35,7 @@ export class EmailRepository implements IEmailRepository {
     );
   }
 
-  private _generateCode() {
+  private _generateCode(): string {
     const verificationCode = codeGenerator();
     // Pads the final verification code to 6 characters
     // The generated code might have less than 6 digits so the version to be
@@ -210,7 +210,7 @@ export class EmailRepository implements IEmailRepository {
     });
   }
 
-  private _isEmailVerificationCodeValid(email: Email) {
+  private _isEmailVerificationCodeValid(email: Email): boolean {
     if (!email.verificationGeneratedOn) return false;
     const window = Date.now() - email.verificationGeneratedOn.getTime();
     return window < this.verificationCodeTtlMs;
@@ -222,7 +222,7 @@ export class EmailRepository implements IEmailRepository {
     code: string;
     emailAddress: string;
     safeAddress: string;
-  }) {
+  }): Promise<void> {
     await this.emailApi.createMessage({
       to: [args.emailAddress],
       template: this.configurationService.getOrThrow(

--- a/src/logging/logging.service.ts
+++ b/src/logging/logging.service.ts
@@ -25,23 +25,29 @@ export class RequestScopedLoggingService implements ILoggingService {
     this.buildNumber = configurationService.get('about.buildNumber');
   }
 
-  info(message: string | unknown) {
+  info(message: string | unknown): void {
     this.logger.log('info', this.formatMessage(message));
   }
 
-  error(message: string | unknown) {
+  error(message: string | unknown): void {
     this.logger.log('error', this.formatMessage(message));
   }
 
-  warn(message: string | unknown) {
+  warn(message: string | unknown): void {
     this.logger.log('warn', this.formatMessage(message));
   }
 
-  debug(message: string | unknown) {
+  debug(message: string | unknown): void {
     this.logger.log('debug', this.formatMessage(message));
   }
 
-  private formatMessage(message: string | unknown) {
+  private formatMessage(message: string | unknown): {
+    message: unknown;
+    build_number: string | undefined;
+    request_id: string;
+    timestamp: string;
+    version: string | undefined;
+  } {
     const requestId = this.cls.getId();
     const timestamp = Date.now();
     const dateAsString = new Date(timestamp).toISOString();

--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -6,7 +6,17 @@ export function formatRouteLogMessage(
   request: any,
   startTimeMs: number,
   detail?: string,
-) {
+): {
+  chain_id: any;
+  client_ip: any;
+  method: any;
+  response_time_ms: number;
+  route: any;
+  path: any;
+  safe_app_user_agent: any;
+  status_code: number;
+  detail: string | null;
+} {
   const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
   const safe_app_user_agent =
     request.header(HEADER_SAFE_APP_USER_AGENT) ?? null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { AppModule } from '@/app.module';
 import { DefaultAppProvider } from '@/app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 
-async function bootstrap() {
+async function bootstrap(): Promise<void> {
   const app = await new DefaultAppProvider().provide(AppModule.register());
 
   const configurationService: IConfigurationService =

--- a/src/middleware/not-found-logger.middleware.ts
+++ b/src/middleware/not-found-logger.middleware.ts
@@ -17,7 +17,7 @@ export class NotFoundLoggerMiddleware implements NestMiddleware {
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
-  use(req: Request, res: Response, next: NextFunction) {
+  use(req: Request, res: Response, next: NextFunction): void {
     const startTimeMs: number = performance.now();
 
     res.on('finish', () => {

--- a/src/routes/alerts/guards/alerts-route.guard.ts
+++ b/src/routes/alerts/guards/alerts-route.guard.ts
@@ -8,7 +8,7 @@ export class AlertsRouteGuard implements CanActivate {
     private readonly configurationService: IConfigurationService,
   ) {}
 
-  canActivate() {
+  canActivate(): boolean {
     return this.configurationService.getOrThrow<boolean>('features.email');
   }
 }

--- a/src/routes/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.spec.ts
@@ -11,7 +11,7 @@ describe('PaginationDataDecorator', () => {
   @Controller()
   class TestController {
     @Get()
-    route(@PaginationDataDecorator() data: PaginationData) {
+    route(@PaginationDataDecorator() data: PaginationData): void {
       paginationData = data;
       return;
     }

--- a/src/routes/common/decorators/utils.ts
+++ b/src/routes/common/decorators/utils.ts
@@ -1,4 +1,4 @@
-export function getRouteUrl(request: any) {
+export function getRouteUrl(request: any): URL {
   const protocol = request.get('X-Forwarded-Proto') ?? request.protocol;
   return new URL(`${protocol}://${request.get('Host')}${request.originalUrl}`);
 }

--- a/src/routes/common/filters/global-error.filter.spec.ts
+++ b/src/routes/common/filters/global-error.filter.spec.ts
@@ -11,7 +11,7 @@ import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 @Controller({})
 class TestController {
   @Get('http-exception')
-  async httpException() {
+  async httpException(): Promise<void> {
     throw new HttpException(
       { message: 'Some http exception' },
       HttpStatus.BAD_GATEWAY,
@@ -19,7 +19,7 @@ class TestController {
   }
 
   @Get('non-http-exception')
-  async nonHttpException() {
+  async nonHttpException(): Promise<void> {
     throw new Error('Some random error');
   }
 }

--- a/src/routes/common/filters/global-error.filter.ts
+++ b/src/routes/common/filters/global-error.filter.ts
@@ -16,7 +16,7 @@ export class GlobalErrorFilter implements ExceptionFilter {
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
-  catch(exception: Error, host: ArgumentsHost): any {
+  catch(exception: Error, host: ArgumentsHost): void {
     const { httpAdapter } = this.httpAdapterHost;
 
     const ctx = host.switchToHttp();

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -22,12 +22,12 @@ const mockLoggingService = {
 @Controller({ path: 'test' })
 class TestController {
   @Get('server-error')
-  getServerError() {
+  getServerError(): void {
     throw new HttpException('Some 500 error', HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   @Get('server-data-source-error')
-  getServerDataSourceError() {
+  getServerDataSourceError(): void {
     throw new DataSourceError(
       'Some DataSource error',
       HttpStatus.NOT_IMPLEMENTED,
@@ -35,22 +35,22 @@ class TestController {
   }
 
   @Get('server-error-non-http')
-  getNonHttpError() {
+  getNonHttpError(): void {
     throw new Error('Some random error');
   }
 
   @Get('client-error')
-  getClientError() {
+  getClientError(): void {
     throw new HttpException('Some 400 error', HttpStatus.METHOD_NOT_ALLOWED);
   }
 
   @Get('success')
-  getSuccess() {
+  getSuccess(): void {
     return;
   }
 
   @Get('success/:chainId')
-  getSuccessWithChainId() {
+  getSuccessWithChainId(): void {
     return;
   }
 }

--- a/src/routes/common/interceptors/route-logger.interceptor.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.ts
@@ -60,7 +60,7 @@ export class RouteLoggerInterceptor implements NestInterceptor {
    * compute the response time of the route
    * @private
    */
-  private onError(request: any, error: Error, startTimeMs: number) {
+  private onError(request: any, error: Error, startTimeMs: number): void {
     let statusCode;
     if (error instanceof HttpException) {
       statusCode = error.getStatus();
@@ -84,7 +84,7 @@ export class RouteLoggerInterceptor implements NestInterceptor {
     }
   }
 
-  private onComplete(request: any, response: any, startTimeMs: number) {
+  private onComplete(request: any, response: any, startTimeMs: number): void {
     this.loggingService.info(
       formatRouteLogMessage(response.statusCode, request, startTimeMs),
     );

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -37,7 +37,7 @@ describe('Email controller edit email tests', () => {
 
     const defaultConfiguration = configuration();
 
-    function testConfiguration() {
+    const testConfiguration: typeof configuration = () => {
       return {
         ...defaultConfiguration,
         email: {
@@ -48,7 +48,7 @@ describe('Email controller edit email tests', () => {
           },
         },
       };
-    }
+    };
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule.register(testConfiguration), EmailControllerModule],

--- a/src/routes/email/email.controller.resend-verification.spec.ts
+++ b/src/routes/email/email.controller.resend-verification.spec.ts
@@ -27,7 +27,7 @@ describe('Email controller resend verification tests', () => {
     jest.useFakeTimers();
 
     const defaultTestConfiguration = configuration();
-    const testConfiguration = () => ({
+    const testConfiguration: typeof configuration = () => ({
       ...defaultTestConfiguration,
       email: {
         ...defaultTestConfiguration['email'],

--- a/src/routes/email/email.controller.verify-email.spec.ts
+++ b/src/routes/email/email.controller.verify-email.spec.ts
@@ -28,7 +28,7 @@ describe('Email controller verify email tests', () => {
     jest.useFakeTimers();
 
     const defaultTestConfiguration = configuration();
-    const testConfiguration = () => ({
+    const testConfiguration: typeof configuration = () => ({
       ...defaultTestConfiguration,
       email: {
         ...defaultTestConfiguration['email'],

--- a/src/routes/email/exception-filters/email-already-verified.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-already-verified.exception-filter.ts
@@ -9,7 +9,7 @@ import { Response } from 'express';
 
 @Catch(EmailAlreadyVerifiedError)
 export class EmailAlreadyVerifiedExceptionFilter implements ExceptionFilter {
-  catch(exception: EmailAlreadyVerifiedError, host: ArgumentsHost) {
+  catch(exception: EmailAlreadyVerifiedError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/exception-filters/email-does-not-exist.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-does-not-exist.exception-filter.ts
@@ -11,7 +11,7 @@ import { EmailAddressDoesNotExistError } from '@/datasources/email/errors/email-
 export class EmailAddressDoesNotExistExceptionFilter
   implements ExceptionFilter
 {
-  catch(exception: EmailAddressDoesNotExistError, host: ArgumentsHost) {
+  catch(exception: EmailAddressDoesNotExistError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/exception-filters/email-edit-matches.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-edit-matches.exception-filter.ts
@@ -9,7 +9,7 @@ import { EmailEditMatchesError } from '@/domain/email/errors/email-edit-matches.
 
 @Catch(EmailEditMatchesError)
 export class EmailEditMatchesExceptionFilter implements ExceptionFilter {
-  catch(exception: EmailEditMatchesError, host: ArgumentsHost) {
+  catch(exception: EmailEditMatchesError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/exception-filters/email-edit-timespan.exception-filter.ts
+++ b/src/routes/email/exception-filters/email-edit-timespan.exception-filter.ts
@@ -9,7 +9,7 @@ import { Response } from 'express';
 
 @Catch(EditTimespanError)
 export class EmailEditTimespanExceptionFilter implements ExceptionFilter {
-  catch(exception: EditTimespanError, host: ArgumentsHost) {
+  catch(exception: EditTimespanError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/exception-filters/invalid-verification-code.exception-filter.ts
+++ b/src/routes/email/exception-filters/invalid-verification-code.exception-filter.ts
@@ -9,7 +9,7 @@ import { InvalidVerificationCodeError } from '@/domain/email/errors/invalid-veri
 
 @Catch(InvalidVerificationCodeError)
 export class InvalidVerificationCodeExceptionFilter implements ExceptionFilter {
-  catch(exception: InvalidVerificationCodeError, host: ArgumentsHost) {
+  catch(exception: InvalidVerificationCodeError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/exception-filters/resend-verification-timespan-error.exception-filter.ts
+++ b/src/routes/email/exception-filters/resend-verification-timespan-error.exception-filter.ts
@@ -11,7 +11,7 @@ import { ResendVerificationTimespanError } from '@/domain/email/errors/verificat
 export class ResendVerificationTimespanExceptionFilter
   implements ExceptionFilter
 {
-  catch(exception: ResendVerificationTimespanError, host: ArgumentsHost) {
+  catch(exception: ResendVerificationTimespanError, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 

--- a/src/routes/email/guards/email-deletion.guard.spec.ts
+++ b/src/routes/email/guards/email-deletion.guard.spec.ts
@@ -15,17 +15,17 @@ class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
   @UseGuards(EmailDeletionGuard)
-  async validRoute() {}
+  async validRoute(): Promise<void> {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
   @UseGuards(EmailDeletionGuard)
-  async invalidRouteWithChainId() {}
+  async invalidRouteWithChainId(): Promise<void> {}
 
   @Post('test/invalid/safes/:safeAddress')
   @HttpCode(200)
   @UseGuards(EmailDeletionGuard)
-  async invalidRouteWithSafeAddress() {}
+  async invalidRouteWithSafeAddress(): Promise<void> {}
 }
 
 describe('EmailDeletionGuard guard tests', () => {

--- a/src/routes/email/guards/email-edit.guard.spec.ts
+++ b/src/routes/email/guards/email-edit.guard.spec.ts
@@ -15,17 +15,17 @@ class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
   @UseGuards(EmailEditGuard)
-  async validRoute() {}
+  async validRoute(): Promise<void> {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
   @UseGuards(EmailEditGuard)
-  async invalidRouteWithChainId() {}
+  async invalidRouteWithChainId(): Promise<void> {}
 
   @Post('test/invalid/safes/:safeAddress')
   @HttpCode(200)
   @UseGuards(EmailEditGuard)
-  async invalidRouteWithSafeAddress() {}
+  async invalidRouteWithSafeAddress(): Promise<void> {}
 }
 
 describe('EmailEdit guard tests', () => {

--- a/src/routes/email/guards/email-registration.guard.spec.ts
+++ b/src/routes/email/guards/email-registration.guard.spec.ts
@@ -15,17 +15,17 @@ class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
   @UseGuards(EmailRegistrationGuard)
-  async validRoute() {}
+  async validRoute(): Promise<void> {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
   @UseGuards(EmailRegistrationGuard)
-  async invalidRouteWithChainId() {}
+  async invalidRouteWithChainId(): Promise<void> {}
 
   @Post('test/invalid/safes/:safeAddress')
   @HttpCode(200)
   @UseGuards(EmailRegistrationGuard)
-  async invalidRouteWithSafeAddress() {}
+  async invalidRouteWithSafeAddress(): Promise<void> {}
 }
 
 describe('EmailRegistration guard tests', () => {

--- a/src/routes/email/guards/only-safe-owner.guard.spec.ts
+++ b/src/routes/email/guards/only-safe-owner.guard.spec.ts
@@ -20,17 +20,17 @@ class TestController {
   @Post('test/:chainId/:safeAddress')
   @HttpCode(200)
   @UseGuards(OnlySafeOwnerGuard)
-  async validRoute() {}
+  async validRoute(): Promise<void> {}
 
   @Post('test/invalid/chains/:chainId')
   @HttpCode(200)
   @UseGuards(OnlySafeOwnerGuard)
-  async invalidRouteWithChainId() {}
+  async invalidRouteWithChainId(): Promise<void> {}
 
   @Post('test/invalid/safes/:safeAddress')
   @HttpCode(200)
   @UseGuards(OnlySafeOwnerGuard)
-  async invalidRouteWithSafeAddress() {}
+  async invalidRouteWithSafeAddress(): Promise<void> {}
 }
 
 describe('OnlySafeOwner guard tests', () => {

--- a/src/routes/email/guards/timestamp.guard.spec.ts
+++ b/src/routes/email/guards/timestamp.guard.spec.ts
@@ -15,7 +15,7 @@ class TestController {
   @Post('test')
   @HttpCode(200)
   @UseGuards(TimestampGuard(MAX_ELAPSED_TIME_MS))
-  async validRoute() {}
+  async validRoute(): Promise<void> {}
 }
 
 describe('TimestampGuard tests', () => {

--- a/src/routes/email/guards/timestamp.guard.ts
+++ b/src/routes/email/guards/timestamp.guard.ts
@@ -1,4 +1,4 @@
-import { CanActivate, ExecutionContext, mixin } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Type, mixin } from '@nestjs/common';
 
 /**
  * Returns a guard mixin that can be used to check if a 'timestamp'
@@ -8,9 +8,9 @@ import { CanActivate, ExecutionContext, mixin } from '@nestjs/common';
  * @param maxElapsedTimeMs - the amount in ms to which this guard should allow
  * the request to go through
  */
-export const TimestampGuard = (maxElapsedTimeMs: number) => {
+export const TimestampGuard = (maxElapsedTimeMs: number): Type<CanActivate> => {
   class TimestampGuardMixin implements CanActivate {
-    canActivate(context: ExecutionContext) {
+    canActivate(context: ExecutionContext): boolean {
       const request = context.switchToHttp().getRequest();
 
       const timestampRaw = request.body['timestamp'];

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -19,6 +19,7 @@ import { registerDeviceDtoBuilder } from '@/routes/notifications/entities/__test
 import { safeRegistrationBuilder } from '@/routes/notifications/entities/__tests__/safe-registration.builder';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import { RegisterDeviceDto } from '@/routes/notifications/entities/register-device.dto.entity';
 
 describe('Notifications Controller (Unit)', () => {
   let app: INestApplication;
@@ -49,7 +50,7 @@ describe('Notifications Controller (Unit)', () => {
     await app.init();
   });
 
-  const buildInputDto = () =>
+  const buildInputDto = (): RegisterDeviceDto =>
     registerDeviceDtoBuilder()
       .with(
         'safeRegistrations',
@@ -61,7 +62,7 @@ describe('Notifications Controller (Unit)', () => {
       )
       .build();
 
-  const rejectForUrl = (url) =>
+  const rejectForUrl = (url: string): Promise<never> =>
     Promise.reject(`No matching rule for url: ${url}`);
 
   describe('POST /register/notifications', () => {

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -63,7 +63,7 @@ describe('Transactions History Controller (Unit)', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
 
-    const testConfiguration = () => ({
+    const testConfiguration: typeof configuration = () => ({
       ...configuration(),
       mappings: {
         history: {

--- a/src/validation/providers/keywords/is-date.keyword.ts
+++ b/src/validation/providers/keywords/is-date.keyword.ts
@@ -14,7 +14,7 @@ import Ajv from 'ajv';
  *
  * @param ajv - the AJV instance to which the isDate keyword should be registered
  */
-export function addIsDate(ajv: Ajv) {
+export function addIsDate(ajv: Ajv): void {
   ajv.addKeyword({
     keyword: 'isDate',
     compile: (schema) => (data, dataContext) => {

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default async () => {
   process.env.TZ = 'UTC';
 };


### PR DESCRIPTION
With the removal of angle bracket (`<Type>value`) type assertion (#1041), favouring return types and `as` assertions (if absolutely necessary), this adds the following linting rules and fixes any issues associated with them.

### Errors
Require explicit return types on functions and class methods. ([`explicit-function-return-type`](https://typescript-eslint.io/rules/explicit-function-return-type/))

### Warnings
Enforce consistent usage of `as` type assertions. ([`consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/))