### PR TITLE
Add Zerion NFTs retrieval

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -96,7 +96,7 @@ export default (): ReturnType<typeof configuration> => ({
   },
   email: {
     applicationCode: faker.string.alphanumeric(),
-    baseUri: faker.internet.url({ appendSlash: true }),
+    baseUri: faker.internet.url({ appendSlash: false }),
     apiKey: faker.string.hexadecimal({ length: 32 }),
     fromEmail: faker.internet.email(),
     fromName: faker.person.fullName(),

--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -12,6 +12,8 @@ const configurationServiceMock = jest.mocked(configurationService);
 const valkBalancesApi = {
   getBalances: jest.fn(),
   clearBalances: jest.fn(),
+  getCollectibles: jest.fn(),
+  clearCollectibles: jest.fn(),
   getFiatCodes: jest.fn(),
 } as IBalancesApi;
 
@@ -20,6 +22,8 @@ const valkBalancesApiMock = jest.mocked(valkBalancesApi);
 const zerionBalancesApi = {
   getBalances: jest.fn(),
   clearBalances: jest.fn(),
+  getCollectibles: jest.fn(),
+  clearCollectibles: jest.fn(),
   getFiatCodes: jest.fn(),
 } as IBalancesApi;
 

--- a/src/datasources/balances-api/balances-api.module.ts
+++ b/src/datasources/balances-api/balances-api.module.ts
@@ -10,10 +10,12 @@ import {
   IZerionBalancesApi,
   ZerionBalancesApi,
 } from '@/datasources/balances-api/zerion-balances-api.service';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 
 @Module({
   imports: [CacheFirstDataSourceModule],
   providers: [
+    HttpErrorFactory,
     { provide: IBalancesApiManager, useClass: BalancesApiManager },
     { provide: IValkBalancesApi, useClass: ValkBalancesApi },
     { provide: IZerionBalancesApi, useClass: ZerionBalancesApi },

--- a/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
+++ b/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
@@ -10,6 +10,10 @@ import { faker } from '@faker-js/faker';
 
 export function zerionNFTInfoBuilder(): IBuilder<ZerionNFTInfo> {
   return new Builder<ZerionNFTInfo>()
+    .with('content', {
+      preview: { url: faker.internet.url({ appendSlash: true }) },
+      detail: { url: faker.internet.url({ appendSlash: true }) },
+    })
     .with('contract_address', faker.finance.ethereumAddress())
     .with('flags', { is_spam: faker.datatype.boolean() })
     .with('interface', faker.string.alphanumeric())

--- a/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
+++ b/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
@@ -49,10 +49,15 @@ export function zerionCollectibleBuilder(): IBuilder<ZerionCollectible> {
 }
 
 export function zerionCollectiblesBuilder(): IBuilder<ZerionCollectibles> {
-  return new Builder<ZerionCollectibles>().with(
-    'data',
-    Array.from({ length: faker.number.int({ min: 0, max: 5 }) }, () =>
-      zerionCollectibleBuilder().build(),
-    ),
-  );
+  return new Builder<ZerionCollectibles>()
+    .with(
+      'data',
+      Array.from({ length: faker.number.int({ min: 0, max: 5 }) }, () =>
+        zerionCollectibleBuilder().build(),
+      ),
+    )
+    .with('links', {
+      self: faker.internet.url({ appendSlash: true }),
+      next: `${faker.internet.url({ appendSlash: true })}?page%5Bafter%5D=IjUwIg%3D%3D&page%5Bsize%5D=50`,
+    });
 }

--- a/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
+++ b/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
@@ -1,0 +1,54 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import {
+  ZerionCollectible,
+  ZerionCollectibleAttributes,
+  ZerionCollectibles,
+  ZerionCollectionInfo,
+  ZerionNFTInfo,
+} from '@/datasources/balances-api/entities/zerion-collectible.entity';
+import { faker } from '@faker-js/faker';
+
+export function zerionNFTInfoBuilder(): IBuilder<ZerionNFTInfo> {
+  return new Builder<ZerionNFTInfo>()
+    .with('contract_address', faker.finance.ethereumAddress())
+    .with('flags', { is_spam: faker.datatype.boolean() })
+    .with('interface', faker.string.alphanumeric())
+    .with('name', faker.string.alphanumeric())
+    .with('token_id', faker.string.numeric());
+}
+
+export function zerionCollectionInfoBuilder(): IBuilder<ZerionCollectionInfo> {
+  return new Builder<ZerionCollectionInfo>()
+    .with('content', {
+      icon: { url: faker.internet.url({ appendSlash: true }) },
+      banner: { url: faker.internet.url({ appendSlash: true }) },
+    })
+    .with('description', faker.string.alphanumeric())
+    .with('name', faker.string.alphanumeric());
+}
+
+export function zerionCollectibleAttributesBuilder(): IBuilder<ZerionCollectibleAttributes> {
+  return new Builder<ZerionCollectibleAttributes>()
+    .with('amount', faker.string.numeric())
+    .with('changed_at', faker.date.recent().toString())
+    .with('collection_info', zerionCollectionInfoBuilder().build())
+    .with('nft_info', zerionNFTInfoBuilder().build())
+    .with('price', faker.number.float())
+    .with('value', faker.number.float());
+}
+
+export function zerionCollectibleBuilder(): IBuilder<ZerionCollectible> {
+  return new Builder<ZerionCollectible>()
+    .with('type', 'nft_positions')
+    .with('id', faker.string.sample())
+    .with('attributes', zerionCollectibleAttributesBuilder().build());
+}
+
+export function zerionCollectiblesBuilder(): IBuilder<ZerionCollectibles> {
+  return new Builder<ZerionCollectibles>().with(
+    'data',
+    Array.from({ length: faker.number.int({ min: 0, max: 5 }) }, () =>
+      zerionCollectibleBuilder().build(),
+    ),
+  );
+}

--- a/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
+++ b/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
@@ -11,8 +11,8 @@ import { faker } from '@faker-js/faker';
 export function zerionNFTInfoBuilder(): IBuilder<ZerionNFTInfo> {
   return new Builder<ZerionNFTInfo>()
     .with('content', {
-      preview: { url: faker.internet.url({ appendSlash: true }) },
-      detail: { url: faker.internet.url({ appendSlash: true }) },
+      preview: { url: faker.internet.url({ appendSlash: false }) },
+      detail: { url: faker.internet.url({ appendSlash: false }) },
     })
     .with('contract_address', faker.finance.ethereumAddress())
     .with('flags', { is_spam: faker.datatype.boolean() })
@@ -24,8 +24,8 @@ export function zerionNFTInfoBuilder(): IBuilder<ZerionNFTInfo> {
 export function zerionCollectionInfoBuilder(): IBuilder<ZerionCollectionInfo> {
   return new Builder<ZerionCollectionInfo>()
     .with('content', {
-      icon: { url: faker.internet.url({ appendSlash: true }) },
-      banner: { url: faker.internet.url({ appendSlash: true }) },
+      icon: { url: faker.internet.url({ appendSlash: false }) },
+      banner: { url: faker.internet.url({ appendSlash: false }) },
     })
     .with('description', faker.string.alphanumeric())
     .with('name', faker.string.alphanumeric());

--- a/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
+++ b/src/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder.ts
@@ -49,6 +49,12 @@ export function zerionCollectibleBuilder(): IBuilder<ZerionCollectible> {
 }
 
 export function zerionCollectiblesBuilder(): IBuilder<ZerionCollectibles> {
+  const limit = faker.number.int({ min: 1 });
+  const offset = Buffer.from(
+    `"${faker.number.int({ min: 1 })}"`,
+    'utf8',
+  ).toString('base64');
+
   return new Builder<ZerionCollectibles>()
     .with(
       'data',
@@ -57,7 +63,8 @@ export function zerionCollectiblesBuilder(): IBuilder<ZerionCollectibles> {
       ),
     )
     .with('links', {
-      self: faker.internet.url({ appendSlash: true }),
-      next: `${faker.internet.url({ appendSlash: true })}?page%5Bafter%5D=IjUwIg%3D%3D&page%5Bsize%5D=50`,
+      next: `${faker.internet.url()}?${encodeURIComponent(
+        `page[after]=${offset}&page[size]=${limit}`,
+      )}`,
     });
 }

--- a/src/datasources/balances-api/entities/zerion-collectible.entity.ts
+++ b/src/datasources/balances-api/entities/zerion-collectible.entity.ts
@@ -1,0 +1,36 @@
+export interface ZerionCollectionInfo {
+  content: {
+    icon: { url: string };
+    banner: { url: string };
+  } | null;
+  description: string | null;
+  name: string | null;
+}
+
+export interface ZerionNFTInfo {
+  content: { preview: { url: string } | null; detail: { url: string } | null };
+  contract_address: string;
+  flags: { is_spam: boolean } | null;
+  interface: string | null;
+  name: string | null;
+  token_id: string;
+}
+
+export interface ZerionCollectibleAttributes {
+  amount: string;
+  changed_at: string;
+  collection_info: ZerionCollectionInfo | null;
+  nft_info: ZerionNFTInfo;
+  price: number;
+  value: number;
+}
+
+export interface ZerionCollectible {
+  attributes: ZerionCollectibleAttributes;
+  id: string;
+  type: 'nft_positions';
+}
+
+export interface ZerionCollectibles {
+  data: ZerionCollectible[];
+}

--- a/src/datasources/balances-api/entities/zerion-collectible.entity.ts
+++ b/src/datasources/balances-api/entities/zerion-collectible.entity.ts
@@ -36,4 +36,8 @@ export interface ZerionCollectible {
 
 export interface ZerionCollectibles {
   data: ZerionCollectible[];
+  links: {
+    self: string | null;
+    next: string | null;
+  };
 }

--- a/src/datasources/balances-api/entities/zerion-collectible.entity.ts
+++ b/src/datasources/balances-api/entities/zerion-collectible.entity.ts
@@ -36,8 +36,5 @@ export interface ZerionCollectible {
 
 export interface ZerionCollectibles {
   data: ZerionCollectible[];
-  links: {
-    self: string | null;
-    next: string | null;
-  };
+  links: { next: string | null };
 }

--- a/src/datasources/balances-api/entities/zerion-collectible.entity.ts
+++ b/src/datasources/balances-api/entities/zerion-collectible.entity.ts
@@ -8,7 +8,10 @@ export interface ZerionCollectionInfo {
 }
 
 export interface ZerionNFTInfo {
-  content: { preview: { url: string } | null; detail: { url: string } | null };
+  content: {
+    preview: { url: string } | null;
+    detail: { url: string } | null;
+  } | null;
   contract_address: string;
   flags: { is_spam: boolean } | null;
   interface: string | null;

--- a/src/datasources/balances-api/valk-balances-api.service.ts
+++ b/src/datasources/balances-api/valk-balances-api.service.ts
@@ -12,7 +12,9 @@ import {
   Erc20Balance,
   NativeBalance,
 } from '@/domain/balances/entities/balance.entity';
+import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
 import { getNumberString } from '@/domain/common/utils/utils';
+import { Page } from '@/domain/entities/page.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { IBalancesApi } from '@/domain/interfaces/balances-api.interface';
 import { asError } from '@/logging/utils';
@@ -91,6 +93,14 @@ export class ValkBalancesApi implements IBalancesApi {
   }): Promise<void> {
     const key = CacheRouter.getValkBalancesCacheKey(args);
     await this.cacheService.deleteByKey(key);
+  }
+
+  async getCollectibles(): Promise<Page<Collectible>> {
+    throw new Error('Method not implemented.');
+  }
+
+  async clearCollectibles(): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   getFiatCodes(): string[] {

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -16,7 +16,9 @@ import {
   Erc20Balance,
   NativeBalance,
 } from '@/domain/balances/entities/balance.entity';
+import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
 import { getNumberString } from '@/domain/common/utils/utils';
+import { Page } from '@/domain/entities/page.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { IBalancesApi } from '@/domain/interfaces/balances-api.interface';
 import { asError } from '@/logging/utils';
@@ -91,6 +93,14 @@ export class ZerionBalancesApi implements IBalancesApi {
         `Error getting ${args.safeAddress} balances from provider: ${asError(error).message}}`,
       );
     }
+  }
+
+  async getCollectibles(): Promise<Page<Collectible>> {
+    throw new Error('Method not implemented.');
+  }
+
+  async clearCollectibles(): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   private _mapBalances(

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -213,18 +213,20 @@ export class ZerionBalancesApi implements IBalancesApi {
       count: zerionCollectibles.data.length, // TODO: count and pagination
       next: null,
       previous: null,
-      results: zerionCollectibles.data.map((zc) => ({
-        address: zc.attributes.nft_info.contract_address,
-        description: zc.attributes.collection_info?.description ?? '',
-        id: zc.attributes.nft_info.token_id,
-        imageUri: zc.attributes.nft_info.content?.preview?.url ?? '',
-        logoUri: zc.attributes.collection_info?.content?.icon.url ?? '',
-        metadata: zc.attributes.nft_info.content,
-        name: zc.attributes.collection_info?.name ?? '',
-        tokenName: zc.attributes.nft_info.name ?? '',
-        tokenSymbol: zc.attributes.nft_info.name ?? '',
-        uri: zc.attributes.nft_info.content?.preview?.url ?? '',
-      })),
+      results: zerionCollectibles.data.map(
+        ({ attributes: { nft_info, collection_info } }) => ({
+          address: nft_info.contract_address,
+          tokenName: nft_info.name ?? '',
+          tokenSymbol: nft_info.name ?? '',
+          logoUri: collection_info?.content?.icon.url ?? '',
+          id: nft_info.token_id,
+          uri: nft_info.content?.detail?.url ?? null,
+          name: collection_info?.name ?? null,
+          description: collection_info?.description ?? null,
+          imageUri: nft_info.content?.preview?.url ?? '',
+          metadata: nft_info.content,
+        }),
+      ),
     };
   }
 }

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -110,7 +110,7 @@ export class ZerionBalancesApi implements IBalancesApi {
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         networkRequest: {
-          headers: { Authorization: `${this.apiKey}` },
+          headers: { Authorization: `Basic ${this.apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
             sort: '-floor_price', // TODO: extract to var/configuration
@@ -209,23 +209,22 @@ export class ZerionBalancesApi implements IBalancesApi {
   private _mapCollectibles(
     zerionCollectibles: ZerionCollectibles,
   ): Page<Collectible> {
-    // const collectibles: Collectible[] = zerionCollectibles.data.map((zc) => ({
-    //   address: zc.attributes.nft_info.contract_address,
-    //   tokenName: zc.attributes.nft_info.name,
-    //   tokenSymbol: zc.attributes.nft_info.name,
-    //   logoUri: zc.attributes.collection_info?.content?.icon,
-    //   id: zc.attributes.nft_info.token_id,
-    //   uri: zc.attributes.nft_info.content.preview?.url,
-    //   name: zc.attributes.collection_info?.name,
-    //   description: zc.attributes.collection_info?.description,
-    //   metadata: zc.attributes.nft_info.content,
-    // }));
-
     return {
       count: zerionCollectibles.data.length, // TODO: count and pagination
       next: null,
       previous: null,
-      results: [],
+      results: zerionCollectibles.data.map((zc) => ({
+        address: zc.attributes.nft_info.contract_address,
+        description: zc.attributes.collection_info?.description ?? '',
+        id: zc.attributes.nft_info.token_id,
+        imageUri: zc.attributes.nft_info.content?.preview?.url ?? '',
+        logoUri: zc.attributes.collection_info?.content?.icon.url ?? '',
+        metadata: zc.attributes.nft_info.content,
+        name: zc.attributes.collection_info?.name ?? '',
+        tokenName: zc.attributes.nft_info.name ?? '',
+        tokenSymbol: zc.attributes.nft_info.name ?? '',
+        uri: zc.attributes.nft_info.content?.preview?.url ?? '',
+      })),
     };
   }
 }

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -147,8 +147,12 @@ export class ZerionBalancesApi implements IBalancesApi {
     }
   }
 
-  async clearCollectibles(): Promise<void> {
-    throw new Error('Method not implemented.');
+  async clearCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
+    const key = CacheRouter.getZerionCollectiblesCacheKey(args);
+    await this.cacheService.deleteByKey(key);
   }
 
   private _mapBalances(

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -3,6 +3,7 @@ import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 export class CacheRouter {
   private static readonly ALL_TRANSACTIONS_KEY = 'all_transactions';
   private static readonly BACKBONE_KEY = 'backbone';
+  private static readonly BALANCES_KEY = 'balances';
   private static readonly CHAIN_KEY = 'chain';
   private static readonly CHAINS_KEY = 'chains';
   private static readonly COLLECTIBLES_KEY = 'collectibles';
@@ -23,14 +24,14 @@ export class CacheRouter {
   private static readonly SAFE_APPS_KEY = 'safe_apps';
   private static readonly SAFE_KEY = 'safe';
   private static readonly SINGLETONS_KEY = 'singletons';
-  private static readonly BALANCES_KEY = 'balances';
-  private static readonly VALK_BALANCES_KEY = 'valk_balances';
-  private static readonly ZERION_BALANCES_KEY = 'zerion_balances';
   private static readonly TOKEN_KEY = 'token';
   private static readonly TOKEN_PRICE_KEY = 'token_price';
   private static readonly TOKENS_KEY = 'tokens';
   private static readonly TRANSFER_KEY = 'transfer';
   private static readonly TRANSFERS_KEY = 'transfers';
+  private static readonly VALK_BALANCES_KEY = 'valk_balances';
+  private static readonly ZERION_BALANCES_KEY = 'zerion_balances';
+  private static readonly ZERION_COLLECTIBLES_KEY = 'zerion_collectibles';
 
   static getBalancesCacheKey(args: {
     chainId: string;
@@ -83,6 +84,20 @@ export class CacheRouter {
       CacheRouter.getZerionBalancesCacheKey(args),
       args.fiatCode,
     );
+  }
+
+  static getZerionCollectiblesCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.ZERION_COLLECTIBLES_KEY}_${args.safeAddress}`;
+  }
+
+  static getZerionCollectiblesCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+  }): CacheDir {
+    return new CacheDir(CacheRouter.getZerionCollectiblesCacheKey(args), '');
   }
 
   static getSafeCacheDir(args: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -96,8 +96,13 @@ export class CacheRouter {
   static getZerionCollectiblesCacheDir(args: {
     chainId: string;
     safeAddress: string;
+    limit?: number;
+    offset?: number;
   }): CacheDir {
-    return new CacheDir(CacheRouter.getZerionCollectiblesCacheKey(args), '');
+    return new CacheDir(
+      CacheRouter.getZerionCollectiblesCacheKey(args),
+      `${args.limit}_${args.offset}`,
+    );
   }
 
   static getSafeCacheDir(args: {

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -32,6 +32,7 @@ export class BalancesRepository implements IBalancesRepository {
     trusted?: boolean;
     excludeSpam?: boolean;
   }): Promise<Balance[]> {
+    // TODO: route TransactionApi balances retrieval from BalancesApiManager
     return this.balancesApiManager.useExternalApi(args.chainId)
       ? this._getBalancesFromBalancesApi(args)
       : this._getBalancesFromTransactionApi(args);

--- a/src/domain/collectibles/collectibles.repository.ts
+++ b/src/domain/collectibles/collectibles.repository.ts
@@ -4,12 +4,15 @@ import { CollectiblesValidator } from '@/domain/collectibles/collectibles.valida
 import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
 import { Page } from '@/domain/entities/page.entity';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import { IBalancesApiManager } from '@/domain/interfaces/balances-api.manager.interface';
 
 @Injectable()
 export class CollectiblesRepository implements ICollectiblesRepository {
   constructor(
     @Inject(ITransactionApiManager)
     private readonly transactionApiManager: ITransactionApiManager,
+    @Inject(IBalancesApiManager)
+    private readonly balancesApiManager: IBalancesApiManager,
     private readonly validator: CollectiblesValidator,
   ) {}
 
@@ -21,16 +24,10 @@ export class CollectiblesRepository implements ICollectiblesRepository {
     trusted?: boolean;
     excludeSpam?: boolean;
   }): Promise<Page<Collectible>> {
-    const transactionApi = await this.transactionApiManager.getTransactionApi(
-      args.chainId,
-    );
-    const page = await transactionApi.getCollectibles({
-      safeAddress: args.safeAddress,
-      limit: args.limit,
-      offset: args.offset,
-      trusted: args.trusted,
-      excludeSpam: args.excludeSpam,
-    });
+    // TODO: route TransactionApi collectibles retrieval from BalancesApiManager
+    const page = (await this.balancesApiManager.useExternalApi(args.chainId))
+      ? await this._getCollectiblesFromBalancesApi(args)
+      : await this._getCollectiblesFromTransactionApi(args);
 
     page?.results.map((result) => this.validator.validate(result));
     return page;
@@ -40,10 +37,44 @@ export class CollectiblesRepository implements ICollectiblesRepository {
     chainId: string;
     safeAddress: string;
   }): Promise<void> {
+    if (this.balancesApiManager.useExternalApi(args.chainId)) {
+      const api = await this.balancesApiManager.getBalancesApi(args.chainId);
+      await api.clearCollectibles(args);
+    } else {
+      const transactionApi = await this.transactionApiManager.getTransactionApi(
+        args.chainId,
+      );
+      await transactionApi.clearCollectibles(args.safeAddress);
+    }
+  }
+
+  private async _getCollectiblesFromBalancesApi(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Collectible>> {
+    const api = this.balancesApiManager.getBalancesApi(args.chainId);
+    return api.getCollectibles(args);
+  }
+
+  private async _getCollectiblesFromTransactionApi(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Page<Collectible>> {
     const transactionApi = await this.transactionApiManager.getTransactionApi(
       args.chainId,
     );
-
-    return transactionApi.clearCollectibles(args.safeAddress);
+    return transactionApi.getCollectibles({
+      safeAddress: args.safeAddress,
+      limit: args.limit,
+      offset: args.offset,
+      trusted: args.trusted,
+      excludeSpam: args.excludeSpam,
+    });
   }
 }

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -1,4 +1,6 @@
 import { Balance } from '@/domain/balances/entities/balance.entity';
+import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
+import { Page } from '@/domain/entities/page.entity';
 
 export interface IBalancesApi {
   getBalances(args: {
@@ -8,6 +10,18 @@ export interface IBalancesApi {
   }): Promise<Balance[]>;
 
   clearBalances(args: { chainId: string; safeAddress: string }): Promise<void>;
+
+  getCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Collectible>>;
+
+  clearCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 
   getFiatCodes(): string[];
 }

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -420,8 +420,8 @@ describe('Balances Controller (Unit)', () => {
           )
           .expect(503)
           .expect({
-            message: `Error getting ${safeAddress} balances from provider: test error}`,
             code: 503,
+            message: 'Service unavailable',
           });
       });
     });

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -143,7 +143,7 @@ describe('Zerion Collectibles Controller', () => {
           .expect(({ body }) => {
             expect(body).toMatchObject({
               count: zerionApiCollectiblesResponse.data.length,
-              next: null,
+              next: expect.any(String), // TODO: check page[size] and page[after] are mapped to limit and offset
               previous: null,
               results: [
                 {
@@ -235,7 +235,11 @@ describe('Zerion Collectibles Controller', () => {
         );
         expect(networkService.get.mock.calls[0][1]).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
-          params: { 'filter[chain_ids]': chainName, sort: '-floor_price' },
+          params: {
+            'filter[chain_ids]': chainName,
+            sort: '-floor_price',
+            'page[size]': 10,
+          },
         });
       });
     });

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -72,7 +72,7 @@ describe('Zerion Collectibles Controller', () => {
         const safeAddress = faker.finance.ethereumAddress();
         const aTokenAddress = faker.finance.ethereumAddress();
         const aNFTName = faker.string.sample();
-        const anUrl = faker.internet.url({ appendSlash: false });
+        const aUrl = faker.internet.url({ appendSlash: false });
         const zerionApiCollectiblesResponse = zerionCollectiblesBuilder()
           .with('data', [
             zerionCollectibleBuilder()
@@ -107,8 +107,8 @@ describe('Zerion Collectibles Controller', () => {
                     'nft_info',
                     zerionNFTInfoBuilder()
                       .with('content', {
-                        preview: { url: anUrl },
-                        detail: { url: anUrl },
+                        preview: { url: aUrl },
+                        detail: { url: aUrl },
                       })
                       .build(),
                   )
@@ -212,7 +212,7 @@ describe('Zerion Collectibles Controller', () => {
                       .collection_info?.content?.icon.url,
                   id: zerionApiCollectiblesResponse.data[2].attributes.nft_info
                     .token_id,
-                  uri: anUrl,
+                  uri: aUrl,
                   name: zerionApiCollectiblesResponse.data[2].attributes
                     .collection_info?.name,
                   description:

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -72,7 +72,7 @@ describe('Zerion Collectibles Controller', () => {
         const safeAddress = faker.finance.ethereumAddress();
         const aTokenAddress = faker.finance.ethereumAddress();
         const aNFTName = faker.string.sample();
-        const anUrl = faker.internet.url({ appendSlash: true });
+        const anUrl = faker.internet.url({ appendSlash: false });
         const zerionApiCollectiblesResponse = zerionCollectiblesBuilder()
           .with('data', [
             zerionCollectibleBuilder()

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -253,10 +253,7 @@ describe('Zerion Collectibles Controller', () => {
             zerionCollectibleBuilder().build(),
             zerionCollectibleBuilder().build(),
           ])
-          .with('links', {
-            next: zerionNext,
-            self: faker.internet.url({ appendSlash: false }),
-          })
+          .with('links', { next: zerionNext })
           .build();
         const chainName = app
           .get(IConfigurationService)
@@ -319,10 +316,7 @@ describe('Zerion Collectibles Controller', () => {
             zerionCollectibleBuilder().build(),
             zerionCollectibleBuilder().build(),
           ])
-          .with('links', {
-            next: zerionNext,
-            self: faker.internet.url({ appendSlash: false }),
-          })
+          .with('links', { next: zerionNext })
           .build();
         const chainName = app
           .get(IConfigurationService)
@@ -384,10 +378,7 @@ describe('Zerion Collectibles Controller', () => {
             zerionCollectibleBuilder().build(),
             zerionCollectibleBuilder().build(),
           ])
-          .with('links', {
-            next: zerionNext,
-            self: faker.internet.url({ appendSlash: false }),
-          })
+          .with('links', { next: zerionNext })
           .build();
         const chainName = app
           .get(IConfigurationService)

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -447,8 +447,8 @@ describe('Zerion Collectibles Controller', () => {
           .get(`/v2/chains/${chain.chainId}/safes/${safeAddress}/collectibles`)
           .expect(503)
           .expect({
-            message: `Error getting ${safeAddress} collectibles from provider: test error}`,
             code: 503,
+            message: 'Service unavailable',
           });
       });
     });

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -1,0 +1,266 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { AppModule } from '@/app.module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import {
+  zerionCollectibleAttributesBuilder,
+  zerionCollectibleBuilder,
+  zerionCollectiblesBuilder,
+  zerionNFTInfoBuilder,
+} from '@/datasources/balances-api/entities/__tests__/zerion-collectible.entity.builder';
+
+describe('Zerion Collectibles Controller', () => {
+  let app: INestApplication;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+  let zerionBaseUri: string;
+  let zerionChainIds: string[];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration)],
+    })
+      .overrideModule(AccountDataSourceModule)
+      .useModule(TestAccountDataSourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    const configurationService = moduleFixture.get(IConfigurationService);
+    zerionBaseUri = configurationService.get(
+      'balances.providers.zerion.baseUri',
+    );
+    zerionChainIds = configurationService.get(
+      'features.zerionBalancesChainIds',
+    );
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Collectibles provider: Zerion', () => {
+    describe('GET /v2/collectibles', () => {
+      it('successfully gets collectibles from Zerion', async () => {
+        const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
+        const safeAddress = faker.finance.ethereumAddress();
+        const aTokenAddress = faker.finance.ethereumAddress();
+        const aNFTName = faker.string.sample();
+        const anUrl = faker.internet.url({ appendSlash: true });
+        const zerionApiCollectiblesResponse = zerionCollectiblesBuilder()
+          .with('data', [
+            zerionCollectibleBuilder()
+              .with(
+                'attributes',
+                zerionCollectibleAttributesBuilder()
+                  .with(
+                    'nft_info',
+                    zerionNFTInfoBuilder()
+                      .with('contract_address', aTokenAddress)
+                      .build(),
+                  )
+                  .build(),
+              )
+              .build(),
+            zerionCollectibleBuilder()
+              .with(
+                'attributes',
+                zerionCollectibleAttributesBuilder()
+                  .with(
+                    'nft_info',
+                    zerionNFTInfoBuilder().with('name', aNFTName).build(),
+                  )
+                  .build(),
+              )
+              .build(),
+            zerionCollectibleBuilder()
+              .with(
+                'attributes',
+                zerionCollectibleAttributesBuilder()
+                  .with(
+                    'nft_info',
+                    zerionNFTInfoBuilder()
+                      .with('content', {
+                        preview: { url: anUrl },
+                        detail: { url: anUrl },
+                      })
+                      .build(),
+                  )
+                  .build(),
+              )
+              .build(),
+          ])
+          .build();
+        const chainName = app
+          .get(IConfigurationService)
+          .getOrThrow(
+            `balances.providers.zerion.chains.${chain.chainId}.chainName`,
+          );
+        const apiKey = app
+          .get(IConfigurationService)
+          .getOrThrow(`balances.providers.zerion.apiKey`);
+        networkService.get.mockImplementation((url) => {
+          switch (url) {
+            case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
+              return Promise.resolve({
+                data: zerionApiCollectiblesResponse,
+                status: 200,
+              });
+            default:
+              return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/v2/chains/${chain.chainId}/safes/${safeAddress}/collectibles`)
+          .expect(200)
+          .expect(({ body }) => {
+            expect(body).toMatchObject({
+              count: zerionApiCollectiblesResponse.data.length,
+              next: null,
+              previous: null,
+              results: [
+                {
+                  address: aTokenAddress,
+                  tokenName:
+                    zerionApiCollectiblesResponse.data[0].attributes.nft_info
+                      .name,
+                  tokenSymbol:
+                    zerionApiCollectiblesResponse.data[0].attributes.nft_info
+                      .name,
+                  logoUri:
+                    zerionApiCollectiblesResponse.data[0].attributes
+                      .collection_info?.content?.icon.url,
+                  id: zerionApiCollectiblesResponse.data[0].attributes.nft_info
+                    .token_id,
+                  uri: zerionApiCollectiblesResponse.data[0].attributes.nft_info
+                    .content?.detail?.url,
+                  name: zerionApiCollectiblesResponse.data[0].attributes
+                    .collection_info?.name,
+                  description:
+                    zerionApiCollectiblesResponse.data[0].attributes
+                      .collection_info?.description,
+                  imageUri:
+                    zerionApiCollectiblesResponse.data[0].attributes.nft_info
+                      .content?.preview?.url,
+                  metadata:
+                    zerionApiCollectiblesResponse.data[0].attributes.nft_info
+                      .content,
+                },
+                {
+                  address:
+                    zerionApiCollectiblesResponse.data[1].attributes.nft_info
+                      .contract_address,
+                  tokenName: aNFTName,
+                  tokenSymbol:
+                    zerionApiCollectiblesResponse.data[1].attributes.nft_info
+                      .name,
+                  logoUri:
+                    zerionApiCollectiblesResponse.data[1].attributes
+                      .collection_info?.content?.icon.url,
+                  id: zerionApiCollectiblesResponse.data[1].attributes.nft_info
+                    .token_id,
+                  uri: zerionApiCollectiblesResponse.data[1].attributes.nft_info
+                    .content?.detail?.url,
+                  name: zerionApiCollectiblesResponse.data[1].attributes
+                    .collection_info?.name,
+                  description:
+                    zerionApiCollectiblesResponse.data[1].attributes
+                      .collection_info?.description,
+                  imageUri:
+                    zerionApiCollectiblesResponse.data[1].attributes.nft_info
+                      .content?.preview?.url,
+                  metadata:
+                    zerionApiCollectiblesResponse.data[1].attributes.nft_info
+                      .content,
+                },
+                {
+                  address:
+                    zerionApiCollectiblesResponse.data[2].attributes.nft_info
+                      .contract_address,
+                  tokenSymbol:
+                    zerionApiCollectiblesResponse.data[2].attributes.nft_info
+                      .name,
+                  logoUri:
+                    zerionApiCollectiblesResponse.data[2].attributes
+                      .collection_info?.content?.icon.url,
+                  id: zerionApiCollectiblesResponse.data[2].attributes.nft_info
+                    .token_id,
+                  uri: anUrl,
+                  name: zerionApiCollectiblesResponse.data[2].attributes
+                    .collection_info?.name,
+                  description:
+                    zerionApiCollectiblesResponse.data[2].attributes
+                      .collection_info?.description,
+                  imageUri:
+                    zerionApiCollectiblesResponse.data[2].attributes.nft_info
+                      .content?.preview?.url,
+                  metadata:
+                    zerionApiCollectiblesResponse.data[2].attributes.nft_info
+                      .content,
+                },
+              ],
+            });
+          });
+
+        expect(networkService.get.mock.calls.length).toBe(1);
+        expect(networkService.get.mock.calls[0][0]).toBe(
+          `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`,
+        );
+        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+          headers: { Authorization: `Basic ${apiKey}` },
+          params: { 'filter[chain_ids]': chainName, sort: '-floor_price' },
+        });
+      });
+    });
+
+    describe('Zerion Balances API Error', () => {
+      it(`500 error response`, async () => {
+        const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
+        const safeAddress = faker.finance.ethereumAddress();
+        networkService.get.mockImplementation((url) => {
+          switch (url) {
+            case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
+              return Promise.reject(new Error('test error'));
+            default:
+              return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(`/v2/chains/${chain.chainId}/safes/${safeAddress}/collectibles`)
+          .expect(503)
+          .expect({
+            message: `Error getting ${safeAddress} collectibles from provider: test error}`,
+            code: 503,
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Summary
This PR implements NFTs (ERC-721 tokens) retrieval using the Zerion API.

### Changes
- Adds `ZerionCollectible` entity and its related interfaces/builders.
- Adds `getCollectibles/clearCollectibles` methods to the `BalancesApi` interface.
- Implement `getCollectibles/clearCollectibles` on `ZerionBalancesApi`.

### Out of scope
- `PaginationData` entity needs to be refactored to accommodate Zerion's pagination format (`string` offset). This PR implements a mapping between the service pagination format and the Zerion API one.