### PR TITLE
Add officiality checks for ProxyFactory

### DIFF
--- a/src/domain/relay/errors/unofficial-proxy-factory.error.ts
+++ b/src/domain/relay/errors/unofficial-proxy-factory.error.ts
@@ -1,0 +1,7 @@
+export class UnofficialProxyFactoryError extends Error {
+  constructor() {
+    super(
+      'ProxyFactory contract is not official. Only official ProxyFactory contracts are supported.',
+    );
+  }
+}

--- a/src/domain/relay/exception-filters/unofficial-proxy-factory.exception-filter.ts
+++ b/src/domain/relay/exception-filters/unofficial-proxy-factory.exception-filter.ts
@@ -1,0 +1,21 @@
+import { Response } from 'express';
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  HttpStatus,
+} from '@nestjs/common';
+import { UnofficialProxyFactoryError } from '@/domain/relay/errors/unofficial-proxy-factory.error';
+
+@Catch(UnofficialProxyFactoryError)
+export class UnofficialProxyFactoryExceptionFilter implements ExceptionFilter {
+  catch(_: UnofficialProxyFactoryError, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.UNPROCESSABLE_ENTITY).json({
+      message: 'Unofficial ProxyFactory contract.',
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+    });
+  }
+}

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -9,6 +9,7 @@ import {
   getSafeL2SingletonDeployment,
   getMultiSendCallOnlyDeployment,
   getMultiSendDeployment,
+  getProxyFactoryDeployment,
 } from '@safe-global/safe-deployments';
 import { SafeDecoder } from '@/domain/contracts/contracts/safe-decoder.helper';
 import { isAddress, isHex } from 'viem';
@@ -16,6 +17,7 @@ import { UnofficialMasterCopyError } from '@/domain/relay/errors/unofficial-mast
 import { UnofficialMultiSendError } from '@/domain/relay/errors/unofficial-multisend.error';
 import { InvalidTransferError } from '@/domain/relay/errors/invalid-transfer.error';
 import { InvalidMultiSendError } from '@/domain/relay/errors/invalid-multisend.error';
+import { UnofficialProxyFactoryError } from '@/domain/relay/errors/unofficial-proxy-factory.error';
 
 @Injectable()
 export class LimitAddressesMapper {
@@ -100,6 +102,15 @@ export class LimitAddressesMapper {
         data: args.data,
       })
     ) {
+      if (
+        !this.isOfficialProxyFactoryDeployment({
+          version: args.version,
+          chainId: args.chainId,
+          address: args.to,
+        })
+      ) {
+        throw new UnofficialProxyFactoryError();
+      }
       // Owners of safe-to-be-created will be limited
       return this.getOwnersFromCreateProxyWithNonce(args.data);
     }
@@ -219,6 +230,22 @@ export class LimitAddressesMapper {
 
     return firstRecipient;
   };
+
+  private isOfficialProxyFactoryDeployment(args: {
+    version: string;
+    chainId: string;
+    address: string;
+  }): boolean {
+    const proxyFactoryDeployment = getProxyFactoryDeployment({
+      version: args.version,
+      network: args.chainId,
+    });
+
+    return (
+      proxyFactoryDeployment?.networkAddresses[args.chainId] === args.address ||
+      proxyFactoryDeployment?.defaultAddress === args.address
+    );
+  }
 
   private isValidCreateProxyWithNonceCall(args: {
     version: string;

--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -8,6 +8,7 @@ import { InvalidMultiSendExceptionFilter } from '@/domain/relay/exception-filter
 import { InvalidTransferExceptionFilter } from '@/domain/relay/exception-filters/invalid-transfer.exception-filter';
 import { UnofficialMasterCopyExceptionFilter } from '@/domain/relay/exception-filters/unofficial-master-copy.exception-filter';
 import { UnofficialMultiSendExceptionFilter } from '@/domain/relay/exception-filters/unofficial-multisend.error';
+import { UnofficialProxyFactoryExceptionFilter } from '@/domain/relay/exception-filters/unofficial-proxy-factory.exception-filter';
 
 @ApiTags('relay')
 @Controller({
@@ -24,6 +25,7 @@ export class RelayController {
     InvalidTransferExceptionFilter,
     UnofficialMasterCopyExceptionFilter,
     UnofficialMultiSendExceptionFilter,
+    UnofficialProxyFactoryExceptionFilter,
   )
   async relay(
     @Param('chainId') chainId: string,


### PR DESCRIPTION
This adds officiality checks for the ProxyFactory contract being called. Providing the calldata matches that of `createProxyWithNonce`, the address of `to` being called is validated against official deployments.