### PR TITLE
Clear notification_types contents on tests execution

### DIFF
--- a/src/datasources/account/account.datasource.spec.ts
+++ b/src/datasources/account/account.datasource.spec.ts
@@ -31,7 +31,7 @@ describe('Account DataSource Tests', () => {
   });
 
   afterEach(async () => {
-    await sql`TRUNCATE TABLE accounts, subscriptions CASCADE`;
+    await sql`TRUNCATE TABLE accounts, notification_types, subscriptions CASCADE`;
   });
 
   afterAll(async () => {


### PR DESCRIPTION
### Summary
The `notification_types` table is not being cleared after the tests' execution. This causes the table rows to incrementally grow on each execution, which fails when a randomly generated `notification_type` row collides with an existing one.

### Changes
- Truncates `notification_types` table after each test execution.