### PR TITLE
Fix Zerion collectibles count attribute

### DIFF
--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -136,10 +136,10 @@ export class ZerionBalancesApi implements IBalancesApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
 
-      // TODO: Zerion does not provide the items count. Change this value to null when count attribute becomes nullable.
+      // Zerion does not provide the items count.
       // Zerion does not provide a "previous" cursor.
       return {
-        count: zerionCollectibles.data.length,
+        count: null,
         next: this._decodeZerionPagination(zerionCollectibles.links.next ?? ''),
         previous: null,
         results: this._mapCollectibles(zerionCollectibles.data),

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -142,7 +142,7 @@ describe('Zerion Collectibles Controller', () => {
           .expect(200)
           .expect(({ body }) => {
             expect(body).toMatchObject({
-              count: zerionApiCollectiblesResponse.data.length,
+              count: null,
               next: expect.any(String),
               previous: null,
               results: [
@@ -282,7 +282,7 @@ describe('Zerion Collectibles Controller', () => {
           .expect(200)
           .expect(({ body }) => {
             expect(body).toMatchObject({
-              count: zerionApiCollectiblesResponse.data.length,
+              count: null,
               next: expect.stringContaining(expectedNext),
               previous: null,
               results: expect.any(Array),
@@ -345,7 +345,7 @@ describe('Zerion Collectibles Controller', () => {
           .expect(200)
           .expect(({ body }) => {
             expect(body).toMatchObject({
-              count: zerionApiCollectiblesResponse.data.length,
+              count: null,
               next: expect.stringContaining(expectedNext),
               previous: null,
               results: expect.any(Array),
@@ -407,7 +407,7 @@ describe('Zerion Collectibles Controller', () => {
           .expect(200)
           .expect(({ body }) => {
             expect(body).toMatchObject({
-              count: zerionApiCollectiblesResponse.data.length,
+              count: null,
               next: expect.stringContaining(expectedNext),
               previous: null,
               results: expect.any(Array),


### PR DESCRIPTION
Depends on #1192 

### Summary
This PR fixes the `count` attribute for Zerion's collectibles retrieval. Since the Zerion API embraces an _infinite scroll_ cursor strategy, it does not provide either `count` or `previous`. Since the CGW was not allowing `null` values for `count`, before #1192 we couldn't use a property value for the `count` attribute.

## Changes
- Set the `count` attribute to `null` on Zerion's collectibles retrieval.
- Adapt the associated tests. 