### PR TITLE
Coerce `RelayDto['gasLimit']` to `bigint`

### DIFF
--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -34,7 +34,7 @@ export class GelatoApi implements IRelayApi {
     chainId: string;
     to: string;
     data: string;
-    gasLimit: string | null;
+    gasLimit: bigint | null;
   }): Promise<{ taskId: string }> {
     const sponsorApiKey = this.configurationService.getOrThrow<string>(
       `relay.apiKey.${args.chainId}`,
@@ -48,7 +48,7 @@ export class GelatoApi implements IRelayApi {
         target: args.to,
         data: args.data,
         ...(args.gasLimit && {
-          gasLimit: this.getRelayGasLimit(args.gasLimit),
+          gasLimit: this.getRelayGasLimit(args.gasLimit).toString(),
         }),
       });
       return data;
@@ -57,7 +57,7 @@ export class GelatoApi implements IRelayApi {
     }
   }
 
-  private getRelayGasLimit(gasLimit: string): string {
-    return (BigInt(gasLimit) + GelatoApi.GAS_LIMIT_BUFFER).toString();
+  private getRelayGasLimit(gasLimit: bigint): bigint {
+    return gasLimit + GelatoApi.GAS_LIMIT_BUFFER;
   }
 }

--- a/src/domain/interfaces/relay-api.interface.ts
+++ b/src/domain/interfaces/relay-api.interface.ts
@@ -5,6 +5,6 @@ export interface IRelayApi {
     chainId: string;
     to: string;
     data: string;
-    gasLimit: string | null;
+    gasLimit: bigint | null;
   }): Promise<{ taskId: string }>;
 }

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -28,19 +28,19 @@ export class RelayRepository {
     this.limit = configurationService.getOrThrow('relay.limit');
   }
 
-  async relay(relayPayload: {
+  async relay(args: {
     version: string;
     chainId: string;
     to: string;
     data: string;
-    gasLimit: string | null;
+    gasLimit: bigint | null;
   }): Promise<{ taskId: string }> {
     const relayAddresses =
-      await this.limitAddressesMapper.getLimitAddresses(relayPayload);
+      await this.limitAddressesMapper.getLimitAddresses(args);
 
     for (const address of relayAddresses) {
       const canRelay = await this.canRelay({
-        chainId: relayPayload.chainId,
+        chainId: args.chainId,
         address,
       });
       if (!canRelay.result) {
@@ -54,12 +54,12 @@ export class RelayRepository {
       }
     }
 
-    const relayResponse = await this.relayApi.relay(relayPayload);
+    const relayResponse = await this.relayApi.relay(args);
 
     // If we fail to increment count, we should not fail the relay
     for (const address of relayAddresses) {
       await this.incrementRelayCount({
-        chainId: relayPayload.chainId,
+        chainId: args.chainId,
         address,
       }).catch((error) => {
         // If we fail to increment count, we should not fail the relay

--- a/src/routes/relay/relay.controller.module.ts
+++ b/src/routes/relay/relay.controller.module.ts
@@ -3,10 +3,11 @@ import { RelayDomainModule } from '@/domain/relay/relay.domain.module';
 import { RelayService } from '@/routes/relay/relay.service';
 import { RelayController } from '@/routes/relay/relay.controller';
 import { RelayLegacyController } from '@/routes/relay/relay.legacy.controller';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 
 @Module({
   imports: [RelayDomainModule],
-  providers: [RelayService],
+  providers: [HttpErrorFactory, RelayService],
   controllers: [RelayController, RelayLegacyController],
 })
 export class RelayControllerModule {}

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -1158,6 +1158,33 @@ describe('Relay controller', () => {
           );
         });
 
+        it('should return 422 if the gasLimit is invalid', async () => {
+          // Version supported by all contracts
+          const version = '1.3.0';
+          const chain = chainBuilder().with('chainId', chainId).build();
+          const safe = safeBuilder().build();
+          const safeAddress = getAddress(safe.address);
+          const data = execTransactionEncoder()
+            .with('value', faker.number.bigInt())
+            .encode() as Hex;
+          const gasLimit = 'invalid';
+
+          await request(app.getHttpServer())
+            .post(`/v1/chains/${chain.chainId}/relay`)
+            .send({
+              version,
+              to: safeAddress,
+              data,
+              gasLimit,
+            })
+            .expect(422)
+            .expect({
+              message: 'Invalid gas limit provided',
+              error: 'Unprocessable Entity',
+              statusCode: 422,
+            });
+        });
+
         it('should otherwise return 422', async () => {
           // Version supported by all contracts
           const version = '1.3.0';

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -1,7 +1,12 @@
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { RelayRepository } from '@/domain/relay/relay.repository';
 import { RelayDto } from '@/routes/relay/entities/relay.dto.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 
 @Injectable()
 export class RelayService {
@@ -11,6 +16,7 @@ export class RelayService {
   constructor(
     @Inject(IConfigurationService) configurationService: IConfigurationService,
     private readonly relayRepository: RelayRepository,
+    private readonly httpErrorFactory: HttpErrorFactory,
   ) {
     this.limit = configurationService.getOrThrow('relay.limit');
   }
@@ -24,8 +30,25 @@ export class RelayService {
       chainId: args.chainId,
       to: args.relayDto.to,
       data: args.relayDto.data,
-      gasLimit: args.relayDto.gasLimit,
+      gasLimit: this.coerceGasLimit(args.relayDto.gasLimit),
     });
+  }
+
+  /**
+   * As AJV does not support bigint, we cannot validate it without
+   * a new keyword. To preserve type safety, it is instead validated
+   * as a string and then manually coerced.
+   */
+  private coerceGasLimit(gasLimit: RelayDto['gasLimit']): bigint | null {
+    if (!gasLimit) {
+      return null;
+    }
+
+    try {
+      return BigInt(gasLimit);
+    } catch (error) {
+      throw new UnprocessableEntityException('Invalid gas limit provided');
+    }
   }
 
   async getRelaysRemaining(args: {


### PR DESCRIPTION
This coerces `RelayDto['gasLimit'` to a `bigint` is specified and initially validated within the service so that the domain needs not adjust the type.