### PR TITLE
Add `GET` `/v1/safes` overview endpoint

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -130,6 +130,9 @@ export default (): ReturnType<typeof configuration> => ({
     history: {
       maxNestedTransfers: faker.number.int({ min: 1, max: 5 }),
     },
+    safe: {
+      maxOverviews: faker.number.int({ min: 1, max: 5 }),
+    },
   },
   prices: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -161,6 +161,9 @@ export default () => ({
         process.env.MAX_NESTED_TRANSFERS ?? `${100}`,
       ),
     },
+    safe: {
+      maxOverviews: parseInt(process.env.MAX_SAFE_OVERVIEWS ?? `${7}`),
+    },
   },
   prices: {
     baseUri:

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -10,6 +10,7 @@ export interface IBalancesRepository {
   getBalances(args: {
     chainId: string;
     safeAddress: string;
+    fiatCode: string;
     trusted?: boolean;
     excludeSpam?: boolean;
   }): Promise<Balance[]>;

--- a/src/routes/safes/entities/safe-overview.entity.ts
+++ b/src/routes/safes/entities/safe-overview.entity.ts
@@ -1,0 +1,37 @@
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SafeOverview {
+  @ApiProperty()
+  readonly address: AddressInfo;
+  @ApiProperty()
+  readonly chainId: string;
+  @ApiProperty()
+  readonly threshold: number;
+  @ApiProperty()
+  readonly owners: Array<AddressInfo>;
+  @ApiProperty()
+  readonly fiatTotal: string;
+  @ApiProperty()
+  readonly queued: number;
+  @ApiProperty()
+  readonly awaitingConfirmation: number | null;
+
+  constructor(
+    address: AddressInfo,
+    chainId: string,
+    threshold: number,
+    owners: Array<AddressInfo>,
+    fiatTotal: string,
+    queued: number,
+    awaitingConfirmation: number | null,
+  ) {
+    this.address = address;
+    this.chainId = chainId;
+    this.threshold = threshold;
+    this.owners = owners;
+    this.fiatTotal = fiatTotal;
+    this.queued = queued;
+    this.awaitingConfirmation = awaitingConfirmation;
+  }
+}

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
@@ -1,0 +1,73 @@
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/configuration';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { Caip10AddressesPipe } from '@/routes/safes/pipes/caip-10-addresses.pipe';
+import { faker } from '@faker-js/faker';
+import { Controller, Get, INestApplication, Query } from '@nestjs/common';
+import { TestingModule, Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+@Controller()
+class TestController {
+  @Get('test')
+  async route(
+    @Query('addresses', new Caip10AddressesPipe())
+    addresses: Array<{ chainId: string; address: string }>,
+  ): Promise<Array<{ chainId: string; address: string }>> {
+    return addresses;
+  }
+}
+
+describe('Caip10AddressesPipe', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns parsed CAIP-10 addresses', async () => {
+    const chainId1 = faker.string.numeric();
+    const chainId2 = faker.string.numeric();
+    const chainId3 = faker.string.numeric();
+    const address1 = faker.finance.ethereumAddress();
+    const address2 = faker.finance.ethereumAddress();
+    const address3 = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .get(
+        `/test?addresses=${chainId1}:${address1},${chainId2}:${address2},${chainId3}:${address3}`,
+      )
+      .expect(200)
+      .expect([
+        { chainId: chainId1, address: address1 },
+        { chainId: chainId2, address: address2 },
+        { chainId: chainId3, address: address3 },
+      ]);
+  });
+
+  it('throws for missing params', async () => {
+    await request(app.getHttpServer()).get('/test?addresses=').expect(500);
+  });
+
+  it('throws for missing chainIds', async () => {
+    await request(app.getHttpServer()).get('/test?addresses=:').expect(500);
+  });
+
+  it('throws for missing addresses', async () => {
+    const chainId = faker.string.numeric();
+
+    await request(app.getHttpServer())
+      .get(`/test?addresses=${chainId}:`)
+      .expect(500);
+  });
+});

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.ts
@@ -1,0 +1,25 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class Caip10AddressesPipe
+  implements PipeTransform<string, Array<{ chainId: string; address: string }>>
+{
+  transform(data: string): Array<{
+    chainId: string;
+    address: string;
+  }> {
+    const addresses = data.split(',').map((caip10Address: string) => {
+      const [chainId, address] = caip10Address.split(':');
+
+      return { chainId, address };
+    });
+
+    if (addresses.length === 0 || !addresses[0].address) {
+      throw new Error(
+        'Provided addresses do not conform to the CAIP-10 standard',
+      );
+    }
+
+    return addresses;
+  }
+}

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -1,0 +1,1217 @@
+import { INestApplication } from '@nestjs/common';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import * as request from 'supertest';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
+import { faker } from '@faker-js/faker';
+import { balanceBuilder } from '@/domain/balances/entities/__tests__/balance.builder';
+import { balanceTokenBuilder } from '@/domain/balances/entities/__tests__/balance.token.builder';
+import {
+  multisigTransactionBuilder,
+  toJson as multisigTransactionToJson,
+} from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
+import { confirmationBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+
+describe('Safes Controller Overview (Unit)', () => {
+  let app: INestApplication;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+  let pricesProviderUrl: string;
+  let pricesApiKey: string;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const testConfiguration: typeof configuration = () => ({
+      ...configuration(),
+      mappings: {
+        ...configuration().mappings,
+        safe: {
+          maxOverviews: 3,
+        },
+      },
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(testConfiguration)],
+    })
+      .overrideModule(AccountDataSourceModule)
+      .useModule(TestAccountDataSourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    const configurationService = moduleFixture.get(IConfigurationService);
+    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    pricesProviderUrl = configurationService.get('prices.baseUri');
+    pricesApiKey = configurationService.get('prices.apiKey');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /safes', () => {
+    it('overview with transactions awaiting confirmation is correctly serialised', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const secondTokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.nativeCoin`);
+      const chainName = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const multisigTransactions = [
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('confirmations', [
+              // Signature provided
+              confirmationBuilder().with('owner', walletAddress).build(),
+            ])
+            .build(),
+        ),
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+      ];
+      const queuedTransactions = pageBuilder()
+        .with('results', multisigTransactions)
+        .with('count', multisigTransactions.length)
+        .build();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: safeInfo, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&walletAddress=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            {
+              address: {
+                value: safeInfo.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain.chainId,
+              threshold: safeInfo.threshold,
+              owners: safeInfo.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: 2,
+              awaitingConfirmation: 1,
+            },
+          ]),
+        );
+
+      expect(networkService.get.mock.calls.length).toBe(7);
+
+      expect(networkService.get.mock.calls[0][0]).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[1][0]).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[2][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
+      );
+      expect(networkService.get.mock.calls[3][1]).toStrictEqual({
+        params: { trusted: false, exclude_spam: true },
+      });
+      expect(networkService.get.mock.calls[4][0]).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      );
+      expect(networkService.get.mock.calls[4][1]).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: {
+          vs_currencies: currency.toLowerCase(),
+          contract_addresses: [
+            tokenAddress.toLowerCase(),
+            secondTokenAddress.toLowerCase(),
+          ].join(','),
+        },
+      });
+      expect(networkService.get.mock.calls[5][0]).toBe(
+        `${pricesProviderUrl}/simple/price`,
+      );
+      expect(networkService.get.mock.calls[5][1]).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+      });
+      expect(networkService.get.mock.calls[6][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+    });
+
+    it('overview of multiple Safes across different chains is correctly serialised', async () => {
+      const chain1 = chainBuilder().with('chainId', '1').build();
+      const chain2 = chainBuilder().with('chainId', '10').build();
+      const safeInfo1 = safeBuilder().build();
+      const safeInfo2 = safeBuilder().build();
+      const safeInfo3 = safeBuilder().build();
+
+      const tokenAddress1 = faker.finance.ethereumAddress();
+      const tokenAddress2 = faker.finance.ethereumAddress();
+      const secondTokenAddress1 = faker.finance.ethereumAddress();
+      const secondTokenAddress2 = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse1 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress1)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress1)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse2 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress2)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress1)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse3 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress1)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress2)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId1 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain1.chainId}.nativeCoin`);
+      const nativeCoinId2 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain2.chainId}.nativeCoin`);
+      const chainName1 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain1.chainId}.chainName`);
+      const chainName2 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain2.chainId}.chainName`);
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
+        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress1]: { [currency.toLowerCase()]: 10 },
+        [secondTokenAddress2]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const queuedTransactions1 = pageBuilder().build();
+      const queuedTransactions2 = pageBuilder().build();
+      const queuedTransactions3 = pageBuilder().build();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
+            return Promise.resolve({ data: chain1, status: 200 });
+          }
+          case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
+            return Promise.resolve({ data: chain2, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
+            return Promise.resolve({ data: safeInfo1, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
+            return Promise.resolve({ data: safeInfo2, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
+            return Promise.resolve({ data: safeInfo3, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse3,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions3,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            {
+              address: {
+                value: safeInfo1.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain1.chainId,
+              threshold: safeInfo1.threshold,
+              owners: safeInfo1.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions1.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo2.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo2.threshold,
+              owners: safeInfo2.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '4910.25',
+              queued: queuedTransactions2.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo3.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo3.threshold,
+              owners: safeInfo3.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions3.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+          ]),
+        );
+    });
+
+    it('should limit the amount of overviewed Safes', async () => {
+      const chain1 = chainBuilder().with('chainId', '1').build();
+      const chain2 = chainBuilder().with('chainId', '10').build();
+      const safeInfo1 = safeBuilder().build();
+      const safeInfo2 = safeBuilder().build();
+      const safeInfo3 = safeBuilder().build();
+      // Extra Safe
+      const safeInfo4 = safeBuilder().build();
+
+      const tokenAddress1 = faker.finance.ethereumAddress();
+      const tokenAddress2 = faker.finance.ethereumAddress();
+      const secondTokenAddress1 = faker.finance.ethereumAddress();
+      const secondTokenAddress2 = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse1 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress1)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress1)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse2 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress2)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress1)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse3 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress1)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress2)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId1 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain1.chainId}.nativeCoin`);
+      const nativeCoinId2 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain2.chainId}.nativeCoin`);
+      const chainName1 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain1.chainId}.chainName`);
+      const chainName2 = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain2.chainId}.chainName`);
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
+        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress1]: { [currency.toLowerCase()]: 10 },
+        [secondTokenAddress2]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const queuedTransactions1 = pageBuilder().build();
+      const queuedTransactions2 = pageBuilder().build();
+      const queuedTransactions3 = pageBuilder().build();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
+            return Promise.resolve({ data: chain1, status: 200 });
+          }
+          case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
+            return Promise.resolve({ data: chain2, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
+            return Promise.resolve({ data: safeInfo1, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
+            return Promise.resolve({ data: safeInfo2, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
+            return Promise.resolve({ data: safeInfo3, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse3,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions3,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address},${chain2.chainId}:${safeInfo4.address}&walletAddress=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            {
+              address: {
+                value: safeInfo1.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain1.chainId,
+              threshold: safeInfo1.threshold,
+              owners: safeInfo1.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions1.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo2.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo2.threshold,
+              owners: safeInfo2.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '4910.25',
+              queued: queuedTransactions2.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo3.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo3.threshold,
+              owners: safeInfo3.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions3.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+          ]),
+        );
+    });
+
+    it('returns awaiting confirmation as null if no wallet address is', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const secondTokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.nativeCoin`);
+      const chainName = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
+      };
+      const multisigTransactions = [
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+      ];
+      const queuedTransactions = pageBuilder()
+        .with('results', multisigTransactions)
+        .with('count', multisigTransactions.length)
+        .build();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: safeInfo, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
+        )
+        .expect(200)
+        .expect([
+          {
+            address: {
+              value: safeInfo.address,
+              name: null,
+              logoUri: null,
+            },
+            chainId: chain.chainId,
+            threshold: safeInfo.threshold,
+            owners: safeInfo.owners.map((owner) => ({
+              value: owner,
+              name: null,
+              logoUri: null,
+            })),
+            fiatTotal: '5410.25',
+            queued: 2,
+            // No wallet address specified
+            awaitingConfirmation: null,
+          },
+        ]);
+
+      expect(networkService.get.mock.calls.length).toBe(7);
+
+      expect(networkService.get.mock.calls[0][0]).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[1][0]).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[2][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
+      );
+      expect(networkService.get.mock.calls[3][1]).toStrictEqual({
+        params: { trusted: false, exclude_spam: true },
+      });
+      expect(networkService.get.mock.calls[4][0]).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      );
+      expect(networkService.get.mock.calls[4][1]).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: {
+          vs_currencies: currency.toLowerCase(),
+          contract_addresses: [
+            tokenAddress.toLowerCase(),
+            secondTokenAddress.toLowerCase(),
+          ].join(','),
+        },
+      });
+      expect(networkService.get.mock.calls[5][0]).toBe(
+        `${pricesProviderUrl}/simple/price`,
+      );
+      expect(networkService.get.mock.calls[5][1]).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+      });
+      expect(networkService.get.mock.calls[6][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+    });
+
+    it('forwards trusted and exlude spam queries', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const secondTokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.nativeCoin`);
+      const chainName = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const multisigTransactions = [
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+      ];
+      const queuedTransactions = pageBuilder()
+        .with('results', multisigTransactions)
+        .with('count', multisigTransactions.length)
+        .build();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: safeInfo, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&walletAddress=${walletAddress}&trusted=${true}&exclude_spam=${false}`,
+        )
+        .expect(200)
+        .expect([
+          {
+            address: {
+              value: safeInfo.address,
+              name: null,
+              logoUri: null,
+            },
+            chainId: chain.chainId,
+            threshold: safeInfo.threshold,
+            owners: safeInfo.owners.map((owner) => ({
+              value: owner,
+              name: null,
+              logoUri: null,
+            })),
+            fiatTotal: '5410.25',
+            queued: 2,
+            awaitingConfirmation: 2,
+          },
+        ]);
+
+      expect(networkService.get.mock.calls.length).toBe(7);
+
+      expect(networkService.get.mock.calls[0][0]).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[1][0]).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[2][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
+      );
+      expect(networkService.get.mock.calls[3][1]).toStrictEqual({
+        // Forwarded params
+        params: { trusted: true, exclude_spam: false },
+      });
+      expect(networkService.get.mock.calls[4][0]).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      );
+      expect(networkService.get.mock.calls[4][1]).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: {
+          vs_currencies: currency.toLowerCase(),
+          contract_addresses: [
+            tokenAddress.toLowerCase(),
+            secondTokenAddress.toLowerCase(),
+          ].join(','),
+        },
+      });
+      expect(networkService.get.mock.calls[5][0]).toBe(
+        `${pricesProviderUrl}/simple/price`,
+      );
+      expect(networkService.get.mock.calls[5][1]).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+      });
+      expect(networkService.get.mock.calls[6][0]).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+    });
+  });
+
+  describe('Validation', () => {
+    it('forwards error responses from the Config Service', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const currency = faker.finance.currencyCode();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            const error = new NetworkResponseError(
+              new URL(`${safeConfigUrl}/api/v1/chains/${chain.chainId}`),
+              {
+                status: 404,
+              } as Response,
+            );
+            return Promise.reject(error);
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
+        )
+        .expect(404);
+    });
+
+    it('forwards error responses from the Transaction Service', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const currency = faker.finance.currencyCode();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            const error = new NetworkResponseError(
+              new URL(
+                `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+              ),
+              {
+                status: 500,
+              } as Response,
+            );
+            return Promise.reject(error);
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
+        )
+        .expect(500);
+    });
+
+    it('throw a 500 if validation of the Transaction Service fails', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const secondTokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress)
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', secondTokenAddress)
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const currency = faker.finance.currencyCode();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: 'invalid', status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
+        )
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+
+    it('should return a 0-balance when an error is thrown by the provider', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', tokenAddress)
+          .with('balance', '40000000000000000000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.nativeCoin`);
+      const chainName = app
+        .get(IConfigurationService)
+        .getOrThrow(`prices.chains.${chain.chainId}.chainName`);
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const multisigTransactions = [
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+      ];
+      const queuedTransactions = pageBuilder()
+        .with('results', multisigTransactions)
+        .with('count', multisigTransactions.length)
+        .build();
+
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: safeInfo, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+            return Promise.reject();
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions,
+              status: 200,
+            });
+          }
+          default: {
+            fail(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&walletAddress=${walletAddress}`,
+        )
+        .expect(200)
+        .expect([
+          {
+            address: {
+              value: safeInfo.address,
+              name: null,
+              logoUri: null,
+            },
+            chainId: chain.chainId,
+            threshold: safeInfo.threshold,
+            owners: safeInfo.owners.map((owner) => ({
+              value: owner,
+              name: null,
+              logoUri: null,
+            })),
+            fiatTotal: '0',
+            queued: 2,
+            awaitingConfirmation: 2,
+          },
+        ]);
+    });
+  });
+});

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -1,8 +1,17 @@
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { Controller, Get, Param } from '@nestjs/common';
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  ParseBoolPipe,
+  Query,
+} from '@nestjs/common';
 import { SafeState } from '@/routes/safes/entities/safe-info.entity';
 import { SafesService } from '@/routes/safes/safes.service';
 import { SafeNonces } from '@/routes/safes/entities/nonces.entity';
+import { SafeOverview } from '@/routes/safes/entities/safe-overview.entity';
+import { Caip10AddressesPipe } from '@/routes/safes/pipes/caip-10-addresses.pipe';
 
 @ApiTags('safes')
 @Controller({
@@ -27,5 +36,25 @@ export class SafesController {
     @Param('safeAddress') safeAddress: string,
   ): Promise<SafeNonces> {
     return this.service.getNonces({ chainId, safeAddress });
+  }
+
+  @Get('safes')
+  async getSafeOverview(
+    @Query('currency') currency: string,
+    @Query('safes', new Caip10AddressesPipe())
+    addresses: Array<{ chainId: string; address: string }>,
+    @Query('trusted', new DefaultValuePipe(false), ParseBoolPipe)
+    trusted: boolean,
+    @Query('exclude_spam', new DefaultValuePipe(true), ParseBoolPipe)
+    excludeSpam: boolean,
+    @Query('walletAddress') walletAddress?: string,
+  ): Promise<Array<SafeOverview>> {
+    return this.service.getSafeOverview({
+      currency,
+      addresses,
+      trusted,
+      excludeSpam,
+      walletAddress,
+    });
   }
 }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -19,9 +19,15 @@ import {
 } from '@/routes/safes/entities/safe-info.entity';
 import { SafeNonces } from '@/routes/safes/entities/nonces.entity';
 import { Page } from '@/domain/entities/page.entity';
+import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
+import { getNumberString } from '@/domain/common/utils/utils';
+import { SafeOverview } from '@/routes/safes/entities/safe-overview.entity';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 
 @Injectable()
 export class SafesService {
+  private readonly maxOverviews: number;
+
   constructor(
     @Inject(ISafeRepository)
     private readonly safeRepository: ISafeRepository,
@@ -30,7 +36,14 @@ export class SafesService {
     private readonly addressInfoHelper: AddressInfoHelper,
     @Inject(IMessagesRepository)
     private readonly messagesRepository: MessagesRepository,
-  ) {}
+    @Inject(IBalancesRepository)
+    private readonly balancesRepository: IBalancesRepository,
+    @Inject(IConfigurationService) configurationService: IConfigurationService,
+  ) {
+    this.maxOverviews = configurationService.getOrThrow(
+      'mappings.safe.maxOverviews',
+    );
+  }
 
   async getSafeInfo(args: {
     chainId: string;
@@ -111,12 +124,77 @@ export class SafesService {
     );
   }
 
+  async getSafeOverview(args: {
+    currency: string;
+    addresses: Array<{ chainId: string; address: string }>;
+    trusted: boolean;
+    excludeSpam: boolean;
+    walletAddress?: string;
+  }): Promise<Array<SafeOverview>> {
+    const limitedSafes = args.addresses.slice(0, this.maxOverviews);
+
+    return Promise.all(
+      limitedSafes.map(async ({ chainId, address }) => {
+        const [safe, balances] = await Promise.all([
+          this.safeRepository.getSafe({
+            chainId,
+            address,
+          }),
+          this.balancesRepository.getBalances({
+            chainId,
+            safeAddress: address,
+            trusted: args.trusted,
+            fiatCode: args.currency,
+            excludeSpam: args.excludeSpam,
+          }),
+        ]);
+        const queue = await this.safeRepository.getTransactionQueue({
+          chainId,
+          safe,
+        });
+
+        const fiatBalance = balances
+          .filter((b) => b.fiatBalance !== null)
+          .reduce((acc, b) => acc + Number(b.fiatBalance), 0);
+
+        const awaitingConfirmation = args.walletAddress
+          ? this.computeAwaitingConfirmation({
+              transactions: queue.results,
+              walletAddress: args.walletAddress,
+            })
+          : null;
+
+        return new SafeOverview(
+          new AddressInfo(safe.address),
+          chainId,
+          safe.threshold,
+          safe.owners.map((ownerAddress) => new AddressInfo(ownerAddress)),
+          getNumberString(fiatBalance),
+          queue.count,
+          awaitingConfirmation,
+        );
+      }),
+    );
+  }
+
   public async getNonces(args: {
     chainId: string;
     safeAddress: string;
   }): Promise<SafeNonces> {
     const nonce = await this.safeRepository.getNonces(args);
     return new SafeNonces(nonce);
+  }
+
+  private computeAwaitingConfirmation(args: {
+    transactions: Array<MultisigTransaction>;
+    walletAddress: string;
+  }): number {
+    return args.transactions.reduce((acc, { confirmations }) => {
+      const isConfirmed = !!confirmations?.some((confirmation) => {
+        return confirmation.owner === args.walletAddress;
+      });
+      return isConfirmed ? acc - 1 : acc;
+    }, args.transactions.length);
   }
 
   private toUnixTimestampInSecondsOrNull(date: Date | null): string | null {

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -71,6 +71,7 @@ describe('Transactions History Controller (Unit)', () => {
     const testConfiguration: typeof configuration = () => ({
       ...configuration(),
       mappings: {
+        ...configuration().mappings,
         history: {
           maxNestedTransfers: 5,
         },


### PR DESCRIPTION
This adds a new `GET` `/v1/safes` endpoint for "overviews" of specified Safes, returning the following:

```ts
type AddressInfo = {
  value: string,
  name: string | null,
  logoUri: string | null
}

type Response = Array<{
  chainId: string;
  address: AddressInfo;
  owners: Array<AddressInfo>;
  threshold: number;
  fiatTotal: string; // e.g. "69.42"
  queued: number;
  awaitingConfirmation: number;
}>
```

It requires the following search parameters: `currency` and `safes`. It also accepts `walletAddress`, `exclude_spam` and `trusted` search parameters:

#### `currency`

The desired fiat to return the balance of the Safe in, e.g. `USD`

#### `safes`

A CAIP-10 comma separated list of Safe addresses, without the EIP155 namespace, e.g. `1:0x123...,1:0x456...,137:0x789`.

⚠️ Note: this is limited to a maximum of 7 but can be modified by setting the `MAX_SAFE_OVERVIEWS` env. var.

#### `walletAddress`

The owner which is checked for awaiting confirmations as a "standard" address, e.g. `0x123...`

#### `trusted` (default: `false`)

Whether to return "trusted" transactions or not.

#### `exclude_spam` (default: `true`)

Whether to exclude "spam" tokens or not.