### PR TITLE
Refactor trusted filtering

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -188,27 +188,21 @@ export class TransactionsHistoryMapper {
     onlyTrusted: boolean,
   ): Promise<TransactionItem[]> {
     const limitedTransfers = transfers.slice(0, this.maxNestedTransfers);
-    const result: TransactionItem[] = [];
 
-    for (const transfer of limitedTransfers) {
-      const nestedTransaction = await this.transferMapper.mapTransfer(
-        chainId,
-        transfer,
-        safe,
-      );
+    const nestedTransactions = await Promise.all(
+      limitedTransfers.map((transfer) =>
+        this.transferMapper.mapTransfer(chainId, transfer, safe),
+      ),
+    );
 
-      const transferWithValue = this.mapZeroValueTransfer(nestedTransaction);
-      // If we do not have a transfer with value, we do not add it to the result
-      if (!transferWithValue) continue;
+    return nestedTransactions
+      .filter((nestedTransaction) => {
+        // If we do not have a transfer with value, we do not add it to the result
+        if (!this.transferHasValue(nestedTransaction)) return false;
 
-      const trustedTransfer = onlyTrusted
-        ? this.mapTrustedTransfer(transferWithValue)
-        : transferWithValue;
-
-      if (!trustedTransfer) continue;
-      result.push(new TransactionItem(nestedTransaction));
-    }
-    return result;
+        return !onlyTrusted || this.isTrustedTransfer(nestedTransaction);
+      })
+      .map((nestedTransaction) => new TransactionItem(nestedTransaction));
   }
 
   /**
@@ -217,25 +211,18 @@ export class TransactionsHistoryMapper {
    *
    * @private
    */
-  private mapZeroValueTransfer(transaction: Transaction): Transaction | null {
-    if (!isTransferTransactionInfo(transaction.txInfo)) return transaction;
-    if (!isErc20Transfer(transaction.txInfo.transferInfo)) return transaction;
+  private transferHasValue(transaction: Transaction): boolean {
+    if (!isTransferTransactionInfo(transaction.txInfo)) return true;
+    if (!isErc20Transfer(transaction.txInfo.transferInfo)) return true;
 
-    if (transaction.txInfo.transferInfo.value === '0') return null;
-    return transaction;
+    return transaction.txInfo.transferInfo.value !== '0';
   }
 
-  private mapTrustedTransfer(transaction: Transaction): Transaction | null {
-    if (!isTransferTransactionInfo(transaction.txInfo)) return transaction;
-    if (!isErc20Transfer(transaction.txInfo.transferInfo)) return transaction;
+  private isTrustedTransfer(transaction: Transaction): boolean {
+    if (!isTransferTransactionInfo(transaction.txInfo)) return true;
+    if (!isErc20Transfer(transaction.txInfo.transferInfo)) return true;
 
-    // If we have successfully retrieved the token information, and it is a
-    // trusted token, return it. Else return null
-    if (transaction.txInfo.transferInfo.trusted) {
-      return transaction;
-    } else {
-      return null;
-    }
+    return !!transaction.txInfo.transferInfo.trusted;
   }
 
   private mapGroupTransactions(


### PR DESCRIPTION
As per [suggestion](https://github.com/safe-global/safe-client-gateway/pull/1061#discussion_r1464091362), this refactors the filtering of trusted transactions to be simpler:

#### Changes
- `for` has been changed to an initial fetching of nested transactions, then `filter`ing
- Mappers that are only used as flags have been adjusted to return `boolean`s
  - `mapZeroValueTransfer` -> `transferHasValue`
  - `mapTrustedTransfer` -> `isTrustedTransfer`