### PR TITLE
Send notification only to subscribed accounts

### DIFF
--- a/src/domain/account/entities/__tests__/subscription.builder.ts
+++ b/src/domain/account/entities/__tests__/subscription.builder.ts
@@ -1,0 +1,9 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { Subscription } from '@/domain/account/entities/subscription.entity';
+import { faker } from '@faker-js/faker';
+
+export function subscriptionBuilder(): IBuilder<Subscription> {
+  return new Builder<Subscription>()
+    .with('key', faker.word.sample())
+    .with('name', faker.word.words());
+}

--- a/src/domain/alerts/alerts.domain.module.ts
+++ b/src/domain/alerts/alerts.domain.module.ts
@@ -6,6 +6,7 @@ import { AlertsDecodersModule } from '@/domain/alerts/alerts-decoders.module';
 import { EmailApiModule } from '@/datasources/email-api/email-api.module';
 import { AccountDomainModule } from '@/domain/account/account.domain.module';
 import { UrlGeneratorModule } from '@/domain/alerts/urls/url-generator.module';
+import { SubscriptionDomainModule } from '@/domain/subscriptions/subscription.domain.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { UrlGeneratorModule } from '@/domain/alerts/urls/url-generator.module';
     AlertsApiModule,
     AlertsDecodersModule,
     EmailApiModule,
+    SubscriptionDomainModule,
     UrlGeneratorModule,
   ],
   providers: [{ provide: IAlertsRepository, useClass: AlertsRepository }],

--- a/src/domain/subscriptions/subscription.repository.interface.ts
+++ b/src/domain/subscriptions/subscription.repository.interface.ts
@@ -3,6 +3,12 @@ import { Subscription } from '@/domain/account/entities/subscription.entity';
 export const ISubscriptionRepository = Symbol('ISubscriptionRepository');
 
 export interface ISubscriptionRepository {
+  getSubscriptions(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<Subscription[]>;
+
   subscribe(args: {
     chainId: string;
     safeAddress: string;

--- a/src/domain/subscriptions/subscription.repository.ts
+++ b/src/domain/subscriptions/subscription.repository.ts
@@ -12,6 +12,14 @@ export class SubscriptionRepository implements ISubscriptionRepository {
     private readonly accountDataSource: IAccountDataSource,
   ) {}
 
+  getSubscriptions(args: {
+    chainId: string;
+    safeAddress: string;
+    signer: string;
+  }): Promise<Subscription[]> {
+    return this.accountDataSource.getSubscriptions(args);
+  }
+
   subscribe(args: {
     chainId: string;
     safeAddress: string;


### PR DESCRIPTION
With the introduction of subscriptions, we should send email notifications only to verified accounts which are subscribed to the `account_recovery` category.