### PR TITLE
Add description regarding `RelayDto['gasLimit']` overhead

### DIFF
--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -15,7 +15,6 @@ export class GelatoApi implements IRelayApi {
    * buffer reduces your chance of the task cancelling before it is executed on-chain.
    * @see https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters
    */
-  // TODO: Add documentationn to Swagger
   private static GAS_LIMIT_BUFFER = BigInt(150_000);
 
   private readonly baseUri: string;

--- a/src/routes/relay/entities/relay.dto.entity.ts
+++ b/src/routes/relay/entities/relay.dto.entity.ts
@@ -7,6 +7,12 @@ export class RelayDto {
   @ApiProperty()
   data!: string;
 
-  @ApiPropertyOptional({ type: BigInt, nullable: true })
+  @ApiPropertyOptional({
+    type: BigInt,
+    nullable: true,
+    description: `If specified, a gas buffer of 150k will be added on top of the expected gas usage for the transaction.
+      This is for the <a href=\"https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters\" target=\"_blank\">
+      Gelato Relay execution overhead</a>, reducing the chance of the task cancelling before it is executed on-chain.`,
+  })
   gasLimit!: string | null;
 }


### PR DESCRIPTION
This adds a `description` regarding the `gasLimit` overhead for relaying via Gelato to Swagger:

![image](https://github.com/safe-global/safe-client-gateway/assets/20442784/5a1cf10b-b330-44ce-919d-d6cdb6ef5ad4)