### PR TITLE
Add SSL configuration to database

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -88,6 +88,10 @@ export default (): ReturnType<typeof configuration> => ({
       database: process.env.POSTGRES_TEST_DB || 'test-db',
       username: process.env.POSTGRES_TEST_USER || 'postgres',
       password: process.env.POSTGRES_TEST_PASSWORD || 'postgres',
+      ssl: {
+        enabled: false,
+        rejectUnauthorized: false,
+      },
     },
   },
   email: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -92,6 +92,15 @@ export default () => ({
       database: process.env.POSTGRES_DB || 'safe-client-gateway',
       username: process.env.POSTGRES_USER || 'postgres',
       password: process.env.POSTGRES_PASSWORD || 'postgres',
+      ssl: {
+        enabled: process.env.POSTGRES_SSL_ENABLED?.toLowerCase() === 'true',
+        // If the value is not explicitly set to false, default should be true
+        // If not false the server will reject any connection which is not authorized with the list of supplied CAs
+        // https://nodejs.org/docs/latest-v20.x/api/tls.html#tlscreateserveroptions-secureconnectionlistener
+        rejectUnauthorized:
+          process.env.POSTGRES_SSL_REJECT_UNAUTHORIZED?.toLowerCase() !==
+          'false',
+      },
     },
   },
   email: {

--- a/src/datasources/db/postgres-database.module.ts
+++ b/src/datasources/db/postgres-database.module.ts
@@ -5,12 +5,20 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { PostgresDatabaseMigrationHook } from '@/datasources/db/postgres-database.migration.hook';
 
 function dbFactory(configurationService: IConfigurationService): postgres.Sql {
+  const sslConfig = configurationService.getOrThrow('db.postgres.ssl.enabled')
+    ? {
+        rejectUnauthorized: configurationService.getOrThrow(
+          'db.postgres.ssl.rejectUnauthorized',
+        ),
+      }
+    : false;
   return postgres({
     host: configurationService.getOrThrow('db.postgres.host'),
     port: configurationService.getOrThrow('db.postgres.port'),
     db: configurationService.getOrThrow('db.postgres.database'),
     user: configurationService.getOrThrow('db.postgres.username'),
     password: configurationService.getOrThrow('db.postgres.password'),
+    ssl: sslConfig,
   });
 }
 


### PR DESCRIPTION
- Adds the option to configure the SSL component of the database connection.
- Enabling SSL can be done by setting `POSTGRES_SSL_ENABLED` to `true`. (default is `false`)
- `POSTGRES_SSL_REJECT_UNAUTHORIZED` can be used to reject any connections which are not authorised with the list of supplied CAs (default is `true`)