### PR TITLE
Make Page count property nullable

### DIFF
--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -136,7 +136,7 @@ export class ZerionBalancesApi implements IBalancesApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
 
-      // TODO: Zerion does not provide the items count. Change the Page entity to make count attribute nullable.
+      // TODO: Zerion does not provide the items count. Change this value to null when count attribute becomes nullable.
       // Zerion does not provide a "previous" cursor.
       return {
         count: zerionCollectibles.data.length,

--- a/src/domain/entities/page.entity.ts
+++ b/src/domain/entities/page.entity.ts
@@ -1,5 +1,5 @@
 export interface Page<T> {
-  count: number;
+  count: number | null;
   next: string | null;
   previous: string | null;
   results: T[];

--- a/src/routes/common/entities/page.entity.ts
+++ b/src/routes/common/entities/page.entity.ts
@@ -16,10 +16,11 @@ import { Page as DomainPage } from '@/domain/entities/page.entity';
  */
 export abstract class Page<T> implements DomainPage<T> {
   @ApiProperty()
-  count!: number;
   // ApiPropertyOptional without any options
   // does not work with unions with null
   // see https://github.com/nestjs/swagger/issues/2129
+  @ApiPropertyOptional({ type: Number, nullable: true })
+  count!: number | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   next!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })

--- a/src/routes/common/pagination/pagination.data.ts
+++ b/src/routes/common/pagination/pagination.data.ts
@@ -69,11 +69,11 @@ export class PaginationData {
  */
 export function buildNextPageURL(
   base: Readonly<URL | string>,
-  itemsCount: number,
+  itemsCount: number | null,
 ): Readonly<URL> | null {
   const baseUrl = new URL(base);
   const { limit, offset } = PaginationData.fromCursor(baseUrl);
-  const hasNext = limit + offset < itemsCount;
+  const hasNext = itemsCount && limit + offset < itemsCount;
   return hasNext
     ? setCursor(baseUrl, new PaginationData(limit, limit + offset))
     : null;


### PR DESCRIPTION
### Summary
Some data providers (e.g.: Safe Transaction Service) provide a `count` attribute within the response payload when requesting a `Page` of data. This attribute is used in the CGW to build the `next` cursor attribute.

But some other providers don't provide this `count` (e.g.: Zerion). In order to bypass this limitation, the CGW was returning the amount of items on the page, but this is not correct (see https://github.com/safe-global/safe-client-gateway/blob/18f400dee910866e3be482595159a23a226b1c0d/src/datasources/balances-api/zerion-balances-api.service.ts#L142).

### Changes
- Allows `null` values on `Page.count` attribute.