### PR TITLE
Enable strict mode

### DIFF
--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -11,6 +11,7 @@ import {
   NetworkService,
 } from '@/datasources/network/network.service.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { isObject } from 'lodash';
 
 /**
  * A data source which tries to retrieve values from cache using
@@ -54,7 +55,7 @@ export class CacheFirstDataSource {
     try {
       return await this._getFromNetworkAndWriteCache(args);
     } catch (error) {
-      if (error?.status === 404) {
+      if (isObject(error) && 'status' in error && error.status === 404) {
         await this.cacheNotFoundError(
           args.cacheDir,
           new NetworkResponseError(error.status, error),

--- a/src/datasources/errors/http-error-factory.ts
+++ b/src/datasources/errors/http-error-factory.ts
@@ -1,9 +1,7 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
-import {
-  NetworkError,
-  NetworkResponseError,
-} from '@/datasources/network/entities/network.error.entity';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
+import { isObject } from 'lodash';
 
 /**
  * Maps a {@link NetworkError} or {@link Error} into a {@link DataSourceError}
@@ -16,7 +14,7 @@ import { DataSourceError } from '@/domain/errors/data-source.error';
  */
 @Injectable()
 export class HttpErrorFactory {
-  from(source: NetworkError | Error): DataSourceError {
+  from(source: unknown): DataSourceError {
     if (isNetworkResponseError(source)) {
       const errorMessage: string = source.data?.message ?? 'An error occurred';
       return new DataSourceError(errorMessage, source.status);
@@ -29,8 +27,12 @@ export class HttpErrorFactory {
   }
 }
 
-function isNetworkResponseError(
-  error: NetworkError | Error,
-): error is NetworkResponseError {
-  return 'status' in error && error.status >= 400 && error.status < 600;
+function isNetworkResponseError(error: unknown): error is NetworkResponseError {
+  return (
+    isObject(error) &&
+    'status' in error &&
+    typeof error.status === 'number' &&
+    error.status >= 400 &&
+    error.status < 600
+  );
 }

--- a/src/domain/email/entities/create-email-message.dto.entity.ts
+++ b/src/domain/email/entities/create-email-message.dto.entity.ts
@@ -1,7 +1,7 @@
 export class CreateEmailMessageDto {
-  to: string[];
-  template: string;
-  subject: string;
-  substitutions: Record<string, unknown> | null;
+  to!: string[];
+  template!: string;
+  subject!: string;
+  substitutions!: Record<string, unknown> | null;
   emailMessageId?: string;
 }

--- a/src/domain/transactions/entities/add-confirmation.dto.entity.ts
+++ b/src/domain/transactions/entities/add-confirmation.dto.entity.ts
@@ -1,3 +1,3 @@
 export class AddConfirmationDto {
-  signedSafeTxHash: string;
+  signedSafeTxHash!: string;
 }

--- a/src/domain/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/domain/transactions/entities/propose-transaction.dto.entity.ts
@@ -1,18 +1,18 @@
 import { Operation } from '@/domain/safe/entities/operation.entity';
 
 export class ProposeTransactionDto {
-  to: string;
-  value: string;
-  data: string | null;
-  nonce: string;
-  operation: Operation;
-  safeTxGas: string;
-  baseGas: string;
-  gasPrice: string;
-  gasToken: string;
-  refundReceiver: string | null;
-  safeTxHash: string;
-  sender: string;
-  signature: string | null;
-  origin: string | null;
+  to!: string;
+  value!: string;
+  data!: string | null;
+  nonce!: string;
+  operation!: Operation;
+  safeTxGas!: string;
+  baseGas!: string;
+  gasPrice!: string;
+  gasToken!: string;
+  refundReceiver!: string | null;
+  safeTxHash!: string;
+  sender!: string;
+  signature!: string | null;
+  origin!: string | null;
 }

--- a/src/logging/utils.spec.ts
+++ b/src/logging/utils.spec.ts
@@ -1,0 +1,54 @@
+import { asError } from '@/logging/utils';
+
+describe('asError', () => {
+  it('should return the same error if thrown is an instance of Error', () => {
+    const thrown = new Error('test error');
+
+    expect(asError(thrown)).toEqual(new Error('test error'));
+  });
+
+  it('should return the same error if thrown is a superset of Error', () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+      }
+    }
+    const thrown = new CustomError('test error');
+
+    expect(asError(thrown)).toEqual(new CustomError('test error'));
+  });
+
+  it('should return a new Error instance with the thrown value if thrown is a string', () => {
+    const thrown = 'test error';
+
+    const result = asError(thrown);
+    expect(result).toEqual(new Error('test error'));
+
+    // If stringified:
+    expect(result).not.toEqual(new Error('"test error'));
+  });
+
+  it('should return a new Error instance with the message thrown value if thrown is object with message', () => {
+    const thrown = { message: 'test error' };
+
+    const result = asError(thrown);
+    expect(result).toEqual(new Error('test error'));
+
+    // If stringified:
+    expect(result).not.toEqual(new Error('{"message":"test error"}'));
+  });
+
+  it('should return a new Error instance with the stringified thrown value if thrown is not an instance of Error', () => {
+    const thrown = { notMessage: 'test error' };
+
+    expect(asError(thrown)).toEqual(new Error('{"notMessage":"test error"}'));
+  });
+
+  it('should return a new Error instance with the string representation of thrown if JSON.stringify throws an error', () => {
+    // Circular dependency
+    const thrown: Record<string, unknown> = {};
+    thrown.a = { b: thrown };
+
+    expect(asError(thrown)).toEqual(new Error('[object Object]'));
+  });
+});

--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -1,3 +1,5 @@
+import { get } from 'lodash';
+
 const HEADER_IP_ADDRESS = 'X-Real-IP';
 const HEADER_SAFE_APP_USER_AGENT = 'Safe-App-User-Agent';
 
@@ -34,3 +36,23 @@ export function formatRouteLogMessage(
     detail: detail ?? null,
   };
 }
+
+export const asError = (thrown: unknown): Error => {
+  if (thrown instanceof Error) {
+    return thrown;
+  }
+
+  let message: string;
+
+  if (typeof thrown === 'string') {
+    message = thrown;
+  } else {
+    try {
+      message = get(thrown, 'message') ?? JSON.stringify(thrown);
+    } catch {
+      message = String(thrown);
+    }
+  }
+
+  return new Error(message);
+};

--- a/src/routes/about/entities/about.entity.ts
+++ b/src/routes/about/entities/about.entity.ts
@@ -2,9 +2,9 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class About {
   @ApiProperty()
-  name: string;
+  name!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  version: string | null;
+  version!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  buildNumber: string | null;
+  buildNumber!: string | null;
 }

--- a/src/routes/alerts/entities/alert.dto.entity.ts
+++ b/src/routes/alerts/entities/alert.dto.entity.ts
@@ -1,26 +1,26 @@
 export class AlertLog {
-  address: string;
-  topics: Array<string>;
-  data: string;
+  address!: string;
+  topics!: Array<string>;
+  data!: string;
 }
 
 export class AlertTransaction {
-  network: string;
-  block_hash: string;
-  block_number: number;
-  hash: string;
-  from: string;
-  to: string;
-  logs: Array<AlertLog>;
-  input: string;
-  value: string;
-  nonce: string;
-  gas: string;
-  gas_used: string;
-  cumulative_gas_used: string;
-  gas_price: string;
-  gas_tip_cap: string;
-  gas_fee_cap: string;
+  network!: string;
+  block_hash!: string;
+  block_number!: number;
+  hash!: string;
+  from!: string;
+  to!: string;
+  logs!: Array<AlertLog>;
+  input!: string;
+  value!: string;
+  nonce!: string;
+  gas!: string;
+  gas_used!: string;
+  cumulative_gas_used!: string;
+  gas_price!: string;
+  gas_tip_cap!: string;
+  gas_fee_cap!: string;
 }
 
 export enum EventType {
@@ -29,7 +29,7 @@ export enum EventType {
 }
 
 export class Alert {
-  id: string;
-  event_type: EventType;
-  transaction: AlertTransaction;
+  id!: string;
+  event_type!: EventType;
+  transaction!: AlertTransaction;
 }

--- a/src/routes/alerts/pipes/alert-validation.pipe.ts
+++ b/src/routes/alerts/pipes/alert-validation.pipe.ts
@@ -1,5 +1,10 @@
 import { ValidateFunction } from 'ajv';
-import { Injectable, PipeTransform, HttpStatus } from '@nestjs/common';
+import {
+  Injectable,
+  PipeTransform,
+  HttpStatus,
+  HttpException,
+} from '@nestjs/common';
 import { Alert } from '@/routes/alerts/entities/alert.dto.entity';
 import {
   ALERT_LOGS_SCHEMA_ID,
@@ -34,7 +39,9 @@ export class AlertValidationPipe implements PipeTransform<Alert> {
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/balances/entities/balance.entity.ts
+++ b/src/routes/balances/entities/balance.entity.ts
@@ -3,11 +3,11 @@ import { Token } from '@/routes/balances/entities/token.entity';
 
 export class Balance {
   @ApiProperty()
-  balance: string;
+  balance!: string;
   @ApiProperty()
-  fiatBalance: string;
+  fiatBalance!: string;
   @ApiProperty()
-  fiatConversion: string;
+  fiatConversion!: string;
   @ApiProperty()
-  tokenInfo: Token;
+  tokenInfo!: Token;
 }

--- a/src/routes/balances/entities/balances.entity.ts
+++ b/src/routes/balances/entities/balances.entity.ts
@@ -4,7 +4,7 @@ import { Balance } from '@/routes/balances/entities/balance.entity';
 @ApiExtraModels(Balance)
 export class Balances {
   @ApiProperty()
-  fiatTotal: string;
+  fiatTotal!: string;
   @ApiProperty({ type: 'array', oneOf: [{ $ref: getSchemaPath(Balance) }] })
-  items: Balance[];
+  items!: Balance[];
 }

--- a/src/routes/balances/entities/token.entity.ts
+++ b/src/routes/balances/entities/token.entity.ts
@@ -3,15 +3,15 @@ import { TokenType } from '@/routes/balances/entities/token-type.entity';
 
 export class Token {
   @ApiProperty()
-  address: string;
+  address!: string;
   @ApiPropertyOptional({ type: Number, nullable: true })
-  decimals: number | null;
+  decimals!: number | null;
   @ApiProperty()
   logoUri?: string;
   @ApiProperty()
-  name: string;
+  name!: string;
   @ApiProperty()
-  symbol: string;
+  symbol!: string;
   @ApiProperty({ enum: Object.values(TokenType) })
-  type: TokenType;
+  type!: TokenType;
 }

--- a/src/routes/chains/entities/backbone.entity.ts
+++ b/src/routes/chains/entities/backbone.entity.ts
@@ -3,17 +3,17 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class Backbone implements DomainBackbone {
   @ApiProperty()
-  api_version: string;
+  api_version!: string;
   @ApiProperty()
-  headers: string[];
+  headers!: string[];
   @ApiProperty()
-  host: string;
+  host!: string;
   @ApiProperty()
-  name: string;
+  name!: string;
   @ApiProperty()
-  secure: boolean;
+  secure!: boolean;
   @ApiProperty()
-  settings: Record<string, string>;
+  settings!: Record<string, string>;
   @ApiProperty()
-  version: string;
+  version!: string;
 }

--- a/src/routes/chains/entities/block-explorer-uri-template.entity.ts
+++ b/src/routes/chains/entities/block-explorer-uri-template.entity.ts
@@ -5,9 +5,9 @@ export class BlockExplorerUriTemplate
   implements DomainBlockExplorerUriTemplate
 {
   @ApiProperty()
-  address: string;
+  address!: string;
   @ApiProperty()
-  api: string;
+  api!: string;
   @ApiProperty()
-  txHash: string;
+  txHash!: string;
 }

--- a/src/routes/chains/entities/chain-page.entity.ts
+++ b/src/routes/chains/entities/chain-page.entity.ts
@@ -4,5 +4,5 @@ import { Page } from '@/routes/common/entities/page.entity';
 
 export class ChainPage extends Page<Chain> {
   @ApiProperty({ type: Chain })
-  results: Chain[];
+  results!: Chain[];
 }

--- a/src/routes/chains/entities/gas-price-fixed-eip-1559.entity.ts
+++ b/src/routes/chains/entities/gas-price-fixed-eip-1559.entity.ts
@@ -3,9 +3,9 @@ import { GasPriceFixedEIP1559 as DomainGasPriceFixedEIP1559 } from '@/domain/cha
 
 export class GasPriceFixedEIP1559 implements DomainGasPriceFixedEIP1559 {
   @ApiProperty()
-  type: 'fixed1559';
+  type!: 'fixed1559';
   @ApiProperty()
-  maxFeePerGas: string;
+  maxFeePerGas!: string;
   @ApiProperty()
-  maxPriorityFeePerGas: string;
+  maxPriorityFeePerGas!: string;
 }

--- a/src/routes/chains/entities/gas-price-fixed.entity.ts
+++ b/src/routes/chains/entities/gas-price-fixed.entity.ts
@@ -3,7 +3,7 @@ import { GasPriceFixed as DomainGasPriceFixed } from '@/domain/chains/entities/g
 
 export class GasPriceFixed implements DomainGasPriceFixed {
   @ApiProperty()
-  type: 'fixed';
+  type!: 'fixed';
   @ApiProperty()
-  weiValue: string;
+  weiValue!: string;
 }

--- a/src/routes/chains/entities/gas-price-oracle.entity.ts
+++ b/src/routes/chains/entities/gas-price-oracle.entity.ts
@@ -3,11 +3,11 @@ import { GasPriceOracle as DomainGasPriceOracle } from '@/domain/chains/entities
 
 export class GasPriceOracle implements DomainGasPriceOracle {
   @ApiProperty()
-  type: 'oracle';
+  type!: 'oracle';
   @ApiProperty()
-  gasParameter: string;
+  gasParameter!: string;
   @ApiProperty()
-  gweiFactor: string;
+  gweiFactor!: string;
   @ApiProperty()
-  uri: string;
+  uri!: string;
 }

--- a/src/routes/chains/entities/master-copy.entity.ts
+++ b/src/routes/chains/entities/master-copy.entity.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class MasterCopy {
   @ApiProperty()
-  address: string;
+  address!: string;
   @ApiProperty()
-  version: string;
+  version!: string;
 }

--- a/src/routes/chains/entities/native-currency.entity.ts
+++ b/src/routes/chains/entities/native-currency.entity.ts
@@ -3,11 +3,11 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class NativeCurrency implements DomainNativeCurrency {
   @ApiProperty()
-  decimals: number;
+  decimals!: number;
   @ApiProperty()
-  logoUri: string;
+  logoUri!: string;
   @ApiProperty()
-  name: string;
+  name!: string;
   @ApiProperty()
-  symbol: string;
+  symbol!: string;
 }

--- a/src/routes/chains/entities/rpc-uri.entity.ts
+++ b/src/routes/chains/entities/rpc-uri.entity.ts
@@ -4,7 +4,7 @@ import { RpcUri as DomainRpcUri } from '@/domain/chains/entities/rpc-uri.entity'
 
 export class RpcUri implements DomainRpcUri {
   @ApiProperty({ enum: Object.values(RpcUriAuthentication) })
-  authentication: RpcUriAuthentication;
+  authentication!: RpcUriAuthentication;
   @ApiProperty()
-  value: string;
+  value!: string;
 }

--- a/src/routes/chains/entities/theme.entity.ts
+++ b/src/routes/chains/entities/theme.entity.ts
@@ -3,7 +3,7 @@ import { Theme as DomainTheme } from '@/domain/chains/entities/theme.entity';
 
 export class Theme implements DomainTheme {
   @ApiProperty()
-  backgroundColor: string;
+  backgroundColor!: string;
   @ApiProperty()
-  textColor: string;
+  textColor!: string;
 }

--- a/src/routes/collectibles/entities/collectible.entity.ts
+++ b/src/routes/collectibles/entities/collectible.entity.ts
@@ -3,23 +3,23 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class Collectible implements DomainCollectible {
   @ApiProperty()
-  address: string;
+  address!: string;
   @ApiProperty()
-  tokenName: string;
+  tokenName!: string;
   @ApiProperty()
-  tokenSymbol: string;
+  tokenSymbol!: string;
   @ApiProperty()
-  logoUri: string;
+  logoUri!: string;
   @ApiProperty()
-  id: string;
+  id!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  uri: string | null;
+  uri!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  name: string | null;
+  name!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  description: string | null;
+  description!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  imageUri: string | null;
+  imageUri!: string | null;
   @ApiPropertyOptional({ type: Object, nullable: true })
-  metadata: Record<string, any> | null;
+  metadata!: Record<string, any> | null;
 }

--- a/src/routes/collectibles/entities/collectible.page.entity.ts
+++ b/src/routes/collectibles/entities/collectible.page.entity.ts
@@ -4,5 +4,5 @@ import { Page } from '@/routes/common/entities/page.entity';
 
 export class CollectiblePage extends Page<Collectible> {
   @ApiProperty({ type: Collectible })
-  results: Collectible[];
+  results!: Collectible[];
 }

--- a/src/routes/common/entities/page.entity.ts
+++ b/src/routes/common/entities/page.entity.ts
@@ -16,13 +16,13 @@ import { Page as DomainPage } from '@/domain/entities/page.entity';
  */
 export abstract class Page<T> implements DomainPage<T> {
   @ApiProperty()
-  count: number;
+  count!: number;
   // ApiPropertyOptional without any options
   // does not work with unions with null
   // see https://github.com/nestjs/swagger/issues/2129
   @ApiPropertyOptional({ type: String, nullable: true })
-  next: string | null;
+  next!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  previous: string | null;
+  previous!: string | null;
   abstract results: T[];
 }

--- a/src/routes/contracts/entities/contract.entity.ts
+++ b/src/routes/contracts/entities/contract.entity.ts
@@ -3,15 +3,15 @@ import { Contract as DomainContract } from '@/domain/contracts/entities/contract
 
 export class Contract implements DomainContract {
   @ApiProperty()
-  address: string;
+  address!: string;
   @ApiProperty()
-  name: string;
+  name!: string;
   @ApiProperty()
-  displayName: string;
+  displayName!: string;
   @ApiProperty()
-  logoUri: string;
+  logoUri!: string;
   @ApiPropertyOptional({ type: Object, nullable: true })
-  contractAbi: object | null;
+  contractAbi!: object | null;
   @ApiProperty()
-  trustedForDelegateCall: boolean;
+  trustedForDelegateCall!: boolean;
 }

--- a/src/routes/data-decode/pipes/get-data-decoded.dto.validation.pipe.ts
+++ b/src/routes/data-decode/pipes/get-data-decoded.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GetDataDecodedDto } from '@/routes/data-decode/entities/get-data-decoded.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class GetDataDecodedDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/delegates/entities/create-delegate.dto.entity.ts
+++ b/src/routes/delegates/entities/create-delegate.dto.entity.ts
@@ -4,11 +4,11 @@ export class CreateDelegateDto {
   @ApiPropertyOptional()
   safe?: string;
   @ApiProperty()
-  delegate: string;
+  delegate!: string;
   @ApiProperty()
-  delegator: string;
+  delegator!: string;
   @ApiProperty()
-  signature: string;
+  signature!: string;
   @ApiProperty()
-  label: string;
+  label!: string;
 }

--- a/src/routes/delegates/entities/delegate.entity.ts
+++ b/src/routes/delegates/entities/delegate.entity.ts
@@ -2,11 +2,11 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class Delegate {
   @ApiPropertyOptional({ type: String, nullable: true })
-  safe: string | null;
+  safe!: string | null;
   @ApiProperty()
-  delegate: string;
+  delegate!: string;
   @ApiProperty()
-  delegator: string;
+  delegator!: string;
   @ApiProperty()
-  label: string;
+  label!: string;
 }

--- a/src/routes/delegates/entities/delegate.page.entity.ts
+++ b/src/routes/delegates/entities/delegate.page.entity.ts
@@ -4,5 +4,5 @@ import { Delegate } from '@/routes/delegates/entities/delegate.entity';
 
 export class DelegatePage extends Page<Delegate> {
   @ApiProperty({ type: Delegate })
-  results: Delegate[];
+  results!: Delegate[];
 }

--- a/src/routes/delegates/entities/delete-delegate.dto.entity.ts
+++ b/src/routes/delegates/entities/delete-delegate.dto.entity.ts
@@ -2,9 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class DeleteDelegateDto {
   @ApiProperty()
-  delegate: string;
+  delegate!: string;
   @ApiProperty()
-  delegator: string;
+  delegator!: string;
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/delegates/entities/delete-safe-delegate.dto.entity.ts
+++ b/src/routes/delegates/entities/delete-safe-delegate.dto.entity.ts
@@ -2,9 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class DeleteSafeDelegateDto {
   @ApiProperty()
-  delegate: string;
+  delegate!: string;
   @ApiProperty()
-  safe: string;
+  safe!: string;
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/delegates/pipes/create-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/create-delegate.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { CreateDelegateDto } from '@/routes/delegates/entities/create-delegate.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class CreateDelegateDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/delegates/pipes/delete-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/delete-delegate.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { DeleteDelegateDto } from '@/routes/delegates/entities/delete-delegate.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class DeleteDelegateDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/delegates/pipes/delete-safe-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/delete-safe-delegate.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { DeleteSafeDelegateDto } from '@/routes/delegates/entities/delete-safe-delegate.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class DeleteSafeDelegateDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/delegates/pipes/get-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/get-delegate.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GetDelegateDto } from '@/routes/delegates/entities/get-delegate.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class GetDelegateDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/email/entities/delete-email-dto.entity.ts
+++ b/src/routes/email/entities/delete-email-dto.entity.ts
@@ -2,11 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class DeleteEmailDto {
   @ApiProperty()
-  account: string;
+  account!: string;
 
   @ApiProperty()
-  timestamp: number;
+  timestamp!: number;
 
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/email/entities/edit-email-dto.entity.ts
+++ b/src/routes/email/entities/edit-email-dto.entity.ts
@@ -2,14 +2,14 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class EditEmailDto {
   @ApiProperty()
-  emailAddress: string;
+  emailAddress!: string;
 
   @ApiProperty()
-  account: string;
+  account!: string;
 
   @ApiProperty()
-  timestamp: number;
+  timestamp!: number;
 
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/email/entities/resend-verification-dto.entity.ts
+++ b/src/routes/email/entities/resend-verification-dto.entity.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class ResendVerificationDto {
   @ApiProperty()
-  account: string;
+  account!: string;
 }

--- a/src/routes/email/entities/save-email-dto.entity.ts
+++ b/src/routes/email/entities/save-email-dto.entity.ts
@@ -2,14 +2,14 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class SaveEmailDto {
   @ApiProperty()
-  emailAddress: string;
+  emailAddress!: string;
 
   @ApiProperty()
-  account: string;
+  account!: string;
 
   @ApiProperty()
-  timestamp: number;
+  timestamp!: number;
 
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/email/entities/verify-email-dto.entity.ts
+++ b/src/routes/email/entities/verify-email-dto.entity.ts
@@ -2,8 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class VerifyEmailDto {
   @ApiProperty()
-  account: string;
+  account!: string;
 
   @ApiProperty()
-  code: string;
+  code!: string;
 }

--- a/src/routes/estimations/entities/get-estimation.dto.entity.ts
+++ b/src/routes/estimations/entities/get-estimation.dto.entity.ts
@@ -4,11 +4,11 @@ import { Operation } from '@/domain/safe/entities/operation.entity';
 
 export class GetEstimationDto implements DomainGetEstimationDto {
   @ApiProperty()
-  to: string;
+  to!: string;
   @ApiProperty()
-  value: string;
+  value!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  data: string | null;
+  data!: string | null;
   @ApiProperty()
-  operation: Operation;
+  operation!: Operation;
 }

--- a/src/routes/estimations/pipes/get-estimation.dto.validation.pipe.ts
+++ b/src/routes/estimations/pipes/get-estimation.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GetEstimationDto } from '@/domain/estimations/entities/get-estimation.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class GetEstimationDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/messages/entities/create-message.dto.entity.ts
+++ b/src/routes/messages/entities/create-message.dto.entity.ts
@@ -4,7 +4,7 @@ export class CreateMessageDto {
   @ApiProperty()
   message: string | unknown;
   @ApiPropertyOptional({ type: Number, nullable: true })
-  safeAppId: number | null;
+  safeAppId!: number | null;
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/messages/entities/messages-page.entity.ts
+++ b/src/routes/messages/entities/messages-page.entity.ts
@@ -12,5 +12,5 @@ export class MessagePage extends Page<MessageItem | DateLabel> {
       { $ref: getSchemaPath(DateLabel) },
     ],
   })
-  results: (MessageItem | DateLabel)[];
+  results!: (MessageItem | DateLabel)[];
 }

--- a/src/routes/messages/entities/update-message-signature.entity.ts
+++ b/src/routes/messages/entities/update-message-signature.entity.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateMessageSignatureDto {
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/messages/pipes/create-message.dto.validation.pipe.ts
+++ b/src/routes/messages/pipes/create-message.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { CreateMessageDto } from '@/routes/messages/entities/create-message.dto.entity';
 import {
@@ -28,7 +33,9 @@ export class CreateMessageDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/messages/pipes/update-message-signature.dto.validation.pipe.ts
+++ b/src/routes/messages/pipes/update-message-signature.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import {
   UPDATE_MESSAGE_SIGNATURE_DTO_SCHEMA_ID,
@@ -28,7 +33,9 @@ export class UpdateMessageSignatureDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/notifications/entities/register-device.dto.entity.ts
+++ b/src/routes/notifications/entities/register-device.dto.entity.ts
@@ -12,20 +12,20 @@ export class RegisterDeviceDto {
   @ApiPropertyOptional({ type: String, nullable: true })
   uuid?: string;
   @ApiProperty()
-  cloudMessagingToken: string;
+  cloudMessagingToken!: string;
   @ApiProperty()
-  buildNumber: string;
+  buildNumber!: string;
   @ApiProperty()
-  bundle: string;
+  bundle!: string;
   @ApiProperty()
-  deviceType: DeviceType;
+  deviceType!: DeviceType;
   @ApiProperty()
-  version: string;
+  version!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
   timestamp?: string;
   @ApiProperty({
     type: 'array',
     items: { $ref: getSchemaPath(SafeRegistration) },
   })
-  safeRegistrations: SafeRegistration[];
+  safeRegistrations!: SafeRegistration[];
 }

--- a/src/routes/notifications/entities/safe-registration.entity.ts
+++ b/src/routes/notifications/entities/safe-registration.entity.ts
@@ -2,9 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class SafeRegistration {
   @ApiProperty()
-  chainId: string;
+  chainId!: string;
   @ApiProperty()
-  safes: string[];
+  safes!: string[];
   @ApiProperty()
-  signatures: string[];
+  signatures!: string[];
 }

--- a/src/routes/owners/entities/safe-list.entity.ts
+++ b/src/routes/owners/entities/safe-list.entity.ts
@@ -3,5 +3,5 @@ import { SafeList as DomainSafeList } from '@/domain/safe/entities/safe-list.ent
 
 export class SafeList implements DomainSafeList {
   @ApiProperty()
-  safes: string[];
+  safes!: string[];
 }

--- a/src/routes/recovery/entities/add-recovery-module.dto.entity.ts
+++ b/src/routes/recovery/entities/add-recovery-module.dto.entity.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class AddRecoveryModuleDto {
   @ApiProperty()
-  moduleAddress: string;
+  moduleAddress!: string;
 }

--- a/src/routes/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-access-control.entity.ts
@@ -6,7 +6,7 @@ import {
 
 export class SafeAppAccessControl implements DomainSafeAppAccessControl {
   @ApiProperty()
-  type: SafeAppAccessControlPolicies;
+  type!: SafeAppAccessControlPolicies;
   @ApiPropertyOptional({ type: String, isArray: true, nullable: true })
-  value: string[] | null;
+  value!: string[] | null;
 }

--- a/src/routes/safe-apps/entities/safe-app-provider.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-provider.entity.ts
@@ -3,7 +3,7 @@ import { SafeAppProvider as DomainSafeAppProvider } from '@/domain/safe-apps/ent
 
 export class SafeAppProvider implements DomainSafeAppProvider {
   @ApiProperty()
-  url: string;
+  url!: string;
   @ApiProperty()
-  name: string;
+  name!: string;
 }

--- a/src/routes/safe-apps/entities/safe-app-social-profile.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-social-profile.entity.ts
@@ -3,7 +3,7 @@ import { SafeAppSocialProfile as DomainSafeAppSocialProfile } from '@/domain/saf
 
 export class SafeAppSocialProfile implements DomainSafeAppSocialProfile {
   @ApiProperty()
-  platform: string;
+  platform!: string;
   @ApiProperty()
-  url: string;
+  url!: string;
 }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -18,6 +18,7 @@ import {
   SafeState,
 } from '@/routes/safes/entities/safe-info.entity';
 import { SafeNonces } from '@/routes/safes/entities/nonces.entity';
+import { Page } from '@/domain/entities/page.entity';
 
 @Injectable()
 export class SafesService {
@@ -190,7 +191,12 @@ export class SafesService {
 
     const dates = txPages
       .filter(
-        <T>(page: PromiseSettledResult<T>): page is PromiseFulfilledResult<T> =>
+        (
+          page,
+        ): page is
+          | PromiseFulfilledResult<Page<MultisigTransaction>>
+          | PromiseFulfilledResult<Page<ModuleTransaction>>
+          | PromiseFulfilledResult<Page<Transfer>> =>
           page.status === 'fulfilled',
       )
       .flatMap(

--- a/src/routes/transactions/entities/add-confirmation.dto.ts
+++ b/src/routes/transactions/entities/add-confirmation.dto.ts
@@ -3,5 +3,5 @@ import { AddConfirmationDto as DomainCreateConfirmationDto } from '@/domain/tran
 
 export class AddConfirmationDto implements DomainCreateConfirmationDto {
   @ApiProperty()
-  signedSafeTxHash: string;
+  signedSafeTxHash!: string;
 }

--- a/src/routes/transactions/entities/incoming-transfer-page.entity.ts
+++ b/src/routes/transactions/entities/incoming-transfer-page.entity.ts
@@ -4,5 +4,5 @@ import { IncomingTransfer } from '@/routes/transactions/entities/incoming-transf
 
 export class IncomingTransferPage extends Page<IncomingTransfer> {
   @ApiProperty({ type: IncomingTransfer })
-  results: IncomingTransfer[];
+  results!: IncomingTransfer[];
 }

--- a/src/routes/transactions/entities/module-transaction-page.entity.ts
+++ b/src/routes/transactions/entities/module-transaction-page.entity.ts
@@ -4,5 +4,5 @@ import { ModuleTransaction } from '@/routes/transactions/entities/module-transac
 
 export class ModuleTransactionPage extends Page<ModuleTransaction> {
   @ApiProperty({ type: ModuleTransaction })
-  results: ModuleTransaction[];
+  results!: ModuleTransaction[];
 }

--- a/src/routes/transactions/entities/multisig-transaction-page.entity.ts
+++ b/src/routes/transactions/entities/multisig-transaction-page.entity.ts
@@ -4,5 +4,5 @@ import { MultisigTransaction } from '@/routes/transactions/entities/multisig-tra
 
 export class MultisigTransactionPage extends Page<MultisigTransaction> {
   @ApiProperty({ type: MultisigTransaction })
-  results: MultisigTransaction[];
+  results!: MultisigTransaction[];
 }

--- a/src/routes/transactions/entities/preview-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/preview-transaction.dto.entity.ts
@@ -3,11 +3,11 @@ import { Operation } from '@/domain/safe/entities/operation.entity';
 
 export class PreviewTransactionDto {
   @ApiProperty()
-  to: string;
+  to!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  data: string | null;
+  data!: string | null;
   @ApiProperty()
-  value: string;
+  value!: string;
   @ApiProperty()
-  operation: Operation;
+  operation!: Operation;
 }

--- a/src/routes/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/propose-transaction.dto.entity.ts
@@ -4,31 +4,31 @@ import { ProposeTransactionDto as DomainProposeTransactionDto } from '@/domain/t
 
 export class ProposeTransactionDto implements DomainProposeTransactionDto {
   @ApiProperty()
-  to: string;
+  to!: string;
   @ApiProperty()
-  value: string;
+  value!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  data: string | null;
+  data!: string | null;
   @ApiProperty()
-  nonce: string;
+  nonce!: string;
   @ApiProperty()
-  operation: Operation;
+  operation!: Operation;
   @ApiProperty()
-  safeTxGas: string;
+  safeTxGas!: string;
   @ApiProperty()
-  baseGas: string;
+  baseGas!: string;
   @ApiProperty()
-  gasPrice: string;
+  gasPrice!: string;
   @ApiProperty()
-  gasToken: string;
+  gasToken!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  refundReceiver: string | null;
+  refundReceiver!: string | null;
   @ApiProperty()
-  safeTxHash: string;
+  safeTxHash!: string;
   @ApiProperty()
-  sender: string;
+  sender!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
-  signature: string | null;
+  signature!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  origin: string | null;
+  origin!: string | null;
 }

--- a/src/routes/transactions/entities/queued-item-page.entity.ts
+++ b/src/routes/transactions/entities/queued-item-page.entity.ts
@@ -19,5 +19,5 @@ export class QueuedItemPage extends Page<QueuedItem> {
       { $ref: getSchemaPath(TransactionQueuedItem) },
     ],
   })
-  results: QueuedItem[];
+  results!: QueuedItem[];
 }

--- a/src/routes/transactions/entities/transaction-details/transaction-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/transaction-details.entity.ts
@@ -20,17 +20,17 @@ import { TransactionStatus } from '@/routes/transactions/entities/transaction-st
 )
 export class TransactionDetails {
   @ApiProperty()
-  safeAddress: string;
+  safeAddress!: string;
   @ApiProperty()
-  txId: string;
+  txId!: string;
   @ApiPropertyOptional({ type: Number, nullable: true })
-  executedAt: number | null;
+  executedAt!: number | null;
   @ApiProperty()
-  txStatus: TransactionStatus;
+  txStatus!: TransactionStatus;
   @ApiProperty()
-  txInfo: TransactionInfo;
+  txInfo!: TransactionInfo;
   @ApiPropertyOptional({ type: TransactionData, nullable: true })
-  txData: TransactionData | null;
+  txData!: TransactionData | null;
   @ApiPropertyOptional({
     oneOf: [
       { $ref: getSchemaPath(MultisigExecutionDetails) },
@@ -38,12 +38,12 @@ export class TransactionDetails {
     ],
     nullable: true,
   })
-  detailedExecutionInfo:
+  detailedExecutionInfo!:
     | MultisigExecutionDetails
     | ModuleExecutionDetails
     | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  txHash: string | null;
+  txHash!: string | null;
   @ApiPropertyOptional({ type: SafeAppInfo, nullable: true })
-  safeAppInfo: SafeAppInfo | null;
+  safeAppInfo!: SafeAppInfo | null;
 }

--- a/src/routes/transactions/entities/transaction-item-page.entity.ts
+++ b/src/routes/transactions/entities/transaction-item-page.entity.ts
@@ -12,5 +12,5 @@ export class TransactionItemPage extends Page<TransactionItem | DateLabel> {
       { $ref: getSchemaPath(DateLabel) },
     ],
   })
-  results: (TransactionItem | DateLabel)[];
+  results!: (TransactionItem | DateLabel)[];
 }

--- a/src/routes/transactions/mappers/common/human-description.mapper.ts
+++ b/src/routes/transactions/mappers/common/human-description.mapper.ts
@@ -24,6 +24,7 @@ import {
   RichTokenValueFragment,
 } from '@/routes/transactions/entities/human-description.entity';
 import { SafeAppInfoMapper } from '@/routes/transactions/mappers/common/safe-app-info.mapper';
+import { asError } from '@/logging/utils';
 
 @Injectable()
 export class HumanDescriptionMapper {
@@ -72,7 +73,7 @@ export class HumanDescriptionMapper {
       return new RichDecodedInfo(richDecodedInfo);
     } catch (error) {
       this.loggingService.debug(
-        `Error trying to decode the input data: ${error.message}`,
+        `Error trying to decode the input data: ${asError(error).message}`,
       );
       return null;
     }

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -14,8 +14,8 @@ import {
 import { TransactionQueuedItem } from '@/routes/transactions/entities/queued-items/transaction-queued-item.entity';
 
 class TransactionGroup {
-  nonce: number;
-  transactions: MultisigTransaction[];
+  nonce!: number;
+  transactions!: MultisigTransaction[];
 }
 
 @Injectable()

--- a/src/routes/transactions/mappers/transaction-preview.mapper.ts
+++ b/src/routes/transactions/mappers/transaction-preview.mapper.ts
@@ -9,6 +9,7 @@ import { TransactionPreview } from '@/routes/transactions/entities/transaction-p
 import { TransactionDataMapper } from '@/routes/transactions/mappers/common/transaction-data.mapper';
 import { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
+import { asError } from '@/logging/utils';
 
 @Injectable()
 export class TransactionPreviewMapper {
@@ -37,7 +38,7 @@ export class TransactionPreviewMapper {
       }
     } catch (error) {
       this.loggingService.info(
-        `Error trying to decode the input data: ${error.message}`,
+        `Error trying to decode the input data: ${asError(error).message}`,
       );
     }
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -25,8 +25,8 @@ import { isErc20Transfer } from '@/routes/transactions/entities/transfers/erc20-
 import { Transaction } from '@/routes/transactions/entities/transaction.entity';
 
 class TransactionDomainGroup {
-  timestamp: number;
-  transactions: (
+  timestamp!: number;
+  transactions!: (
     | MultisigTransaction
     | ModuleTransaction
     | EthereumTransaction

--- a/src/routes/transactions/pipes/add-confirmation.validation.pipe.ts
+++ b/src/routes/transactions/pipes/add-confirmation.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '@/validation/providers/generic.validator';
 import { JsonSchemaService } from '@/validation/providers/json-schema.service';
@@ -27,7 +32,9 @@ export class AddConfirmationDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/transactions/pipes/preview-transaction.validation.pipe.ts
+++ b/src/routes/transactions/pipes/preview-transaction.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { PreviewTransactionDto } from '@/routes/transactions/entities/preview-transaction.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class PreviewTransactionDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/src/routes/transactions/pipes/propose-transaction.dto.validation.pipe.ts
+++ b/src/routes/transactions/pipes/propose-transaction.dto.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { ProposeTransactionDto } from '@/routes/transactions/entities/propose-transaction.dto.entity';
 import {
@@ -27,7 +32,9 @@ export class ProposeTransactionDtoValidationPipe
     try {
       return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
-      err.status = HttpStatus.BAD_REQUEST;
+      if (err instanceof HttpException) {
+        Object.assign(err, { status: HttpStatus.BAD_REQUEST });
+      }
       throw err;
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "resolveJsonModule": true,
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "strict": true
   }
 }


### PR DESCRIPTION
This enables the `strict` flag of TypeScript to "a wide range of type checking behavior that results in stronger guarantees of program correctness" and updates the associated issues found, notably:

- Error type checking ("standard" errrors that are thrown are `unknown`)
- Assertions added to DTOs ([as per NestJS' author suggestion](https://github.com/nestjs/nest/issues/4178#issuecomment-614006219))