### PR TITLE
Check for 'signer' in email guards

### DIFF
--- a/src/routes/email/email.controller.delete-email.spec.ts
+++ b/src/routes/email/email.controller.delete-email.spec.ts
@@ -95,7 +95,7 @@ describe('Email controller delete email tests', () => {
     await request(app.getHttpServer())
       .delete(`/v1/chains/${chain.chainId}/safes/${safeAddress}/emails`)
       .send({
-        account: signer.address,
+        signer: signer.address,
         timestamp: timestamp,
         signature: signature,
       })
@@ -137,7 +137,7 @@ describe('Email controller delete email tests', () => {
     await request(app.getHttpServer())
       .delete(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
-        account: signer.address,
+        signer: signer.address,
         timestamp: timestamp,
         signature: signature,
       })
@@ -248,7 +248,7 @@ describe('Email controller delete email tests', () => {
     await request(app.getHttpServer())
       .delete(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
-        account: signer.address,
+        signer: signer.address,
         timestamp: timestamp,
         signature: signature,
       })

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -93,16 +93,16 @@ describe('Email controller edit email tests', () => {
     const emailAddress = faker.internet.email();
     const timestamp = jest.now();
     const privateKey = generatePrivateKey();
-    const account = privateKeyToAccount(privateKey);
-    const accountAddress = account.address;
+    const signer = privateKeyToAccount(privateKey);
+    const signerAddress = signer.address;
     // Signer is owner of safe
     const safe = safeBuilder()
-      .with('owners', [accountAddress])
+      .with('owners', [signerAddress])
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
-    const signature = await account.signMessage({ message });
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -122,7 +122,7 @@ describe('Email controller edit email tests', () => {
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
         emailAddress,
-        account: account.address,
+        signer: signer.address,
         timestamp,
         signature,
       })
@@ -140,16 +140,16 @@ describe('Email controller edit email tests', () => {
     const emailAddress = faker.internet.email();
     const timestamp = jest.now();
     const privateKey = generatePrivateKey();
-    const account = privateKeyToAccount(privateKey);
-    const accountAddress = account.address;
+    const signer = privateKeyToAccount(privateKey);
+    const signerAddress = signer.address;
     // Signer is owner of safe
     const safe = safeBuilder()
-      .with('owners', [accountAddress])
+      .with('owners', [signerAddress])
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
-    const signature = await account.signMessage({ message });
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -170,7 +170,7 @@ describe('Email controller edit email tests', () => {
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
         emailAddress,
-        account: account.address,
+        signer: signer.address,
         timestamp,
         signature,
       })
@@ -186,16 +186,16 @@ describe('Email controller edit email tests', () => {
     const emailAddress = faker.internet.email();
     const timestamp = jest.now();
     const privateKey = generatePrivateKey();
-    const account = privateKeyToAccount(privateKey);
-    const accountAddress = account.address;
+    const signer = privateKeyToAccount(privateKey);
+    const signerAddress = signer.address;
     // Signer is owner of safe
     const safe = safeBuilder()
-      .with('owners', [accountAddress])
+      .with('owners', [signerAddress])
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
-    const signature = await account.signMessage({ message });
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -214,7 +214,7 @@ describe('Email controller edit email tests', () => {
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
         emailAddress,
-        account: account.address,
+        signer: signer.address,
         timestamp,
         signature,
       })
@@ -259,7 +259,7 @@ describe('Email controller edit email tests', () => {
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
         emailAddress,
-        account: signer.address,
+        signer: signer.address,
         timestamp,
         signature,
       })
@@ -277,16 +277,16 @@ describe('Email controller edit email tests', () => {
     const emailAddress = faker.internet.email();
     const timestamp = jest.now();
     const privateKey = generatePrivateKey();
-    const account = privateKeyToAccount(privateKey);
-    const accountAddress = account.address;
+    const signer = privateKeyToAccount(privateKey);
+    const signerAddress = signer.address;
     // Signer is owner of safe
     const safe = safeBuilder()
-      .with('owners', [accountAddress])
+      .with('owners', [signerAddress])
       // Faker generates non-checksum addresses only
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
-    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
-    const signature = await account.signMessage({ message });
+    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -306,7 +306,7 @@ describe('Email controller edit email tests', () => {
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
         emailAddress,
-        account: account.address,
+        signer: signer.address,
         timestamp,
         signature,
       })

--- a/src/routes/email/email.controller.save-email.spec.ts
+++ b/src/routes/email/email.controller.save-email.spec.ts
@@ -104,7 +104,7 @@ describe('Email controller save email tests', () => {
       .post(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)
       .send({
         emailAddress: emailAddress,
-        account: signer.address,
+        signer: signer.address,
         timestamp: timestamp,
         signature: signature,
       })

--- a/src/routes/email/guards/email-deletion.guard.spec.ts
+++ b/src/routes/email/guards/email-deletion.guard.spec.ts
@@ -41,13 +41,13 @@ describe('EmailDeletionGuard guard tests', () => {
   const safe = faker.finance.ethereumAddress();
   const timestamp = faker.date.recent().getTime();
   const privateKey = generatePrivateKey();
-  const account = privateKeyToAccount(privateKey);
-  const accountAddress = account.address;
+  const signer = privateKeyToAccount(privateKey);
+  const signerAddress = signer.address;
   let signature: Hash;
 
   beforeAll(async () => {
-    const message = `email-delete-${chainId}-${safe}-${accountAddress}-${timestamp}`;
-    signature = await account.signMessage({ message });
+    const message = `email-delete-${chainId}-${safe}-${signerAddress}-${timestamp}`;
+    signature = await signer.signMessage({ message });
   });
 
   beforeEach(async () => {
@@ -78,7 +78,7 @@ describe('EmailDeletionGuard guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/${chainId}/${safe}`)
       .send({
-        account: accountAddress,
+        signer: signerAddress,
         signature: signature,
         timestamp: timestamp,
       })
@@ -120,7 +120,7 @@ describe('EmailDeletionGuard guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/${chainId}/${safe}`)
       .send({
-        account: accountAddress,
+        account: signerAddress,
         timestamp,
       })
       .expect(403)
@@ -138,7 +138,7 @@ describe('EmailDeletionGuard guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/${chainId}/${safeAddress}`)
       .send({
-        account: accountAddress,
+        account: signerAddress,
         signature,
       })
       .expect(403)
@@ -155,7 +155,7 @@ describe('EmailDeletionGuard guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/invalid/chains/${chainId}`)
       .send({
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -173,7 +173,7 @@ describe('EmailDeletionGuard guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/invalid/safes/${safeAddress}`)
       .send({
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })

--- a/src/routes/email/guards/email-deletion.guard.ts
+++ b/src/routes/email/guards/email-deletion.guard.ts
@@ -11,17 +11,17 @@ import { verifyMessage } from 'viem';
  * The EmailDeletionGuard guard should be used on routes that require
  * authenticated actions for deleting email addresses.
  *
- * This guard therefore validates if the message came from the specified account.
+ * This guard therefore validates if the message came from the specified signer.
  *
  * The following message should be signed:
- * email-delete-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}
+ * email-delete-${chainId}-${safe}-${emailAddress}-${signer}-${timestamp}
  *
  * (where ${} represents placeholder values for the respective data)
  *
  * To use this guard, the route should have:
  * - the 'chainId' declared as a parameter
  * - the 'safeAddress' declared as a parameter
- * - the 'account' as part of the JSON body (top level)
+ * - the 'signer' as part of the JSON body (top level)
  * - the 'signature' as part of the JSON body (top level) - see message format to be signed
  * - the 'timestamp' as part of the JSON body (top level)
  */
@@ -38,18 +38,18 @@ export class EmailDeletionGuard implements CanActivate {
 
     const chainId = request.params['chainId'];
     const safe = request.params['safeAddress'];
-    const account = request.body['account'];
+    const signer = request.body['signer'];
     const signature = request.body['signature'];
     const timestamp = request.body['timestamp'];
 
     // Required fields
-    if (!chainId || !safe || !signature || !account || !timestamp) return false;
+    if (!chainId || !safe || !signature || !signer || !timestamp) return false;
 
-    const message = `${EmailDeletionGuard.ACTION_PREFIX}-${chainId}-${safe}-${account}-${timestamp}`;
+    const message = `${EmailDeletionGuard.ACTION_PREFIX}-${chainId}-${safe}-${signer}-${timestamp}`;
 
     try {
       return await verifyMessage({
-        address: account,
+        address: signer,
         message,
         signature,
       });

--- a/src/routes/email/guards/email-edit.guard.spec.ts
+++ b/src/routes/email/guards/email-edit.guard.spec.ts
@@ -42,13 +42,13 @@ describe('EmailEdit guard tests', () => {
   const emailAddress = faker.internet.email();
   const timestamp = faker.date.recent().getTime();
   const privateKey = generatePrivateKey();
-  const account = privateKeyToAccount(privateKey);
-  const accountAddress = account.address;
+  const signer = privateKeyToAccount(privateKey);
+  const signerAddress = signer.address;
   let signature: Hash;
 
   beforeAll(async () => {
-    const message = `email-edit-${chainId}-${safe}-${emailAddress}-${accountAddress}-${timestamp}`;
-    signature = await account.signMessage({ message });
+    const message = `email-edit-${chainId}-${safe}-${emailAddress}-${signerAddress}-${timestamp}`;
+    signature = await signer.signMessage({ message });
   });
 
   beforeEach(async () => {
@@ -80,7 +80,7 @@ describe('EmailEdit guard tests', () => {
       .post(`/test/${chainId}/${safe}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        signer: signerAddress,
         signature,
         timestamp,
       })
@@ -92,7 +92,7 @@ describe('EmailEdit guard tests', () => {
       .post(`/test/${chainId}/${safe}`)
       .send({
         emailAddress: faker.internet.email(), // different email should have different signature
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -108,7 +108,7 @@ describe('EmailEdit guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/${chainId}/${safe}`)
       .send({
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -141,7 +141,7 @@ describe('EmailEdit guard tests', () => {
       .post(`/test/${chainId}/${safe}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         timestamp,
       })
       .expect(403)
@@ -160,7 +160,7 @@ describe('EmailEdit guard tests', () => {
       .post(`/test/${chainId}/${safeAddress}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         signature,
       })
       .expect(403)
@@ -178,7 +178,7 @@ describe('EmailEdit guard tests', () => {
       .post(`/test/invalid/chains/${chainId}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -197,7 +197,7 @@ describe('EmailEdit guard tests', () => {
       .post(`/test/invalid/safes/${safeAddress}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })

--- a/src/routes/email/guards/email-edit.guard.ts
+++ b/src/routes/email/guards/email-edit.guard.ts
@@ -11,10 +11,10 @@ import { verifyMessage } from 'viem';
  * The EmailEditGuard guard should be used on routes that require
  * authenticated actions on updating email addresses.
  *
- * This guard therefore validates if the message came from the specified account.
+ * This guard therefore validates if the message came from the specified signer.
  *
  * The following message should be signed:
- * email-edit-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}
+ * email-edit-${chainId}-${safe}-${emailAddress}-${signer}-${timestamp}
  *
  * (where ${} represents placeholder values for the respective data)
  *
@@ -22,7 +22,7 @@ import { verifyMessage } from 'viem';
  * - the 'chainId' declared as a parameter
  * - the 'safeAddress' declared as a parameter
  * - the 'emailAddress' as part of the JSON body (top level)
- * - the 'account' as part of the JSON body (top level)
+ * - the 'signer' as part of the JSON body (top level)
  * - the 'signature' as part of the JSON body (top level) - see message format to be signed
  * - the 'timestamp' as part of the JSON body (top level)
  */
@@ -40,7 +40,7 @@ export class EmailEditGuard implements CanActivate {
     const chainId = request.params['chainId'];
     const safe = request.params['safeAddress'];
     const emailAddress = request.body['emailAddress'];
-    const account = request.body['account'];
+    const signer = request.body['signer'];
     const signature = request.body['signature'];
     const timestamp = request.body['timestamp'];
 
@@ -50,16 +50,16 @@ export class EmailEditGuard implements CanActivate {
       !safe ||
       !signature ||
       !emailAddress ||
-      !account ||
+      !signer ||
       !timestamp
     )
       return false;
 
-    const message = `${EmailEditGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}`;
+    const message = `${EmailEditGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${signer}-${timestamp}`;
 
     try {
       return await verifyMessage({
-        address: account,
+        address: signer,
         message,
         signature,
       });

--- a/src/routes/email/guards/email-registration.guard.spec.ts
+++ b/src/routes/email/guards/email-registration.guard.spec.ts
@@ -42,13 +42,13 @@ describe('EmailRegistration guard tests', () => {
   const emailAddress = faker.internet.email();
   const timestamp = faker.date.recent().getTime();
   const privateKey = generatePrivateKey();
-  const account = privateKeyToAccount(privateKey);
-  const accountAddress = account.address;
+  const signer = privateKeyToAccount(privateKey);
+  const signerAddress = signer.address;
   let signature: Hash;
 
   beforeAll(async () => {
-    const message = `email-register-${chainId}-${safe}-${emailAddress}-${accountAddress}-${timestamp}`;
-    signature = await account.signMessage({ message });
+    const message = `email-register-${chainId}-${safe}-${emailAddress}-${signerAddress}-${timestamp}`;
+    signature = await signer.signMessage({ message });
   });
 
   beforeEach(async () => {
@@ -80,7 +80,7 @@ describe('EmailRegistration guard tests', () => {
       .post(`/test/${chainId}/${safe}`)
       .send({
         emailAddress: emailAddress,
-        account: accountAddress,
+        signer: signerAddress,
         signature: signature,
         timestamp: timestamp,
       })
@@ -92,7 +92,7 @@ describe('EmailRegistration guard tests', () => {
       .post(`/test/${chainId}/${safe}`)
       .send({
         emailAddress: faker.internet.email(), // different email should have different signature
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -108,7 +108,7 @@ describe('EmailRegistration guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/${chainId}/${safe}`)
       .send({
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -141,7 +141,7 @@ describe('EmailRegistration guard tests', () => {
       .post(`/test/${chainId}/${safe}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         timestamp,
       })
       .expect(403)
@@ -160,7 +160,7 @@ describe('EmailRegistration guard tests', () => {
       .post(`/test/${chainId}/${safeAddress}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         signature,
       })
       .expect(403)
@@ -178,7 +178,7 @@ describe('EmailRegistration guard tests', () => {
       .post(`/test/invalid/chains/${chainId}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })
@@ -197,7 +197,7 @@ describe('EmailRegistration guard tests', () => {
       .post(`/test/invalid/safes/${safeAddress}`)
       .send({
         emailAddress,
-        account: accountAddress,
+        account: signerAddress,
         signature,
         timestamp,
       })

--- a/src/routes/email/guards/email-registration.guard.ts
+++ b/src/routes/email/guards/email-registration.guard.ts
@@ -11,10 +11,10 @@ import { verifyMessage } from 'viem';
  * The EmailRegistrationGuard guard should be used on routes that require
  * authenticated actions on registering email addresses.
  *
- * This guard therefore validates if the message came from the specified account.
+ * This guard therefore validates if the message came from the specified signer.
  *
  * The following message should be signed:
- * email-register-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}
+ * email-register-${chainId}-${safe}-${emailAddress}-${signer}-${timestamp}
  *
  * (where ${} represents placeholder values for the respective data)
  *
@@ -22,7 +22,7 @@ import { verifyMessage } from 'viem';
  * - the 'chainId' declared as a parameter
  * - the 'safeAddress' declared as a parameter
  * - the 'emailAddress' as part of the JSON body (top level)
- * - the 'account' as part of the JSON body (top level)
+ * - the 'signer' as part of the JSON body (top level)
  * - the 'signature' as part of the JSON body (top level) - see message format to be signed
  * - the 'timestamp' as part of the JSON body (top level)
  */
@@ -40,7 +40,7 @@ export class EmailRegistrationGuard implements CanActivate {
     const chainId = request.params['chainId'];
     const safe = request.params['safeAddress'];
     const emailAddress = request.body['emailAddress'];
-    const account = request.body['account'];
+    const signer = request.body['signer'];
     const signature = request.body['signature'];
     const timestamp = request.body['timestamp'];
 
@@ -50,16 +50,16 @@ export class EmailRegistrationGuard implements CanActivate {
       !safe ||
       !signature ||
       !emailAddress ||
-      !account ||
+      !signer ||
       !timestamp
     )
       return false;
 
-    const message = `${EmailRegistrationGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${account}-${timestamp}`;
+    const message = `${EmailRegistrationGuard.ACTION_PREFIX}-${chainId}-${safe}-${emailAddress}-${signer}-${timestamp}`;
 
     try {
       return await verifyMessage({
-        address: account,
+        address: signer,
         message,
         signature,
       });

--- a/src/routes/email/guards/only-safe-owner.guard.spec.ts
+++ b/src/routes/email/guards/only-safe-owner.guard.spec.ts
@@ -79,11 +79,11 @@ describe('OnlySafeOwner guard tests', () => {
   it('returns 200 if account is an owner of the safe', async () => {
     const chainId = faker.string.numeric();
     const safe = faker.finance.ethereumAddress();
-    const account = faker.finance.ethereumAddress();
+    const signer = faker.finance.ethereumAddress();
     safeRepositoryMock.isOwner.mockImplementation((args) => {
       if (
         args.chainId !== chainId ||
-        args.address !== account ||
+        args.address !== signer ||
         args.safeAddress !== safe
       )
         return Promise.reject();
@@ -93,7 +93,7 @@ describe('OnlySafeOwner guard tests', () => {
     await request(app.getHttpServer())
       .post(`/test/${chainId}/${safe}`)
       .send({
-        account: account,
+        signer: signer,
       })
       .expect(200);
   });

--- a/src/routes/email/guards/only-safe-owner.guard.ts
+++ b/src/routes/email/guards/only-safe-owner.guard.ts
@@ -8,14 +8,14 @@ import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 
 /**
  * The OnlySafeOwner guard can be applied to any route that requires
- * that a provided 'account' (owner) is part of a Safe
+ * that a provided 'signer' (owner) is part of a Safe
  *
  * This guard does not validate that a message came from said owner.
  *
  * To use this guard, the route should have:
  * - the 'chainId' declared as a parameter
  * - the 'safeAddress' declared as a parameter
- * - the 'account' as part of the JSON body (top level)
+ * - the 'signer' as part of the JSON body (top level)
  */
 @Injectable()
 export class OnlySafeOwnerGuard implements CanActivate {
@@ -28,15 +28,15 @@ export class OnlySafeOwnerGuard implements CanActivate {
 
     const chainId = request.params['chainId'];
     const safe = request.params['safeAddress'];
-    const account = request.body['account'];
+    const signer = request.body['signer'];
 
     // Required fields
-    if (!chainId || !safe || !account) return false;
+    if (!chainId || !safe || !signer) return false;
 
     return await this.safeRepository.isOwner({
       chainId,
       safeAddress: safe,
-      address: account,
+      address: signer,
     });
   }
 }


### PR DESCRIPTION
With the refactor in 3d92650895d20055f3b177b59893b1c22bdbc7fa, the expected payload for the email routes included a `signer` instead of an `account`. The `signer` property should therefore be used and expected in the related Email Guards.