### PR TITLE
Add comment regarding pagination for all owned Safes endpoint

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -377,6 +377,8 @@ export class SafeRepository implements ISafeRepository {
   async getAllSafesByOwner(args: {
     ownerAddress: string;
   }): Promise<{ [chainId: string]: Array<string> }> {
+    // Note: does not take pagination into account but we do not support
+    // enough chains for it to be an issue
     const { results } = await this.chainsRepository.getChains();
     const allSafeLists = await Promise.all(
       results.map(async ({ chainId }) => {


### PR DESCRIPTION
This adds a comment regarding the all owned Safes endpoint not referencing the Config Service pagination.