### PR TITLE
Add bug and feature issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,32 @@
+name: Bug report
+description: Create a new issue reporting a bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction steps
+      description: Steps to reproduce the behavior.
+      placeholder: 1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional information
+      description: Add any other context about the problem here e.g. screenshots, logs, etc.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Create a new issue reporting a bug
+labels: ['bug']
 body:
   - type: textarea
     id: description
@@ -13,7 +14,8 @@ body:
     attributes:
       label: Reproduction steps
       description: Steps to reproduce the behavior.
-      placeholder: 1. ...
+      placeholder: |
+        1. ...
         2. ...
         3. ...
     validations:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Create a new issue requesting a feature
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the feature is.
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: What are the feature requirements?
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional information
+      description: Add any other context about the feature here e.g. proposed API, etc.


### PR DESCRIPTION
This adds two issue templates:

- Bug report
- Feature request

Adding these templates prevents "blank" issues from being created but this can be adjusted by adding a config file should we deem it necessary.