### PR TITLE
Remove trusted tokens feature flag

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -55,7 +55,6 @@ export default (): ReturnType<typeof configuration> => ({
   features: {
     richFragments: true,
     email: true,
-    trustedTokens: true,
   },
   httpClient: { requestTimeout: faker.number.int() },
   log: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -72,7 +72,6 @@ export default () => ({
   features: {
     richFragments: process.env.FF_RICH_FRAGMENTS?.toLowerCase() === 'true',
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
-    trustedTokens: process.env.FF_TRUSTED_TOKENS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/domain/tokens/entities/schemas/token.schema.ts
+++ b/src/domain/tokens/entities/schemas/token.schema.ts
@@ -17,8 +17,15 @@ export const tokenSchema: JSONSchemaType<Token> = {
     type: { type: 'string', enum: Object.values(TokenType) },
     trusted: { type: 'boolean' },
   },
-  // TODO: trusted should be required. Add to required fields once features.trustedTokens is removed
-  required: ['address', 'decimals', 'logoUri', 'name', 'symbol', 'type'],
+  required: [
+    'address',
+    'decimals',
+    'logoUri',
+    'name',
+    'symbol',
+    'type',
+    'trusted',
+  ],
 };
 
 export const TOKEN_PAGE_SCHEMA_ID =

--- a/src/domain/tokens/entities/token.entity.ts
+++ b/src/domain/tokens/entities/token.entity.ts
@@ -11,6 +11,5 @@ export interface Token {
   name: string;
   symbol: string;
   type: TokenType;
-  // TODO: trusted should be non-null. Remove null type once features.trustedTokens is removed
-  trusted: boolean | null;
+  trusted: boolean;
 }

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -37,7 +37,6 @@ class TransactionDomainGroup {
 @Injectable()
 export class TransactionsHistoryMapper {
   private readonly maxNestedTransfers: number;
-  private readonly isTrustedTokensEnabled: boolean;
 
   constructor(
     @Inject(IConfigurationService) configurationService: IConfigurationService,
@@ -48,9 +47,6 @@ export class TransactionsHistoryMapper {
   ) {
     this.maxNestedTransfers = configurationService.getOrThrow(
       'mappings.history.maxNestedTransfers',
-    );
-    this.isTrustedTokensEnabled = configurationService.getOrThrow(
-      'features.trustedTokens',
     );
   }
 
@@ -205,11 +201,9 @@ export class TransactionsHistoryMapper {
       // If we do not have a transfer with value, we do not add it to the result
       if (!transferWithValue) continue;
 
-      // TODO remove isTrustedTokensEnabled when feature is considered stable
-      const trustedTransfer =
-        this.isTrustedTokensEnabled && onlyTrusted
-          ? this.mapTrustedTransfer(transferWithValue)
-          : transferWithValue;
+      const trustedTransfer = onlyTrusted
+        ? this.mapTrustedTransfer(transferWithValue)
+        : transferWithValue;
 
       if (!trustedTransfer) continue;
       result.push(new TransactionItem(nestedTransaction));


### PR DESCRIPTION
This removes the feature flag for toggling trusted tokens as it is now considered stable. The domain `Token['trusted']` is now also a `required` field.

