### PR TITLE
Mark `isTestnet` as required

### DIFF
--- a/src/domain/chains/entities/chain.entity.ts
+++ b/src/domain/chains/entities/chain.entity.ts
@@ -13,8 +13,7 @@ export interface Chain {
   // TODO: Make required when deemed stable on config service
   chainLogoUri?: string;
   l2: boolean;
-  // TODO: Make required when deemed stable on config service
-  isTestnet?: boolean;
+  isTestnet: boolean;
   shortName: string;
   rpcUri: RpcUri;
   safeAppsRpcUri: RpcUri;

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -123,8 +123,7 @@ export const chainSchema: JSONSchemaType<Chain> = {
     // TODO: Make required when deemed stable on config service
     chainLogoUri: { type: 'string', format: 'uri', nullable: true },
     l2: { type: 'boolean' },
-    // TODO: Make required when deemed stable on config service
-    isTestnet: { type: 'boolean', nullable: true },
+    isTestnet: { type: 'boolean' },
     shortName: { type: 'string' },
     rpcUri: { $ref: 'rpc-uri.json' },
     safeAppsRpcUri: { $ref: 'rpc-uri.json' },
@@ -149,7 +148,7 @@ export const chainSchema: JSONSchemaType<Chain> = {
     'description',
     // 'chainLogoUri',
     'l2',
-    // isTestnet,
+    'isTestnet',
     'shortName',
     'rpcUri',
     'safeAppsRpcUri',

--- a/src/routes/chains/entities/chain.entity.ts
+++ b/src/routes/chains/entities/chain.entity.ts
@@ -46,9 +46,8 @@ export class Chain {
   chainLogoUri?: string;
   @ApiProperty()
   l2: boolean;
-  // TODO: Make required when implemented on config service and deemed stable
-  @ApiPropertyOptional()
-  isTestnet?: boolean;
+  @ApiProperty()
+  isTestnet: boolean;
   @ApiProperty()
   nativeCurrency: ApiNativeCurrency;
   @ApiProperty()
@@ -102,8 +101,7 @@ export class Chain {
     shortName: string,
     theme: Theme,
     ensRegistryAddress: string | null,
-    // TODO: Make required when deemed stable on config service
-    isTestnet?: boolean,
+    isTestnet: boolean,
     // TODO: Make required when deemed stable on config service
     chainLogoUri?: string,
   ) {


### PR DESCRIPTION
This marks `Chain['isTestnet']` as required now that the [clients are using it successfully](https://github.com/safe-global/safe-wallet-web/blob/1be52b50d8f79eef46e2e5da621442a87f0b0234/src/components/common/NetworkSelector/index.tsx#L40).