### PR TITLE
Remove unnecessary `expect` in test

### DIFF
--- a/src/logging/utils.spec.ts
+++ b/src/logging/utils.spec.ts
@@ -33,9 +33,6 @@ describe('asError', () => {
 
     const result = asError(thrown);
     expect(result).toEqual(new Error('test error'));
-
-    // If stringified:
-    expect(result).not.toEqual(new Error('{"message":"test error"}'));
   });
 
   it('should return a new Error instance with the stringified thrown value if thrown is not an instance of Error', () => {

--- a/src/logging/utils.spec.ts
+++ b/src/logging/utils.spec.ts
@@ -23,9 +23,6 @@ describe('asError', () => {
 
     const result = asError(thrown);
     expect(result).toEqual(new Error('test error'));
-
-    // If stringified:
-    expect(result).not.toEqual(new Error('"test error'));
   });
 
   it('should return a new Error instance with the message thrown value if thrown is object with message', () => {


### PR DESCRIPTION
This removes an unnecessary `expect` in the `asError` test as it is checked prior as per https://github.com/safe-global/safe-client-gateway/pull/1051#discussion_r1464590239.