### PR TITLE
Reapply `noImplicitAny` in TypeScript

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,7 +37,6 @@ import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 import { DataSourceErrorFilter } from '@/routes/common/filters/data-source-error.filter';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { RootModule } from '@/routes/root/root.module';
-import { ConfigFactory } from '@nestjs/config/dist/interfaces/config-factory.interface';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { AlertsControllerModule } from '@/routes/alerts/alerts.controller.module';
 import { RecoveryModule } from '@/routes/recovery/recovery.module';
@@ -47,7 +46,7 @@ export class AppModule implements NestModule {
   // Important: values read via the config factory do not take the .env file
   // into account. The .env file loading is done by the ConfigurationModule
   // which is not available at this stage.
-  static register(configFactory: ConfigFactory = configuration): DynamicModule {
+  static register(configFactory = configuration): DynamicModule {
     const isEmailFeatureEnabled = configFactory()['features']['email'];
 
     return {

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -30,7 +30,7 @@ describe('ConfigApi', () => {
   const baseUri = faker.internet.url({ appendSlash: false });
   const expirationTimeInSeconds = faker.number.int();
   const notFoundExpirationTimeInSeconds = faker.number.int();
-  let fakeConfigurationService;
+  let fakeConfigurationService: FakeConfigurationService;
   let service: ConfigApi;
 
   beforeAll(async () => {

--- a/src/datasources/network/entities/network.error.entity.ts
+++ b/src/datasources/network/entities/network.error.entity.ts
@@ -8,7 +8,7 @@ export type NetworkError = NetworkResponseError | NetworkRequestError;
  */
 export class NetworkResponseError extends Error {
   constructor(
-    readonly status,
+    readonly status: number,
     readonly data?: any,
   ) {
     super();

--- a/src/datasources/network/fetch.network.service.spec.ts
+++ b/src/datasources/network/fetch.network.service.spec.ts
@@ -98,7 +98,7 @@ describe('FetchNetworkService', () => {
       (fetchClientMock as any).mockRejectedValueOnce(error);
 
       await expect(target.get(url)).rejects.toThrow(
-        new NetworkResponseError(error.response.data, error.response.status),
+        new NetworkResponseError(error.response.status, error.response.data),
       );
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
@@ -210,7 +210,7 @@ describe('FetchNetworkService', () => {
       (fetchClientMock as any).mockRejectedValueOnce(error);
 
       await expect(target.post(url, data)).rejects.toThrow(
-        new NetworkResponseError(error.response.data, error.response.status),
+        new NetworkResponseError(error.response.status, error.response.data),
       );
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
@@ -300,7 +300,7 @@ describe('FetchNetworkService', () => {
       fetchClientMock.mockRejectedValueOnce(error);
 
       await expect(target.delete(url, data)).rejects.toThrow(
-        new NetworkResponseError(error.response.data, error.response.status),
+        new NetworkResponseError(error.response.status, error.response.data),
       );
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);

--- a/src/datasources/network/fetch.network.service.ts
+++ b/src/datasources/network/fetch.network.service.ts
@@ -87,7 +87,7 @@ export class FetchNetworkService implements INetworkService {
     return urlObject.toString();
   }
 
-  private handleError(error, responseTimeMs: number): never {
+  private handleError(error: any, responseTimeMs: number): never {
     if (error.response) {
       this.logErrorResponse(error, responseTimeMs);
       throw new NetworkResponseError(error.response.status, error.data);
@@ -96,7 +96,7 @@ export class FetchNetworkService implements INetworkService {
     }
   }
 
-  private logErrorResponse(error, responseTimeMs: number): void {
+  private logErrorResponse(error: any, responseTimeMs: number): void {
     this.loggingService.debug({
       type: 'external_request',
       protocol: error.request?.protocol,

--- a/src/domain/relay/contracts/safe-contract.helper.spec.ts
+++ b/src/domain/relay/contracts/safe-contract.helper.spec.ts
@@ -6,7 +6,7 @@ import { getSafeSingletonDeployment } from '@safe-global/safe-deployments';
 
 describe('Safe Contract Helper Tests', () => {
   let target: SafeContractHelper;
-  let abi;
+  let abi: Array<unknown>;
 
   const supportedSafeVersion = '1.3.0';
 

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -33,7 +33,10 @@ import {
   swapOwnerEncoder,
 } from '@/domain/alerts/__tests__/safe-transactions.encoder';
 import { transactionAddedEventBuilder } from '@/domain/alerts/__tests__/delay-modifier.encoder';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { getAddress } from 'viem';
@@ -67,16 +70,16 @@ function fakeTenderlySignature(args: {
 }
 
 describe('Alerts (Unit)', () => {
-  let configurationService;
-  let emailApi;
-  let emailDataSource;
-  let urlGenerator;
+  let configurationService: jest.MockedObjectDeep<IConfigurationService>;
+  let emailApi: jest.MockedObjectDeep<IEmailApi>;
+  let emailDataSource: jest.MockedObjectDeep<IEmailDataSource>;
+  let urlGenerator: UrlGeneratorHelper;
 
   describe('/alerts route enabled', () => {
     let app: INestApplication;
     let signingKey: string;
-    let networkService;
-    let safeConfigUrl;
+    let networkService: jest.MockedObjectDeep<INetworkService>;
+    let safeConfigUrl: string | undefined;
 
     beforeEach(async () => {
       jest.clearAllMocks();
@@ -183,11 +186,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -284,11 +290,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -384,11 +393,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -474,11 +486,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -595,11 +610,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -688,11 +706,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -804,11 +825,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -894,11 +918,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -971,11 +998,14 @@ describe('Alerts (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-              return Promise.resolve({ data: { safes: [safe.address] } });
+              return Promise.resolve({
+                data: { safes: [safe.address] },
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-              return Promise.resolve({ data: safe });
+              return Promise.resolve({ data: safe, status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -1093,11 +1123,14 @@ describe('Alerts (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ data: { safes: [safe.address] } });
+            return Promise.resolve({
+              data: { safes: [safe.address] },
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -1200,11 +1233,14 @@ describe('Alerts (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ data: { safes: [safe.address] } });
+            return Promise.resolve({
+              data: { safes: [safe.address] },
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -1297,11 +1333,14 @@ describe('Alerts (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/modules/${delayModifier}/safes/`:
-            return Promise.resolve({ data: { safes: [safe.address] } });
+            return Promise.resolve({
+              data: { safes: [safe.address] },
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -9,7 +9,10 @@ import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { faker } from '@faker-js/faker';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -22,9 +25,9 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('Balances Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let pricesProviderUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let pricesProviderUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -96,13 +99,22 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
-            return Promise.resolve({ data: transactionApiBalancesResponse });
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
           case `${pricesProviderUrl}/simple/price`:
-            return Promise.resolve({ data: nativeCoinPriceProviderResponse });
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
           case `${pricesProviderUrl}/simple/token_price/${chainName}`:
-            return Promise.resolve({ data: tokenPriceProviderResponse });
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -217,11 +229,17 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
-            return Promise.resolve({ data: transactionApiBalancesResponse });
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
           case `${pricesProviderUrl}/simple/token_price/${chainName}`:
-            return Promise.resolve({ data: tokenPriceProviderResponse });
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -262,11 +280,17 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
-            return Promise.resolve({ data: transactionApiBalancesResponse });
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
           case `${pricesProviderUrl}/simple/price`:
-            return Promise.resolve({ data: nativeCoinPriceProviderResponse });
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -320,11 +344,17 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
-            return Promise.resolve({ data: transactionApiBalancesResponse });
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
           case `${pricesProviderUrl}/simple/token_price/${chainName}`:
-            return Promise.resolve({ data: tokenPriceProviderResponse });
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -409,9 +439,12 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
-              return Promise.resolve({ data: transactionApiBalancesResponse });
+              return Promise.resolve({
+                data: transactionApiBalancesResponse,
+                status: 200,
+              });
             case `${pricesProviderUrl}/simple/token_price/${chainName}`:
               return Promise.reject();
             default:
@@ -466,11 +499,17 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain });
+              return Promise.resolve({ data: chain, status: 200 });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
-              return Promise.resolve({ data: transactionApiBalancesResponse });
+              return Promise.resolve({
+                data: transactionApiBalancesResponse,
+                status: 200,
+              });
             case `${pricesProviderUrl}/simple/token_price/${chainName}`:
-              return Promise.resolve({ data: tokenPriceProviderResponse });
+              return Promise.resolve({
+                data: tokenPriceProviderResponse,
+                status: 200,
+              });
             default:
               return Promise.reject(new Error(`Could not match ${url}`));
           }
@@ -513,7 +552,7 @@ describe('Balances Controller (Unit)', () => {
         const chainResponse = chainBuilder().with('chainId', chainId).build();
         networkService.get.mockImplementation((url) => {
           if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           } else if (
             url ==
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/`
@@ -541,12 +580,15 @@ describe('Balances Controller (Unit)', () => {
         const chainResponse = chainBuilder().with('chainId', chainId).build();
         networkService.get.mockImplementation((url) => {
           if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           } else if (
             url ==
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/`
           ) {
-            return Promise.resolve({ data: [{ invalid: 'data' }] });
+            return Promise.resolve({
+              data: [{ invalid: 'data' }],
+              status: 200,
+            });
           } else {
             return Promise.reject(new Error(`Could not match ${url}`));
           }
@@ -572,7 +614,10 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({ data: pricesProviderFiatCodes });
+            return Promise.resolve({
+              data: pricesProviderFiatCodes,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -604,11 +649,14 @@ describe('Balances Controller (Unit)', () => {
     });
 
     it('validation error getting fiat currencies data from prices provider', async () => {
-      const pricesProviderFiatCodes = [];
+      const pricesProviderFiatCodes: Array<string> = [];
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({ data: pricesProviderFiatCodes });
+            return Promise.resolve({
+              data: pricesProviderFiatCodes,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -629,7 +677,10 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({ data: pricesProviderFiatCodes });
+            return Promise.resolve({
+              data: pricesProviderFiatCodes,
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -15,16 +15,19 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication;
-  let authToken;
-  let safeConfigUrl;
+  let authToken: string;
+  let safeConfigUrl: string;
   let fakeCacheService: FakeCacheService;
-  let networkService;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -143,6 +146,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -166,6 +170,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/1`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', '1').build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -218,6 +223,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -270,6 +276,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -322,6 +329,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -366,6 +374,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -415,6 +424,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -464,6 +474,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -508,6 +519,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -547,6 +559,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -611,6 +624,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -653,6 +667,7 @@ describe('Post Hook Events (Unit)', () => {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
             data: chainBuilder().with('chainId', chainId).build(),
+            status: 200,
           });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -11,7 +11,10 @@ import { CacheModule } from '@/datasources/cache/cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { backboneBuilder } from '@/domain/backbone/entities/__tests__/backbone.builder';
 import { Backbone } from '@/domain/backbone/entities/backbone.entity';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
@@ -31,11 +34,11 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 describe('Chains Controller (Unit)', () => {
   let app: INestApplication;
 
-  let safeConfigUrl;
-  let name;
-  let version;
-  let buildNumber;
-  let networkService;
+  let safeConfigUrl: string;
+  let name: string;
+  let version: string;
+  let buildNumber: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   const chainsResponse: Page<Chain> = {
     count: 2,
@@ -76,7 +79,10 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /chains', () => {
     it('Success', async () => {
-      networkService.get.mockResolvedValueOnce({ data: chainsResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainsResponse,
+        status: 200,
+      });
 
       await request(app.getHttpServer())
         .get('/v1/chains')
@@ -167,6 +173,7 @@ describe('Chains Controller (Unit)', () => {
           ...chainsResponse,
           results: [...chainsResponse.results, { invalid: 'item' }],
         },
+        status: 200,
       });
 
       await request(app.getHttpServer()).get('/v1/chains').expect(500).expect({
@@ -210,7 +217,10 @@ describe('Chains Controller (Unit)', () => {
         theme: chainDomain.theme,
         ensRegistryAddress: chainDomain.ensRegistryAddress,
       };
-      networkService.get.mockResolvedValueOnce({ data: chainDomain });
+      networkService.get.mockResolvedValueOnce({
+        data: chainDomain,
+        status: 200,
+      });
 
       await request(app.getHttpServer())
         .get(`/v1/chains/${chainId}`)
@@ -252,8 +262,14 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /:chainId/about/backbone', () => {
     it('Success', async () => {
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
-      networkService.get.mockResolvedValueOnce({ data: backboneResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
+      networkService.get.mockResolvedValueOnce({
+        data: backboneResponse,
+        status: 200,
+      });
 
       await request(app.getHttpServer())
         .get('/v1/chains/1/about/backbone')
@@ -291,7 +307,10 @@ describe('Chains Controller (Unit)', () => {
     });
 
     it('Failure getting the backbone data', async () => {
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       networkService.get.mockRejectedValueOnce({
         status: 502,
       });
@@ -317,13 +336,17 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /:chainId/about/master-copies', () => {
     it('Success', async () => {
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       const domainMasterCopiesResponse: DomainMasterCopy[] = [
         masterCopyBuilder().build(),
         masterCopyBuilder().build(),
       ];
       networkService.get.mockResolvedValueOnce({
         data: domainMasterCopiesResponse,
+        status: 200,
       });
       const masterCopiesResponse = [
         {
@@ -372,7 +395,10 @@ describe('Chains Controller (Unit)', () => {
     });
 
     it('Should fail getting the master-copies data', async () => {
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       networkService.get.mockRejectedValueOnce({
         status: 502,
       });
@@ -396,13 +422,17 @@ describe('Chains Controller (Unit)', () => {
     });
 
     it('Should return validation error', async () => {
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       const domainMasterCopiesResponse = [
         { address: 1223, safe: 'error' },
         masterCopyBuilder().build(),
       ];
       networkService.get.mockResolvedValueOnce({
         data: domainMasterCopiesResponse,
+        status: 200,
       });
 
       await request(app.getHttpServer())
@@ -425,7 +455,10 @@ describe('Chains Controller (Unit)', () => {
         version,
         buildNumber,
       };
-      networkService.get.mockResolvedValueOnce({ data: chainDomain });
+      networkService.get.mockResolvedValueOnce({
+        data: chainDomain,
+        status: 200,
+      });
 
       await request(app.getHttpServer())
         .get(`/v1/chains/${chainDomain.chainId}/about`)

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -14,7 +14,10 @@ import {
   NetworkResponseError,
 } from '@/datasources/network/entities/network.error.entity';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { collectibleBuilder } from '@/domain/collectibles/entities/__tests__/collectible.builder';
 import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
@@ -30,8 +33,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -80,9 +83,9 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
-            return Promise.resolve({ data: collectiblesResponse });
+            return Promise.resolve({ data: collectiblesResponse, status: 200 });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -123,9 +126,9 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
-            return Promise.resolve({ data: collectiblesResponse });
+            return Promise.resolve({ data: collectiblesResponse, status: 200 });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -167,9 +170,9 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
-            return Promise.resolve({ data: collectiblesResponse });
+            return Promise.resolve({ data: collectiblesResponse, status: 200 });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -201,7 +204,7 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
             return Promise.reject(transactionServiceError);
           default:
@@ -226,7 +229,7 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse });
+            return Promise.resolve({ data: chainResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
             return Promise.reject(transactionServiceError);
           default:

--- a/src/routes/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.spec.ts
@@ -6,7 +6,7 @@ import { PaginationData } from '@/routes/common/pagination/pagination.data';
 
 describe('PaginationDataDecorator', () => {
   let app: INestApplication;
-  let paginationData;
+  let paginationData: PaginationData;
 
   @Controller()
   class TestController {

--- a/src/routes/common/decorators/utils.spec.ts
+++ b/src/routes/common/decorators/utils.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { getRouteUrl } from '@/routes/common/decorators/utils';
+import { Request } from 'express';
 
 describe('utils tests', () => {
   describe('getRouteUrl tests', () => {
@@ -7,7 +8,7 @@ describe('utils tests', () => {
       get: jest.fn(),
       originalUrl: faker.system.filePath(),
       protocol: faker.internet.protocol(),
-    } as unknown as any;
+    } as jest.MockedObjectDeep<Request>;
 
     const requestMock = jest.mocked(request);
 

--- a/src/routes/common/decorators/utils.ts
+++ b/src/routes/common/decorators/utils.ts
@@ -1,4 +1,6 @@
-export function getRouteUrl(request: any): URL {
+import { Request } from 'express';
+
+export function getRouteUrl(request: Request): URL {
   const protocol = request.get('X-Forwarded-Proto') ?? request.protocol;
   return new URL(`${protocol}://${request.get('Host')}${request.originalUrl}`);
 }

--- a/src/routes/common/filters/global-error.filter.spec.ts
+++ b/src/routes/common/filters/global-error.filter.spec.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  INestApplication,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import * as request from 'supertest';
@@ -25,7 +31,7 @@ class TestController {
 }
 
 describe('GlobalErrorFilter tests', () => {
-  let app;
+  let app: INestApplication;
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [TestLoggingModule, ConfigurationModule.register(configuration)],

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -13,14 +13,17 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
 
 describe('Contracts controller', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -57,9 +60,9 @@ describe('Contracts controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
-            return Promise.resolve({ data: contract });
+            return Promise.resolve({ data: contract, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -94,7 +97,7 @@ describe('Contracts controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
             return Promise.reject(new Error());
           default:
@@ -113,9 +116,12 @@ describe('Contracts controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
-            return Promise.resolve({ data: { ...contract, name: false } });
+            return Promise.resolve({
+              data: { ...contract, name: false },
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -12,7 +12,10 @@ import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -25,8 +28,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('Delegates controller', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -67,10 +70,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation((url) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         }
         if (url === `${chain.transactionService}/api/v1/delegates/`) {
-          return Promise.resolve({ data: delegatesPage });
+          return Promise.resolve({ data: delegatesPage, status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -95,10 +98,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation((url) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         }
         if (url === `${chain.transactionService}/api/v1/delegates/`) {
-          return Promise.resolve({ data: delegatesPage });
+          return Promise.resolve({ data: delegatesPage, status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -124,10 +127,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation((url) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         }
         if (url === `${chain.transactionService}/api/v1/delegates/`) {
-          return Promise.resolve({ data: delegatesPage });
+          return Promise.resolve({ data: delegatesPage, status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -154,12 +157,12 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
         url === `${chain.transactionService}/api/v1/delegates/`
-          ? Promise.resolve({ status: 201 })
+          ? Promise.resolve({ status: 201, data: {} })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -185,12 +188,12 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
         url === `${chain.transactionService}/api/v1/delegates/`
-          ? Promise.resolve({ status: 201 })
+          ? Promise.resolve({ status: 201, data: {} })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -205,7 +208,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
@@ -232,7 +235,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
@@ -258,7 +261,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation((url) =>
@@ -281,7 +284,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation((url) =>
@@ -311,7 +314,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation((url) =>
@@ -353,7 +356,7 @@ describe('Delegates controller', () => {
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation((url) =>
@@ -376,7 +379,7 @@ describe('Delegates controller', () => {
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation((url) =>

--- a/src/routes/email/email.controller.delete-email.spec.ts
+++ b/src/routes/email/email.controller.delete-email.spec.ts
@@ -14,7 +14,10 @@ import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
@@ -25,13 +28,14 @@ import { EmailApiModule } from '@/datasources/email-api/email-api.module';
 import { TestEmailApiModule } from '@/datasources/email-api/__tests__/test.email-api.module';
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
 import { emailBuilder } from '@/domain/email/entities/__tests__/email.builder';
+import { INestApplication } from '@nestjs/common';
 
 describe('Email controller delete email tests', () => {
-  let app;
-  let safeConfigUrl;
-  let emailDatasource;
-  let emailApi;
-  let networkService;
+  let app: INestApplication;
+  let safeConfigUrl: string;
+  let emailDatasource: jest.MockedObjectDeep<IEmailDataSource>;
+  let emailApi: jest.MockedObjectDeep<IEmailApi>;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -119,9 +123,9 @@ describe('Email controller delete email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -235,9 +239,9 @@ describe('Email controller delete email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -14,22 +14,26 @@ import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { getAddress } from 'viem';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { EmailAddressDoesNotExistError } from '@/datasources/email/errors/email-address-does-not-exist.error';
-import { EmailAddress } from '@/domain/email/entities/email.entity';
+import { Email, EmailAddress } from '@/domain/email/entities/email.entity';
+import { INestApplication } from '@nestjs/common';
 
 const verificationCodeTtlMs = 100;
 
 describe('Email controller edit email tests', () => {
-  let app;
-  let safeConfigUrl;
-  let emailDatasource;
-  let networkService;
+  let app: INestApplication;
+  let safeConfigUrl: string;
+  let emailDatasource: jest.MockedObjectDeep<IEmailDataSource>;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -99,16 +103,16 @@ describe('Email controller edit email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
     emailDatasource.getEmail.mockResolvedValue({
       emailAddress: new EmailAddress(prevEmailAddress),
-    });
+    } as Email);
     emailDatasource.updateEmail.mockResolvedValue();
 
     await request(app.getHttpServer())
@@ -146,9 +150,9 @@ describe('Email controller edit email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -156,7 +160,7 @@ describe('Email controller edit email tests', () => {
     emailDatasource.getEmail.mockResolvedValue({
       emailAddress: new EmailAddress(prevEmailAddress),
       verificationGeneratedOn: verificationGeneratedOn,
-    });
+    } as Email);
     emailDatasource.updateEmail.mockResolvedValue();
 
     await request(app.getHttpServer())
@@ -192,16 +196,16 @@ describe('Email controller edit email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
     emailDatasource.getEmail.mockResolvedValue({
       emailAddress: new EmailAddress(emailAddress),
-    });
+    } as Email);
 
     await request(app.getHttpServer())
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
@@ -237,9 +241,9 @@ describe('Email controller edit email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -287,16 +291,16 @@ describe('Email controller edit email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
     emailDatasource.getEmail.mockResolvedValue({
       emailAddress: new EmailAddress(prevEmailAddress),
-    });
+    } as Email);
     emailDatasource.updateEmail.mockRejectedValue(new Error());
 
     await request(app.getHttpServer())
@@ -397,9 +401,9 @@ describe('Email controller edit email tests', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/email/email.controller.resend-verification.spec.ts
+++ b/src/routes/email/email.controller.resend-verification.spec.ts
@@ -15,12 +15,13 @@ import { faker } from '@faker-js/faker';
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { emailBuilder } from '@/domain/email/entities/__tests__/email.builder';
+import { INestApplication } from '@nestjs/common';
 
 const resendLockWindowMs = 100;
 const ttlMs = 1000;
 describe('Email controller resend verification tests', () => {
-  let app;
-  let emailDatasource;
+  let app: INestApplication;
+  let emailDatasource: jest.MockedObjectDeep<IEmailDataSource>;
 
   beforeEach(async () => {
     jest.clearAllMocks();

--- a/src/routes/email/email.controller.verify-email.spec.ts
+++ b/src/routes/email/email.controller.verify-email.spec.ts
@@ -15,13 +15,14 @@ import { faker } from '@faker-js/faker';
 import { IEmailDataSource } from '@/domain/interfaces/email.datasource.interface';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { emailBuilder } from '@/domain/email/entities/__tests__/email.builder';
+import { INestApplication } from '@nestjs/common';
 
 const resendLockWindowMs = 100;
 const ttlMs = 1000;
 
 describe('Email controller verify email tests', () => {
-  let app;
-  let emailDatasource;
+  let app: INestApplication;
+  let emailDatasource: jest.MockedObjectDeep<IEmailDataSource>;
 
   beforeEach(async () => {
     jest.clearAllMocks();

--- a/src/routes/email/guards/email-deletion.guard.spec.ts
+++ b/src/routes/email/guards/email-deletion.guard.spec.ts
@@ -1,4 +1,10 @@
-import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  HttpCode,
+  INestApplication,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
@@ -29,7 +35,7 @@ class TestController {
 }
 
 describe('EmailDeletionGuard guard tests', () => {
-  let app;
+  let app: INestApplication;
 
   const chainId = faker.string.numeric();
   const safe = faker.finance.ethereumAddress();

--- a/src/routes/email/guards/email-edit.guard.spec.ts
+++ b/src/routes/email/guards/email-edit.guard.spec.ts
@@ -1,4 +1,10 @@
-import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  HttpCode,
+  INestApplication,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
@@ -29,7 +35,7 @@ class TestController {
 }
 
 describe('EmailEdit guard tests', () => {
-  let app;
+  let app: INestApplication;
 
   const chainId = faker.string.numeric();
   const safe = faker.finance.ethereumAddress();

--- a/src/routes/email/guards/email-registration.guard.spec.ts
+++ b/src/routes/email/guards/email-registration.guard.spec.ts
@@ -1,4 +1,10 @@
-import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  HttpCode,
+  INestApplication,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
@@ -29,7 +35,7 @@ class TestController {
 }
 
 describe('EmailRegistration guard tests', () => {
-  let app;
+  let app: INestApplication;
 
   const chainId = faker.string.numeric();
   const safe = faker.finance.ethereumAddress();

--- a/src/routes/email/guards/only-safe-owner.guard.spec.ts
+++ b/src/routes/email/guards/only-safe-owner.guard.spec.ts
@@ -1,4 +1,10 @@
-import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  HttpCode,
+  INestApplication,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
@@ -34,7 +40,7 @@ class TestController {
 }
 
 describe('OnlySafeOwner guard tests', () => {
-  let app;
+  let app: INestApplication;
 
   beforeEach(async () => {
     jest.resetAllMocks();

--- a/src/routes/email/guards/timestamp.guard.spec.ts
+++ b/src/routes/email/guards/timestamp.guard.spec.ts
@@ -2,7 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/configuration';
-import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  HttpCode,
+  INestApplication,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { TimestampGuard } from '@/routes/email/guards/timestamp.guard';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import * as request from 'supertest';
@@ -19,7 +25,7 @@ class TestController {
 }
 
 describe('TimestampGuard tests', () => {
-  let app;
+  let app: INestApplication;
 
   beforeEach(async () => {
     jest.useFakeTimers();

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -22,14 +22,17 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
 
 describe('Estimations Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -70,10 +73,10 @@ describe('Estimations Controller (Unit)', () => {
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
         const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
         if (url === chainsUrl) {
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         }
         if (url === getSafeUrl) {
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         }
         if (url === multisigTransactionsUrl) {
           return Promise.resolve({
@@ -81,6 +84,7 @@ describe('Estimations Controller (Unit)', () => {
               .with('count', 1)
               .with('results', [multisigTransactionToJson(lastTransaction)])
               .build(),
+            status: 200,
           });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
@@ -88,7 +92,7 @@ describe('Estimations Controller (Unit)', () => {
       networkService.post.mockImplementation((url) => {
         const estimationsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/estimations/`;
         return url === estimationsUrl
-          ? Promise.resolve({ data: estimation })
+          ? Promise.resolve({ data: estimation, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`);
       });
 
@@ -144,10 +148,10 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
@@ -155,6 +159,7 @@ describe('Estimations Controller (Unit)', () => {
             .with('count', 1)
             .with('results', [multisigTransactionToJson(lastTransaction)])
             .build(),
+          status: 200,
         });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
@@ -162,7 +167,7 @@ describe('Estimations Controller (Unit)', () => {
     networkService.post.mockImplementation((url) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation })
+        ? Promise.resolve({ data: estimation, status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 
@@ -196,14 +201,15 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
           data: pageBuilder().with('count', 0).with('results', []).build(),
+          status: 200,
         });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
@@ -211,7 +217,7 @@ describe('Estimations Controller (Unit)', () => {
     networkService.post.mockImplementation((url) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation })
+        ? Promise.resolve({ data: estimation, status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 
@@ -248,10 +254,10 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
@@ -259,6 +265,7 @@ describe('Estimations Controller (Unit)', () => {
             .with('count', 1)
             .with('results', [multisigTransactionToJson(lastTransaction)])
             .build(),
+          status: 200,
         });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
@@ -266,7 +273,7 @@ describe('Estimations Controller (Unit)', () => {
     networkService.post.mockImplementation((url) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation })
+        ? Promise.resolve({ data: estimation, status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -21,17 +21,21 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { createMessageDtoBuilder } from '@/routes/messages/entities/__tests__/create-message.dto.builder';
 import { updateMessageSignatureDtoBuilder } from '@/routes/messages/entities/__tests__/update-message-signature.dto.builder';
 import { MessageStatus } from '@/routes/messages/entities/message.entity';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
+import { SafeApp } from '@/routes/safe-apps/entities/safe-app.entity';
 
 describe('Messages controller', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -60,7 +64,7 @@ describe('Messages controller', () => {
   describe('GET messages by hash', () => {
     it('Get a confirmed message with no safe app associated', async () => {
       const chain = chainBuilder().build();
-      const safeApps = [];
+      const safeApps: Array<SafeApp> = [];
       const messageConfirmations = faker.helpers.multiple(
         () => messageConfirmationBuilder().build(),
         { count: { min: 2, max: 5 } },
@@ -77,13 +81,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
-            return Promise.resolve({ data: messageToJson(message) });
+            return Promise.resolve({
+              data: messageToJson(message),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps });
+            return Promise.resolve({ data: safeApps, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -141,13 +148,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
-            return Promise.resolve({ data: messageToJson(message) });
+            return Promise.resolve({
+              data: messageToJson(message),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps });
+            return Promise.resolve({ data: safeApps, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -185,7 +195,7 @@ describe('Messages controller', () => {
 
     it('Get an unconfirmed message with no safe app associated', async () => {
       const chain = chainBuilder().build();
-      const safeApps = [];
+      const safeApps: Array<SafeApp> = [];
       const messageConfirmations = faker.helpers.multiple(
         () => messageConfirmationBuilder().build(),
         { count: { min: 2, max: 5 } },
@@ -202,13 +212,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
-            return Promise.resolve({ data: messageToJson(message) });
+            return Promise.resolve({
+              data: messageToJson(message),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps });
+            return Promise.resolve({ data: safeApps, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -266,13 +279,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
-            return Promise.resolve({ data: messageToJson(message) });
+            return Promise.resolve({
+              data: messageToJson(message),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps });
+            return Promise.resolve({ data: safeApps, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -327,13 +343,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
-            return Promise.resolve({ data: messageToJson(message) });
+            return Promise.resolve({
+              data: messageToJson(message),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: [] });
+            return Promise.resolve({ data: [], status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -388,11 +407,14 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
-            return Promise.resolve({ data: messageToJson(message) });
+            return Promise.resolve({
+              data: messageToJson(message),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -437,12 +459,13 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
             return Promise.resolve({
               data: { ...page, previous: faker.number.int() },
+              status: 200,
             });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -481,11 +504,11 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
-            return Promise.resolve({ data: page });
+            return Promise.resolve({ data: page, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -567,11 +590,11 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
-            return Promise.resolve({ data: page });
+            return Promise.resolve({ data: page, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -666,11 +689,11 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain });
+            return Promise.resolve({ data: chain, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe });
+            return Promise.resolve({ data: safe, status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
-            return Promise.resolve({ data: page });
+            return Promise.resolve({ data: page, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -728,13 +751,13 @@ describe('Messages controller', () => {
       const message = messageBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`
-          ? Promise.resolve({ data: messageToJson(message) })
+          ? Promise.resolve({ data: messageToJson(message), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -751,7 +774,7 @@ describe('Messages controller', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
@@ -801,10 +824,11 @@ describe('Messages controller', () => {
         .build();
       const expectedResponse = {
         data: { signature: faker.string.hexadecimal() },
+        status: 200,
       };
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>
@@ -832,7 +856,7 @@ describe('Messages controller', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation((url) =>

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -14,7 +14,10 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { registerDeviceDtoBuilder } from '@/routes/notifications/entities/__tests__/register-device.dto.builder';
 import { safeRegistrationBuilder } from '@/routes/notifications/entities/__tests__/safe-registration.builder';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
@@ -23,8 +26,8 @@ import { RegisterDeviceDto } from '@/routes/notifications/entities/register-devi
 
 describe('Notifications Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -70,12 +73,12 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation((url) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build() })
+          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve()
+          ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
 
@@ -90,7 +93,7 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation((url) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build() })
+          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url);
       });
       networkService.post.mockImplementationOnce((url) =>
@@ -104,7 +107,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve()
+          ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
 
@@ -125,7 +128,7 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation((url) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build() })
+          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementationOnce((url) =>
@@ -139,7 +142,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve()
+          ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
 
@@ -158,7 +161,7 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation((url) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build() })
+          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url);
       });
       networkService.post.mockImplementationOnce((url) =>
@@ -181,7 +184,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve()
+          ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
 
@@ -203,12 +206,12 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation((url) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build() })
+          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementationOnce((url) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve()
+          ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementationOnce((url) =>
@@ -218,7 +221,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve()
+          ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
 
@@ -241,11 +244,13 @@ describe('Notifications Controller (Unit)', () => {
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}`;
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation((url) =>
-        url === expectedProviderURL ? Promise.resolve() : rejectForUrl(url),
+        url === expectedProviderURL
+          ? Promise.resolve({ data: {}, status: 200 })
+          : rejectForUrl(url),
       );
 
       await request(app.getHttpServer())
@@ -276,7 +281,7 @@ describe('Notifications Controller (Unit)', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation((url) =>
@@ -301,11 +306,13 @@ describe('Notifications Controller (Unit)', () => {
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation((url) =>
-        url === expectedProviderURL ? Promise.resolve() : rejectForUrl(url),
+        url === expectedProviderURL
+          ? Promise.resolve({ data: {}, status: 200 })
+          : rejectForUrl(url),
       );
 
       await request(app.getHttpServer())
@@ -342,7 +349,7 @@ describe('Notifications Controller (Unit)', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain })
+          ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation((url) =>

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -9,7 +9,10 @@ import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -19,8 +22,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -62,9 +65,13 @@ describe('Owners Controller (Unit)', () => {
           faker.finance.ethereumAddress(),
         ],
       };
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       networkService.get.mockResolvedValueOnce({
         data: transactionApiSafeListResponse,
+        status: 200,
       });
 
       await request(app.getHttpServer())
@@ -99,7 +106,10 @@ describe('Owners Controller (Unit)', () => {
       const chainId = faker.string.numeric();
       const ownerAddress = faker.finance.ethereumAddress();
       const chainResponse = chainBuilder().with('chainId', chainId).build();
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       networkService.get.mockRejectedValueOnce({
         status: 500,
       });
@@ -134,9 +144,13 @@ describe('Owners Controller (Unit)', () => {
           faker.finance.ethereumAddress(),
         ],
       };
-      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
+        data: chainResponse,
+        status: 200,
+      });
       networkService.get.mockResolvedValueOnce({
         data: transactionApiSafeListResponse,
+        status: 200,
       });
 
       await request(app.getHttpServer())

--- a/src/routes/recovery/recovery.controller.spec.ts
+++ b/src/routes/recovery/recovery.controller.spec.ts
@@ -9,7 +9,10 @@ import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { addRecoveryModuleDtoBuilder } from '@/routes/recovery/entities/__tests__/add-recovery-module.dto.builder';
@@ -23,7 +26,7 @@ describe('Recovery (Unit)', () => {
   let alertsUrl: string;
   let alertsAccount: string;
   let alertsProject: string;
-  let networkService;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -73,7 +76,7 @@ describe('Recovery (Unit)', () => {
       networkService.post.mockImplementation((url) =>
         url ===
         `${alertsUrl}/api/v2/accounts/${alertsAccount}/projects/${alertsProject}/contracts`
-          ? Promise.resolve({ status: 200 })
+          ? Promise.resolve({ status: 200, data: {} })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 

--- a/src/routes/root/root.controller.ts
+++ b/src/routes/root/root.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get, Res } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
+import { Response } from 'express';
 
 @Controller()
 @ApiExcludeController()
 export class RootController {
   @Get()
-  getIndex(@Res() res): void {
+  getIndex(@Res() res: Response): void {
     return res.redirect('/index.html');
   }
 }

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -6,6 +6,7 @@ import { AppModule } from '@/app.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { redisClientFactory } from '@/__tests__/redis-client.factory';
 import { CacheKeyPrefix } from '@/datasources/cache/constants';
+import { SafeApp } from '@/routes/safe-apps/entities/safe-app.entity';
 
 describe('Get Safe Apps e2e test', () => {
   let app: INestApplication;
@@ -40,7 +41,7 @@ describe('Get Safe Apps e2e test', () => {
       .expect(200)
       .expect(({ body }) => {
         expect(body).toBeInstanceOf(Array);
-        body.forEach((safeApp) =>
+        body.forEach((safeApp: SafeApp) =>
           expect(safeApp).toEqual(
             expect.objectContaining({
               id: expect.any(Number),

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -16,14 +16,17 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
 
 describe('Safe Apps Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -77,7 +80,7 @@ describe('Safe Apps Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({ data: safeAppsResponse, status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -136,6 +139,7 @@ describe('Safe Apps Controller (Unit)', () => {
                 },
               },
             ],
+            status: 200,
           });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
@@ -183,7 +187,7 @@ describe('Safe Apps Controller (Unit)', () => {
       networkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({ data: safeAppsResponse, status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });

--- a/src/routes/safes/safes.controller.nonces.spec.ts
+++ b/src/routes/safes/safes.controller.nonces.spec.ts
@@ -8,7 +8,10 @@ import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import * as request from 'supertest';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
@@ -24,9 +27,9 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('Safes Controller Nonces (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
-  let configurationService;
+  let safeConfigUrl: string | undefined;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+  let configurationService: jest.MockedObjectDeep<IConfigurationService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -68,11 +71,14 @@ describe('Safes Controller Nonces (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactionsPage });
+          return Promise.resolve({
+            data: multisigTransactionsPage,
+            status: 200,
+          });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -102,11 +108,14 @@ describe('Safes Controller Nonces (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactionsPage });
+          return Promise.resolve({
+            data: multisigTransactionsPage,
+            status: 200,
+          });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -128,11 +137,14 @@ describe('Safes Controller Nonces (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactionsPage });
+          return Promise.resolve({
+            data: multisigTransactionsPage,
+            status: 200,
+          });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -33,15 +33,18 @@ import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { EmailDataSourceModule } from '@/datasources/email/email.datasource.module';
 import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.email.datasource.module';
 
 describe('Safes Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -112,17 +115,17 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
             data: pageBuilder()
@@ -134,6 +137,7 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
@@ -146,11 +150,12 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -219,25 +224,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -272,25 +277,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -326,25 +331,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -381,25 +386,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -439,25 +444,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -490,19 +495,19 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
             data: pageBuilder()
@@ -524,11 +529,12 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -567,25 +573,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions });
+          return Promise.resolve({ data: multisigTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -625,25 +631,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -697,25 +703,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions });
+          return Promise.resolve({ data: multisigTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -754,25 +760,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions });
+          return Promise.resolve({ data: multisigTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -812,25 +818,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions });
+          return Promise.resolve({ data: multisigTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -865,19 +871,19 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
             data: pageBuilder()
@@ -899,11 +905,12 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -936,19 +943,19 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
             data: pageBuilder()
@@ -973,11 +980,12 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1009,17 +1017,17 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
             data: pageBuilder()
@@ -1031,6 +1039,7 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
@@ -1044,11 +1053,12 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1079,20 +1089,21 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
             data: pageBuilder().build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
@@ -1106,6 +1117,7 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.resolve({
@@ -1118,9 +1130,10 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1159,25 +1172,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions });
+          return Promise.resolve({ data: multisigTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1210,17 +1223,17 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
             data: pageBuilder()
@@ -1232,15 +1245,17 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.resolve({
             data: pageBuilder().build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1271,17 +1286,17 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
@@ -1297,9 +1312,10 @@ describe('Safes Controller (Unit)', () => {
                 ),
               ])
               .build(),
+            status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1335,17 +1351,17 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
@@ -1353,7 +1369,7 @@ describe('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1408,25 +1424,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1467,31 +1483,31 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${module1}`:
-          return Promise.resolve({ data: moduleInfo1 });
+          return Promise.resolve({ data: moduleInfo1, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${module2}`:
-          return Promise.resolve({ data: moduleInfo2 });
+          return Promise.resolve({ data: moduleInfo2, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${module3}`:
-          return Promise.resolve({ data: moduleInfo3 });
+          return Promise.resolve({ data: moduleInfo3, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1542,25 +1558,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1594,25 +1610,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${safeInfo.fallbackHandler}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1641,26 +1657,26 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${safeInfo.fallbackHandler}`:
           // Return 404 for Fallback Handler Info
           return Promise.reject({ status: 404 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1694,25 +1710,25 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo });
+          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo });
+          return Promise.resolve({ data: guardInfo, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1742,26 +1758,26 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo });
+          return Promise.resolve({ data: safeInfo, status: 200 });
         case `${chain.transactionService}/api/v1/about/master-copies/`:
-          return Promise.resolve({ data: masterCopies });
+          return Promise.resolve({ data: masterCopies, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
-          return Promise.resolve({ data: masterCopyInfo });
+          return Promise.resolve({ data: masterCopyInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${safeInfo.fallbackHandler}`:
-          return Promise.resolve({ data: fallbackInfo });
+          return Promise.resolve({ data: fallbackInfo, status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
           // Return 404 for Guard Info
           return Promise.reject({ status: 404 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({ data: collectibleTransfers, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
+          return Promise.resolve({ data: queuedTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions });
+          return Promise.resolve({ data: moduleTransactions, status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages });
+          return Promise.resolve({ data: messages, status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -23,13 +23,16 @@ import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { addConfirmationDtoBuilder } from '@/routes/transactions/__tests__/entities/add-confirmation.dto.builder';
 
 describe('Add transaction confirmations - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -99,23 +102,23 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: transaction });
+          return Promise.resolve({ data: transaction, status: 200 });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeApps });
+          return Promise.resolve({ data: safeApps, status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken });
+          return Promise.resolve({ data: gasToken, status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getToTokenUrl:
-          return Promise.resolve({ data: token });
+          return Promise.resolve({ data: token, status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({ data: safeAppsResponse, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -124,7 +127,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       switch (url) {
         case postConfirmationUrl:
-          return Promise.resolve();
+          return Promise.resolve({ data: {}, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -28,7 +28,10 @@ import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -38,8 +41,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('Get by id - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -100,7 +103,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getModuleTransactionUrl:
           return Promise.reject({ status: 500 });
         default:
@@ -137,9 +140,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getModuleTransactionUrl:
           return Promise.reject({ status: 404 });
         default:
@@ -181,17 +184,18 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getModuleTransactionUrl:
           return Promise.resolve({
             data: moduleTransactionToJson(moduleTransaction),
+            status: 200,
           });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getModuleContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -250,9 +254,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getTransferUrl:
           return Promise.reject({ status: 404 });
         default:
@@ -289,17 +293,18 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getTransferUrl:
           return Promise.resolve({
             data: nativeTokenTransferToJson(transfer),
+            status: 200,
           });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getFromContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -345,9 +350,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getMultisigTransactionUrl:
           return Promise.reject({ status: 404 });
         default:
@@ -422,21 +427,21 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(tx) });
+          return Promise.resolve({ data: multisigToJson(tx), status: 200 });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken });
+          return Promise.resolve({ data: gasToken, status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getToTokenUrl:
-          return Promise.resolve({ data: token });
+          return Promise.resolve({ data: token, status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({ data: safeAppsResponse, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -589,21 +594,21 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(tx) });
+          return Promise.resolve({ data: multisigToJson(tx), status: 200 });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken });
+          return Promise.resolve({ data: gasToken, status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getToTokenUrl:
-          return Promise.resolve({ data: token });
+          return Promise.resolve({ data: token, status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({ data: safeAppsResponse, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -757,19 +762,19 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(tx) });
+          return Promise.resolve({ data: multisigToJson(tx), status: 200 });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken });
+          return Promise.resolve({ data: gasToken, status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({ data: safeAppsResponse, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -25,7 +25,10 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -35,8 +38,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('List incoming transfers by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -94,7 +97,10 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     const limit = faker.number.int({ min: 0, max: 100 });
     const offset = faker.number.int({ min: 0, max: 100 });
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockRejectedValueOnce({
       status: 500,
     });
@@ -126,9 +132,13 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockResolvedValueOnce({
       data: { results: ['invalidData'] },
+      status: 200,
     });
 
     await request(app.getHttpServer())
@@ -145,9 +155,10 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
     const page = pageBuilder().build();
-    networkService.get.mockResolvedValueOnce({ data: chain });
+    networkService.get.mockResolvedValueOnce({ data: chain, status: 200 });
     networkService.get.mockResolvedValueOnce({
       data: { ...page, next: faker.datatype.boolean() },
+      status: 200,
     });
 
     await request(app.getHttpServer())
@@ -182,23 +193,24 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${erc20Transfer.tokenAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
           data: pageBuilder()
             .with('results', [erc20TransferToJson(erc20Transfer)])
             .build(),
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found' });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token });
+        return Promise.resolve({ data: token, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -261,23 +273,24 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${erc721Transfer.tokenAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
           data: pageBuilder()
             .with('results', [erc721TransferToJson(erc721Transfer)])
             .build(),
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found' });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token });
+        return Promise.resolve({ data: token, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -333,20 +346,21 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
           data: pageBuilder()
             .with('results', [nativeTokenTransferToJson(nativeTokenTransfer)])
             .build(),
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.reject({ detail: 'Not found' });
+        return Promise.reject({ detail: 'Not found', status: 404 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -14,7 +14,10 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -25,8 +28,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('List module transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -82,7 +85,10 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockRejectedValueOnce({
       status: 500,
     });
@@ -107,9 +113,10 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const safeAddress = faker.finance.ethereumAddress();
     const page = pageBuilder().build();
     const chain = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chain });
+    networkService.get.mockResolvedValueOnce({ data: chain, status: 200 });
     networkService.get.mockResolvedValueOnce({
       data: { ...page, count: faker.word.words() },
+      status: 200,
     });
 
     await request(app.getHttpServer())
@@ -126,7 +133,10 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockRejectedValueOnce({
       status: 404,
     });
@@ -163,9 +173,15 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     };
 
     const safe = safeBuilder().build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
-    networkService.get.mockResolvedValueOnce({ data: moduleTransaction });
-    networkService.get.mockResolvedValueOnce({ data: safe });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
+    networkService.get.mockResolvedValueOnce({
+      data: moduleTransaction,
+      status: 200,
+    });
+    networkService.get.mockResolvedValueOnce({ data: safe, status: 200 });
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -24,7 +24,10 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -34,8 +37,8 @@ import { TestEmailDatasourceModule } from '@/datasources/email/__tests__/test.em
 
 describe('List multisig transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -91,7 +94,10 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockRejectedValueOnce({
       status: 500,
     });
@@ -125,9 +131,13 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockResolvedValueOnce({
       data: { results: ['invalidData'] },
+      status: 200,
     });
 
     await request(app.getHttpServer())
@@ -145,9 +155,13 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     const page = pageBuilder().build();
-    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: chainResponse,
+      status: 200,
+    });
     networkService.get.mockResolvedValueOnce({
       data: { ...page, count: null },
+      status: 200,
     });
 
     await request(app.getHttpServer())
@@ -207,23 +221,24 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
           data: pageBuilder()
             .with('results', [multisigTransactionToJson(multisigTransaction)])
             .build(),
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.reject({ detail: 'Not found' });
+        return Promise.reject({ detail: 'Not found', status: 404 });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token });
+        return Promise.resolve({ data: token, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -329,23 +344,24 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/0x7Af3460d552f832fD7E2DE973c628ACeA59B0712`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
           data: pageBuilder()
             .with('results', [multisigTransactionToJson(multisigTransaction)])
             .build(),
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.reject({ detail: 'Not found' });
+        return Promise.reject({ detail: 'Not found', status: 404 });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token });
+        return Promise.resolve({ data: token, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -425,21 +441,22 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${domainTransaction.safe}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse });
+        return Promise.resolve({ data: safeAppsResponse, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
           data: { results: [multisigTransactionToJson(domainTransaction)] },
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeBuilder().build() });
+        return Promise.resolve({ data: safeBuilder().build(), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse });
+        return Promise.resolve({ data: contractResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -21,13 +21,16 @@ import { TransactionsModule } from '@/routes/transactions/transactions.module';
 import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 
 describe('List queued transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -68,15 +71,16 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
           data: { ...page, count: faker.word.words() },
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -171,7 +175,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
@@ -181,16 +185,17 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             previous: null,
             results: transactions,
           },
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse });
+        return Promise.resolve({ data: safeAppsResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse });
+        return Promise.resolve({ data: contractResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -364,7 +369,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
@@ -378,16 +383,17 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             })}/?limit=10&offset=30`,
             results: transactions,
           },
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse });
+        return Promise.resolve({ data: safeAppsResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse });
+        return Promise.resolve({ data: contractResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -497,16 +503,19 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .build(),
       ) as MultisigTransaction,
     ];
-    networkService.get.mockImplementation((url: string, query) => {
+    networkService.get.mockImplementation((url, query) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
+        if (!query) {
+          fail('Query params not found');
+        }
         expect(query.params.trusted).toBe(false);
 
         return Promise.resolve({
@@ -516,16 +525,17 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             previous: null,
             results: transactions,
           },
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse });
+        return Promise.resolve({ data: safeAppsResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse });
+        return Promise.resolve({ data: contractResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -22,14 +22,17 @@ import { ValidationModule } from '@/validation/validation.module';
 import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { TransactionsModule } from '@/routes/transactions/transactions.module';
 import { previewTransactionDtoBuilder } from '@/routes/transactions/entities/__tests__/preview-transaction.dto.builder';
 
 describe('Preview transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -87,20 +90,20 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse });
+        return Promise.resolve({ data: contractResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
     networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
-        return Promise.resolve({ data: dataDecodedResponse });
+        return Promise.resolve({ data: dataDecodedResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -154,10 +157,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ status: 404 });
@@ -167,7 +170,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
-        return Promise.resolve({ data: dataDecodedResponse });
+        return Promise.resolve({ data: dataDecodedResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -220,10 +223,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ status: 404 });
@@ -301,20 +304,20 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse });
+        return Promise.resolve({ data: safeResponse, status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse });
+        return Promise.resolve({ data: contractResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
     networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
-        return Promise.resolve({ data: dataDecodedResponse });
+        return Promise.resolve({ data: dataDecodedResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -21,14 +21,17 @@ import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { TransactionsModule } from '@/routes/transactions/transactions.module';
 import { proposeTransactionDtoBuilder } from '@/routes/transactions/entities/__tests__/propose-transaction.dto.builder';
 
 describe('Propose transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -94,21 +97,24 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(transaction) });
+          return Promise.resolve({
+            data: multisigToJson(transaction),
+            status: 200,
+          });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: transactions });
+          return Promise.resolve({ data: transactions, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeApps });
+          return Promise.resolve({ data: safeApps, status: 200 });
         case getContractUrl:
-          return Promise.resolve({ data: contract });
+          return Promise.resolve({ data: contract, status: 200 });
         case getTokenUrl:
-          return Promise.resolve({ data: token });
+          return Promise.resolve({ data: token, status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken });
+          return Promise.resolve({ data: gasToken, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -117,7 +123,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       switch (url) {
         case proposeTransactionUrl:
-          return Promise.resolve({ data: {} });
+          return Promise.resolve({ data: {}, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -5,6 +5,7 @@ import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/mul
 import { ILoggingService } from '@/logging/logging.interface';
 import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity';
 import { SafeAppInfoMapper } from '@/routes/transactions/mappers/common/safe-app-info.mapper';
+import { SafeApp } from '@/domain/safe-apps/entities/safe-app.entity';
 
 describe('SafeAppInfo mapper (Unit)', () => {
   const safeAppsRepositoryMock = jest.mocked({
@@ -56,7 +57,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
 
   it('should return null if no SafeApp is found and origin is not null', async () => {
     const chainId = faker.string.numeric();
-    const safeApps = [];
+    const safeApps: Array<SafeApp> = [];
     const transaction = multisigTransactionBuilder().build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
 

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -39,7 +39,10 @@ import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { Transfer } from '@/domain/safe/entities/transfer.entity';
-import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
@@ -54,11 +57,12 @@ import {
   erc721TransferBuilder,
   toJson as erc721TransferToJson,
 } from '@/domain/safe/entities/__tests__/erc721-transfer.builder';
+import { TransactionItem } from '@/routes/transactions/entities/transaction-item.entity';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
-  let safeConfigUrl;
-  let networkService;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -125,7 +129,7 @@ describe('Transactions History Controller (Unit)', () => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.reject({ status: 500 });
@@ -149,11 +153,12 @@ describe('Transactions History Controller (Unit)', () => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
           data: { ...page, results: faker.word.words() },
+          status: 200,
         });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
@@ -190,17 +195,21 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/creation/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getAllTransactions) {
-        return Promise.resolve({ data: transactionHistoryBuilder });
+        return Promise.resolve({
+          data: transactionHistoryBuilder,
+          status: 200,
+        });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url === getSafeCreationUrl) {
         return Promise.resolve({
           data: creationTransactionToJson(creationTransaction),
+          status: 200,
         });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
@@ -253,13 +262,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getAllTransactions) {
-        return Promise.resolve({ data: transactionHistoryBuilder });
+        return Promise.resolve({
+          data: transactionHistoryBuilder,
+          status: 200,
+        });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -308,13 +320,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getAllTransactions) {
-        return Promise.resolve({ data: transactionHistoryBuilder });
+        return Promise.resolve({
+          data: transactionHistoryBuilder,
+          status: 200,
+        });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -360,13 +375,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getAllTransactions) {
-        return Promise.resolve({ data: transactionHistoryBuilder });
+        return Promise.resolve({
+          data: transactionHistoryBuilder,
+          status: 200,
+        });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -468,7 +486,7 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain });
+        return Promise.resolve({ data: chain, status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
@@ -479,13 +497,14 @@ describe('Transactions History Controller (Unit)', () => {
               ethereumTransactionToJson(incomingTransaction),
             ])
             .build(),
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: tokenResponse });
+        return Promise.resolve({ data: tokenResponse, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -616,26 +635,30 @@ describe('Transactions History Controller (Unit)', () => {
       const getContractUrl = `${chainResponse.transactionService}/api/v1/contracts/`;
       const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/creation/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
           data: allTransactionsResponse,
+          status: 200,
         });
       }
       if (url === getSafeUrl) {
         return Promise.resolve({
           data: safe,
+          status: 200,
         });
       }
       if (url === getSafeCreationUrl) {
         return Promise.resolve({
           data: creationTransactionToJson(creationTransaction),
+          status: 200,
         });
       }
       if (url.includes(getContractUrl)) {
         return Promise.reject({
           detail: 'Not found',
+          status: 404,
         });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
@@ -687,13 +710,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse });
+        return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getAllTransactions) {
-        return Promise.resolve({ data: transactionHistoryBuilder });
+        return Promise.resolve({
+          data: transactionHistoryBuilder,
+          status: 200,
+        });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe });
+        return Promise.resolve({ data: safe, status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -758,11 +784,11 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -776,7 +802,9 @@ describe('Transactions History Controller (Unit)', () => {
       .then(({ body }) => {
         // the amount of TransactionItems is limited to the max value
         expect(
-          body.results.filter((item) => item.type === 'TRANSACTION'),
+          body.results.filter(
+            (item: TransactionItem) => item.type === 'TRANSACTION',
+          ),
         ).toHaveLength(maxNestedTransfers);
       });
   });
@@ -818,15 +846,15 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken });
+          return Promise.resolve({ data: trustedToken, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken });
+          return Promise.resolve({ data: untrustedToken, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -906,13 +934,13 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken });
+          return Promise.resolve({ data: untrustedToken, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -997,15 +1025,15 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken });
+          return Promise.resolve({ data: trustedToken, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken });
+          return Promise.resolve({ data: untrustedToken, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1083,15 +1111,15 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken });
+          return Promise.resolve({ data: trustedToken, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken });
+          return Promise.resolve({ data: untrustedToken, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1164,13 +1192,13 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken });
+          return Promise.resolve({ data: trustedToken, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1240,15 +1268,15 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain });
+          return Promise.resolve({ data: chain, status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData });
+          return Promise.resolve({ data: transactionHistoryData, status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe });
+          return Promise.resolve({ data: safe, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedErc721.address}`:
-          return Promise.resolve({ data: trustedErc721 });
+          return Promise.resolve({ data: trustedErc721, status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${notTrustedErc721.address}`:
-          return Promise.resolve({ data: notTrustedErc721 });
+          return Promise.resolve({ data: notTrustedErc721, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/types/postgres-shift.d.ts
+++ b/src/types/postgres-shift.d.ts
@@ -1,0 +1,1 @@
+declare module 'postgres-shift';

--- a/src/validation/providers/validation-error-factory.spec.ts
+++ b/src/validation/providers/validation-error-factory.spec.ts
@@ -28,8 +28,19 @@ describe('ValidationErrorFactory', () => {
 
     expect(err.message).toBe('Validation failed');
     expect(err.getStatus()).toBe(500);
-    expect(err.getResponse()['code']).toBe(42);
-    expect(err.getResponse()['message']).toBe('Validation failed');
-    expect(err.getResponse()['arguments']).toEqual([]);
+    const response = err.getResponse();
+
+    if (
+      typeof response === 'string' ||
+      !('code' in response) ||
+      !('message' in response) ||
+      !('arguments' in response)
+    ) {
+      fail('Malformed response');
+    }
+
+    expect(response.code).toBe(42);
+    expect(response.message).toBe('Validation failed');
+    expect(response.arguments).toEqual([]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "resolveJsonModule": true,


### PR DESCRIPTION
This reenables `noImplicitAny` in TypeScript after having to revert it due to issues with the migration from `axios` to `fetch`.

Note: these changes are untouched. They are the same as those approeved in #1057.