### PR TITLE
Generate `AbiDecoder` helpers for testing if calldata is of method

### DIFF
--- a/src/domain/contracts/contracts/__tests__/abi-decoder.helper.spec.ts
+++ b/src/domain/contracts/contracts/__tests__/abi-decoder.helper.spec.ts
@@ -1,0 +1,47 @@
+import { faker } from '@faker-js/faker';
+import { Hex, encodeFunctionData, parseAbi } from 'viem';
+import { _generateHelpers } from '@/domain/contracts/contracts/abi-decoder.helper';
+
+describe('AbiDecoder', () => {
+  describe('generateHelpers', () => {
+    it('should generate helpers', () => {
+      const abi = parseAbi(['function example()', 'function example2()']);
+
+      const helpers = _generateHelpers(abi);
+
+      expect(helpers.isExample).toBeDefined();
+      expect(helpers.isExample2).toBeDefined();
+    });
+
+    it('should not generate helpers for non-function types', () => {
+      const abi = parseAbi(['event example()', 'function example2()']);
+
+      const helpers = _generateHelpers(abi);
+
+      // @ts-expect-error - isExample is not defined
+      expect(helpers.isExample).not.toBeDefined();
+      expect(helpers.isExample2).toBeDefined();
+    });
+
+    it('should return true if the data is of the method', () => {
+      const abi = parseAbi(['function example()']);
+      const data = encodeFunctionData({
+        abi,
+        functionName: 'example',
+      });
+
+      const helpers = _generateHelpers(abi);
+
+      expect(helpers.isExample(data)).toBe(true);
+    });
+
+    it('should return false if the data is not of the method', () => {
+      const abi = parseAbi(['function example()']);
+      const data = faker.string.hexadecimal() as Hex;
+
+      const helpers = _generateHelpers(abi);
+
+      expect(helpers.isExample(data)).toBe(false);
+    });
+  });
+});

--- a/src/domain/contracts/contracts/__tests__/multi-send-decoder.helper.spec.ts
+++ b/src/domain/contracts/contracts/__tests__/multi-send-decoder.helper.spec.ts
@@ -50,12 +50,12 @@ describe('MultiSendDecoder', () => {
   describe('isMultiSend', () => {
     it('returns true if data is a multiSend call', () => {
       const data = multiSendEncoder().encode();
-      expect(target.isMultiSend(data)).toBe(true);
+      expect(target.helpers.isMultiSend(data)).toBe(true);
     });
 
     it('returns false if data is not a multiSend call', () => {
       const data = addOwnerWithThresholdEncoder().encode();
-      expect(target.isMultiSend(data)).toBe(false);
+      expect(target.helpers.isMultiSend(data)).toBe(false);
     });
   });
 });

--- a/src/domain/contracts/contracts/multi-send-decoder.helper.ts
+++ b/src/domain/contracts/contracts/multi-send-decoder.helper.ts
@@ -76,11 +76,4 @@ export class MultiSendDecoder extends AbiDecoder<typeof MultiSendCallOnly130> {
 
     return mapped;
   }
-
-  isMultiSend(data: `0x${string}`): boolean {
-    return this._isFunctionCall({
-      functionName: 'multiSend',
-      data,
-    });
-  }
 }


### PR DESCRIPTION
This extends the logic of `AbiDecoder` to automatically generate `is{FunctionName}` methods for testing whether calldata is of a method or not, e.g.

```ts
isMultiSend = (data: Hex) => boolean
```