### PR TITLE
Add `owners/:ownerAddress/safes` endpoint for all Safes on all chains

### DIFF
--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -182,10 +182,17 @@ describe('Owners Controller (Unit)', () => {
       const ownerAddress = faker.finance.ethereumAddress();
 
       const chainId1 = faker.string.numeric();
+      const chainId2 = faker.string.numeric({ exclude: [chainId1] });
 
       const chain1 = chainBuilder().with('chainId', chainId1).build();
+      const chain2 = chainBuilder().with('chainId', chainId2).build();
 
-      const safesOnChain = [
+      const safesOnChain1 = [
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+      ];
+      const safesOnChain2 = [
         faker.finance.ethereumAddress(),
         faker.finance.ethereumAddress(),
         faker.finance.ethereumAddress(),
@@ -196,7 +203,7 @@ describe('Owners Controller (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains`: {
             return Promise.resolve({
               data: {
-                results: [chain1],
+                results: [chain1, chain2],
               },
               status: 200,
             });
@@ -209,9 +216,23 @@ describe('Owners Controller (Unit)', () => {
             });
           }
 
+          case `${safeConfigUrl}/api/v1/chains/${chainId2}`: {
+            return Promise.resolve({
+              data: chain2,
+              status: 200,
+            });
+          }
+
           case `${chain1.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
             return Promise.resolve({
-              data: { safes: safesOnChain },
+              data: { safes: safesOnChain1 },
+              status: 200,
+            });
+          }
+
+          case `${chain2.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
+            return Promise.resolve({
+              data: { safes: safesOnChain2 },
               status: 200,
             });
           }
@@ -226,7 +247,8 @@ describe('Owners Controller (Unit)', () => {
         .get(`/v1/owners/${ownerAddress}/safes`)
         .expect(200)
         .expect({
-          [chainId1]: safesOnChain,
+          [chainId1]: safesOnChain1,
+          [chainId2]: safesOnChain2,
         });
     });
 
@@ -264,9 +286,9 @@ describe('Owners Controller (Unit)', () => {
     it('Failure: data validation fails', async () => {
       const ownerAddress = faker.finance.ethereumAddress();
 
-      const chainId1 = faker.string.numeric();
+      const chainId = faker.string.numeric();
 
-      const chain1 = chainBuilder().with('chainId', chainId1).build();
+      const chain = chainBuilder().with('chainId', chainId).build();
 
       const safesOnChain = [
         faker.finance.ethereumAddress(),
@@ -279,20 +301,20 @@ describe('Owners Controller (Unit)', () => {
           case `${safeConfigUrl}/api/v1/chains`: {
             return Promise.resolve({
               data: {
-                results: [chain1],
+                results: [chain],
               },
               status: 200,
             });
           }
 
-          case `${safeConfigUrl}/api/v1/chains/${chainId1}`: {
+          case `${safeConfigUrl}/api/v1/chains/${chainId}`: {
             return Promise.resolve({
-              data: chain1,
+              data: chain,
               status: 200,
             });
           }
 
-          case `${chain1.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
+          case `${chain.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
             return Promise.resolve({
               data: { safes: safesOnChain },
               status: 200,

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -176,4 +176,143 @@ describe('Owners Controller (Unit)', () => {
         });
     });
   });
+
+  describe('GET all safes by owner address', () => {
+    it('Success', async () => {
+      const ownerAddress = faker.finance.ethereumAddress();
+
+      const chainId1 = faker.string.numeric();
+
+      const chain1 = chainBuilder().with('chainId', chainId1).build();
+
+      const safesOnChain = [
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+      ];
+
+      networkService.get.mockImplementation((url: string) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains`: {
+            return Promise.resolve({
+              data: {
+                results: [chain1],
+              },
+              status: 200,
+            });
+          }
+
+          case `${safeConfigUrl}/api/v1/chains/${chainId1}`: {
+            return Promise.resolve({
+              data: chain1,
+              status: 200,
+            });
+          }
+
+          case `${chain1.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
+            return Promise.resolve({
+              data: { safes: safesOnChain },
+              status: 200,
+            });
+          }
+
+          default: {
+            fail(`Unexpected URL: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/owners/${ownerAddress}/safes`)
+        .expect(200)
+        .expect({
+          [chainId1]: safesOnChain,
+        });
+    });
+
+    it('Failure: Config API fails', async () => {
+      const ownerAddress = faker.finance.ethereumAddress();
+
+      networkService.get.mockImplementation((url: string) => {
+        if (url === `${safeConfigUrl}/api/v1/chains`) {
+          const error = new NetworkResponseError(
+            new URL(`${safeConfigUrl}/api/v1/chains`),
+            {
+              status: 500,
+            } as Response,
+          );
+          return Promise.reject(error);
+        }
+        fail(`Unexpected URL: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/owners/${ownerAddress}/safes`)
+        .expect(500)
+        .expect({
+          message: 'An error occurred',
+          code: 500,
+        });
+
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledWith(
+        `${safeConfigUrl}/api/v1/chains`,
+        { params: { limit: undefined, offset: undefined } },
+      );
+    });
+
+    it('Failure: data validation fails', async () => {
+      const ownerAddress = faker.finance.ethereumAddress();
+
+      const chainId1 = faker.string.numeric();
+
+      const chain1 = chainBuilder().with('chainId', chainId1).build();
+
+      const safesOnChain = [
+        faker.finance.ethereumAddress(),
+        faker.number.int(),
+        faker.finance.ethereumAddress(),
+      ];
+
+      networkService.get.mockImplementation((url: string) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains`: {
+            return Promise.resolve({
+              data: {
+                results: [chain1],
+              },
+              status: 200,
+            });
+          }
+
+          case `${safeConfigUrl}/api/v1/chains/${chainId1}`: {
+            return Promise.resolve({
+              data: chain1,
+              status: 200,
+            });
+          }
+
+          case `${chain1.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
+            return Promise.resolve({
+              data: { safes: safesOnChain },
+              status: 200,
+            });
+          }
+
+          default: {
+            fail(`Unexpected URL: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/owners/${ownerAddress}/safes`)
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+  });
 });

--- a/src/routes/owners/owners.controller.ts
+++ b/src/routes/owners/owners.controller.ts
@@ -19,4 +19,12 @@ export class OwnersController {
   ): Promise<SafeList> {
     return this.ownersService.getSafesByOwner({ chainId, ownerAddress });
   }
+
+  @ApiOkResponse({ type: SafeList })
+  @Get('owners/:ownerAddress/safes')
+  async getAllSafesByOwner(
+    @Param('ownerAddress') ownerAddress: string,
+  ): Promise<{ [chainId: string]: Array<string> }> {
+    return this.ownersService.getAllSafesByOwner({ ownerAddress });
+  }
 }

--- a/src/routes/owners/owners.service.ts
+++ b/src/routes/owners/owners.service.ts
@@ -16,4 +16,10 @@ export class OwnersService {
   }): Promise<SafeList> {
     return this.safeRepository.getSafesByOwner(args);
   }
+
+  async getAllSafesByOwner(args: {
+    ownerAddress: string;
+  }): Promise<{ [chainId: string]: Array<string> }> {
+    return this.safeRepository.getAllSafesByOwner(args);
+  }
 }


### PR DESCRIPTION
This adds a new `GET` `owners/:ownerAddress/safes` endpoint for retrieving all Safes on all chains for a specified `ownerAddress`, returning `{ [chainId: string]: Array<string> }` of addresses.