### PR TITLE
Add PreExecutionLogGuard to POST /v1/hooks/events route

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -4,6 +4,7 @@ import { CacheHooksService } from '@/routes/cache-hooks/cache-hooks.service';
 import { EventValidationPipe } from '@/routes/cache-hooks/pipes/event-validation.pipe';
 import { BasicAuthGuard } from '@/routes/common/auth/basic-auth.guard';
 import { Event } from '@/routes/cache-hooks/entities/event.entity';
+import { PreExecutionLogGuard } from '@/routes/cache-hooks/guards/pre-execution.guard';
 
 @Controller({
   path: '',
@@ -13,7 +14,7 @@ import { Event } from '@/routes/cache-hooks/entities/event.entity';
 export class CacheHooksController {
   constructor(private readonly service: CacheHooksService) {}
 
-  @UseGuards(BasicAuthGuard)
+  @UseGuards(PreExecutionLogGuard, BasicAuthGuard)
   @Post('/hooks/events')
   @HttpCode(202)
   async postEvent(@Body(EventValidationPipe) event: Event): Promise<void> {

--- a/src/routes/cache-hooks/guards/pre-execution.guard.ts
+++ b/src/routes/cache-hooks/guards/pre-execution.guard.ts
@@ -1,0 +1,38 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { formatRouteLogMessage } from '@/logging/utils';
+
+/**
+ * The PreExecutionLogGuard guard outputs a log line containing the request data.
+ */
+@Injectable()
+export class PreExecutionLogGuard implements CanActivate {
+  private readonly PRE_EXECUTION_LOGGING_DETAIL = 'pre-execution-log';
+  private readonly PRE_EXECUTION_LOGGING_STATUS = 202;
+
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const startTimeMs: number = performance.now();
+    const httpContext = context.switchToHttp();
+    const request = httpContext.getRequest();
+
+    this.loggingService.info(
+      formatRouteLogMessage(
+        this.PRE_EXECUTION_LOGGING_STATUS,
+        request,
+        startTimeMs,
+        this.PRE_EXECUTION_LOGGING_DETAIL,
+      ),
+    );
+
+    return true;
+  }
+}

--- a/src/routes/cache-hooks/guards/pre-execution.guard.ts
+++ b/src/routes/cache-hooks/guards/pre-execution.guard.ts
@@ -1,38 +1,30 @@
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import {
   CanActivate,
   ExecutionContext,
   Inject,
   Injectable,
 } from '@nestjs/common';
-import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { formatRouteLogMessage } from '@/logging/utils';
 
 /**
- * The PreExecutionLogGuard guard outputs a log line containing the request data.
+ * The PreExecutionLogGuard guard outputs a log line containing parts of the request data.
+ * Currently only the request path is being logged.
  */
 @Injectable()
 export class PreExecutionLogGuard implements CanActivate {
-  private readonly PRE_EXECUTION_LOGGING_DETAIL = 'pre-execution-log';
-  private readonly PRE_EXECUTION_LOGGING_STATUS = 202;
+  private static readonly PRE_EXECUTION_LOGGING_DETAIL = 'pre-execution-log';
 
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const startTimeMs: number = performance.now();
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest();
-
-    this.loggingService.info(
-      formatRouteLogMessage(
-        this.PRE_EXECUTION_LOGGING_STATUS,
-        request,
-        startTimeMs,
-        this.PRE_EXECUTION_LOGGING_DETAIL,
-      ),
-    );
-
+    this.loggingService.info({
+      type: PreExecutionLogGuard.PRE_EXECUTION_LOGGING_DETAIL,
+      route: request.route.path,
+    });
     return true;
   }
 }

--- a/src/routes/common/interceptors/route-logger.interceptor.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.ts
@@ -27,6 +27,10 @@ import { Request, Response } from 'express';
  */
 @Injectable()
 export class RouteLoggerInterceptor implements NestInterceptor {
+  private readonly PRE_EXECUTION_LOGGING_ROUTE = '/v1/hooks/events';
+  private readonly PRE_EXECUTION_LOGGING_DETAIL = 'pre-execution-log';
+  private readonly PRE_EXECUTION_LOGGING_STATUS = 202;
+
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
@@ -37,6 +41,8 @@ export class RouteLoggerInterceptor implements NestInterceptor {
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest();
     const response = httpContext.getResponse();
+
+    this.onPreExecution(request, startTimeMs);
 
     return next.handle().pipe(
       tap({
@@ -93,5 +99,18 @@ export class RouteLoggerInterceptor implements NestInterceptor {
     this.loggingService.info(
       formatRouteLogMessage(response.statusCode, request, startTimeMs),
     );
+  }
+
+  private onPreExecution(request: Request, startTimeMs: number): void {
+    if (request.route.path === this.PRE_EXECUTION_LOGGING_ROUTE) {
+      this.loggingService.info(
+        formatRouteLogMessage(
+          this.PRE_EXECUTION_LOGGING_STATUS,
+          request,
+          startTimeMs,
+          this.PRE_EXECUTION_LOGGING_DETAIL,
+        ),
+      );
+    }
   }
 }

--- a/src/routes/common/interceptors/route-logger.interceptor.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.ts
@@ -27,10 +27,6 @@ import { Request, Response } from 'express';
  */
 @Injectable()
 export class RouteLoggerInterceptor implements NestInterceptor {
-  private readonly PRE_EXECUTION_LOGGING_ROUTE = '/v1/hooks/events';
-  private readonly PRE_EXECUTION_LOGGING_DETAIL = 'pre-execution-log';
-  private readonly PRE_EXECUTION_LOGGING_STATUS = 202;
-
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
@@ -41,8 +37,6 @@ export class RouteLoggerInterceptor implements NestInterceptor {
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest();
     const response = httpContext.getResponse();
-
-    this.onPreExecution(request, startTimeMs);
 
     return next.handle().pipe(
       tap({
@@ -99,18 +93,5 @@ export class RouteLoggerInterceptor implements NestInterceptor {
     this.loggingService.info(
       formatRouteLogMessage(response.statusCode, request, startTimeMs),
     );
-  }
-
-  private onPreExecution(request: Request, startTimeMs: number): void {
-    if (request.route.path === this.PRE_EXECUTION_LOGGING_ROUTE) {
-      this.loggingService.info(
-        formatRouteLogMessage(
-          this.PRE_EXECUTION_LOGGING_STATUS,
-          request,
-          startTimeMs,
-          this.PRE_EXECUTION_LOGGING_DETAIL,
-        ),
-      );
-    }
   }
 }


### PR DESCRIPTION
Closes #1118 

### Changes:
- Adds `PreExecutionLogGuard` to `CacheHooksController.postEvent`, which prints a log line holding the request data each time an event reaches the service.
