### PR TITLE
Remove safe owner restriction from email edition

### DIFF
--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -21,7 +21,6 @@ import {
 import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
-import { getAddress } from 'viem';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { INestApplication } from '@nestjs/common';
 import { AccountDoesNotExistError } from '@/domain/account/errors/account-does-not-exist.error';
@@ -96,7 +95,6 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const signerAddress = signer.address;
-    // Signer is owner of safe
     const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
@@ -174,12 +172,7 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const signerAddress = signer.address;
-    // Signer is owner of safe
-    const safe = safeBuilder()
-      .with('owners', [signerAddress])
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
+    const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
@@ -225,12 +218,7 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const signerAddress = signer.address;
-    // Signer is owner of safe
-    const safe = safeBuilder()
-      .with('owners', [signerAddress])
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
+    const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
@@ -277,12 +265,7 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const signerAddress = signer.address;
-    // Signer is owner of safe
-    const safe = safeBuilder()
-      .with('owners', [signerAddress])
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
+    const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
@@ -329,12 +312,7 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const account = privateKeyToAccount(privateKey);
     const accountAddress = account.address;
-    // Signer is owner of safe
-    const safe = safeBuilder()
-      .with('owners', [accountAddress])
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
+    const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
 
@@ -370,12 +348,7 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const account = privateKeyToAccount(privateKey);
     const accountAddress = account.address;
-    // Signer is owner of safe
-    const safe = safeBuilder()
-      .with('owners', [accountAddress])
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
+    const safe = safeBuilder().build();
     const message = `some-action-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
 

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -97,11 +97,7 @@ describe('Email controller edit email tests', () => {
     const signer = privateKeyToAccount(privateKey);
     const signerAddress = signer.address;
     // Signer is owner of safe
-    const safe = safeBuilder()
-      .with('owners', [signerAddress])
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
+    const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
@@ -382,54 +378,6 @@ describe('Email controller edit email tests', () => {
       .build();
     const message = `some-action-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
-
-    await request(app.getHttpServer())
-      .put(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/${account.address}`,
-      )
-      .set('Safe-Wallet-Signature', signature)
-      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
-      .send({
-        emailAddress,
-      })
-      .expect(403)
-      .expect({
-        message: 'Forbidden resource',
-        error: 'Forbidden',
-        statusCode: 403,
-      });
-
-    expect(accountDataSource.updateAccountEmail).toHaveBeenCalledTimes(0);
-    expect(accountDataSource.setEmailVerificationCode).toHaveBeenCalledTimes(0);
-    expect(
-      accountDataSource.setEmailVerificationSentDate,
-    ).toHaveBeenCalledTimes(0);
-  });
-
-  it('returns 403 if message not signed by owner', async () => {
-    const chain = chainBuilder().build();
-    const emailAddress = faker.internet.email();
-    const timestamp = jest.now();
-    const privateKey = generatePrivateKey();
-    const account = privateKeyToAccount(privateKey);
-    const accountAddress = account.address;
-    // Signer is owner of safe
-    const safe = safeBuilder()
-      // Faker generates non-checksum addresses only
-      .with('address', getAddress(faker.finance.ethereumAddress()))
-      .build();
-    const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
-    const signature = await account.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
-      switch (url) {
-        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
-        case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-          return Promise.resolve({ data: safe, status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
 
     await request(app.getHttpServer())
       .put(

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -133,7 +133,6 @@ export class EmailController {
   @UseGuards(
     EmailEditGuard,
     TimestampGuard(5 * 60 * 1000), // 5 minutes
-    OnlySafeOwnerGuard,
   )
   @UseFilters(
     EmailEditMatchesExceptionFilter,


### PR DESCRIPTION
Editing an email address should be allowed given ownership of the EOA, if the ownership of a Safe changes, the signer should still be able to change its email address.