### PR TITLE
Remove safe owner requirement for email deletion

### DIFF
--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -95,7 +95,6 @@ export class EmailController {
   @UseGuards(
     EmailDeletionGuard,
     TimestampGuard(5 * 60 * 1000), // 5 minutes
-    OnlySafeOwnerGuard,
   )
   @UseFilters(EmailAddressDoesNotExistExceptionFilter)
   @HttpCode(HttpStatus.NO_CONTENT)


### PR DESCRIPTION
Deleting an email address should not require the signer to be an active owner of the safe. A change to the safe configuration (different owners) should allow previous owners to delete the respective email addresses.