### PR TITLE
Generate chain-specific deployment versions for tests

### DIFF
--- a/src/__tests__/deployments.helper.spec.ts
+++ b/src/__tests__/deployments.helper.spec.ts
@@ -1,0 +1,125 @@
+import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
+
+describe('Deployments helper', () => {
+  describe('getDeploymentVersionsByChainIds', () => {
+    it('should return all CompatibilityFallbackHandler versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds(
+        'CompatibilityFallbackHandler',
+        ['100', '11155111'],
+      );
+
+      expect(versions).toStrictEqual({
+        '100': ['1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all CreateCall versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('CreateCall', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all DefaultCallbackHandler versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds(
+        'DefaultCallbackHandler',
+        ['100', '11155111'],
+      );
+
+      expect(versions).toStrictEqual({
+        '100': ['1.1.1'],
+        '11155111': [],
+      });
+    });
+
+    it('should return all MultiSend for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('MultiSend', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.1.1', '1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all MultiSendCallOnly versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('MultiSendCallOnly', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all ProxyFactory versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('ProxyFactory', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all Safe versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('Safe', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all L2 Safe versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('SafeL2', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all SignMessageLib versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('SignMessageLib', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+
+    it('should return all SimulateTxAccessor versions for the specified chain ID', () => {
+      const versions = getDeploymentVersionsByChainIds('SimulateTxAccessor', [
+        '100',
+        '11155111',
+      ]);
+
+      expect(versions).toStrictEqual({
+        '100': ['1.3.0', '1.4.1'],
+        '11155111': ['1.3.0', '1.4.1'],
+      });
+    });
+  });
+});

--- a/src/__tests__/deployments.helper.ts
+++ b/src/__tests__/deployments.helper.ts
@@ -1,0 +1,108 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * This generates a map of chain IDs to an array of versions for a given deployment
+ * from the `@safe-global/safe-deployments` package.
+ *
+ * It is important to note that not all versions of a contract are deployed on all
+ * chains and there is naming variation across versions.
+ *
+ * Note: if there is a contract update, the alias mapping may need updating.
+ */
+
+// All deployment name variations
+const deploymentAliases = {
+  CompatibilityFallbackHandler: [
+    'CompatibilityFallbackHandler', // 1.3.0, 1.4.1
+  ],
+  CreateCall: [
+    'CreateCall', // 1.3.0, 1.4.1
+  ],
+  DefaultCallbackHandler: [
+    'DefaultCallbackHandler', // 1.1.1
+  ],
+  MultiSend: [
+    'MultiSend', // 1.3.0, 1.4.1
+  ],
+  MultiSendCallOnly: [
+    'MultiSendCallOnly', // 1.3.0, 1.4.1
+  ],
+  ProxyFactory: [
+    'ProxyFactory', // 1.0.0, 1.1.1
+    'GnosisSafeProxyFactory', // 1.3.0
+    'SafeProxyFactory', // 1.4.1
+  ],
+  Safe: [
+    'GnosisSafe', // 1.0.0, 1.1.1, 1.2.0, 1.3.0
+    'Safe', // 1.4.1
+  ],
+  SafeL2: [
+    'GnosisSafeL2', // 1.3.0
+    'SafeL2', // 1.4.1
+  ],
+  SignMessageLib: [
+    'SignMessageLib', // 1.3.0, 1.4.1
+  ],
+  SimulateTxAccessor: [
+    'SimulateTxAccessor', // 1.3.0, 1.4.1
+  ],
+};
+
+const allDeploymentAliases = Object.values(deploymentAliases).flat();
+
+// Path to directory containing JSON assets
+const assetsDir = path.join(
+  process.cwd(),
+  'node_modules',
+  '@safe-global',
+  'safe-deployments',
+  'dist',
+  'assets',
+);
+
+function getDeploymentVersionsByChainId(
+  contractAlias: keyof typeof deploymentAliases,
+  chainId: string,
+): Array<string> {
+  const versionsByChain: Array<string> = [];
+
+  // For each version...
+  for (const version of fs.readdirSync(assetsDir)) {
+    const versionDir = path.join(assetsDir, version);
+
+    // ...parse each asset
+    for (const assetFile of fs.readdirSync(versionDir)) {
+      // Read the asset JSON
+      const assetPath = path.join(assetsDir, version, assetFile);
+      const assetJson = fs.readFileSync(assetPath, 'utf8');
+
+      // Parse the asset JSON
+      const deployment = JSON.parse(assetJson);
+
+      // If there is a deployment on the given chain and the alias is known
+      if (
+        deployment.networkAddresses[chainId] &&
+        deploymentAliases[contractAlias].includes(deployment.contractName)
+      ) {
+        versionsByChain.push(deployment.version);
+      }
+      // Else if the deployment is name is not mapped (is a new version alias)
+      else if (!allDeploymentAliases.includes(deployment.contractName)) {
+        throw new Error(`The ${test} contract alias is not known!`);
+      }
+    }
+  }
+
+  return versionsByChain;
+}
+
+export function getDeploymentVersionsByChainIds(
+  contractAlias: keyof typeof deploymentAliases,
+  chainIds: Array<string>,
+): Record<string, Array<string>> {
+  return chainIds.reduce<Record<string, Array<string>>>((acc, chainId) => {
+    acc[chainId] = getDeploymentVersionsByChainId(contractAlias, chainId);
+    return acc;
+  }, {});
+}

--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -32,28 +32,30 @@ import {
 } from '@safe-global/safe-deployments';
 import { Hex, getAddress } from 'viem';
 import configuration from '@/config/entities/configuration';
+import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 
-// TODO: Generate these from safe-deployments package
-const SAFE_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const SAFE_L2_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const MULTI_SEND_CALL_ONLY_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const MULTI_SEND_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.1.1', '1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const PROXY_FACTORY_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
+const supportedChainIds = Object.keys(configuration().relay.apiKey);
+
+const SAFE_VERSIONS = getDeploymentVersionsByChainIds(
+  'Safe',
+  supportedChainIds,
+);
+const SAFE_L2_VERSIONS = getDeploymentVersionsByChainIds(
+  'SafeL2',
+  supportedChainIds,
+);
+const MULTI_SEND_CALL_ONLY_VERSIONS = getDeploymentVersionsByChainIds(
+  'MultiSendCallOnly',
+  supportedChainIds,
+);
+const MULTI_SEND_VERSIONS = getDeploymentVersionsByChainIds(
+  'MultiSend',
+  supportedChainIds,
+);
+const PROXY_FACTORY_VERSIONS = getDeploymentVersionsByChainIds(
+  'ProxyFactory',
+  supportedChainIds,
+);
 
 const mockSafeRepository = jest.mocked({
   getSafe: jest.fn(),
@@ -78,8 +80,6 @@ describe('LimitAddressesMapper', () => {
       proxyFactoryDecoder,
     );
   });
-
-  const supportedChainIds = Object.keys(configuration().relay.apiKey);
 
   describe.each(supportedChainIds)('Chain %s', (chainId) => {
     describe('Safe', () => {

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -45,28 +45,30 @@ import {
   getSafeSingletonDeployment,
 } from '@safe-global/safe-deployments';
 import { createProxyWithNonceEncoder } from '@/domain/relay/contracts/__tests__/encoders/proxy-factory-encoder.builder';
+import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 
-// TODO: Generate these from safe-deployments package
-const SAFE_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const SAFE_L2_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const MULTI_SEND_CALL_ONLY_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const MULTI_SEND_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.1.1', '1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
-const PROXY_FACTORY_VERSIONS: Record<string, Array<string>> = {
-  '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1'],
-  '11155111': ['1.3.0', '1.4.1'],
-};
+const supportedChainIds = Object.keys(configuration().relay.apiKey);
+
+const SAFE_VERSIONS = getDeploymentVersionsByChainIds(
+  'Safe',
+  supportedChainIds,
+);
+const SAFE_L2_VERSIONS = getDeploymentVersionsByChainIds(
+  'SafeL2',
+  supportedChainIds,
+);
+const MULTI_SEND_CALL_ONLY_VERSIONS = getDeploymentVersionsByChainIds(
+  'MultiSendCallOnly',
+  supportedChainIds,
+);
+const MULTI_SEND_VERSIONS = getDeploymentVersionsByChainIds(
+  'MultiSend',
+  supportedChainIds,
+);
+const PROXY_FACTORY_VERSIONS = getDeploymentVersionsByChainIds(
+  'ProxyFactory',
+  supportedChainIds,
+);
 
 describe('Relay controller', () => {
   let app: INestApplication;
@@ -116,8 +118,6 @@ describe('Relay controller', () => {
   afterAll(async () => {
     await app.close();
   });
-
-  const supportedChainIds = Object.keys(configuration().relay.apiKey);
 
   describe.each(supportedChainIds)('Chain %s', (chainId) => {
     describe('POST /v1/chains/:chainId/relay', () => {


### PR DESCRIPTION
This adds a function to generate type safe mappings of chain IDs to deployment versions from the `@safe-global/safe-deployments` package e.g.

```ts
const versions = getDeploymentVersionsByChainIds(
  'CompatibilityFallbackHandler',
  ['100', '11155111'],
);

expect(versions).toStrictEqual({
  '100': ['1.3.0', '1.4.1'],
  '11155111': ['1.3.0', '1.4.1'],
});
```