### PR TITLE
Move e2e test target network to mainnet

### DIFF
--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -10,7 +10,7 @@ import { CacheKeyPrefix } from '@/datasources/cache/constants';
 describe('Get contract e2e test', () => {
   let app: INestApplication;
   let redisClient: RedisClientType;
-  const chainId = '5'; // Görli testnet
+  const chainId = '1'; // Mainnet
   const cacheKeyPrefix = crypto.randomUUID();
 
   beforeAll(async () => {

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -10,7 +10,7 @@ import { CacheKeyPrefix } from '@/datasources/cache/constants';
 
 describe('Data decode e2e tests', () => {
   let app: INestApplication;
-  const chainId = '5'; // Görli testnet
+  const chainId = '1'; // Mainnet
 
   beforeAll(async () => {
     const cacheKeyPrefix = crypto.randomUUID();

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -9,7 +9,7 @@ import { CacheKeyPrefix } from '@/datasources/cache/constants';
 describe('Get safes by owner e2e test', () => {
   let app: INestApplication;
   let redisClient: RedisClientType;
-  const chainId = '5'; // Görli testnet
+  const chainId = '1'; // Mainnet
   const cacheKeyPrefix = crypto.randomUUID();
 
   beforeAll(async () => {

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -11,7 +11,7 @@ import { SafeApp } from '@/routes/safe-apps/entities/safe-app.entity';
 describe('Get Safe Apps e2e test', () => {
   let app: INestApplication;
   let redisClient: RedisClientType;
-  const chainId = '5'; // Görli testnet
+  const chainId = '1'; // Mainnet
   const cacheKeyPrefix = crypto.randomUUID();
 
   beforeAll(async () => {


### PR DESCRIPTION
**Changes:**
- It switches end-to-end tests target network from Goerli to Mainnet, as the first has been deprecated.