### PR TITLE
Add route to retrieve email address

### DIFF
--- a/src/domain/account/account.repository.interface.ts
+++ b/src/domain/account/account.repository.interface.ts
@@ -1,6 +1,14 @@
+import { Account } from '@/domain/account/entities/account.entity';
+
 export const IAccountRepository = Symbol('IAccountRepository');
 
 export interface IAccountRepository {
+  getAccount(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<Account>;
+
   /**
    * Gets the verified emails associated with a Safe address.
    *

--- a/src/domain/account/account.repository.ts
+++ b/src/domain/account/account.repository.ts
@@ -2,6 +2,7 @@ import { IAccountDataSource } from '@/domain/interfaces/account.datasource.inter
 import { Inject, Injectable } from '@nestjs/common';
 import codeGenerator from '@/domain/account/code-generator';
 import {
+  Account,
   EmailAddress,
   VerificationCode,
 } from '@/domain/account/entities/account.entity';
@@ -51,6 +52,14 @@ export class AccountRepository implements IAccountRepository {
     // The generated code might have less than 6 digits so the version to be
     // validated against should account with the leading zeroes
     return verificationCode.toString().padStart(6, '0');
+  }
+
+  async getAccount(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<Account> {
+    return this.accountDataSource.getAccount(args);
   }
 
   async createAccount(args: {

--- a/src/routes/email/email.controller.get-email.spec.ts
+++ b/src/routes/email/email.controller.get-email.spec.ts
@@ -1,0 +1,177 @@
+import { INestApplication } from '@nestjs/common';
+import configuration from '@/config/entities/__tests__/configuration';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '@/app.module';
+import { EmailControllerModule } from '@/routes/email/email.controller.module';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import * as request from 'supertest';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
+import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
+import { faker } from '@faker-js/faker';
+import { AccountDoesNotExistError } from '@/domain/account/errors/account-does-not-exist.error';
+
+describe('Email controller get email tests', () => {
+  let app: INestApplication;
+  let accountDataSource: jest.MockedObjectDeep<IAccountDataSource>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration), EmailControllerModule],
+    })
+      .overrideModule(AccountDataSourceModule)
+      .useModule(TestAccountDataSourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    accountDataSource = moduleFixture.get(IAccountDataSource);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('Retrieves email if correctly authenticated', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const timestamp = Date.now();
+    const message = `email-retrieval-${chain.chainId}-${safe.address}-${signer.address}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
+    const account = accountBuilder()
+      .with('signer', signer.address)
+      .with('chainId', chain.chainId)
+      .with('safeAddress', safe.address)
+      .build();
+    accountDataSource.getAccount.mockResolvedValue(account);
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/${signer.address}`,
+      )
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(200)
+      .expect({
+        email: account.emailAddress.value,
+        verified: account.isVerified,
+      });
+
+    expect(accountDataSource.getAccount).toHaveBeenCalledTimes(1);
+    expect(accountDataSource.getAccount).toHaveBeenCalledWith({
+      chainId: chain.chainId.toString(),
+      safeAddress: safe.address.toString(),
+      signer: signer.address,
+    });
+  });
+
+  it('Returns 403 if wrong message was signed', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const timestamp = Date.now();
+    const message = faker.string.sample(32);
+    const signature = await signer.signMessage({ message });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/${signer.address}`,
+      )
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(accountDataSource.getAccount).toHaveBeenCalledTimes(0);
+  });
+
+  it('Returns 403 if signature expired', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const timestamp = Date.now();
+    const message = `email-retrieval-${chain.chainId}-${safe.address}-${signer.address}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
+    const account = accountBuilder()
+      .with('signer', signer.address)
+      .with('chainId', chain.chainId)
+      .with('safeAddress', safe.address)
+      .build();
+    accountDataSource.getAccount.mockResolvedValue(account);
+
+    // Advance time by 5 minutes
+    jest.advanceTimersByTime(5 * 60 * 1000);
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/${signer.address}`,
+      )
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    expect(accountDataSource.getAccount).toHaveBeenCalledTimes(0);
+  });
+
+  it('Returns 404 if signer has no emails', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const timestamp = Date.now();
+    const message = `email-retrieval-${chain.chainId}-${safe.address}-${signer.address}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
+    accountDataSource.getAccount.mockRejectedValue(
+      new AccountDoesNotExistError(chain.chainId, safe.address, signer.address),
+    );
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/${signer.address}`,
+      )
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(404)
+      .expect({
+        message: `No email address was found for the provided signer ${signer.address}.`,
+        statusCode: 404,
+      });
+  });
+});

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   HttpCode,
   HttpStatus,
   Param,
@@ -27,6 +28,8 @@ import { AccountDoesNotExistExceptionFilter } from '@/routes/email/exception-fil
 import { EditEmailDto } from '@/routes/email/entities/edit-email-dto.entity';
 import { EmailEditGuard } from '@/routes/email/guards/email-edit.guard';
 import { EmailEditMatchesExceptionFilter } from '@/routes/email/exception-filters/email-edit-matches.exception-filter';
+import { EmailRetrievalGuard } from '@/routes/email/guards/email-retrieval.guard';
+import { Email } from '@/routes/email/entities/email.entity';
 
 @ApiTags('email')
 @Controller({
@@ -36,6 +39,24 @@ import { EmailEditMatchesExceptionFilter } from '@/routes/email/exception-filter
 @ApiExcludeController()
 export class EmailController {
   constructor(private readonly service: EmailService) {}
+
+  @Get(':signer')
+  @UseGuards(
+    EmailRetrievalGuard,
+    TimestampGuard(5 * 60 * 1000), // 5 minutes
+  )
+  @UseFilters(AccountDoesNotExistExceptionFilter)
+  async getEmail(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @Param('signer') signer: string,
+  ): Promise<Email> {
+    return this.service.getEmail({
+      chainId,
+      safeAddress,
+      signer,
+    });
+  }
 
   @Post('')
   @UseGuards(

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IAccountRepository } from '@/domain/account/account.repository.interface';
+import { Email } from '@/routes/email/entities/email.entity';
 
 @Injectable()
 export class EmailService {
@@ -48,5 +49,14 @@ export class EmailService {
     emailAddress: string;
   }): Promise<void> {
     return this.repository.editEmail(args);
+  }
+
+  async getEmail(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<Email> {
+    const account = await this.repository.getAccount(args);
+    return new Email(account.emailAddress.value, account.isVerified);
   }
 }

--- a/src/routes/email/entities/email.entity.ts
+++ b/src/routes/email/entities/email.entity.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Email {
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  verified: boolean;
+
+  constructor(email: string, verified: boolean) {
+    this.email = email;
+    this.verified = verified;
+  }
+}

--- a/src/routes/email/guards/email-retrieval.guard.spec.ts
+++ b/src/routes/email/guards/email-retrieval.guard.spec.ts
@@ -1,0 +1,146 @@
+import { Controller, Get, INestApplication, UseGuards } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { Hash } from 'viem';
+import { EmailRetrievalGuard } from '@/routes/email/guards/email-retrieval.guard';
+
+@Controller()
+class TestController {
+  @Get('test/:chainId/:safeAddress/:signer')
+  @UseGuards(EmailRetrievalGuard)
+  async validRoute(): Promise<void> {}
+
+  @Get('test/invalid/1/:chainId/:safeAddress')
+  @UseGuards(EmailRetrievalGuard)
+  async invalidRouteWithoutSigner(): Promise<void> {}
+
+  @Get('test/invalid/2/:chainId/:signer')
+  @UseGuards(EmailRetrievalGuard)
+  async invalidRouteWithoutSafeAddress(): Promise<void> {}
+
+  @Get('test/invalid/3/:safeAddress/:signer')
+  @UseGuards(EmailRetrievalGuard)
+  async invalidRouteWithoutChainId(): Promise<void> {}
+}
+
+describe('EmailRetrievalGuard tests', () => {
+  let app: INestApplication;
+
+  const chainId = faker.string.numeric();
+  const safe = faker.finance.ethereumAddress();
+  const timestamp = faker.date.recent().getTime();
+  const privateKey = generatePrivateKey();
+  const signer = privateKeyToAccount(privateKey);
+  let signature: Hash;
+
+  beforeAll(async () => {
+    const message = `email-retrieval-${chainId}-${safe}-${signer.address}-${timestamp}`;
+    signature = await signer.signMessage({ message });
+  });
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 403 if Safe-Wallet-Signature is missing', async () => {
+    await request(app.getHttpServer())
+      .get(`/test/${chainId}/${safe}/${signer.address}`)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 if Safe-Wallet-Signature-Timestamp is missing', async () => {
+    await request(app.getHttpServer())
+      .get(`/test/${chainId}/${safe}/${signer.address}`)
+      .set('Safe-Wallet-Signature', signature)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 200 on a valid signature', async () => {
+    await request(app.getHttpServer())
+      .get(`/test/${chainId}/${safe}/${signer.address}`)
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(200);
+  });
+
+  it('returns 403 on an invalid signature', async () => {
+    await request(app.getHttpServer())
+      .get(`/test/${chainId}/${safe}/${signer}`)
+      .set('Safe-Wallet-Signature', faker.string.sample(32))
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without signer', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .get(`/test/invalid/1/${chainId}/${safeAddress}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without safe address', async () => {
+    const chainId = faker.string.numeric();
+    const signer = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .get(`/test/invalid/2/${chainId}/${signer}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  it('returns 403 on routes without chain id', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const signer = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .get(`/test/invalid/3/${safeAddress}/${signer}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+});

--- a/src/routes/email/guards/email-retrieval.guard.ts
+++ b/src/routes/email/guards/email-retrieval.guard.ts
@@ -1,0 +1,61 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { verifyMessage } from 'viem';
+
+/**
+ * The EmailRetrievalGuard guard should be used on routes that require
+ * authenticated actions for retrieving email addresses.
+ *
+ * This guard therefore validates if the message came from the specified signer.
+ *
+ * The following message should be signed:
+ * email-retrieval-${chainId}-${safe}-${signer}-${timestamp}
+ *
+ * (where ${} represents placeholder values for the respective data)
+ *
+ * To use this guard, the route should have:
+ * - the 'chainId' as part of the path parameters
+ * - the 'safeAddress' as part of the path parameters
+ * - the 'signer' as part of the path parameters
+ * - the 'Safe-Wallet-Signature' header set to the signature
+ * - the 'Safe-Wallet-Signature-Timestamp' header set to the signature timestamp
+ */
+@Injectable()
+export class EmailRetrievalGuard implements CanActivate {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  private static readonly ACTION_PREFIX = 'email-retrieval';
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const chainId = request.params['chainId'];
+    const safe = request.params['safeAddress'];
+    const signer = request.params['signer'];
+    const signature = request.headers['safe-wallet-signature'];
+    const timestamp = request.headers['safe-wallet-signature-timestamp'];
+
+    // Required fields
+    if (!chainId || !safe || !signature || !signer || !timestamp) return false;
+
+    const message = `${EmailRetrievalGuard.ACTION_PREFIX}-${chainId}-${safe}-${signer}-${timestamp}`;
+
+    try {
+      return await verifyMessage({
+        address: signer,
+        message,
+        signature,
+      });
+    } catch (e) {
+      this.loggingService.debug(e);
+      return false;
+    }
+  }
+}

--- a/src/routes/email/guards/timestamp.guard.ts
+++ b/src/routes/email/guards/timestamp.guard.ts
@@ -1,4 +1,4 @@
-import { CanActivate, ExecutionContext, Type, mixin } from '@nestjs/common';
+import { CanActivate, ExecutionContext, mixin, Type } from '@nestjs/common';
 
 /**
  * Returns a guard mixin that can be used to check if a 'timestamp'
@@ -13,7 +13,9 @@ export const TimestampGuard = (maxElapsedTimeMs: number): Type<CanActivate> => {
     canActivate(context: ExecutionContext): boolean {
       const request = context.switchToHttp().getRequest();
 
-      const timestampRaw = request.body['timestamp'];
+      const timestampRaw =
+        request.body['timestamp'] ??
+        request.headers['safe-wallet-signature-timestamp'];
       const timestamp = parseInt(timestampRaw);
       if (isNaN(timestamp)) return false;
 


### PR DESCRIPTION
- Adds a new route to retrieve an email address: `GET /v1/chains/:chainId/safes/:safeAddress/emails/:signerAddress`
- This route returns the `emailAddress` and respective verification status for authenticated requests. If there are no emails associated with the signer a `404 Not Found` is returned. 

```javascript
GET /v1/chains/:chainId/safes/:safeAddress/emails/:signerAddress

{
  email: <string>, // the signer's email address
  verified: <boolean>, // the current verification status of the email
}
```

- This new route requires two headers to be set:
  * `Safe-Wallet-Signature` – which includes the signature of the expected message
  * `Safe-Wallet-Signature-Timestamp` – which includes the timestamp that is signed with the message
- The expected message to be signed is: `email-retrieval-${chainId}-${safe}-${signer}-${timestamp}`
- A signature is only valid for 5 minutes. If a signature is re-used after these 5 minutes, a `403 Forbidden` is returned.

### Future work

We can move the authentication components to the headers instead for the other endpoints that require some sort of authentication. This decouples the authentication part with the payload part of each request which was an issue when building this `GET` endpoint.