### PR TITLE
Remove redundant TODO

### DIFF
--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -14,7 +14,7 @@ export type MultisigTransaction = {
   blockNumber: number | null;
   confirmations: Confirmation[] | null;
   confirmationsRequired: number;
-  data: string | null; // TODO: replace with DataDecoded entity
+  data: string | null;
   dataDecoded: DataDecoded | null;
   ethGasPrice: string | null;
   executionDate: Date | null;


### PR DESCRIPTION
This removes a note to change the type of the domain `MultisigTransaction['data']` from `string | null`. According to the `/v1/multisig-transactions/{safe_tx_hash}/` endpoint of the [`Transaction Service`](https://safe-transaction-mainnet.safe.global/), `data` is `string | null` and does therefore not need changing.