### PR TITLE
Send unsubscription token when sending email

### DIFF
--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -265,7 +265,7 @@ export class AlertsRepository implements IAlertsRepository {
         if (result.status === 'rejected') {
           const signer = args.accountsToNotify.at(index)?.signer;
           this.loggingService.warn(
-            `Error sending email to user with account ${signer}, for safe ${args.safeAddress} on chain ${args.chainId}`,
+            `Error sending email to user with account ${signer}, for Safe ${args.safeAddress} on chain ${args.chainId}`,
           );
         }
       });
@@ -317,7 +317,7 @@ export class AlertsRepository implements IAlertsRepository {
         if (result.status === 'rejected') {
           const signer = args.accountsToNotify.at(index)?.signer;
           this.loggingService.warn(
-            `Error sending email to user with account ${signer}, for safe ${args.newSafeState.address} on chain ${args.chainId}`,
+            `Error sending email to user with account ${signer}, for Safe ${args.newSafeState.address} on chain ${args.chainId}`,
           );
         }
       });

--- a/src/domain/alerts/urls/url-generator.helper.ts
+++ b/src/domain/alerts/urls/url-generator.helper.ts
@@ -23,4 +23,9 @@ export class UrlGeneratorHelper {
       args.address,
     );
   }
+
+  // TODO: The final URL needs to be confirmed
+  unsubscriptionSafeWebAppUrl(args: { unsubscriptionToken: string }): string {
+    return `${this.webAppBaseUri}/unsubscribe?token=${args.unsubscriptionToken}`;
+  }
 }


### PR DESCRIPTION
Sends a `unsubscriptionUrl` substitution to the email provider. This URL includes the token which can be used to unsubscribe from further email notifications.

Since this token is unique, and a token cannot be mapped to a target email address if multiple email addresses are involved, the `AlertsRepository` now triggers multiple calls to `IEmailApi.createMessage` (one per each recipient).