### PR TITLE
Wait for redis connection

### DIFF
--- a/src/__tests__/redis-client.factory.ts
+++ b/src/__tests__/redis-client.factory.ts
@@ -5,6 +5,6 @@ export async function redisClientFactory(): Promise<RedisClientType> {
   const client: RedisClientType = createClient({
     url: `redis://${REDIS_HOST}:${REDIS_PORT}`,
   });
-  client.connect();
+  await client.connect();
   return client;
 }


### PR DESCRIPTION
When creating a new connection with `redisClientFactory`, we do not wait for the connection to be established and return the promise immediately.

While the promise will end up being resolved, it can prove more difficult to debug issues if there's an attempt to connect to the client before the promise is resolved.