### PR TITLE
Wait for notification handlers

### DIFF
--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -95,12 +95,12 @@ export class AlertsRepository implements IAlertsRepository {
         decodedTransactions,
       });
 
-      this._notifySafeSetup({
+      await this._notifySafeSetup({
         chainId,
         newSafeState,
       });
     } catch {
-      this._notifyUnknownTransaction({ chainId, safeAddress, emails });
+      await this._notifyUnknownTransaction({ chainId, safeAddress, emails });
     }
   }
 


### PR DESCRIPTION
The `AlertsRepository.handleAlertLog` should `await` when notifying about the new Safe setup. Not doing so can result in the error handler not being triggered correctly (i.e. `_notifyUnknownTransaction`).