### PR TITLE
Fix flaky test

### DIFF
--- a/src/domain/safe/entities/__tests__/erc20-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/erc20-transfer.builder.ts
@@ -10,7 +10,7 @@ export function erc20TransferBuilder(): IBuilder<ERC20Transfer> {
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.string.hexadecimal())
     .with('tokenAddress', faker.finance.ethereumAddress())
-    .with('value', faker.string.hexadecimal())
+    .with('value', faker.string.numeric())
     .with('transferId', faker.string.sample());
 }
 

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -1097,12 +1097,14 @@ describe('Transactions History Controller (Unit)', () => {
         erc20TransferBuilder()
           .with('tokenAddress', untrustedToken.address)
           .with('executionDate', date)
+          .with('value', faker.string.numeric({ exclude: ['0'] }))
           .build(),
       ) as Transfer,
       erc20TransferToJson(
         erc20TransferBuilder()
           .with('tokenAddress', trustedToken.address)
           .with('executionDate', date)
+          .with('value', faker.string.numeric({ exclude: ['0'] }))
           .build(),
       ) as Transfer,
     ];


### PR DESCRIPTION
The test `Untrusted transfers are returned when trusted=false` was generating transfers with a value of `0` therefore creating variance in the final number of entries returned.

Additionally, the `erc20TransferBuilder` should generate payloads with a decimal string value (and not a hexadecimal one).