### PR TITLE
Add getAccounts to AccountDataSource

### DIFF
--- a/src/datasources/account/__tests__/test.account.datasource.module.ts
+++ b/src/datasources/account/__tests__/test.account.datasource.module.ts
@@ -2,8 +2,8 @@ import { Module } from '@nestjs/common';
 import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
 
 const accountDataSource = {
-  getVerifiedAccountEmailsBySafeAddress: jest.fn(),
   getAccount: jest.fn(),
+  getAccounts: jest.fn(),
   getAccountVerificationCode: jest.fn(),
   createAccount: jest.fn(),
   setEmailVerificationCode: jest.fn(),

--- a/src/domain/account/account.repository.interface.ts
+++ b/src/domain/account/account.repository.interface.ts
@@ -9,16 +9,11 @@ export interface IAccountRepository {
     signer: string;
   }): Promise<Account>;
 
-  /**
-   * Gets the verified emails associated with a Safe address.
-   *
-   * @param args.chainId - the chain id of where the Safe is deployed
-   * @param args.safeAddress - the Safe address to use as filter
-   */
-  getVerifiedEmailsBySafeAddress(args: {
+  getAccounts(args: {
     chainId: string;
     safeAddress: string;
-  }): Promise<string[]>;
+    onlyVerified: boolean;
+  }): Promise<Account[]>;
 
   /**
    * Creates a new account.

--- a/src/domain/account/account.repository.ts
+++ b/src/domain/account/account.repository.ts
@@ -62,6 +62,14 @@ export class AccountRepository implements IAccountRepository {
     return this.accountDataSource.getAccount(args);
   }
 
+  getAccounts(args: {
+    chainId: string;
+    safeAddress: string;
+    onlyVerified: boolean;
+  }): Promise<Account[]> {
+    return this.accountDataSource.getAccounts(args);
+  }
+
   async createAccount(args: {
     chainId: string;
     safeAddress: string;
@@ -95,15 +103,6 @@ export class AccountRepository implements IAccountRepository {
     } catch (e) {
       throw new AccountSaveError(args.chainId, args.safeAddress, args.signer);
     }
-  }
-
-  async getVerifiedEmailsBySafeAddress(args: {
-    chainId: string;
-    safeAddress: string;
-  }): Promise<string[]> {
-    const emails =
-      await this.accountDataSource.getVerifiedAccountEmailsBySafeAddress(args);
-    return emails.map(({ email }) => email);
   }
 
   async resendEmailVerification(args: {

--- a/src/domain/account/entities/__tests__/account.builder.ts
+++ b/src/domain/account/entities/__tests__/account.builder.ts
@@ -11,5 +11,6 @@ export function accountBuilder(): IBuilder<Account> {
     .with('emailAddress', new EmailAddress(faker.internet.email()))
     .with('isVerified', faker.datatype.boolean())
     .with('safeAddress', faker.finance.ethereumAddress())
-    .with('signer', faker.finance.ethereumAddress());
+    .with('signer', faker.finance.ethereumAddress())
+    .with('unsubscriptionToken', faker.string.uuid());
 }

--- a/src/domain/account/entities/account.entity.ts
+++ b/src/domain/account/entities/account.entity.ts
@@ -10,6 +10,7 @@ export interface Account {
   isVerified: boolean;
   safeAddress: string;
   signer: string;
+  unsubscriptionToken: string;
 }
 
 export interface VerificationCode {

--- a/src/domain/interfaces/account.datasource.interface.ts
+++ b/src/domain/interfaces/account.datasource.interface.ts
@@ -9,17 +9,6 @@ export const IAccountDataSource = Symbol('IAccountDataSource');
 
 export interface IAccountDataSource {
   /**
-   * Gets the verified emails associated with a Safe address.
-   *
-   * @param args.chainId - the chain id of where the Safe is deployed
-   * @param args.safeAddress - the Safe address to use as filter
-   */
-  getVerifiedAccountEmailsBySafeAddress(args: {
-    chainId: string;
-    safeAddress: string;
-  }): Promise<{ email: string }[]>;
-
-  /**
    * Gets the account associated with a signer/owner of a Safe for a specific chain.
    *
    * @param args.chainId - the chain id of where the Safe is deployed
@@ -33,6 +22,20 @@ export interface IAccountDataSource {
     safeAddress: string;
     signer: string;
   }): Promise<Account>;
+
+  /**
+   * Gets all accounts associated with a Safe address for a specific chain
+   *
+   * @param args.chainId - the chain id of where the Safe is deployed
+   * @param args.safeAddress - the Safe address of the account
+   * @param args.onlyVerified - if set to true, returns only verified emails.
+   * Else, returns all emails.
+   */
+  getAccounts(args: {
+    chainId: string;
+    safeAddress: string;
+    onlyVerified: boolean;
+  }): Promise<Account[]>;
 
   getAccountVerificationCode(args: {
     chainId: string;

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -46,6 +46,8 @@ import {
   multiSendTransactionsEncoder,
 } from '@/domain/alerts/__tests__/multi-send-transactions.encoder';
 import { UrlGeneratorHelper } from '@/domain/alerts/urls/url-generator.helper';
+import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
+import { EmailAddress } from '@/domain/account/entities/account.entity';
 
 // The `x-tenderly-signature` header contains a cryptographic signature. The webhook request signature is
 // a HMAC SHA256 hash of concatenated signing secret, request payload, and timestamp, in this order.
@@ -178,10 +180,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -207,8 +212,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -282,10 +287,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -311,8 +319,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -385,10 +393,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -414,8 +425,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -478,10 +489,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -507,8 +521,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -602,10 +616,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -631,8 +648,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -698,10 +715,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -727,8 +747,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(2);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -814,13 +834,17 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [
-          { email: faker.internet.email() },
-          { email: faker.internet.email() },
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
         ];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -846,8 +870,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -910,10 +934,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -939,8 +966,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -990,10 +1017,13 @@ describe('Alerts (Unit)', () => {
           alert,
           timestamp,
         });
-        const verifiedSignerEmails = [{ email: faker.internet.email() }];
-        accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-          verifiedSignerEmails,
-        );
+        const verifiedAccounts = [
+          accountBuilder()
+            .with('emailAddress', new EmailAddress(faker.internet.email()))
+            .with('isVerified', true)
+            .build(),
+        ];
+        accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
         networkService.get.mockImplementation((url) => {
           switch (url) {
@@ -1019,8 +1049,8 @@ describe('Alerts (Unit)', () => {
           .expect(202)
           .expect({});
 
-        const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-          ({ email }) => email,
+        const expectedTargetEmailAddresses = verifiedAccounts.map(
+          ({ emailAddress }) => emailAddress.value,
         );
         expect(emailApi.createMessage).toHaveBeenCalledTimes(2);
         expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -1115,10 +1145,13 @@ describe('Alerts (Unit)', () => {
         alert,
         timestamp,
       });
-      const verifiedSignerEmails = [{ email: faker.internet.email() }];
-      accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-        verifiedSignerEmails,
-      );
+      const verifiedAccounts = [
+        accountBuilder()
+          .with('emailAddress', new EmailAddress(faker.internet.email()))
+          .with('isVerified', true)
+          .build(),
+      ];
+      accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
       networkService.get.mockImplementation((url) => {
         switch (url) {
@@ -1144,8 +1177,8 @@ describe('Alerts (Unit)', () => {
         .expect(202)
         .expect({});
 
-      const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-        ({ email }) => email,
+      const expectedTargetEmailAddresses = verifiedAccounts.map(
+        ({ emailAddress }) => emailAddress.value,
       );
       expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -1225,10 +1258,13 @@ describe('Alerts (Unit)', () => {
         alert,
         timestamp,
       });
-      const verifiedSignerEmails = [{ email: faker.internet.email() }];
-      accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-        verifiedSignerEmails,
-      );
+      const verifiedAccounts = [
+        accountBuilder()
+          .with('emailAddress', new EmailAddress(faker.internet.email()))
+          .with('isVerified', true)
+          .build(),
+      ];
+      accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
       networkService.get.mockImplementation((url) => {
         switch (url) {
@@ -1254,8 +1290,8 @@ describe('Alerts (Unit)', () => {
         .expect(202)
         .expect({});
 
-      const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-        ({ email }) => email,
+      const expectedTargetEmailAddresses = verifiedAccounts.map(
+        ({ emailAddress }) => emailAddress.value,
       );
       expect(emailApi.createMessage).toHaveBeenCalledTimes(2);
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {
@@ -1322,13 +1358,17 @@ describe('Alerts (Unit)', () => {
         timestamp,
       });
       // Multiple emails
-      const verifiedSignerEmails = [
-        { email: faker.internet.email() },
-        { email: faker.internet.email() },
+      const verifiedAccounts = [
+        accountBuilder()
+          .with('emailAddress', new EmailAddress(faker.internet.email()))
+          .with('isVerified', true)
+          .build(),
+        accountBuilder()
+          .with('emailAddress', new EmailAddress(faker.internet.email()))
+          .with('isVerified', true)
+          .build(),
       ];
-      accountDataSource.getVerifiedAccountEmailsBySafeAddress.mockResolvedValue(
-        verifiedSignerEmails,
-      );
+      accountDataSource.getAccounts.mockResolvedValue(verifiedAccounts);
 
       networkService.get.mockImplementation((url) => {
         switch (url) {
@@ -1354,8 +1394,8 @@ describe('Alerts (Unit)', () => {
         .expect(202)
         .expect({});
 
-      const expectedTargetEmailAddresses = verifiedSignerEmails.map(
-        ({ email }) => email,
+      const expectedTargetEmailAddresses = verifiedAccounts.map(
+        ({ emailAddress }) => emailAddress.value,
       );
       expect(emailApi.createMessage).toHaveBeenCalledTimes(1);
       expect(emailApi.createMessage).toHaveBeenNthCalledWith(1, {


### PR DESCRIPTION
Adds a function to retrieve all the accounts tied to a Safe Address. This is particularly useful when only the Safe Address and chain id are available (e.g.: alert triggering).

The functionality was previously covered by `getVerifiedAccountEmailsBySafeAddress`. However, it was only returning the string values of the respective email addresses. While this covers some use-cases (to whom to send an email address), some other properties of the `Account` are still useful when sending email address such as the ability to check and send the unsubscription token.