### PR TITLE
Remove unnecessary build step before VSCode debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,6 @@
       "name": "Launch Program",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/src/main.ts",
-      "preLaunchTask": "tsc: build - tsconfig.json",
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "console": "integratedTerminal",
       "outputCapture": "std"


### PR DESCRIPTION
### Changes
- Removes unnecesary `preLaunchTask` in Visual Studio Code specific debug configuration.