### PR TITLE
Set invalidation time of keys deleted via pattern

### DIFF
--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -63,7 +63,6 @@ export class ConfigApi implements IConfigApi {
     await Promise.all([
       this.cacheService.deleteByKey(key),
       this.cacheService.deleteByKeyPattern(pattern),
-      // TODO: call _setInvalidationTimeForKey for each item matching the pattern
     ]);
   }
 
@@ -126,7 +125,6 @@ export class ConfigApi implements IConfigApi {
       // if a chain id is not provided, delete all the safe apps data
       const pattern = CacheRouter.getSafeAppsCachePattern();
       await this.cacheService.deleteByKeyPattern(pattern);
-      // TODO: call _setInvalidationTimeForKey for each item matching the pattern
     }
   }
 }


### PR DESCRIPTION
This adjusts `RedisCacheService['deleteByKeyPattern']` to set the `invalidationTimeMs:*` of each key deleted as they were not being set:

### Changes

- New `setInvalidationTime` method extracted from and called in `deleteByKey`.
- Said method called in `deleteByKeyPattern` with non-prefixed keys (from new `_removePrefixFromKey` method).

Test coverage has been added for the above in the same manner as that testing the invalidation times set in `deleteByKey`.