### PR TITLE
Test each chain depending on supported contract versions

### DIFF
--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -31,12 +31,29 @@ import {
   getSafeSingletonDeployment,
 } from '@safe-global/safe-deployments';
 import { Hex, getAddress } from 'viem';
+import configuration from '@/config/entities/configuration';
 
-const SAFE_VERSIONS = ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'];
-const SAFE_L2_VERSIONS = ['1.3.0', '1.4.1'];
-const MULTI_SEND_CALL_ONLY_VERSIONS = ['1.3.0', '1.4.1'];
-const MULTI_SEND_VERSIONS = ['1.1.1', ...MULTI_SEND_CALL_ONLY_VERSIONS];
-const PROXY_FACTORY_VERSIONS = ['1.0.0', '1.1.1', '1.3.0', '1.4.1'];
+// TODO: Generate these from safe-deployments package
+const SAFE_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const SAFE_L2_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const MULTI_SEND_CALL_ONLY_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const MULTI_SEND_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.1.1', '1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const PROXY_FACTORY_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
 
 const mockSafeRepository = jest.mocked({
   getSafe: jest.fn(),
@@ -62,16 +79,330 @@ describe('LimitAddressesMapper', () => {
     );
   });
 
-  describe('Safe', () => {
-    describe.each(SAFE_VERSIONS)('v%s execTransaction', (version) => {
-      // execTransaction
-      it('should return the limit address when sending native currency to another party', async () => {
-        const chainId = faker.string.numeric();
+  const supportedChainIds = Object.keys(configuration().relay.apiKey);
+
+  describe.each(supportedChainIds)('Chain %s', (chainId) => {
+    describe('Safe', () => {
+      describe.each(SAFE_VERSIONS[chainId])(
+        'v%s execTransaction',
+        (version) => {
+          // execTransaction
+          it('should return the limit address when sending native currency to another party', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('value', faker.number.bigInt())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // transfer (execTransaction)
+          it('should return the limit when sending ERC-20 tokens to another party', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('data', erc20TransferEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // cancellation (execTransaction)
+          it('should return the limit address when cancelling a transaction', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', '0x')
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // addOwnerWithThreshold (execTransaction)
+          it('should return the limit address when making an addOwnerWithThreshold call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', addOwnerWithThresholdEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // changeThreshold (execTransaction)
+          it('should return the limit address when making a changeThreshold call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', changeThresholdEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // enableModule (execTransaction)
+          it('should return the limit address when making a enableModule call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', enableModuleEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // disableModule (execTransaction)
+          it('should return the limit address when making a disableModule call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', disableModuleEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // removeOwner (execTransaction)
+          it('should return the limit address when making a removeOwner call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', removeOwnerEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // setFallbackHandler (execTransaction)
+          it('should return the limit address when making a setFallbackHandler call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', setFallbackHandlerEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // setGuard (execTransaction)
+          it('should return the limit address when making a setGuard call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', setGuardEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // swapOwner (execTransaction)
+          it('should return the limit address when making a swapOwner call', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', swapOwnerEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // execTransaction (execTransaction)
+          it('should return the limit address calling execTransaction on a nested Safe', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('data', execTransactionEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: safeAddress,
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+
+          // execTransaction
+          it('should throw when sending native currency to self', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('value', faker.number.bigInt())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockRejectedValue(true);
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: safeAddress,
+              }),
+            ).rejects.toThrow(
+              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+            );
+          });
+
+          // transfer (execTransaction)
+          it('should throw when sending ERC-20 tokens to self', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with(
+                'data',
+                erc20TransferEncoder().with('to', safeAddress).encode(),
+              )
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: safeAddress,
+              }),
+            ).rejects.toThrow(
+              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+            );
+          });
+
+          // Unofficial mastercopy
+          it('should throw when the mastercopy is not official', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .encode() as Hex;
+            // Unofficial mastercopy
+            mockSafeRepository.getSafe.mockRejectedValue(
+              new Error('Not official mastercopy'),
+            );
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: safeAddress,
+              }),
+            ).rejects.toThrow(
+              'Safe attempting to relay is not official. Only official Safe singletons are supported.',
+            );
+          });
+        },
+      );
+
+      it('should default to the current version', async () => {
+        // Non-existent version
+        const version = '0.0.1';
         const safe = safeBuilder().build();
         const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('value', faker.number.bigInt())
-          .encode() as Hex;
+        const data = execTransactionEncoder().encode() as Hex;
         // Official mastercopy
         mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -82,337 +413,196 @@ describe('LimitAddressesMapper', () => {
           to: safeAddress,
         });
         expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
 
-      // transfer (execTransaction)
-      it('should return the limit when sending ERC-20 tokens to another party', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('data', erc20TransferEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // cancellation (execTransaction)
-      it('should return the limit address when cancelling a transaction', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', '0x')
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // addOwnerWithThreshold (execTransaction)
-      it('should return the limit address when making an addOwnerWithThreshold call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', addOwnerWithThresholdEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // changeThreshold (execTransaction)
-      it('should return the limit address when making a changeThreshold call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', changeThresholdEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // enableModule (execTransaction)
-      it('should return the limit address when making a enableModule call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', enableModuleEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // disableModule (execTransaction)
-      it('should return the limit address when making a disableModule call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', disableModuleEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // removeOwner (execTransaction)
-      it('should return the limit address when making a removeOwner call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', removeOwnerEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // setFallbackHandler (execTransaction)
-      it('should return the limit address when making a setFallbackHandler call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', setFallbackHandlerEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // setGuard (execTransaction)
-      it('should return the limit address when making a setGuard call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', setGuardEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // swapOwner (execTransaction)
-      it('should return the limit address when making a swapOwner call', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('data', swapOwnerEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // execTransaction (execTransaction)
-      it('should return the limit address calling execTransaction on a nested Safe', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('data', execTransactionEncoder().encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      // execTransaction
-      it('should throw when sending native currency to self', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .with('value', faker.number.bigInt())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockRejectedValue(true);
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to: safeAddress,
-          }),
-        ).rejects.toThrow(
-          'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-        );
-      });
-
-      // transfer (execTransaction)
-      it('should throw when sending ERC-20 tokens to self', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('data', erc20TransferEncoder().with('to', safeAddress).encode())
-          .encode() as Hex;
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to: safeAddress,
-          }),
-        ).rejects.toThrow(
-          'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-        );
-      });
-
-      // Unofficial mastercopy
-      it('should throw when the mastercopy is not official', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('to', safeAddress)
-          .encode() as Hex;
-        // Unofficial mastercopy
-        mockSafeRepository.getSafe.mockRejectedValue(
-          new Error('Not official mastercopy'),
-        );
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to: safeAddress,
-          }),
-        ).rejects.toThrow(
-          'Safe attempting to relay is not official. Only official Safe singletons are supported.',
-        );
+        expect(SAFE_VERSIONS[chainId].includes(version)).toBe(false);
       });
     });
 
-    it('should default to the current version', async () => {
-      // Non-existent version
-      const version = '0.0.1';
-      const chainId = faker.string.numeric();
-      const safe = safeBuilder().build();
-      const safeAddress = getAddress(safe.address);
-      const data = execTransactionEncoder().encode() as Hex;
-      // Official mastercopy
-      mockSafeRepository.getSafe.mockResolvedValue(safe);
+    describe('MultiSendCallOnly', () => {
+      describe.each(MULTI_SEND_CALL_ONLY_VERSIONS[chainId])(
+        'v%s multiSend',
+        (version) => {
+          it('should return the limit address when entire batch is valid', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const transactions = [
+              execTransactionEncoder()
+                .with('data', addOwnerWithThresholdEncoder().encode())
+                .encode(),
+              execTransactionEncoder()
+                .with('data', changeThresholdEncoder().encode())
+                .encode(),
+            ].map((data) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              to: safeAddress,
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            const to = getMultiSendCallOnlyDeployment({
+              version,
+              network: chainId,
+            })!.networkAddresses[chainId];
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
 
-      const expectedLimitAddresses = await target.getLimitAddresses({
-        version,
-        chainId,
-        data,
-        to: safeAddress,
-      });
-      expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: getAddress(to),
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
 
-      expect(SAFE_VERSIONS.includes(version)).toBe(false);
-    });
-  });
+          it('should throw when the batch has an invalid transaction', async () => {
+            const safe = safeBuilder().build();
+            const transactions = [
+              execTransactionEncoder().encode(),
+              // Native ERC-20 transfer
+              erc20TransferEncoder().encode(),
+            ].map((data) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              to: getAddress(safe.address),
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            const to = getMultiSendCallOnlyDeployment({
+              version,
+              network: chainId,
+            })!.networkAddresses[chainId];
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
 
-  describe('MultiSendCallOnly', () => {
-    describe.each(MULTI_SEND_CALL_ONLY_VERSIONS)('v%s multiSend', (version) => {
-      it('should return the limit address when entire batch is valid', async () => {
-        // Fixed chain ID for deployment address
-        const chainId = '1';
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: getAddress(to),
+              }),
+            ).rejects.toThrow(
+              'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
+            );
+          });
+
+          it('should throw when the mastercopy is not official', async () => {
+            const safe = safeBuilder().build();
+            const transactions = [
+              execTransactionEncoder().encode(),
+              execTransactionEncoder().encode(),
+            ].map((data) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              to: getAddress(safe.address),
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            const to = getMultiSendCallOnlyDeployment({
+              version,
+              network: chainId,
+            })!.networkAddresses[chainId];
+            // Unofficial mastercopy
+            mockSafeRepository.getSafe.mockRejectedValue(
+              new Error('Not official mastercopy'),
+            );
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: getAddress(to),
+              }),
+            ).rejects.toThrow(
+              'Safe attempting to relay is not official. Only official Safe singletons are supported.',
+            );
+          });
+
+          it('should throw when the batch is to varying parties', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const otherParty = getAddress(faker.finance.ethereumAddress());
+            const transactions = [
+              execTransactionEncoder().with('to', safeAddress).encode(),
+              execTransactionEncoder().with('to', otherParty).encode(),
+            ].map((data, i) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              // Varying parties
+              to: i === 0 ? safeAddress : otherParty,
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            const to = getMultiSendCallOnlyDeployment({
+              version,
+              network: chainId,
+            })!.networkAddresses[chainId];
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: getAddress(to),
+              }),
+            ).rejects.toThrow(
+              'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
+            );
+          });
+
+          it('should throw for unofficial MultiSend deployments', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const transactions = [
+              execTransactionEncoder()
+                .with('data', addOwnerWithThresholdEncoder().encode())
+                .encode(),
+              execTransactionEncoder()
+                .with('data', changeThresholdEncoder().encode())
+                .encode(),
+            ].map((data) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              to: safeAddress,
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            // Unofficial MultiSend deployment
+            const to = getAddress(faker.finance.ethereumAddress());
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to,
+              }),
+            ).rejects.toThrow(
+              'MultiSend contract is not official. Only official MultiSend contracts are supported.',
+            );
+          });
+        },
+      );
+
+      it('should throw for non-existent MultiSendCallOnly versions', async () => {
+        // Non-existent version
+        const version = '1.0.0';
         const safe = safeBuilder().build();
         const safeAddress = getAddress(safe.address);
         const transactions = [
@@ -431,45 +621,7 @@ describe('LimitAddressesMapper', () => {
         const data = multiSendEncoder()
           .with('transactions', multiSendTransactionsEncoder(transactions))
           .encode();
-        const to = getMultiSendCallOnlyDeployment({
-          version,
-          network: chainId,
-        })!.networkAddresses[chainId];
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: getAddress(to),
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-
-      it('should throw when the batch has an invalid transaction', async () => {
-        // Fixed chain ID for deployment address
-        const chainId = '1';
-        const safe = safeBuilder().build();
-        const transactions = [
-          execTransactionEncoder().encode(),
-          // Native ERC-20 transfer
-          erc20TransferEncoder().encode(),
-        ].map((data) => ({
-          operation: faker.number.int({ min: 0, max: 1 }),
-          data,
-          to: getAddress(safe.address),
-          value: faker.number.bigInt(),
-        }));
-        const data = multiSendEncoder()
-          .with('transactions', multiSendTransactionsEncoder(transactions))
-          .encode();
-        const to = getMultiSendCallOnlyDeployment({
-          version,
-          network: chainId,
-        })!.networkAddresses[chainId];
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
+        const to = faker.finance.ethereumAddress();
 
         await expect(
           target.getLimitAddresses({
@@ -477,169 +629,61 @@ describe('LimitAddressesMapper', () => {
             chainId,
             data,
             to: getAddress(to),
-          }),
-        ).rejects.toThrow(
-          'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
-        );
-      });
-
-      it('should throw when the mastercopy is not official', async () => {
-        // Fixed chain ID for deployment address
-        const chainId = '1';
-        const safe = safeBuilder().build();
-        const transactions = [
-          execTransactionEncoder().encode(),
-          execTransactionEncoder().encode(),
-        ].map((data) => ({
-          operation: faker.number.int({ min: 0, max: 1 }),
-          data,
-          to: getAddress(safe.address),
-          value: faker.number.bigInt(),
-        }));
-        const data = multiSendEncoder()
-          .with('transactions', multiSendTransactionsEncoder(transactions))
-          .encode();
-        const to = getMultiSendCallOnlyDeployment({
-          version,
-          network: chainId,
-        })!.networkAddresses[chainId];
-        // Unofficial mastercopy
-        mockSafeRepository.getSafe.mockRejectedValue(
-          new Error('Not official mastercopy'),
-        );
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to: getAddress(to),
-          }),
-        ).rejects.toThrow(
-          'Safe attempting to relay is not official. Only official Safe singletons are supported.',
-        );
-      });
-
-      it('should throw when the batch is to varying parties', async () => {
-        const chainId = '1';
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const otherParty = getAddress(faker.finance.ethereumAddress());
-        const transactions = [
-          execTransactionEncoder().with('to', safeAddress).encode(),
-          execTransactionEncoder().with('to', otherParty).encode(),
-        ].map((data, i) => ({
-          operation: faker.number.int({ min: 0, max: 1 }),
-          data,
-          // Varying parties
-          to: i === 0 ? safeAddress : otherParty,
-          value: faker.number.bigInt(),
-        }));
-        const data = multiSendEncoder()
-          .with('transactions', multiSendTransactionsEncoder(transactions))
-          .encode();
-        const to = getMultiSendCallOnlyDeployment({
-          version,
-          network: chainId,
-        })!.networkAddresses[chainId];
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to: getAddress(to),
-          }),
-        ).rejects.toThrow(
-          'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
-        );
-      });
-
-      it('should throw for unofficial MultiSend deployments', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const transactions = [
-          execTransactionEncoder()
-            .with('data', addOwnerWithThresholdEncoder().encode())
-            .encode(),
-          execTransactionEncoder()
-            .with('data', changeThresholdEncoder().encode())
-            .encode(),
-        ].map((data) => ({
-          operation: faker.number.int({ min: 0, max: 1 }),
-          data,
-          to: safeAddress,
-          value: faker.number.bigInt(),
-        }));
-        const data = multiSendEncoder()
-          .with('transactions', multiSendTransactionsEncoder(transactions))
-          .encode();
-        // Unofficial MultiSend deployment
-        const to = getAddress(faker.finance.ethereumAddress());
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to,
           }),
         ).rejects.toThrow(
           'MultiSend contract is not official. Only official MultiSend contracts are supported.',
         );
+
+        expect(MULTI_SEND_CALL_ONLY_VERSIONS[chainId].includes(version)).toBe(
+          false,
+        );
       });
     });
 
-    it('should throw for non-existent MultiSendCallOnly versions', async () => {
-      // Fixed chain ID for deployment address
-      const chainId = '1';
-      // Non-existent version
-      const version = '1.0.0';
-      const safe = safeBuilder().build();
-      const safeAddress = getAddress(safe.address);
-      const transactions = [
-        execTransactionEncoder()
-          .with('data', addOwnerWithThresholdEncoder().encode())
-          .encode(),
-        execTransactionEncoder()
-          .with('data', changeThresholdEncoder().encode())
-          .encode(),
-      ].map((data) => ({
-        operation: faker.number.int({ min: 0, max: 1 }),
-        data,
-        to: safeAddress,
-        value: faker.number.bigInt(),
-      }));
-      const data = multiSendEncoder()
-        .with('transactions', multiSendTransactionsEncoder(transactions))
-        .encode();
-      const to = faker.finance.ethereumAddress();
+    describe('MultiSend', () => {
+      describe.each(MULTI_SEND_VERSIONS[chainId])(
+        'v%s multiSend',
+        (version) => {
+          it('should return the limit address for valid "standard" MultiSend calls', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const transactions = [
+              execTransactionEncoder()
+                .with('data', addOwnerWithThresholdEncoder().encode())
+                .encode(),
+              execTransactionEncoder()
+                .with('data', changeThresholdEncoder().encode())
+                .encode(),
+            ].map((data) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              to: safeAddress,
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            const to = getMultiSendDeployment({
+              version,
+              network: chainId,
+            })!.networkAddresses[chainId];
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
 
-      await expect(
-        target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: getAddress(to),
-        }),
-      ).rejects.toThrow(
-        'MultiSend contract is not official. Only official MultiSend contracts are supported.',
+            const expectedLimitAddresses = await target.getLimitAddresses({
+              version,
+              chainId,
+              data,
+              to: getAddress(to),
+            });
+            expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
+          });
+        },
       );
 
-      expect(MULTI_SEND_CALL_ONLY_VERSIONS.includes(version)).toBe(false);
-    });
-  });
-
-  describe('MultiSend', () => {
-    describe.each(MULTI_SEND_VERSIONS)('v%s multiSend', (version) => {
-      it('should return the limit address for valid "standard" MultiSend calls', async () => {
-        // Fixed chain ID for deployment address
-        const chainId = '1';
+      it('should throw for non-existent MultiSend versions', async () => {
+        // Non-existent version
+        const version = '1.0.0';
         const safe = safeBuilder().build();
         const safeAddress = getAddress(safe.address);
         const transactions = [
@@ -658,105 +702,35 @@ describe('LimitAddressesMapper', () => {
         const data = multiSendEncoder()
           .with('transactions', multiSendTransactionsEncoder(transactions))
           .encode();
-        const to = getMultiSendDeployment({
-          version,
-          network: chainId,
-        })!.networkAddresses[chainId];
+        const to = faker.finance.ethereumAddress();
         // Official mastercopy
         mockSafeRepository.getSafe.mockResolvedValue(safe);
 
-        const expectedLimitAddresses = await target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: getAddress(to),
-        });
-        expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
-      });
-    });
-
-    it('should throw for non-existent MultiSend versions', async () => {
-      // Fixed chain ID for deployment address
-      const chainId = '1';
-      // Non-existent version
-      const version = '1.0.0';
-      const safe = safeBuilder().build();
-      const safeAddress = getAddress(safe.address);
-      const transactions = [
-        execTransactionEncoder()
-          .with('data', addOwnerWithThresholdEncoder().encode())
-          .encode(),
-        execTransactionEncoder()
-          .with('data', changeThresholdEncoder().encode())
-          .encode(),
-      ].map((data) => ({
-        operation: faker.number.int({ min: 0, max: 1 }),
-        data,
-        to: safeAddress,
-        value: faker.number.bigInt(),
-      }));
-      const data = multiSendEncoder()
-        .with('transactions', multiSendTransactionsEncoder(transactions))
-        .encode();
-      const to = faker.finance.ethereumAddress();
-      // Official mastercopy
-      mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-      await expect(
-        target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: getAddress(to),
-        }),
-      ).rejects.toThrow(
-        'MultiSend contract is not official. Only official MultiSend contracts are supported.',
-      );
-
-      expect(MULTI_SEND_VERSIONS.includes(version)).toBe(false);
-    });
-  });
-
-  describe('ProxyFactory', () => {
-    describe.each(PROXY_FACTORY_VERSIONS)(
-      'v%s createProxyWithNonce',
-      (version) => {
-        it('should return the limit addresses when creating an official Safe', async () => {
-          // Fixed chain ID for deployment address
-          const chainId = '1';
-          const owners = [
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(faker.finance.ethereumAddress()),
-          ];
-          const singleton = getSafeSingletonDeployment({
-            version,
-            network: chainId,
-          })!.networkAddresses[chainId];
-          const data = createProxyWithNonceEncoder()
-            .with('singleton', getAddress(singleton))
-            .with('initializer', setupEncoder().with('owners', owners).encode())
-            .encode();
-          // ProxyFactory address (singletons are checked for official mastercopies so we need not check this)
-          const to = getAddress(faker.finance.ethereumAddress());
-
-          const expectedLimitAddresses = await target.getLimitAddresses({
+        await expect(
+          target.getLimitAddresses({
             version,
             chainId,
             data,
-            to,
-          });
-          expect(expectedLimitAddresses).toStrictEqual(owners);
-        });
+            to: getAddress(to),
+          }),
+        ).rejects.toThrow(
+          'MultiSend contract is not official. Only official MultiSend contracts are supported.',
+        );
 
-        if (SAFE_L2_VERSIONS.includes(version)) {
-          it('should return the limit addresses when creating an official L2 Safe', async () => {
-            // Fixed chain ID for deployment address
-            const chainId = '1';
+        expect(MULTI_SEND_VERSIONS[chainId].includes(version)).toBe(false);
+      });
+    });
+
+    describe('ProxyFactory', () => {
+      describe.each(PROXY_FACTORY_VERSIONS[chainId])(
+        'v%s createProxyWithNonce',
+        (version) => {
+          it('should return the limit addresses when creating an official Safe', async () => {
             const owners = [
               getAddress(faker.finance.ethereumAddress()),
               getAddress(faker.finance.ethereumAddress()),
             ];
-            const singleton = getSafeL2SingletonDeployment({
+            const singleton = getSafeSingletonDeployment({
               version,
               network: chainId,
             })!.networkAddresses[chainId];
@@ -778,136 +752,168 @@ describe('LimitAddressesMapper', () => {
             });
             expect(expectedLimitAddresses).toStrictEqual(owners);
           });
-        }
 
-        it('should throw when creating an unofficial Safe', async () => {
-          const chainId = faker.string.numeric();
-          const owners = [
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(faker.finance.ethereumAddress()),
-          ];
-          // Unofficial singleton
-          const singleton = getAddress(faker.finance.ethereumAddress());
-          const data = createProxyWithNonceEncoder()
-            .with('singleton', getAddress(singleton))
-            .with('initializer', setupEncoder().with('owners', owners).encode())
-            .encode();
-          // ProxyFactory address (singletons are checked for official mastercopies so we need not check this)
-          const to = getAddress(faker.finance.ethereumAddress());
+          if (SAFE_L2_VERSIONS[chainId].includes(version)) {
+            it('should return the limit addresses when creating an official L2 Safe', async () => {
+              const owners = [
+                getAddress(faker.finance.ethereumAddress()),
+                getAddress(faker.finance.ethereumAddress()),
+              ];
+              const singleton = getSafeL2SingletonDeployment({
+                version,
+                network: chainId,
+              })!.networkAddresses[chainId];
+              const data = createProxyWithNonceEncoder()
+                .with('singleton', getAddress(singleton))
+                .with(
+                  'initializer',
+                  setupEncoder().with('owners', owners).encode(),
+                )
+                .encode();
+              // ProxyFactory address (singletons are checked for official mastercopies so we need not check this)
+              const to = getAddress(faker.finance.ethereumAddress());
 
-          await expect(
-            target.getLimitAddresses({
-              version,
-              chainId,
-              data,
-              to,
-            }),
-          ).rejects.toThrow(
-            'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-          );
-        });
+              const expectedLimitAddresses = await target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to,
+              });
+              expect(expectedLimitAddresses).toStrictEqual(owners);
+            });
+          }
 
-        it('should throw for non-existent ProxyFactory versions', async () => {
-          // Non-existent version
-          const version = '1.2.0';
-          const chainId = faker.string.numeric();
-          const owners = [
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(faker.finance.ethereumAddress()),
-          ];
-          // Unofficial singleton
-          const singleton = getAddress(faker.finance.ethereumAddress());
-          const data = createProxyWithNonceEncoder()
-            .with('singleton', getAddress(singleton))
-            .with('initializer', setupEncoder().with('owners', owners).encode())
-            .encode();
-          const to = faker.finance.ethereumAddress();
+          it('should throw when creating an unofficial Safe', async () => {
+            const owners = [
+              getAddress(faker.finance.ethereumAddress()),
+              getAddress(faker.finance.ethereumAddress()),
+            ];
+            // Unofficial singleton
+            const singleton = getAddress(faker.finance.ethereumAddress());
+            const data = createProxyWithNonceEncoder()
+              .with('singleton', getAddress(singleton))
+              .with(
+                'initializer',
+                setupEncoder().with('owners', owners).encode(),
+              )
+              .encode();
+            // ProxyFactory address (singletons are checked for official mastercopies so we need not check this)
+            const to = getAddress(faker.finance.ethereumAddress());
 
-          await expect(
-            target.getLimitAddresses({
-              version,
-              chainId,
-              data,
-              to,
-            }),
-          ).rejects.toThrow(
-            'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-          );
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to,
+              }),
+            ).rejects.toThrow(
+              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+            );
+          });
 
-          expect(PROXY_FACTORY_VERSIONS.includes(version)).toBe(false);
-        });
-      },
-    );
-  });
+          it('should throw for non-existent ProxyFactory versions', async () => {
+            // Non-existent version
+            const version = '1.2.0';
+            const owners = [
+              getAddress(faker.finance.ethereumAddress()),
+              getAddress(faker.finance.ethereumAddress()),
+            ];
+            // Unofficial singleton
+            const singleton = getAddress(faker.finance.ethereumAddress());
+            const data = createProxyWithNonceEncoder()
+              .with('singleton', getAddress(singleton))
+              .with(
+                'initializer',
+                setupEncoder().with('owners', owners).encode(),
+              )
+              .encode();
+            const to = faker.finance.ethereumAddress();
 
-  describe('Validation', () => {
-    it('should throw if not an execTransaction, multiSend or createProxyWithNonceCall', async () => {
-      const chainId = faker.string.numeric();
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS);
-      const safe = safeBuilder().build();
-      const safeAddress = getAddress(safe.address);
-      const data = erc20TransferEncoder().encode();
-      // Official mastercopy
-      mockSafeRepository.getSafe.mockResolvedValue(safe);
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to,
+              }),
+            ).rejects.toThrow(
+              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+            );
 
-      await expect(
-        target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to: safeAddress,
-        }),
-      ).rejects.toThrow(
-        'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+            expect(PROXY_FACTORY_VERSIONS[chainId].includes(version)).toBe(
+              false,
+            );
+          });
+        },
       );
     });
 
-    it('should throw if the to address is not valid', async () => {
-      const chainId = faker.string.numeric();
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS);
-      const to = '0x000000000000000000000000000000000INVALID';
-      const data = erc20TransferEncoder().encode();
+    describe('Validation', () => {
+      it('should throw if not an execTransaction, multiSend or createProxyWithNonceCall', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const safe = safeBuilder().build();
+        const safeAddress = getAddress(safe.address);
+        const data = erc20TransferEncoder().encode();
+        // Official mastercopy
+        mockSafeRepository.getSafe.mockResolvedValue(safe);
 
-      await expect(
-        target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to,
-        }),
-      ).rejects.toThrow('Invalid to provided');
-    });
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data,
+            to: safeAddress,
+          }),
+        ).rejects.toThrow(
+          'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+        );
+      });
 
-    it('should throw if the to address is not hexadecimal', async () => {
-      const chainId = faker.string.numeric();
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS);
-      const to = 'not hexadecimal';
-      const data = erc20TransferEncoder().encode();
+      it('should throw if the to address is not valid', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const to = '0x000000000000000000000000000000000INVALID';
+        const data = erc20TransferEncoder().encode();
 
-      await expect(
-        target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to,
-        }),
-      ).rejects.toThrow('Invalid to provided');
-    });
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data,
+            to,
+          }),
+        ).rejects.toThrow('Invalid to provided');
+      });
 
-    it('should throw if the calldata is not hexadecimal', async () => {
-      const chainId = faker.string.numeric();
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS);
-      const to = faker.finance.ethereumAddress();
-      const data = 'not hexadecimal';
+      it('should throw if the to address is not hexadecimal', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const to = 'not hexadecimal';
+        const data = erc20TransferEncoder().encode();
 
-      await expect(
-        target.getLimitAddresses({
-          version,
-          chainId,
-          data,
-          to,
-        }),
-      ).rejects.toThrow('Invalid data provided');
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data,
+            to,
+          }),
+        ).rejects.toThrow('Invalid to provided');
+      });
+
+      it('should throw if the calldata is not hexadecimal', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const to = faker.finance.ethereumAddress();
+        const data = 'not hexadecimal';
+
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data,
+            to,
+          }),
+        ).rejects.toThrow('Invalid data provided');
+      });
     });
   });
 });

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -46,11 +46,27 @@ import {
 } from '@safe-global/safe-deployments';
 import { createProxyWithNonceEncoder } from '@/domain/relay/contracts/__tests__/proxy-factory-encoder.builder';
 
-const SAFE_VERSIONS = ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'];
-const SAFE_L2_VERSIONS = ['1.3.0', '1.4.1'];
-const MULTI_SEND_CALL_ONLY_VERSIONS = ['1.3.0', '1.4.1'];
-const MULTI_SEND_VERSIONS = ['1.1.1', ...MULTI_SEND_CALL_ONLY_VERSIONS];
-const PROXY_FACTORY_VERSIONS = ['1.0.0', '1.1.1', '1.3.0', '1.4.1'];
+// TODO: Generate these from safe-deployments package
+const SAFE_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const SAFE_L2_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const MULTI_SEND_CALL_ONLY_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const MULTI_SEND_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.1.1', '1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
+const PROXY_FACTORY_VERSIONS: Record<string, Array<string>> = {
+  '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1'],
+  '11155111': ['1.3.0', '1.4.1'],
+};
 
 describe('Relay controller', () => {
   let app: INestApplication;
@@ -58,14 +74,6 @@ describe('Relay controller', () => {
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let safeConfigUrl: string;
   let relayUrl: string;
-
-  // Remove Sepolia from tests as only >=1.3.0 are deployed there
-  const supportedChainIds = Object.keys(configuration().relay.apiKey).filter(
-    (chainId) => {
-      const sepoliaChainId = '11155111';
-      return chainId !== sepoliaChainId;
-    },
-  );
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -109,546 +117,30 @@ describe('Relay controller', () => {
     await app.close();
   });
 
-  describe('POST /v1/chains/:chainId/relay', () => {
-    describe('Relayer', () => {
-      describe('Safe', () => {
-        describe.each(SAFE_VERSIONS)('v%s execTransaction', (version) => {
-          it('should return 201 when sending native currency to another party', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const data = execTransactionEncoder()
-              .with('value', faker.number.bigInt())
-              .encode() as Hex;
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
+  const supportedChainIds = Object.keys(configuration().relay.apiKey);
 
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-              })
-              .expect(201)
-              .expect({
-                taskId,
-              });
-          });
-
-          it('should return 201 with manual gasLimit', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const gasLimit = faker.number.bigInt();
-            const data = execTransactionEncoder().encode() as Hex;
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-                gasLimit: gasLimit.toString(),
-              })
-              .expect(201)
-              .expect({
-                taskId,
-              });
-
-            // The gasLimit should have a buffer added
-            const expectedGasLimit = (
-              BigInt(gasLimit) + BigInt(150_000)
-            ).toString();
-            expect(networkService.post).toHaveBeenCalledWith(
-              `${relayUrl}/relays/v2/sponsored-call`,
-              expect.objectContaining({
-                gasLimit: expectedGasLimit,
-              }),
-            );
-          });
-
-          it.each([
-            [
-              'sending ERC-20 tokens to another party',
-              erc20TransferEncoder().encode(),
-            ],
-            ['cancelling a transaction', '0x' as const],
-            [
-              'making an addOwnerWithThreshold call',
-              addOwnerWithThresholdEncoder().encode(),
-            ],
-            [
-              'making a changeThreshold call',
-              changeThresholdEncoder().encode(),
-            ],
-            ['making an enableModule call', enableModuleEncoder().encode()],
-            ['making a disableModule call', disableModuleEncoder().encode()],
-            ['making a removeOwner call', removeOwnerEncoder().encode()],
-            [
-              'making a setFallbackHandler call',
-              setFallbackHandlerEncoder().encode(),
-            ],
-            ['making a setGuard call', setGuardEncoder().encode()],
-            ['making a swapOwner call', swapOwnerEncoder().encode()],
-          ])(`should return 201 when %s`, async (_, execTransactionData) => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const data = execTransactionEncoder()
-              .with('data', execTransactionData)
-              .encode() as Hex;
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safe.address,
-                data,
-              })
-              .expect(201)
-              .expect({
-                taskId,
-              });
-          });
-
-          it('should return 201 calling execTransaction on a nested Safe', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const data = execTransactionEncoder()
-              .with('to', safeAddress)
-              .with('data', execTransactionEncoder().encode())
-              .encode() as Hex;
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-              })
-              .expect(201)
-              .expect({
-                taskId,
-              });
-          });
-        });
-      });
-
-      describe('MultiSendCallOnly', () => {
-        describe.each(MULTI_SEND_CALL_ONLY_VERSIONS)(
-          'v%s multiSend',
-          (version) => {
-            it('should return 201 when entire batch is valid', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const safe = safeBuilder().build();
-              const safeAddress = getAddress(safe.address);
-              const transactions = [
-                execTransactionEncoder()
-                  .with('data', addOwnerWithThresholdEncoder().encode())
-                  .encode(),
-                execTransactionEncoder()
-                  .with('data', changeThresholdEncoder().encode())
-                  .encode(),
-              ].map((data) => ({
-                operation: faker.number.int({ min: 0, max: 1 }),
-                data,
-                to: safeAddress,
-                value: faker.number.bigInt(),
-              }));
-              const data = multiSendEncoder()
-                .with(
-                  'transactions',
-                  multiSendTransactionsEncoder(transactions),
-                )
-                .encode();
-              const to = getMultiSendCallOnlyDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                    // Official mastercopy
-                    return Promise.resolve({ data: safe, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-              networkService.post.mockImplementation((url) => {
-                switch (url) {
-                  case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(201)
-                .expect({
-                  taskId,
-                });
-            });
-          },
-        );
-
-        it('should otherwise default to version 1.3.0', async () => {
-          const version = '1.3.0';
-          const chainId = faker.helpers.arrayElement(supportedChainIds);
-          const chain = chainBuilder().with('chainId', chainId).build();
-          const safe = safeBuilder().build();
-          const safeAddress = getAddress(safe.address);
-          const transactions = [
-            execTransactionEncoder()
-              .with('data', addOwnerWithThresholdEncoder().encode())
-              .encode(),
-            execTransactionEncoder()
-              .with('data', changeThresholdEncoder().encode())
-              .encode(),
-          ].map((data) => ({
-            operation: faker.number.int({ min: 0, max: 1 }),
-            data,
-            to: safeAddress,
-            value: faker.number.bigInt(),
-          }));
-          const data = multiSendEncoder()
-            .with('transactions', multiSendTransactionsEncoder(transactions))
-            .encode();
-          const to = getMultiSendCallOnlyDeployment({
-            version,
-            network: chainId,
-          })!.networkAddresses[chainId];
-          const taskId = faker.string.uuid();
-          networkService.get.mockImplementation((url) => {
-            switch (url) {
-              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
-              case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
-              default:
-                fail(`Unexpected URL: ${url}`);
-            }
-          });
-          networkService.post.mockImplementation((url) => {
-            switch (url) {
-              case `${relayUrl}/relays/v2/sponsored-call`:
-                return Promise.resolve({ data: { taskId }, status: 200 });
-              default:
-                fail(`Unexpected URL: ${url}`);
-            }
-          });
-
-          await request(app.getHttpServer())
-            .post(`/v1/chains/${chain.chainId}/relay`)
-            .send({
-              // No version
-              to,
-              data,
-            })
-            .expect(201)
-            .expect({
-              taskId,
-            });
-        });
-      });
-
-      describe('MultiSend', () => {
-        describe.each(MULTI_SEND_VERSIONS)('v%s multiSend', (version) => {
-          it('should return 201 when entire batch is valid', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const transactions = [
-              execTransactionEncoder()
-                .with('data', addOwnerWithThresholdEncoder().encode())
-                .encode(),
-              execTransactionEncoder()
-                .with('data', changeThresholdEncoder().encode())
-                .encode(),
-            ].map((data) => ({
-              operation: faker.number.int({ min: 0, max: 1 }),
-              data,
-              to: safeAddress,
-              value: faker.number.bigInt(),
-            }));
-            const data = multiSendEncoder()
-              .with('transactions', multiSendTransactionsEncoder(transactions))
-              .encode();
-            const to = getMultiSendDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to,
-                data,
-              })
-              .expect(201)
-              .expect({
-                taskId,
-              });
-          });
-        });
-
-        // TODO: Remove when legacy support is removed
-        it('should otherwise default to version 1.3.0', async () => {
-          const version = '1.3.0';
-          const chainId = faker.helpers.arrayElement(supportedChainIds);
-          const chain = chainBuilder().with('chainId', chainId).build();
-          const safe = safeBuilder().build();
-          const safeAddress = getAddress(safe.address);
-          const transactions = [
-            execTransactionEncoder()
-              .with('data', addOwnerWithThresholdEncoder().encode())
-              .encode(),
-            execTransactionEncoder()
-              .with('data', changeThresholdEncoder().encode())
-              .encode(),
-          ].map((data) => ({
-            operation: faker.number.int({ min: 0, max: 1 }),
-            data,
-            to: safeAddress,
-            value: faker.number.bigInt(),
-          }));
-          const data = multiSendEncoder()
-            .with('transactions', multiSendTransactionsEncoder(transactions))
-            .encode();
-          const to = getMultiSendDeployment({
-            version,
-            network: chainId,
-          })!.networkAddresses[chainId];
-          const taskId = faker.string.uuid();
-          networkService.get.mockImplementation((url) => {
-            switch (url) {
-              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
-              case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
-              default:
-                fail(`Unexpected URL: ${url}`);
-            }
-          });
-          networkService.post.mockImplementation((url) => {
-            switch (url) {
-              case `${relayUrl}/relays/v2/sponsored-call`:
-                return Promise.resolve({ data: { taskId }, status: 200 });
-              default:
-                fail(`Unexpected URL: ${url}`);
-            }
-          });
-
-          await request(app.getHttpServer())
-            .post(`/v1/chains/${chain.chainId}/relay`)
-            .send({
-              // No version
-              to,
-              data,
-            })
-            .expect(201)
-            .expect({
-              taskId,
-            });
-        });
-      });
-
-      describe('ProxyFactory', () => {
-        describe.each(PROXY_FACTORY_VERSIONS)(
-          'v%s createProxyWithNonce',
-          (version) => {
-            it('should return the limit addresses when creating an official Safe', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const owners = [
-                getAddress(faker.finance.ethereumAddress()),
-                getAddress(faker.finance.ethereumAddress()),
-              ];
-              const singleton = getSafeSingletonDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const to = faker.finance.ethereumAddress();
-              const data = createProxyWithNonceEncoder()
-                .with('singleton', getAddress(singleton))
-                .with(
-                  'initializer',
-                  setupEncoder().with('owners', owners).encode(),
-                )
-                .encode();
-              const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-              networkService.post.mockImplementation((url) => {
-                switch (url) {
-                  case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(201)
-                .expect({
-                  taskId,
-                });
-            });
-
-            if (SAFE_L2_VERSIONS.includes(version)) {
-              it('should return the limit addresses when creating an official L2 Safe', async () => {
-                const chainId = faker.helpers.arrayElement(supportedChainIds);
+  describe.each(supportedChainIds)('Chain %s', (chainId) => {
+    describe('POST /v1/chains/:chainId/relay', () => {
+      describe('Relayer', () => {
+        describe('Safe', () => {
+          describe.each(SAFE_VERSIONS[chainId])(
+            'v%s execTransaction',
+            (version) => {
+              it('should return 201 when sending native currency to another party', async () => {
                 const chain = chainBuilder().with('chainId', chainId).build();
-                const owners = [
-                  getAddress(faker.finance.ethereumAddress()),
-                  getAddress(faker.finance.ethereumAddress()),
-                ];
-                const singleton = getSafeL2SingletonDeployment({
-                  version,
-                  network: chainId,
-                })!.networkAddresses[chainId];
-                const to = faker.finance.ethereumAddress();
-                const data = createProxyWithNonceEncoder()
-                  .with('singleton', getAddress(singleton))
-                  .with(
-                    'initializer',
-                    setupEncoder().with('owners', owners).encode(),
-                  )
-                  .encode();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const data = execTransactionEncoder()
+                  .with('value', faker.number.bigInt())
+                  .encode() as Hex;
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation((url) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
                     default:
                       fail(`Unexpected URL: ${url}`);
                   }
@@ -656,10 +148,241 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation((url) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({
-                        data: { taskId },
-                        status: 200,
-                      });
+                      return Promise.resolve({ data: { taskId }, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(201)
+                  .expect({
+                    taskId,
+                  });
+              });
+
+              it('should return 201 with manual gasLimit', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const gasLimit = faker.number.bigInt();
+                const data = execTransactionEncoder().encode() as Hex;
+                const taskId = faker.string.uuid();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+                networkService.post.mockImplementation((url) => {
+                  switch (url) {
+                    case `${relayUrl}/relays/v2/sponsored-call`:
+                      return Promise.resolve({ data: { taskId }, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                    gasLimit: gasLimit.toString(),
+                  })
+                  .expect(201)
+                  .expect({
+                    taskId,
+                  });
+
+                // The gasLimit should have a buffer added
+                const expectedGasLimit = (
+                  BigInt(gasLimit) + BigInt(150_000)
+                ).toString();
+                expect(networkService.post).toHaveBeenCalledWith(
+                  `${relayUrl}/relays/v2/sponsored-call`,
+                  expect.objectContaining({
+                    gasLimit: expectedGasLimit,
+                  }),
+                );
+              });
+
+              it.each([
+                [
+                  'sending ERC-20 tokens to another party',
+                  erc20TransferEncoder().encode(),
+                ],
+                ['cancelling a transaction', '0x' as const],
+                [
+                  'making an addOwnerWithThreshold call',
+                  addOwnerWithThresholdEncoder().encode(),
+                ],
+                [
+                  'making a changeThreshold call',
+                  changeThresholdEncoder().encode(),
+                ],
+                ['making an enableModule call', enableModuleEncoder().encode()],
+                [
+                  'making a disableModule call',
+                  disableModuleEncoder().encode(),
+                ],
+                ['making a removeOwner call', removeOwnerEncoder().encode()],
+                [
+                  'making a setFallbackHandler call',
+                  setFallbackHandlerEncoder().encode(),
+                ],
+                ['making a setGuard call', setGuardEncoder().encode()],
+                ['making a swapOwner call', swapOwnerEncoder().encode()],
+              ])(
+                `should return 201 when %s`,
+                async (_, execTransactionData) => {
+                  const chain = chainBuilder().with('chainId', chainId).build();
+                  const safe = safeBuilder().build();
+                  const data = execTransactionEncoder()
+                    .with('data', execTransactionData)
+                    .encode() as Hex;
+                  const taskId = faker.string.uuid();
+                  networkService.get.mockImplementation((url) => {
+                    switch (url) {
+                      case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                        return Promise.resolve({ data: chain, status: 200 });
+                      case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+                        // Official mastercopy
+                        return Promise.resolve({ data: safe, status: 200 });
+                      default:
+                        fail(`Unexpected URL: ${url}`);
+                    }
+                  });
+                  networkService.post.mockImplementation((url) => {
+                    switch (url) {
+                      case `${relayUrl}/relays/v2/sponsored-call`:
+                        return Promise.resolve({
+                          data: { taskId },
+                          status: 200,
+                        });
+                      default:
+                        fail(`Unexpected URL: ${url}`);
+                    }
+                  });
+
+                  await request(app.getHttpServer())
+                    .post(`/v1/chains/${chain.chainId}/relay`)
+                    .send({
+                      version,
+                      to: safe.address,
+                      data,
+                    })
+                    .expect(201)
+                    .expect({
+                      taskId,
+                    });
+                },
+              );
+
+              it('should return 201 calling execTransaction on a nested Safe', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const data = execTransactionEncoder()
+                  .with('to', safeAddress)
+                  .with('data', execTransactionEncoder().encode())
+                  .encode() as Hex;
+                const taskId = faker.string.uuid();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+                networkService.post.mockImplementation((url) => {
+                  switch (url) {
+                    case `${relayUrl}/relays/v2/sponsored-call`:
+                      return Promise.resolve({ data: { taskId }, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(201)
+                  .expect({
+                    taskId,
+                  });
+              });
+            },
+          );
+        });
+
+        describe('MultiSendCallOnly', () => {
+          describe.each(MULTI_SEND_CALL_ONLY_VERSIONS[chainId])(
+            'v%s multiSend',
+            (version) => {
+              it('should return 201 when entire batch is valid', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const transactions = [
+                  execTransactionEncoder()
+                    .with('data', addOwnerWithThresholdEncoder().encode())
+                    .encode(),
+                  execTransactionEncoder()
+                    .with('data', changeThresholdEncoder().encode())
+                    .encode(),
+                ].map((data) => ({
+                  operation: faker.number.int({ min: 0, max: 1 }),
+                  data,
+                  to: safeAddress,
+                  value: faker.number.bigInt(),
+                }));
+                const data = multiSendEncoder()
+                  .with(
+                    'transactions',
+                    multiSendTransactionsEncoder(transactions),
+                  )
+                  .encode();
+                const to = getMultiSendCallOnlyDeployment({
+                  version,
+                  network: chainId,
+                })!.networkAddresses[chainId];
+                const taskId = faker.string.uuid();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+                networkService.post.mockImplementation((url) => {
+                  switch (url) {
+                    case `${relayUrl}/relays/v2/sponsored-call`:
+                      return Promise.resolve({ data: { taskId }, status: 200 });
                     default:
                       fail(`Unexpected URL: ${url}`);
                   }
@@ -677,566 +400,11 @@ describe('Relay controller', () => {
                     taskId,
                   });
               });
-            }
-          },
-        );
+            },
+          );
 
-        // TODO: Remove when legacy support is removed
-        it.each([
-          [
-            'creating an official Safe',
-            faker.helpers.arrayElement(supportedChainIds),
-            (chainId: string): string =>
-              getSafeSingletonDeployment({
-                version: '1.3.0',
-                network: chainId,
-              })!.networkAddresses[chainId],
-          ],
-          [
-            'creating an official L2 Safe',
-            faker.helpers.arrayElement(supportedChainIds),
-            (chainId: string): string =>
-              getSafeL2SingletonDeployment({
-                version: '1.3.0',
-                network: chainId,
-              })!.networkAddresses[chainId],
-          ],
-        ])(
-          'should otherwise default to version 1.3.0 singletons when %s',
-          async (_, chainId, getSingleton) => {
+          it('should otherwise default to version 1.3.0', async () => {
             const version = '1.3.0';
-            const singleton = getSingleton(chainId);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const owners = [
-              getAddress(faker.finance.ethereumAddress()),
-              getAddress(faker.finance.ethereumAddress()),
-            ];
-            const to = faker.finance.ethereumAddress();
-            const data = createProxyWithNonceEncoder()
-              .with('singleton', getAddress(singleton))
-              .with(
-                'initializer',
-                setupEncoder().with('owners', owners).encode(),
-              )
-              .encode();
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to,
-                data,
-              })
-              .expect(201)
-              .expect({
-                taskId,
-              });
-          },
-        );
-      });
-    });
-
-    describe('Transaction validation', () => {
-      describe('Safe', () => {
-        describe.each(SAFE_VERSIONS)('v%s execTransaction', (version) => {
-          // execTransaction
-          it('should return 422 when sending native currency to self', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const data = execTransactionEncoder()
-              .with('to', safeAddress)
-              .with('value', faker.number.bigInt())
-              .encode() as Hex;
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-              })
-              .expect(422)
-              .expect({
-                message:
-                  'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-                statusCode: 422,
-              });
-          });
-
-          // transfer (execTransaction)
-          it('should return 422 sending ERC-20 tokens to self', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const data = execTransactionEncoder()
-              .with(
-                'data',
-                erc20TransferEncoder().with('to', safeAddress).encode(),
-              )
-              .encode() as Hex;
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-              })
-              .expect(422)
-              .expect({
-                message:
-                  'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-                statusCode: 422,
-              });
-          });
-
-          // Unofficial mastercopy
-          it('should return 422 when the mastercopy is not official', async () => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safeAddress = faker.finance.ethereumAddress();
-            const data = execTransactionEncoder()
-              .with('value', faker.number.bigInt())
-              .encode() as Hex;
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Unofficial mastercopy
-                  return Promise.reject(new Error('Not found'));
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-              })
-              .expect(422)
-              .expect({
-                message: 'Unsupported base contract.',
-                statusCode: 422,
-              });
-          });
-        });
-      });
-
-      describe('MultiSendCallOnly', () => {
-        describe.each(MULTI_SEND_CALL_ONLY_VERSIONS)(
-          'v%s multiSend',
-          (version) => {
-            it('should return 422 when the batch has an invalid transaction', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const safe = safeBuilder().build();
-              const transactions = [
-                execTransactionEncoder().encode(),
-                // Native ERC-20 transfer
-                erc20TransferEncoder().encode(),
-              ].map((data) => ({
-                operation: faker.number.int({ min: 0, max: 1 }),
-                data,
-                to: getAddress(safe.address),
-                value: faker.number.bigInt(),
-              }));
-              const data = multiSendEncoder()
-                .with(
-                  'transactions',
-                  multiSendTransactionsEncoder(transactions),
-                )
-                .encode();
-              const to = getMultiSendCallOnlyDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-                    // Official mastercopy
-                    return Promise.resolve({ data: safe, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-              networkService.post.mockImplementation((url) => {
-                switch (url) {
-                  case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({
-                      data: { taskId },
-                      status: 200,
-                    });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(422)
-                .expect({
-                  message:
-                    'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
-                  statusCode: 422,
-                });
-            });
-
-            it('should return 422 when the mastercopy is not official', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const safe = safeBuilder().build();
-              const safeAddress = getAddress(safe.address);
-              const transactions = [
-                execTransactionEncoder()
-                  .with('data', addOwnerWithThresholdEncoder().encode())
-                  .encode(),
-                execTransactionEncoder()
-                  .with('data', changeThresholdEncoder().encode())
-                  .encode(),
-              ].map((data) => ({
-                operation: faker.number.int({ min: 0, max: 1 }),
-                data,
-                to: safeAddress,
-                value: faker.number.bigInt(),
-              }));
-              const data = multiSendEncoder()
-                .with(
-                  'transactions',
-                  multiSendTransactionsEncoder(transactions),
-                )
-                .encode();
-              const to = getMultiSendCallOnlyDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                    // Unofficial mastercopy
-                    return Promise.reject(new Error('Not found'));
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(422)
-                .expect({
-                  message: 'Unsupported base contract.',
-                  statusCode: 422,
-                });
-            });
-
-            it('should return 422 when the batch is to varying parties', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const safe = safeBuilder().build();
-              const safeAddress = getAddress(safe.address);
-              const otherParty = getAddress(faker.finance.ethereumAddress());
-              const transactions = [
-                execTransactionEncoder().with('to', safeAddress).encode(),
-                execTransactionEncoder().with('to', otherParty).encode(),
-              ].map((data, i) => ({
-                operation: faker.number.int({ min: 0, max: 1 }),
-                data,
-                // Varying parties
-                to: i === 0 ? safeAddress : otherParty,
-                value: faker.number.bigInt(),
-              }));
-              const data = multiSendEncoder()
-                .with(
-                  'transactions',
-                  multiSendTransactionsEncoder(transactions),
-                )
-                .encode();
-              const to = getMultiSendCallOnlyDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                    // Unofficial mastercopy
-                    return Promise.reject(new Error('Not found'));
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(422)
-                .expect({
-                  message:
-                    'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
-                  statusCode: 422,
-                });
-            });
-
-            it('should return 422 for unofficial MultiSend deployments', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const safe = safeBuilder().build();
-              const safeAddress = getAddress(safe.address);
-              const transactions = [
-                execTransactionEncoder()
-                  .with('data', addOwnerWithThresholdEncoder().encode())
-                  .encode(),
-                execTransactionEncoder()
-                  .with('data', changeThresholdEncoder().encode())
-                  .encode(),
-              ].map((data) => ({
-                operation: faker.number.int({ min: 0, max: 1 }),
-                data,
-                to: safeAddress,
-                value: faker.number.bigInt(),
-              }));
-              const data = multiSendEncoder()
-                .with(
-                  'transactions',
-                  multiSendTransactionsEncoder(transactions),
-                )
-                .encode();
-              // Unofficial MultiSend deployment
-              const to = faker.finance.ethereumAddress();
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                    // Official mastercopy
-                    return Promise.resolve({ data: safe, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(422)
-                .expect({
-                  message: 'Unofficial MultiSend contract.',
-                  statusCode: 422,
-                });
-            });
-          },
-        );
-      });
-
-      describe('ProxyFactory', () => {
-        describe.each(PROXY_FACTORY_VERSIONS)(
-          'v%s createProxyWithNonce',
-          (version) => {
-            it('should return 422 creating an unofficial Safe', async () => {
-              const chainId = faker.helpers.arrayElement(supportedChainIds);
-              const chain = chainBuilder().with('chainId', chainId).build();
-              const owners = [
-                getAddress(faker.finance.ethereumAddress()),
-                getAddress(faker.finance.ethereumAddress()),
-              ];
-              const singleton = faker.finance.ethereumAddress();
-              const to = faker.finance.ethereumAddress();
-              const data = createProxyWithNonceEncoder()
-                .with('singleton', getAddress(singleton))
-                .with(
-                  'initializer',
-                  setupEncoder().with('owners', owners).encode(),
-                )
-                .encode();
-              networkService.get.mockImplementation((url) => {
-                switch (url) {
-                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
-                  default:
-                    fail(`Unexpected URL: ${url}`);
-                }
-              });
-
-              await request(app.getHttpServer())
-                .post(`/v1/chains/${chain.chainId}/relay`)
-                .send({
-                  version,
-                  to,
-                  data,
-                })
-                .expect(422)
-                .expect({
-                  message:
-                    'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-                  statusCode: 422,
-                });
-            });
-          },
-        );
-      });
-
-      it('should otherwise return 422', async () => {
-        // Version supported by all contracts
-        const version = '1.3.0';
-        const chainId = faker.helpers.arrayElement(supportedChainIds);
-        const chain = chainBuilder().with('chainId', chainId).build();
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = erc20TransferEncoder().encode();
-        networkService.get.mockImplementation((url) => {
-          switch (url) {
-            case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
-            case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-              // Official mastercopy
-              return Promise.resolve({ data: safe, status: 200 });
-            default:
-              fail(`Unexpected URL: ${url}`);
-          }
-        });
-
-        await request(app.getHttpServer())
-          .post(`/v1/chains/${chain.chainId}/relay`)
-          .send({
-            version,
-            to: safeAddress,
-            data,
-          })
-          .expect(422)
-          .expect({
-            message:
-              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
-            statusCode: 422,
-          });
-      });
-    });
-
-    describe('Rate limiting', () => {
-      describe('Safe', () => {
-        it.each(SAFE_VERSIONS)(
-          'should increment the rate limit counter of v%s execTransaction calls',
-          async (version) => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
-            const chain = chainBuilder().with('chainId', chainId).build();
-            const safe = safeBuilder().build();
-            const safeAddress = getAddress(safe.address);
-            const data = execTransactionEncoder()
-              .with('value', faker.number.bigInt())
-              .encode() as Hex;
-            const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
-              switch (url) {
-                case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                  return Promise.resolve({ data: chain, status: 200 });
-                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-                  // Official mastercopy
-                  return Promise.resolve({ data: safe, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-            networkService.post.mockImplementation((url) => {
-              switch (url) {
-                case `${relayUrl}/relays/v2/sponsored-call`:
-                  return Promise.resolve({ data: { taskId }, status: 200 });
-                default:
-                  fail(`Unexpected URL: ${url}`);
-              }
-            });
-
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                version,
-                to: safeAddress,
-                data,
-              });
-
-            await request(app.getHttpServer())
-              .get(`/v1/chains/${chain.chainId}/relay/${safeAddress}`)
-              .expect(({ body }) => {
-                expect(body).toMatchObject({
-                  remaining: 4,
-                });
-              });
-          },
-        );
-      });
-
-      describe('MultiSendCallOnly', () => {
-        it.each(MULTI_SEND_CALL_ONLY_VERSIONS)(
-          'should increment the rate limit counter of v%s multiSend calls',
-          async (version) => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
             const chain = chainBuilder().with('chainId', chainId).build();
             const safe = safeBuilder().build();
             const safeAddress = getAddress(safe.address);
@@ -1284,50 +452,118 @@ describe('Relay controller', () => {
             await request(app.getHttpServer())
               .post(`/v1/chains/${chain.chainId}/relay`)
               .send({
-                version,
+                // No version
                 to,
                 data,
+              })
+              .expect(201)
+              .expect({
+                taskId,
               });
+          });
+        });
 
-            await request(app.getHttpServer())
-              .get(`/v1/chains/${chain.chainId}/relay/${safeAddress}`)
-              .expect(({ body }) => {
-                expect(body).toMatchObject({
-                  remaining: 4,
+        describe('MultiSend', () => {
+          describe.each(MULTI_SEND_VERSIONS[chainId])(
+            'v%s multiSend',
+            (version) => {
+              it('should return 201 when entire batch is valid', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const transactions = [
+                  execTransactionEncoder()
+                    .with('data', addOwnerWithThresholdEncoder().encode())
+                    .encode(),
+                  execTransactionEncoder()
+                    .with('data', changeThresholdEncoder().encode())
+                    .encode(),
+                ].map((data) => ({
+                  operation: faker.number.int({ min: 0, max: 1 }),
+                  data,
+                  to: safeAddress,
+                  value: faker.number.bigInt(),
+                }));
+                const data = multiSendEncoder()
+                  .with(
+                    'transactions',
+                    multiSendTransactionsEncoder(transactions),
+                  )
+                  .encode();
+                const to = getMultiSendDeployment({
+                  version,
+                  network: chainId,
+                })!.networkAddresses[chainId];
+                const taskId = faker.string.uuid();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
                 });
+                networkService.post.mockImplementation((url) => {
+                  switch (url) {
+                    case `${relayUrl}/relays/v2/sponsored-call`:
+                      return Promise.resolve({ data: { taskId }, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(201)
+                  .expect({
+                    taskId,
+                  });
               });
-          },
-        );
-      });
+            },
+          );
 
-      describe('ProxyFactory', () => {
-        it.each(PROXY_FACTORY_VERSIONS)(
-          'should increment the rate limit counter of the owners of a v%s createProxyWithNonce call',
-          async (version) => {
-            const chainId = faker.helpers.arrayElement(supportedChainIds);
+          // TODO: Remove when legacy support is removed
+          it('should otherwise default to version 1.3.0', async () => {
+            const version = '1.3.0';
             const chain = chainBuilder().with('chainId', chainId).build();
-
-            const owners = [
-              getAddress(faker.finance.ethereumAddress()),
-              getAddress(faker.finance.ethereumAddress()),
-            ];
-            const singleton = getSafeSingletonDeployment({
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const transactions = [
+              execTransactionEncoder()
+                .with('data', addOwnerWithThresholdEncoder().encode())
+                .encode(),
+              execTransactionEncoder()
+                .with('data', changeThresholdEncoder().encode())
+                .encode(),
+            ].map((data) => ({
+              operation: faker.number.int({ min: 0, max: 1 }),
+              data,
+              to: safeAddress,
+              value: faker.number.bigInt(),
+            }));
+            const data = multiSendEncoder()
+              .with('transactions', multiSendTransactionsEncoder(transactions))
+              .encode();
+            const to = getMultiSendDeployment({
               version,
               network: chainId,
             })!.networkAddresses[chainId];
-            const to = faker.finance.ethereumAddress();
-            const data = createProxyWithNonceEncoder()
-              .with('singleton', getAddress(singleton))
-              .with(
-                'initializer',
-                setupEncoder().with('owners', owners).encode(),
-              )
-              .encode();
             const taskId = faker.string.uuid();
             networkService.get.mockImplementation((url) => {
               switch (url) {
                 case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                   return Promise.resolve({ data: chain, status: 200 });
+                case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                  // Official mastercopy
+                  return Promise.resolve({ data: safe, status: 200 });
                 default:
                   fail(`Unexpected URL: ${url}`);
               }
@@ -1344,95 +580,965 @@ describe('Relay controller', () => {
             await request(app.getHttpServer())
               .post(`/v1/chains/${chain.chainId}/relay`)
               .send({
-                version,
+                // No version
                 to,
                 data,
+              })
+              .expect(201)
+              .expect({
+                taskId,
+              });
+          });
+        });
+
+        describe('ProxyFactory', () => {
+          describe.each(PROXY_FACTORY_VERSIONS[chainId])(
+            'v%s createProxyWithNonce',
+            (version) => {
+              it('should return the limit addresses when creating an official Safe', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const owners = [
+                  getAddress(faker.finance.ethereumAddress()),
+                  getAddress(faker.finance.ethereumAddress()),
+                ];
+                const singleton = getSafeSingletonDeployment({
+                  version,
+                  network: chainId,
+                })!.networkAddresses[chainId];
+                const to = faker.finance.ethereumAddress();
+                const data = createProxyWithNonceEncoder()
+                  .with('singleton', getAddress(singleton))
+                  .with(
+                    'initializer',
+                    setupEncoder().with('owners', owners).encode(),
+                  )
+                  .encode();
+                const taskId = faker.string.uuid();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+                networkService.post.mockImplementation((url) => {
+                  switch (url) {
+                    case `${relayUrl}/relays/v2/sponsored-call`:
+                      return Promise.resolve({ data: { taskId }, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(201)
+                  .expect({
+                    taskId,
+                  });
               });
 
-            for (const owner of owners) {
+              if (SAFE_L2_VERSIONS[chainId].includes(version)) {
+                it('should return the limit addresses when creating an official L2 Safe', async () => {
+                  const chain = chainBuilder().with('chainId', chainId).build();
+                  const owners = [
+                    getAddress(faker.finance.ethereumAddress()),
+                    getAddress(faker.finance.ethereumAddress()),
+                  ];
+                  const singleton = getSafeL2SingletonDeployment({
+                    version,
+                    network: chainId,
+                  })!.networkAddresses[chainId];
+                  const to = faker.finance.ethereumAddress();
+                  const data = createProxyWithNonceEncoder()
+                    .with('singleton', getAddress(singleton))
+                    .with(
+                      'initializer',
+                      setupEncoder().with('owners', owners).encode(),
+                    )
+                    .encode();
+                  const taskId = faker.string.uuid();
+                  networkService.get.mockImplementation((url) => {
+                    switch (url) {
+                      case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                        return Promise.resolve({ data: chain, status: 200 });
+                      default:
+                        fail(`Unexpected URL: ${url}`);
+                    }
+                  });
+                  networkService.post.mockImplementation((url) => {
+                    switch (url) {
+                      case `${relayUrl}/relays/v2/sponsored-call`:
+                        return Promise.resolve({
+                          data: { taskId },
+                          status: 200,
+                        });
+                      default:
+                        fail(`Unexpected URL: ${url}`);
+                    }
+                  });
+
+                  await request(app.getHttpServer())
+                    .post(`/v1/chains/${chain.chainId}/relay`)
+                    .send({
+                      version,
+                      to,
+                      data,
+                    })
+                    .expect(201)
+                    .expect({
+                      taskId,
+                    });
+                });
+              }
+            },
+          );
+
+          // TODO: Remove when legacy support is removed
+          it.each([
+            [
+              'creating an official Safe',
+              faker.helpers.arrayElement(supportedChainIds),
+              (chainId: string): string =>
+                getSafeSingletonDeployment({
+                  version: '1.3.0',
+                  network: chainId,
+                })!.networkAddresses[chainId],
+            ],
+            [
+              'creating an official L2 Safe',
+              faker.helpers.arrayElement(supportedChainIds),
+              (chainId: string): string =>
+                getSafeL2SingletonDeployment({
+                  version: '1.3.0',
+                  network: chainId,
+                })!.networkAddresses[chainId],
+            ],
+          ])(
+            'should otherwise default to version 1.3.0 singletons when %s',
+            async (_, chainId, getSingleton) => {
+              const version = '1.3.0';
+              const singleton = getSingleton(chainId);
+              const chain = chainBuilder().with('chainId', chainId).build();
+              const owners = [
+                getAddress(faker.finance.ethereumAddress()),
+                getAddress(faker.finance.ethereumAddress()),
+              ];
+              const to = faker.finance.ethereumAddress();
+              const data = createProxyWithNonceEncoder()
+                .with('singleton', getAddress(singleton))
+                .with(
+                  'initializer',
+                  setupEncoder().with('owners', owners).encode(),
+                )
+                .encode();
+              const taskId = faker.string.uuid();
+              networkService.get.mockImplementation((url) => {
+                switch (url) {
+                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                    return Promise.resolve({ data: chain, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+              networkService.post.mockImplementation((url) => {
+                switch (url) {
+                  case `${relayUrl}/relays/v2/sponsored-call`:
+                    return Promise.resolve({ data: { taskId }, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+
               await request(app.getHttpServer())
-                .get(`/v1/chains/${chain.chainId}/relay/${owner}`)
+                .post(`/v1/chains/${chain.chainId}/relay`)
+                .send({
+                  version,
+                  to,
+                  data,
+                })
+                .expect(201)
+                .expect({
+                  taskId,
+                });
+            },
+          );
+        });
+      });
+
+      describe('Transaction validation', () => {
+        describe('Safe', () => {
+          describe.each(SAFE_VERSIONS[chainId])(
+            'v%s execTransaction',
+            (version) => {
+              // execTransaction
+              it('should return 422 when sending native currency to self', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const data = execTransactionEncoder()
+                  .with('to', safeAddress)
+                  .with('value', faker.number.bigInt())
+                  .encode() as Hex;
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                    statusCode: 422,
+                  });
+              });
+
+              // transfer (execTransaction)
+              it('should return 422 sending ERC-20 tokens to self', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const data = execTransactionEncoder()
+                  .with(
+                    'data',
+                    erc20TransferEncoder().with('to', safeAddress).encode(),
+                  )
+                  .encode() as Hex;
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                    statusCode: 422,
+                  });
+              });
+
+              // Unofficial mastercopy
+              it('should return 422 when the mastercopy is not official', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safeAddress = faker.finance.ethereumAddress();
+                const data = execTransactionEncoder()
+                  .with('value', faker.number.bigInt())
+                  .encode() as Hex;
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Unofficial mastercopy
+                      return Promise.reject(new Error('Not found'));
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message: 'Unsupported base contract.',
+                    statusCode: 422,
+                  });
+              });
+            },
+          );
+        });
+
+        describe('MultiSendCallOnly', () => {
+          describe.each(MULTI_SEND_CALL_ONLY_VERSIONS[chainId])(
+            'v%s multiSend',
+            (version) => {
+              it('should return 422 when the batch has an invalid transaction', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const transactions = [
+                  execTransactionEncoder().encode(),
+                  // Native ERC-20 transfer
+                  erc20TransferEncoder().encode(),
+                ].map((data) => ({
+                  operation: faker.number.int({ min: 0, max: 1 }),
+                  data,
+                  to: getAddress(safe.address),
+                  value: faker.number.bigInt(),
+                }));
+                const data = multiSendEncoder()
+                  .with(
+                    'transactions',
+                    multiSendTransactionsEncoder(transactions),
+                  )
+                  .encode();
+                const to = getMultiSendCallOnlyDeployment({
+                  version,
+                  network: chainId,
+                })!.networkAddresses[chainId];
+                const taskId = faker.string.uuid();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+                networkService.post.mockImplementation((url) => {
+                  switch (url) {
+                    case `${relayUrl}/relays/v2/sponsored-call`:
+                      return Promise.resolve({
+                        data: { taskId },
+                        status: 200,
+                      });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
+                    statusCode: 422,
+                  });
+              });
+
+              it('should return 422 when the mastercopy is not official', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const transactions = [
+                  execTransactionEncoder()
+                    .with('data', addOwnerWithThresholdEncoder().encode())
+                    .encode(),
+                  execTransactionEncoder()
+                    .with('data', changeThresholdEncoder().encode())
+                    .encode(),
+                ].map((data) => ({
+                  operation: faker.number.int({ min: 0, max: 1 }),
+                  data,
+                  to: safeAddress,
+                  value: faker.number.bigInt(),
+                }));
+                const data = multiSendEncoder()
+                  .with(
+                    'transactions',
+                    multiSendTransactionsEncoder(transactions),
+                  )
+                  .encode();
+                const to = getMultiSendCallOnlyDeployment({
+                  version,
+                  network: chainId,
+                })!.networkAddresses[chainId];
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Unofficial mastercopy
+                      return Promise.reject(new Error('Not found'));
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message: 'Unsupported base contract.',
+                    statusCode: 422,
+                  });
+              });
+
+              it('should return 422 when the batch is to varying parties', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const otherParty = getAddress(faker.finance.ethereumAddress());
+                const transactions = [
+                  execTransactionEncoder().with('to', safeAddress).encode(),
+                  execTransactionEncoder().with('to', otherParty).encode(),
+                ].map((data, i) => ({
+                  operation: faker.number.int({ min: 0, max: 1 }),
+                  data,
+                  // Varying parties
+                  to: i === 0 ? safeAddress : otherParty,
+                  value: faker.number.bigInt(),
+                }));
+                const data = multiSendEncoder()
+                  .with(
+                    'transactions',
+                    multiSendTransactionsEncoder(transactions),
+                  )
+                  .encode();
+                const to = getMultiSendCallOnlyDeployment({
+                  version,
+                  network: chainId,
+                })!.networkAddresses[chainId];
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Unofficial mastercopy
+                      return Promise.reject(new Error('Not found'));
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
+                    statusCode: 422,
+                  });
+              });
+
+              it('should return 422 for unofficial MultiSend deployments', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const transactions = [
+                  execTransactionEncoder()
+                    .with('data', addOwnerWithThresholdEncoder().encode())
+                    .encode(),
+                  execTransactionEncoder()
+                    .with('data', changeThresholdEncoder().encode())
+                    .encode(),
+                ].map((data) => ({
+                  operation: faker.number.int({ min: 0, max: 1 }),
+                  data,
+                  to: safeAddress,
+                  value: faker.number.bigInt(),
+                }));
+                const data = multiSendEncoder()
+                  .with(
+                    'transactions',
+                    multiSendTransactionsEncoder(transactions),
+                  )
+                  .encode();
+                // Unofficial MultiSend deployment
+                const to = faker.finance.ethereumAddress();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message: 'Unofficial MultiSend contract.',
+                    statusCode: 422,
+                  });
+              });
+            },
+          );
+        });
+
+        describe('ProxyFactory', () => {
+          describe.each(PROXY_FACTORY_VERSIONS[chainId])(
+            'v%s createProxyWithNonce',
+            (version) => {
+              it('should return 422 creating an unofficial Safe', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const owners = [
+                  getAddress(faker.finance.ethereumAddress()),
+                  getAddress(faker.finance.ethereumAddress()),
+                ];
+                const singleton = faker.finance.ethereumAddress();
+                const to = faker.finance.ethereumAddress();
+                const data = createProxyWithNonceEncoder()
+                  .with('singleton', getAddress(singleton))
+                  .with(
+                    'initializer',
+                    setupEncoder().with('owners', owners).encode(),
+                  )
+                  .encode();
+                networkService.get.mockImplementation((url) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    default:
+                      fail(`Unexpected URL: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                    statusCode: 422,
+                  });
+              });
+            },
+          );
+        });
+
+        it('should otherwise return 422', async () => {
+          // Version supported by all contracts
+          const version = '1.3.0';
+          const chain = chainBuilder().with('chainId', chainId).build();
+          const safe = safeBuilder().build();
+          const safeAddress = getAddress(safe.address);
+          const data = erc20TransferEncoder().encode();
+          networkService.get.mockImplementation((url) => {
+            switch (url) {
+              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                return Promise.resolve({ data: chain, status: 200 });
+              case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                // Official mastercopy
+                return Promise.resolve({ data: safe, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
+            }
+          });
+
+          await request(app.getHttpServer())
+            .post(`/v1/chains/${chain.chainId}/relay`)
+            .send({
+              version,
+              to: safeAddress,
+              data,
+            })
+            .expect(422)
+            .expect({
+              message:
+                'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+              statusCode: 422,
+            });
+        });
+      });
+
+      describe('Rate limiting', () => {
+        describe('Safe', () => {
+          it.each(SAFE_VERSIONS[chainId])(
+            'should increment the rate limit counter of v%s execTransaction calls',
+            async (version) => {
+              const chain = chainBuilder().with('chainId', chainId).build();
+              const safe = safeBuilder().build();
+              const safeAddress = getAddress(safe.address);
+              const data = execTransactionEncoder()
+                .with('value', faker.number.bigInt())
+                .encode() as Hex;
+              const taskId = faker.string.uuid();
+              networkService.get.mockImplementation((url) => {
+                switch (url) {
+                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                    return Promise.resolve({ data: chain, status: 200 });
+                  case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                    // Official mastercopy
+                    return Promise.resolve({ data: safe, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+              networkService.post.mockImplementation((url) => {
+                switch (url) {
+                  case `${relayUrl}/relays/v2/sponsored-call`:
+                    return Promise.resolve({ data: { taskId }, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+
+              await request(app.getHttpServer())
+                .post(`/v1/chains/${chain.chainId}/relay`)
+                .send({
+                  version,
+                  to: safeAddress,
+                  data,
+                });
+
+              await request(app.getHttpServer())
+                .get(`/v1/chains/${chain.chainId}/relay/${safeAddress}`)
                 .expect(({ body }) => {
                   expect(body).toMatchObject({
                     remaining: 4,
                   });
                 });
+            },
+          );
+        });
+
+        describe('MultiSendCallOnly', () => {
+          it.each(MULTI_SEND_CALL_ONLY_VERSIONS[chainId])(
+            'should increment the rate limit counter of v%s multiSend calls',
+            async (version) => {
+              const chain = chainBuilder().with('chainId', chainId).build();
+              const safe = safeBuilder().build();
+              const safeAddress = getAddress(safe.address);
+              const transactions = [
+                execTransactionEncoder()
+                  .with('data', addOwnerWithThresholdEncoder().encode())
+                  .encode(),
+                execTransactionEncoder()
+                  .with('data', changeThresholdEncoder().encode())
+                  .encode(),
+              ].map((data) => ({
+                operation: faker.number.int({ min: 0, max: 1 }),
+                data,
+                to: safeAddress,
+                value: faker.number.bigInt(),
+              }));
+              const data = multiSendEncoder()
+                .with(
+                  'transactions',
+                  multiSendTransactionsEncoder(transactions),
+                )
+                .encode();
+              const to = getMultiSendCallOnlyDeployment({
+                version,
+                network: chainId,
+              })!.networkAddresses[chainId];
+              const taskId = faker.string.uuid();
+              networkService.get.mockImplementation((url) => {
+                switch (url) {
+                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                    return Promise.resolve({ data: chain, status: 200 });
+                  case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                    // Official mastercopy
+                    return Promise.resolve({ data: safe, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+              networkService.post.mockImplementation((url) => {
+                switch (url) {
+                  case `${relayUrl}/relays/v2/sponsored-call`:
+                    return Promise.resolve({ data: { taskId }, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+
+              await request(app.getHttpServer())
+                .post(`/v1/chains/${chain.chainId}/relay`)
+                .send({
+                  version,
+                  to,
+                  data,
+                });
+
+              await request(app.getHttpServer())
+                .get(`/v1/chains/${chain.chainId}/relay/${safeAddress}`)
+                .expect(({ body }) => {
+                  expect(body).toMatchObject({
+                    remaining: 4,
+                  });
+                });
+            },
+          );
+        });
+
+        describe('ProxyFactory', () => {
+          it.each(PROXY_FACTORY_VERSIONS[chainId])(
+            'should increment the rate limit counter of the owners of a v%s createProxyWithNonce call',
+            async (version) => {
+              const chain = chainBuilder().with('chainId', chainId).build();
+
+              const owners = [
+                getAddress(faker.finance.ethereumAddress()),
+                getAddress(faker.finance.ethereumAddress()),
+              ];
+              const singleton = getSafeSingletonDeployment({
+                version,
+                network: chainId,
+              })!.networkAddresses[chainId];
+              const to = faker.finance.ethereumAddress();
+              const data = createProxyWithNonceEncoder()
+                .with('singleton', getAddress(singleton))
+                .with(
+                  'initializer',
+                  setupEncoder().with('owners', owners).encode(),
+                )
+                .encode();
+              const taskId = faker.string.uuid();
+              networkService.get.mockImplementation((url) => {
+                switch (url) {
+                  case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                    return Promise.resolve({ data: chain, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+              networkService.post.mockImplementation((url) => {
+                switch (url) {
+                  case `${relayUrl}/relays/v2/sponsored-call`:
+                    return Promise.resolve({ data: { taskId }, status: 200 });
+                  default:
+                    fail(`Unexpected URL: ${url}`);
+                }
+              });
+
+              await request(app.getHttpServer())
+                .post(`/v1/chains/${chain.chainId}/relay`)
+                .send({
+                  version,
+                  to,
+                  data,
+                });
+
+              for (const owner of owners) {
+                await request(app.getHttpServer())
+                  .get(`/v1/chains/${chain.chainId}/relay/${owner}`)
+                  .expect(({ body }) => {
+                    expect(body).toMatchObject({
+                      remaining: 4,
+                    });
+                  });
+              }
+            },
+          );
+        });
+
+        it('should handle both checksummed and non-checksummed addresses', async () => {
+          const chain = chainBuilder().with('chainId', chainId).build();
+          const safe = safeBuilder().build();
+          const nonChecksummedAddress = safe.address.toLowerCase();
+          const checksummedSafeAddress = getAddress(safe.address);
+          const data = execTransactionEncoder()
+            .with('value', faker.number.bigInt())
+            .encode() as Hex;
+          const taskId = faker.string.uuid();
+          networkService.get.mockImplementation((url) => {
+            switch (url) {
+              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                return Promise.resolve({ data: chain, status: 200 });
+              case `${chain.transactionService}/api/v1/safes/${nonChecksummedAddress}`:
+              case `${chain.transactionService}/api/v1/safes/${checksummedSafeAddress}`:
+                // Official mastercopy
+                return Promise.resolve({ data: safe, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
             }
-          },
-        );
-      });
+          });
+          networkService.post.mockImplementation((url) => {
+            switch (url) {
+              case `${relayUrl}/relays/v2/sponsored-call`:
+                return Promise.resolve({ data: { taskId }, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
+            }
+          });
 
-      it('should handle both checksummed and non-checksummed addresses', async () => {
-        const chainId = faker.helpers.arrayElement(supportedChainIds);
-        const chain = chainBuilder().with('chainId', chainId).build();
-        const safe = safeBuilder().build();
-        const nonChecksummedAddress = safe.address.toLowerCase();
-        const checksummedSafeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('value', faker.number.bigInt())
-          .encode() as Hex;
-        const taskId = faker.string.uuid();
-        networkService.get.mockImplementation((url) => {
-          switch (url) {
-            case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
-            case `${chain.transactionService}/api/v1/safes/${nonChecksummedAddress}`:
-            case `${chain.transactionService}/api/v1/safes/${checksummedSafeAddress}`:
-              // Official mastercopy
-              return Promise.resolve({ data: safe, status: 200 });
-            default:
-              fail(`Unexpected URL: ${url}`);
+          for (const address of [
+            nonChecksummedAddress,
+            checksummedSafeAddress,
+          ]) {
+            await request(app.getHttpServer())
+              .post(`/v1/chains/${chain.chainId}/relay`)
+              .send({
+                to: address,
+                data,
+              });
           }
-        });
-        networkService.post.mockImplementation((url) => {
-          switch (url) {
-            case `${relayUrl}/relays/v2/sponsored-call`:
-              return Promise.resolve({ data: { taskId }, status: 200 });
-            default:
-              fail(`Unexpected URL: ${url}`);
-          }
+
+          await request(app.getHttpServer())
+            .get(`/v1/chains/${chain.chainId}/relay/${nonChecksummedAddress}`)
+            .expect(({ body }) => {
+              expect(body).toMatchObject({
+                remaining: 3,
+              });
+            });
+          await request(app.getHttpServer())
+            .get(`/v1/chains/${chain.chainId}/relay/${checksummedSafeAddress}`)
+            .expect(({ body }) => {
+              expect(body).toMatchObject({
+                remaining: 3,
+              });
+            });
         });
 
-        for (const address of [nonChecksummedAddress, checksummedSafeAddress]) {
+        it('should not rate limit the same address on different chains', async () => {
+          const differentChainId = faker.string.numeric({ exclude: chainId });
+          const chain = chainBuilder().with('chainId', chainId).build();
+          const safe = safeBuilder().build();
+          const safeAddress = getAddress(safe.address);
+          const data = execTransactionEncoder()
+            .with('value', faker.number.bigInt())
+            .encode() as Hex;
+          const taskId = faker.string.uuid();
+          networkService.get.mockImplementation((url) => {
+            switch (url) {
+              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                return Promise.resolve({ data: chain, status: 200 });
+              case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                // Official mastercopy
+                return Promise.resolve({ data: safe, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
+            }
+          });
+          networkService.post.mockImplementation((url) => {
+            switch (url) {
+              case `${relayUrl}/relays/v2/sponsored-call`:
+                return Promise.resolve({ data: { taskId }, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
+            }
+          });
+
           await request(app.getHttpServer())
             .post(`/v1/chains/${chain.chainId}/relay`)
             .send({
-              to: address,
+              to: safeAddress,
               data,
             });
-        }
 
-        await request(app.getHttpServer())
-          .get(`/v1/chains/${chain.chainId}/relay/${nonChecksummedAddress}`)
-          .expect(({ body }) => {
-            expect(body).toMatchObject({
-              remaining: 3,
+          await request(app.getHttpServer())
+            .get(`/v1/chains/${differentChainId}/relay/${safeAddress}`)
+            .expect(({ body }) => {
+              expect(body).toMatchObject({
+                remaining: 5,
+              });
             });
+        });
+
+        it('should return 429 if the rate limit is reached', async () => {
+          const chain = chainBuilder().with('chainId', chainId).build();
+          const safe = safeBuilder().build();
+          const safeAddress = getAddress(safe.address);
+          const data = execTransactionEncoder()
+            .with('value', faker.number.bigInt())
+            .encode() as Hex;
+          const taskId = faker.string.uuid();
+          networkService.get.mockImplementation((url) => {
+            switch (url) {
+              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                return Promise.resolve({ data: chain, status: 200 });
+              case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                // Official mastercopy
+                return Promise.resolve({ data: safe, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
+            }
           });
-        await request(app.getHttpServer())
-          .get(`/v1/chains/${chain.chainId}/relay/${checksummedSafeAddress}`)
-          .expect(({ body }) => {
-            expect(body).toMatchObject({
-              remaining: 3,
+          networkService.post.mockImplementation((url) => {
+            switch (url) {
+              case `${relayUrl}/relays/v2/sponsored-call`:
+                return Promise.resolve({ data: { taskId }, status: 200 });
+              default:
+                fail(`Unexpected URL: ${url}`);
+            }
+          });
+
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          for (const _ of Array.from({ length: 5 })) {
+            await request(app.getHttpServer())
+              .post(`/v1/chains/${chain.chainId}/relay`)
+              .send({
+                to: safeAddress,
+                data,
+              });
+          }
+
+          await request(app.getHttpServer())
+            .post(`/v1/chains/${chain.chainId}/relay`)
+            .send({
+              to: safeAddress,
+              data,
+            })
+            .expect(429)
+            .expect({
+              message: `Relay limit reached for ${safeAddress}`,
+              statusCode: 429,
             });
-          });
+        });
       });
 
-      it('should not rate limit the same address on different chains', async () => {
-        const chainId = faker.helpers.arrayElement(supportedChainIds);
-        const differentChainId = faker.string.numeric({ exclude: chainId });
+      it('should return 503 if the relayer throws', async () => {
         const chain = chainBuilder().with('chainId', chainId).build();
         const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder()
-          .with('value', faker.number.bigInt())
-          .encode() as Hex;
-        const taskId = faker.string.uuid();
+        const data = execTransactionEncoder().encode() as Hex;
         networkService.get.mockImplementation((url) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
-            case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+            case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               // Official mastercopy
               return Promise.resolve({ data: safe, status: 200 });
             default:
@@ -1442,7 +1548,7 @@ describe('Relay controller', () => {
         networkService.post.mockImplementation((url) => {
           switch (url) {
             case `${relayUrl}/relays/v2/sponsored-call`:
-              return Promise.resolve({ data: { taskId }, status: 200 });
+              return Promise.reject(new Error('Relayer error'));
             default:
               fail(`Unexpected URL: ${url}`);
           }
@@ -1451,21 +1557,23 @@ describe('Relay controller', () => {
         await request(app.getHttpServer())
           .post(`/v1/chains/${chain.chainId}/relay`)
           .send({
-            to: safeAddress,
+            to: safe.address,
             data,
-          });
+          })
+          .expect(503);
+      });
+    });
 
+    describe('GET /v1/chains/:chainId/relay/:safeAddress', () => {
+      it('should return the limit and remaining relay attempts', async () => {
+        const safeAddress = faker.finance.ethereumAddress();
         await request(app.getHttpServer())
-          .get(`/v1/chains/${differentChainId}/relay/${safeAddress}`)
-          .expect(({ body }) => {
-            expect(body).toMatchObject({
-              remaining: 5,
-            });
-          });
+          .get(`/v1/chains/${chainId}/relay/${safeAddress}`)
+          .expect(200)
+          .expect({ remaining: 5, limit: 5 });
       });
 
-      it('should return 429 if the rate limit is reached', async () => {
-        const chainId = faker.helpers.arrayElement(supportedChainIds);
+      it('should not return negative limits if more requests were made than the limit', async () => {
         const chain = chainBuilder().with('chainId', chainId).build();
         const safe = safeBuilder().build();
         const safeAddress = getAddress(safe.address);
@@ -1494,7 +1602,7 @@ describe('Relay controller', () => {
         });
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const _ of Array.from({ length: 5 })) {
+        for (const _ of Array.from({ length: 6 })) {
           await request(app.getHttpServer())
             .post(`/v1/chains/${chain.chainId}/relay`)
             .send({
@@ -1504,111 +1612,14 @@ describe('Relay controller', () => {
         }
 
         await request(app.getHttpServer())
-          .post(`/v1/chains/${chain.chainId}/relay`)
-          .send({
-            to: safeAddress,
-            data,
-          })
-          .expect(429)
+          .get(`/v1/chains/${chain.chainId}/relay/${safeAddress}`)
+          .expect(200)
           .expect({
-            message: `Relay limit reached for ${safeAddress}`,
-            statusCode: 429,
+            // Not negative
+            remaining: 0,
+            limit: 5,
           });
       });
-    });
-
-    it('should return 503 if the relayer throws', async () => {
-      const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const chain = chainBuilder().with('chainId', chainId).build();
-      const safe = safeBuilder().build();
-      const data = execTransactionEncoder().encode() as Hex;
-      networkService.get.mockImplementation((url) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
-          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            // Official mastercopy
-            return Promise.resolve({ data: safe, status: 200 });
-          default:
-            fail(`Unexpected URL: ${url}`);
-        }
-      });
-      networkService.post.mockImplementation((url) => {
-        switch (url) {
-          case `${relayUrl}/relays/v2/sponsored-call`:
-            return Promise.reject(new Error('Relayer error'));
-          default:
-            fail(`Unexpected URL: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .post(`/v1/chains/${chain.chainId}/relay`)
-        .send({
-          to: safe.address,
-          data,
-        })
-        .expect(503);
-    });
-  });
-
-  describe('GET /v1/chains/:chainId/relay/:safeAddress', () => {
-    it('should return the limit and remaining relay attempts', async () => {
-      const chainId = faker.string.numeric();
-      const safeAddress = faker.finance.ethereumAddress();
-      await request(app.getHttpServer())
-        .get(`/v1/chains/${chainId}/relay/${safeAddress}`)
-        .expect(200)
-        .expect({ remaining: 5, limit: 5 });
-    });
-
-    it('should not return negative limits if more requests were made than the limit', async () => {
-      const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const chain = chainBuilder().with('chainId', chainId).build();
-      const safe = safeBuilder().build();
-      const safeAddress = getAddress(safe.address);
-      const data = execTransactionEncoder()
-        .with('value', faker.number.bigInt())
-        .encode() as Hex;
-      const taskId = faker.string.uuid();
-      networkService.get.mockImplementation((url) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
-          case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-            // Official mastercopy
-            return Promise.resolve({ data: safe, status: 200 });
-          default:
-            fail(`Unexpected URL: ${url}`);
-        }
-      });
-      networkService.post.mockImplementation((url) => {
-        switch (url) {
-          case `${relayUrl}/relays/v2/sponsored-call`:
-            return Promise.resolve({ data: { taskId }, status: 200 });
-          default:
-            fail(`Unexpected URL: ${url}`);
-        }
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const _ of Array.from({ length: 6 })) {
-        await request(app.getHttpServer())
-          .post(`/v1/chains/${chain.chainId}/relay`)
-          .send({
-            to: safeAddress,
-            data,
-          });
-      }
-
-      await request(app.getHttpServer())
-        .get(`/v1/chains/${chain.chainId}/relay/${safeAddress}`)
-        .expect(200)
-        .expect({
-          // Not negative
-          remaining: 0,
-          limit: 5,
-        });
     });
   });
 });

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -58,7 +58,14 @@ describe('Relay controller', () => {
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let safeConfigUrl: string;
   let relayUrl: string;
-  const supportedChainIds = Object.keys(configuration().relay.apiKey);
+
+  // Remove Sepolia from tests as only >=1.3.0 are deployed there
+  const supportedChainIds = Object.keys(configuration().relay.apiKey).filter(
+    (chainId) => {
+      const sepoliaChainId = '11155111';
+      return chainId !== sepoliaChainId;
+    },
+  );
 
   beforeEach(async () => {
     jest.resetAllMocks();

--- a/src/routes/relay/relay.legacy.controller.spec.ts
+++ b/src/routes/relay/relay.legacy.controller.spec.ts
@@ -16,7 +16,14 @@ import { faker } from '@faker-js/faker';
 
 describe('Relay controller', () => {
   let app: INestApplication;
-  const supportedChainIds = Object.keys(configuration().relay.apiKey);
+
+  // Remove Sepolia from tests as only >=1.3.0 are deployed there
+  const supportedChainIds = Object.keys(configuration().relay.apiKey).filter(
+    (chainId) => {
+      const sepoliaChainId = '11155111';
+      return chainId !== sepoliaChainId;
+    },
+  );
 
   beforeEach(async () => {
     jest.resetAllMocks();


### PR DESCRIPTION
This adds a chain-contract version map for each relevant contract and loops over the relay tests accordingly.