### PR TITLE
Add Sepolia to relay configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,9 +23,10 @@
 #ZERION_API_KEY=
 
 # Relay Provider - Gelato API
-# The API key to be used for Gnosis Chain
 # FF_RELAY=
+# The API key to be used for a specific chain
 # GELATO_API_KEY_GNOSIS_CHAIN=
+# GELATO_API_KEY_SEPOLIA=
 
 # The cache TTL for each token price datapoint.
 #BALANCES_TTL_SECONDS=

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -187,6 +187,7 @@ export default (): ReturnType<typeof configuration> => ({
     limit: faker.number.int({ min: 1 }),
     apiKey: {
       100: faker.string.hexadecimal({ length: 32 }),
+      11155111: faker.string.hexadecimal({ length: 32 }),
     },
   },
   safeConfig: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -185,6 +185,7 @@ export default () => ({
     limit: parseInt(process.env.RELAY_THROTTLE_LIMIT ?? `${5}`),
     apiKey: {
       100: process.env.GELATO_API_KEY_GNOSIS_CHAIN,
+      11155111: process.env.GELATO_API_KEY_SEPOLIA,
     },
   },
   safeConfig: {


### PR DESCRIPTION
This adds the relevant configuration for Sepolia to relay via Gelato, with the env. var. `GELATO_API_KEY_SEPOLIA`.