### PR TITLE
Exclude `value` of `0` in trusted tokens tests not testing `value`

### DIFF
--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -832,12 +832,14 @@ describe('Transactions History Controller (Unit)', () => {
         erc20TransferBuilder()
           .with('tokenAddress', untrustedToken.address)
           .with('executionDate', date)
+          .with('value', faker.string.numeric({ exclude: ['0'] }))
           .build(),
       ) as Transfer,
       erc20TransferToJson(
         erc20TransferBuilder()
           .with('tokenAddress', trustedToken.address)
           .with('executionDate', date)
+          .with('value', faker.string.numeric({ exclude: ['0'] }))
           .build(),
       ) as Transfer,
     ];
@@ -909,11 +911,13 @@ describe('Transactions History Controller (Unit)', () => {
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
             ])
@@ -926,11 +930,13 @@ describe('Transactions History Controller (Unit)', () => {
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
             ])
@@ -988,11 +994,13 @@ describe('Transactions History Controller (Unit)', () => {
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', trustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
             ])
@@ -1005,11 +1013,13 @@ describe('Transactions History Controller (Unit)', () => {
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
             ])
@@ -1022,6 +1032,7 @@ describe('Transactions History Controller (Unit)', () => {
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', trustedToken.address)
+                  .with('value', faker.string.numeric({ exclude: ['0'] }))
                   .build(),
               ) as Transfer,
             ])
@@ -1178,7 +1189,7 @@ describe('Transactions History Controller (Unit)', () => {
         erc20TransferBuilder()
           .with('tokenAddress', trustedToken.address)
           .with('executionDate', date)
-          .with('value', '1')
+          .with('value', faker.string.numeric({ exclude: ['0'] }))
           .build(),
       ) as Transfer,
       erc20TransferToJson(

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -1189,7 +1189,7 @@ describe('Transactions History Controller (Unit)', () => {
         erc20TransferBuilder()
           .with('tokenAddress', trustedToken.address)
           .with('executionDate', date)
-          .with('value', faker.string.numeric({ exclude: ['0'] }))
+          .with('value', '1')
           .build(),
       ) as Transfer,
       erc20TransferToJson(


### PR DESCRIPTION
The untrusted token tests that do not reference a `value` of `0` have been adjusted to exclude a `value` of `0`, hence fixing their flakiness and isolating the test cases. The tests updated are:

- `Untrusted token transfers are ignored by default`
- `Should return an empty array with no date labels if all the token transfers are untrusted`
- `Should not return a date label if all the token transfers for that date are untrusted`