### PR TITLE
Migrate deprecated `faker.internet.avatar`

### DIFF
--- a/src/routes/transactions/entities/__tests__/human-description.builder.ts
+++ b/src/routes/transactions/entities/__tests__/human-description.builder.ts
@@ -13,7 +13,7 @@ function richTokenValueFragmentBuilder(): IBuilder<RichTokenValueFragment> {
     .with('type', RichFragmentType.TokenValue)
     .with('value', faker.string.numeric())
     .with('symbol', faker.finance.currencySymbol())
-    .with('logoUri', faker.internet.avatar());
+    .with('logoUri', faker.image.avatar());
 }
 
 function richTextFragmentBuilder(): IBuilder<RichTextFragment> {

--- a/src/routes/transactions/mappers/common/human-descriptions.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/human-descriptions.mapper.spec.ts
@@ -204,7 +204,7 @@ describe('Human descriptions mapper (Unit)', () => {
     const mockSafeAppInfo = new SafeAppInfo(
       mockSafeAppName,
       faker.internet.url(),
-      faker.internet.avatar(),
+      faker.image.avatar(),
     );
     safeAppInfoMapper.mapSafeAppInfo.mockImplementation(() =>
       Promise.resolve(mockSafeAppInfo),


### PR DESCRIPTION
`faker.internet.avatar` [will be deprecated](https://fakerjs.dev/api/internet.html#avatar) in the next major version, replaced with `faker.image.avatar`. This migrates all instances of it.