### PR TITLE
Fix serialization of error responses

### DIFF
--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -155,7 +155,11 @@ export class CacheFirstDataSource {
   ): Promise<void> {
     return this.cacheService.set(
       cacheDir,
-      JSON.stringify(error),
+      JSON.stringify({
+        data: error.data,
+        response: { status: error.response.status },
+        url: error.url,
+      }),
       notFoundExpireTimeSeconds,
     );
   }


### PR DESCRIPTION
The `Response` object used in `NetworkResponseError` has no enumerable properties – this results on an empty object being serialized `{}`.

Subsequent calls to the cache that retrieve this object will then fail to correctly return the expected status code (which is read via `CacheFirstDataSource._getFromCachedData`).