### PR TITLE
Add transaction deletion endpoint

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -589,6 +589,20 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async deleteTransaction(args: {
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void> {
+    try {
+      const url = `${this.baseUrl}/api/v1/transactions/${args.safeTxHash}`;
+      await this.networkService.delete(url, {
+        signature: args.signature,
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async clearMultisigTransaction(safeTransactionHash: string): Promise<void> {
     const key = CacheRouter.getMultisigTransactionCacheKey({
       chainId: this.chainId,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -129,6 +129,11 @@ export interface ITransactionApi {
     safeTransactionHash: string,
   ): Promise<MultisigTransaction>;
 
+  deleteTransaction(args: {
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void>;
+
   clearMultisigTransaction(safeTransactionHash: string): Promise<void>;
 
   getMultisigTransactions(args: {

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -143,6 +143,12 @@ export interface ISafeRepository {
     offset?: number;
   }): Promise<Page<MultisigTransaction>>;
 
+  deleteTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void>;
+
   getTransfer(args: { chainId: string; transferId: string }): Promise<Transfer>;
 
   getTransfers(args: {

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -280,6 +280,16 @@ export class SafeRepository implements ISafeRepository {
     return this.multisigTransactionValidator.validate(multiSigTransaction);
   }
 
+  async deleteTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.deleteTransaction(args);
+  }
+
   async clearMultisigTransactions(args: {
     chainId: string;
     safeAddress: string;

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -64,7 +64,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     await request(app.getHttpServer())
       .delete(`/v1/chains/${chainId}/transactions/${safeTxHash}`)
       .send(invalidDeleteTransactionDto)
-      .expect(500)
+      .expect(400)
       .expect({
         message: 'Validation failed',
         code: 42,

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -1,0 +1,137 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { DeleteTransactionDto } from '@/routes/transactions/entities/delete-transaction.dto.entity';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+
+describe('Delete Transaction - Transactions Controller (Unit', () => {
+  let app: INestApplication;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration)],
+    })
+      .overrideModule(EmailDataSourceModule)
+      .useModule(TestEmailDatasourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    const configurationService = moduleFixture.get(IConfigurationService);
+    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should throw a validation error', async () => {
+    const chainId = faker.string.numeric();
+    const safeTxHash = faker.string.hexadecimal({ length: 16 });
+    const invalidDeleteTransactionDto = {
+      signature: faker.number.int(),
+    };
+
+    await request(app.getHttpServer())
+      .delete(`/v1/chains/${chainId}/transactions/${safeTxHash}`)
+      .send(invalidDeleteTransactionDto)
+      .expect(500)
+      .expect({
+        message: 'Validation failed',
+        code: 42,
+        arguments: [],
+      });
+  });
+
+  it('should delete a multisig transaction', async () => {
+    const chain = chainBuilder().build();
+    const safeTxHash = faker.string.hexadecimal({ length: 16 });
+    const deleteTransactionDto: DeleteTransactionDto = {
+      signature: faker.string.hexadecimal({ length: 16 }),
+    };
+
+    networkService.get.mockImplementation((url) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: chain, status: 200 });
+      }
+      fail(`No matching rule for url: ${url}`);
+    });
+    networkService.delete.mockImplementation((url) => {
+      if (
+        url === `${chain.transactionService}/api/v1/transactions/${safeTxHash}`
+      ) {
+        return Promise.resolve({ data: {}, status: 204 });
+      }
+      fail(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .delete(`/v1/chains/${chain.chainId}/transactions/${safeTxHash}`)
+      .send(deleteTransactionDto)
+      .expect(200);
+  });
+
+  it('should forward an error from the Transaction Service', async () => {
+    const chain = chainBuilder().build();
+    const safeTxHash = faker.string.hexadecimal({ length: 16 });
+    const deleteTransactionDto: DeleteTransactionDto = {
+      signature: faker.string.hexadecimal({ length: 16 }),
+    };
+
+    networkService.get.mockImplementation((url) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: chain, status: 200 });
+      }
+      fail(`No matching rule for url: ${url}`);
+    });
+    networkService.delete.mockImplementation((url) => {
+      if (
+        url === `${chain.transactionService}/api/v1/transactions/${safeTxHash}`
+      ) {
+        return Promise.reject({
+          data: { message: 'Transaction not found', status: 404 },
+          status: 404,
+        });
+      }
+      fail(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .delete(`/v1/chains/${chain.chainId}/transactions/${safeTxHash}`)
+      .send(deleteTransactionDto)
+      .expect(404)
+      .expect({
+        message: 'Transaction not found',
+        code: 404,
+      });
+  });
+});

--- a/src/routes/transactions/entities/delete-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/delete-transaction.dto.entity.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteTransactionDto {
+  @ApiProperty()
+  signature: string;
+}

--- a/src/routes/transactions/entities/delete-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/delete-transaction.dto.entity.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class DeleteTransactionDto {
   @ApiProperty()
-  signature: string;
+  signature!: string;
 }

--- a/src/routes/transactions/entities/schemas/delete-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/delete-transaction.dto.schema.ts
@@ -1,0 +1,15 @@
+import { JSONSchemaType } from 'ajv';
+import { DeleteTransactionDto } from '@/routes/transactions/entities/delete-transaction.dto.entity';
+
+export const DELETE_TRANSACTION_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/transactions/delete-transaction.dto.json';
+
+export const deleteTransactionDtoSchema: JSONSchemaType<DeleteTransactionDto> =
+  {
+    $id: DELETE_TRANSACTION_DTO_SCHEMA_ID,
+    type: 'object',
+    properties: {
+      signature: { type: 'string' },
+    },
+    required: ['signature'],
+  };

--- a/src/routes/transactions/pipes/delete-transaction.validation.pipe.ts
+++ b/src/routes/transactions/pipes/delete-transaction.validation.pipe.ts
@@ -1,4 +1,9 @@
-import { Injectable, PipeTransform } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '@/validation/providers/generic.validator';
 import { JsonSchemaService } from '@/validation/providers/json-schema.service';
@@ -23,7 +28,15 @@ export class DeleteTransactionDtoValidationPipe
       deleteTransactionDtoSchema,
     );
   }
+
   transform(data: unknown): DeleteTransactionDto {
-    return this.genericValidator.validate(this.isValid, data);
+    try {
+      return this.genericValidator.validate(this.isValid, data);
+    } catch (err) {
+      if (err instanceof HttpException) {
+        throw new HttpException(err.getResponse(), HttpStatus.BAD_REQUEST);
+      }
+      throw err;
+    }
   }
 }

--- a/src/routes/transactions/pipes/delete-transaction.validation.pipe.ts
+++ b/src/routes/transactions/pipes/delete-transaction.validation.pipe.ts
@@ -1,0 +1,29 @@
+import { Injectable, PipeTransform } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+import { GenericValidator } from '@/validation/providers/generic.validator';
+import { JsonSchemaService } from '@/validation/providers/json-schema.service';
+import { DeleteTransactionDto } from '@/routes/transactions/entities/delete-transaction.dto.entity';
+import {
+  DELETE_TRANSACTION_DTO_SCHEMA_ID,
+  deleteTransactionDtoSchema,
+} from '@/routes/transactions/entities/schemas/delete-transaction.dto.schema';
+
+@Injectable()
+export class DeleteTransactionDtoValidationPipe
+  implements PipeTransform<unknown, DeleteTransactionDto>
+{
+  private readonly isValid: ValidateFunction<DeleteTransactionDto>;
+
+  constructor(
+    private readonly genericValidator: GenericValidator,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValid = this.jsonSchemaService.getSchema(
+      DELETE_TRANSACTION_DTO_SCHEMA_ID,
+      deleteTransactionDtoSchema,
+    );
+  }
+  transform(data: unknown): DeleteTransactionDto {
+    return this.genericValidator.validate(this.isValid, data);
+  }
+}

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   DefaultValuePipe,
+  Delete,
   Get,
   HttpCode,
   Param,
@@ -34,6 +35,8 @@ import { AddConfirmationDtoValidationPipe } from '@/routes/transactions/pipes/ad
 import { PreviewTransactionDtoValidationPipe } from '@/routes/transactions/pipes/preview-transaction.validation.pipe';
 import { ProposeTransactionDtoValidationPipe } from '@/routes/transactions/pipes/propose-transaction.dto.validation.pipe';
 import { TransactionsService } from '@/routes/transactions/transactions.service';
+import { DeleteTransactionDtoValidationPipe } from '@/routes/transactions/pipes/delete-transaction.validation.pipe';
+import { DeleteTransactionDto } from '@/routes/transactions/entities/delete-transaction.dto.entity';
 
 @ApiTags('transactions')
 @Controller({
@@ -88,6 +91,20 @@ export class TransactionsController {
       value,
       nonce,
       executed,
+    });
+  }
+
+  @Delete('chains/:chainId/transactions/:safeTxHash')
+  async deleteTransaction(
+    @Param('chainId') chainId: string,
+    @Param('safeTxHash') safeTxHash: string,
+    @Body(DeleteTransactionDtoValidationPipe)
+    deleteTransactionDto: DeleteTransactionDto,
+  ): Promise<void> {
+    return this.transactionsService.deleteTransaction({
+      chainId,
+      safeTxHash,
+      signature: deleteTransactionDto.signature,
     });
   }
 

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -175,6 +175,14 @@ export class TransactionsService {
     };
   }
 
+  async deleteTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void> {
+    return await this.safeRepository.deleteTransaction(args);
+  }
+
   async addConfirmation(args: {
     chainId: string;
     safeTxHash: string;


### PR DESCRIPTION
This adds the `DELETE` `chains/:chainId/transactions/:safeTxHash` endpoint for deleting transactions (in accordance with the `DELETE` `/v1/transactions/{safe_tx_hash}` endpoint of the Transaction Service) with associated test coverage.

#### Changes

From "root" to call:

- `deleteTransaction` has been added to the `TransactionApi` and `ITransactionApi` interface
- `deleteTransaction` has been added to the `SafeRepository` and `ISafeRepository` interface
- `deleteTransaction` has been added to the `TransactionsService`
- `DELETE` `chains/:chainId/transactions/:safeTxHash` has been added to the `TransactionsController`, accepting the `DeleteTransactionDto` (and validated by the `DeleteTransactionDtoValidationPipe`)

#### DeleteTransactionDto

```json
 {
    "signature": signature,
 }
```

---

According to the Transaction Service, the above is used as follows:

An EOA is required to sign the following EIP712 data:

```json
 {
    "types": {
        "EIP712Domain": [
            {"name": "name", "type": "string"},
            {"name": "version", "type": "string"},
            {"name": "chainId", "type": "uint256"},
            {"name": "verifyingContract", "type": "address"},
        ],
        "DeleteRequest": [
            {"name": "safeTxHash", "type": "bytes32"},
            {"name": "totp", "type": "uint256"},
        ],
    },
    "primaryType": "DeleteRequest",
    "domain": {
        "name": "Safe Transaction Service",
        "version": "1.0",
        "chainId": chain_id,
        "verifyingContract": safe_address,
    },
    "message": {
        "safeTxHash": safe_tx_hash,
        "totp": totp,
    },
}
```

The `totp` parameter is calculated with T0=0 and Tx=3600. It is calculated by taking the Unix UTC epoch time (without milliseconds) and dividing it by 3600 (natural division, no decimals).
