### PR TITLE
Extract Verification Code table

### DIFF
--- a/migrations/00001_initial/index.sql
+++ b/migrations/00001_initial/index.sql
@@ -1,17 +1,25 @@
 DROP TABLE IF EXISTS accounts CASCADE;
 CREATE table accounts
 (
-    id                             SERIAL PRIMARY KEY,
-    chain_id                       int                   NOT NULL,
-    email_address                  text                  NOT NULL,
-    safe_address                   character varying(42) NOT NULL,
-    signer                         character varying(42) NOT NULL,
-    verified                       boolean               NOT NULL DEFAULT false,
-    verification_code              text,
-    verification_code_generated_on timestamp with time zone,
-    verification_sent_on           timestamp with time zone,
-    unsubscription_token           uuid                  NOT NULL,
+    id                   SERIAL PRIMARY KEY,
+    chain_id             int                   NOT NULL,
+    email_address        text                  NOT NULL,
+    safe_address         character varying(42) NOT NULL,
+    signer               character varying(42) NOT NULL,
+    verified             boolean               NOT NULL DEFAULT false,
+    unsubscription_token uuid                  NOT NULL,
     UNIQUE (chain_id, safe_address, signer)
+);
+
+DROP TABLE IF EXISTS verification_codes CASCADE;
+CREATE TABLE verification_codes
+(
+    account_id   INT,
+    code         text                     NOT NULL,
+    generated_on timestamp with time zone NOT NULL,
+    sent_on      timestamp with time zone,
+    FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE,
+    UNIQUE (account_id)
 );
 
 DROP TABLE IF EXISTS notification_types CASCADE;

--- a/src/datasources/account/__tests__/test.account.datasource.module.ts
+++ b/src/datasources/account/__tests__/test.account.datasource.module.ts
@@ -4,6 +4,7 @@ import { IAccountDataSource } from '@/domain/interfaces/account.datasource.inter
 const accountDataSource = {
   getVerifiedAccountEmailsBySafeAddress: jest.fn(),
   getAccount: jest.fn(),
+  getAccountVerificationCode: jest.fn(),
   createAccount: jest.fn(),
   setEmailVerificationCode: jest.fn(),
   setEmailVerificationSentDate: jest.fn(),

--- a/src/datasources/account/errors/verification-code-does-not-exist.error.ts
+++ b/src/datasources/account/errors/verification-code-does-not-exist.error.ts
@@ -1,0 +1,10 @@
+export class VerificationCodeDoesNotExistError extends Error {
+  readonly signer: string;
+
+  constructor(chainId: string, safeAddress: string, signer: string) {
+    super(
+      `Verification code for account of ${signer} of ${safeAddress} on chain ${chainId} does not exist.`,
+    );
+    this.signer = signer;
+  }
+}

--- a/src/domain/account/account-repository.service.ts
+++ b/src/domain/account/account-repository.service.ts
@@ -232,12 +232,17 @@ export class AccountRepository implements IAccountRepository {
 
     await this.accountDataSource.updateAccountEmail({
       chainId: args.chainId,
-      code: newVerificationCode,
       emailAddress: newEmail,
       safeAddress: args.safeAddress,
       signer: args.signer,
-      codeGenerationDate: new Date(),
       unsubscriptionToken: crypto.randomUUID(),
+    });
+    await this.accountDataSource.setEmailVerificationCode({
+      chainId: args.chainId,
+      code: newVerificationCode,
+      signer: args.signer,
+      codeGenerationDate: new Date(),
+      safeAddress: args.safeAddress,
     });
     // TODO if the following throws we should not throw
     await this._sendEmailVerification({
@@ -272,7 +277,9 @@ export class AccountRepository implements IAccountRepository {
 
     // Update verification-sent date on a successful response
     await this.accountDataSource.setEmailVerificationSentDate({
-      ...args,
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+      signer: args.signer,
       sentOn: new Date(),
     });
   }

--- a/src/domain/account/entities/__tests__/account.builder.ts
+++ b/src/domain/account/entities/__tests__/account.builder.ts
@@ -11,8 +11,5 @@ export function accountBuilder(): IBuilder<Account> {
     .with('emailAddress', new EmailAddress(faker.internet.email()))
     .with('isVerified', faker.datatype.boolean())
     .with('safeAddress', faker.finance.ethereumAddress())
-    .with('signer', faker.finance.ethereumAddress())
-    .with('verificationCode', null)
-    .with('verificationGeneratedOn', null)
-    .with('verificationSentOn', null);
+    .with('signer', faker.finance.ethereumAddress());
 }

--- a/src/domain/account/entities/__tests__/verification-code.builder.ts
+++ b/src/domain/account/entities/__tests__/verification-code.builder.ts
@@ -1,0 +1,10 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { VerificationCode } from '@/domain/account/entities/account.entity';
+import { faker } from '@faker-js/faker';
+
+export function verificationCodeBuilder(): IBuilder<VerificationCode> {
+  return new Builder<VerificationCode>()
+    .with('code', faker.string.numeric({ length: 6 }))
+    .with('generatedOn', new Date())
+    .with('sentOn', null);
+}

--- a/src/domain/account/entities/account.entity.ts
+++ b/src/domain/account/entities/account.entity.ts
@@ -10,9 +10,12 @@ export interface Account {
   isVerified: boolean;
   safeAddress: string;
   signer: string;
-  verificationCode: string | null;
-  verificationGeneratedOn: Date | null;
-  verificationSentOn: Date | null;
+}
+
+export interface VerificationCode {
+  code: string;
+  generatedOn: Date;
+  sentOn: Date | null;
 }
 
 export class EmailAddress {

--- a/src/domain/interfaces/account.datasource.interface.ts
+++ b/src/domain/interfaces/account.datasource.interface.ts
@@ -2,7 +2,6 @@ import {
   Account,
   EmailAddress,
   VerificationCode,
-  VerificationCode as DomainVerificationCode,
 } from '@/domain/account/entities/account.entity';
 import { Subscription } from '@/domain/account/entities/subscription.entity';
 
@@ -37,7 +36,7 @@ export interface IAccountDataSource {
     chainId: string;
     safeAddress: string;
     signer: string;
-  }): Promise<DomainVerificationCode>;
+  }): Promise<VerificationCode>;
 
   /**
    * Creates a new account entry
@@ -104,7 +103,7 @@ export interface IAccountDataSource {
     chainId: string;
     safeAddress: string;
     signer: string;
-  }): Promise<Account>;
+  }): Promise<void>;
 
   /**
    * Deletes the given account.
@@ -134,8 +133,6 @@ export interface IAccountDataSource {
     safeAddress: string;
     emailAddress: EmailAddress;
     signer: string;
-    code: string;
-    codeGenerationDate: Date;
     unsubscriptionToken: string;
   }): Promise<Account>;
 

--- a/src/domain/interfaces/account.datasource.interface.ts
+++ b/src/domain/interfaces/account.datasource.interface.ts
@@ -1,6 +1,8 @@
 import {
   Account,
   EmailAddress,
+  VerificationCode,
+  VerificationCode as DomainVerificationCode,
 } from '@/domain/account/entities/account.entity';
 import { Subscription } from '@/domain/account/entities/subscription.entity';
 
@@ -31,6 +33,12 @@ export interface IAccountDataSource {
     signer: string;
   }): Promise<Account>;
 
+  getAccountVerificationCode(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<DomainVerificationCode>;
+
   /**
    * Creates a new account entry
    *
@@ -49,7 +57,7 @@ export interface IAccountDataSource {
     code: string;
     codeGenerationDate: Date;
     unsubscriptionToken: string;
-  }): Promise<void>;
+  }): Promise<[Account, VerificationCode]>;
 
   /**
    * Sets the verification code for an account.
@@ -68,7 +76,7 @@ export interface IAccountDataSource {
     signer: string;
     code: string;
     codeGenerationDate: Date;
-  }): Promise<void>;
+  }): Promise<VerificationCode>;
 
   /**
    * Sets the verification date for an email entry.
@@ -83,7 +91,7 @@ export interface IAccountDataSource {
     safeAddress: string;
     signer: string;
     sentOn: Date;
-  }): Promise<void>;
+  }): Promise<VerificationCode>;
 
   /**
    * Verifies the email address for an account of a Safe.
@@ -96,7 +104,7 @@ export interface IAccountDataSource {
     chainId: string;
     safeAddress: string;
     signer: string;
-  }): Promise<void>;
+  }): Promise<Account>;
 
   /**
    * Deletes the given account.
@@ -109,7 +117,7 @@ export interface IAccountDataSource {
     chainId: string;
     safeAddress: string;
     signer: string;
-  }): Promise<void>;
+  }): Promise<Account>;
 
   /**
    * Updates the email address of an account.
@@ -129,7 +137,7 @@ export interface IAccountDataSource {
     code: string;
     codeGenerationDate: Date;
     unsubscriptionToken: string;
-  }): Promise<void>;
+  }): Promise<Account>;
 
   /**
    * Gets all the subscriptions for the account on chainId, with the specified safeAddress.

--- a/src/routes/email/email.controller.delete-email.spec.ts
+++ b/src/routes/email/email.controller.delete-email.spec.ts
@@ -89,7 +89,7 @@ describe('Email controller delete email tests', () => {
     const message = `email-delete-${chain.chainId}-${safeAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     accountDataSource.getAccount.mockResolvedValue(account);
-    accountDataSource.deleteAccount.mockImplementation(() => Promise.resolve());
+    accountDataSource.deleteAccount.mockResolvedValue(account);
     emailApi.deleteEmailAddress.mockResolvedValue();
 
     await request(app.getHttpServer())

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -29,6 +29,8 @@ import {
   Account,
   EmailAddress,
 } from '@/domain/account/entities/account.entity';
+import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
+import { verificationCodeBuilder } from '@/domain/account/entities/__tests__/verification-code.builder';
 
 const verificationCodeTtlMs = 100;
 
@@ -113,10 +115,23 @@ describe('Email controller edit email tests', () => {
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
-    accountDataSource.getAccount.mockResolvedValue({
-      emailAddress: new EmailAddress(prevEmailAddress),
-    } as Account);
-    accountDataSource.updateAccountEmail.mockResolvedValue();
+    accountDataSource.getAccount.mockResolvedValue(
+      accountBuilder()
+        .with('chainId', chain.chainId)
+        .with('signer', signerAddress)
+        .with('isVerified', true)
+        .with('safeAddress', safe.address)
+        .with('emailAddress', new EmailAddress(prevEmailAddress))
+        .build(),
+    );
+    accountDataSource.updateAccountEmail.mockResolvedValue(
+      accountBuilder()
+        .with('emailAddress', new EmailAddress(emailAddress))
+        .build(),
+    );
+    accountDataSource.setEmailVerificationSentDate.mockResolvedValue(
+      verificationCodeBuilder().build(),
+    );
 
     await request(app.getHttpServer())
       .put(`/v1/chains/${chain.chainId}/safes/${safe.address}/emails`)

--- a/src/routes/email/email.controller.save-email.spec.ts
+++ b/src/routes/email/email.controller.save-email.spec.ts
@@ -27,6 +27,9 @@ import { IEmailApi } from '@/domain/interfaces/email-api.interface';
 import { TestEmailApiModule } from '@/datasources/email-api/__tests__/test.email-api.module';
 import { EmailApiModule } from '@/datasources/email-api/email-api.module';
 import { INestApplication } from '@nestjs/common';
+import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
+import { verificationCodeBuilder } from '@/domain/account/entities/__tests__/verification-code.builder';
+import { EmailAddress } from '@/domain/account/entities/account.entity';
 
 describe('Email controller save email tests', () => {
   let app: INestApplication;
@@ -98,7 +101,16 @@ describe('Email controller save email tests', () => {
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
-    accountDataSource.createAccount.mockResolvedValue();
+    accountDataSource.createAccount.mockResolvedValue([
+      accountBuilder()
+        .with('chainId', chain.chainId)
+        .with('emailAddress', new EmailAddress(emailAddress))
+        .with('safeAddress', safe.address)
+        .with('signer', signerAddress)
+        .with('isVerified', false)
+        .build(),
+      verificationCodeBuilder().build(),
+    ]);
     accountDataSource.subscribe.mockResolvedValue([
       {
         key: faker.word.sample(),


### PR DESCRIPTION
The verification code related data was extracted from the Accounts' table. Verification Codes are temporary data that should only be present while an account is being verified.

Previously, after an account was verified, most of the data tied to the verification process was set to `null` as it was still part of the `accounts` table. By extracting the verification code related data, we can now delete the respective rows instead of holding null values that were mostly used for temporary purposes.