### PR TITLE
Bundle migrations in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY --chown=node:node .yarn/patches ./.yarn/patches
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
 RUN --mount=type=cache,target=/root/.yarn yarn
 COPY --chown=node:node assets ./assets
+COPY --chown=node:node migrations ./migrations
 COPY --chown=node:node src ./src
 RUN --mount=type=cache,target=/root/.yarn yarn run build \
     && rm -rf ./node_modules \
@@ -30,4 +31,5 @@ ENV APPLICATION_VERSION=${VERSION} \
 COPY --chown=node:node --from=base /app/node_modules ./node_modules
 COPY --chown=node:node --from=base /app/dist ./dist
 COPY --chown=node:node --from=base /app/assets ./assets
+COPY --chown=node:node --from=base /app/migrations ./migrations
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
Migrations were not being bundled in the Docker image meaning that the database integration wouldn't work if enabled.