### PR TITLE
Add custom TTL for owners, disabling caching

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -180,6 +180,9 @@ export default (): ReturnType<typeof configuration> => ({
       maxNestedTransfers: faker.number.int({ min: 1, max: 5 }),
     },
   },
+  owners: {
+    ownersTtlSeconds: faker.number.int(),
+  },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -172,6 +172,10 @@ export default () => ({
     level: process.env.LOG_LEVEL || 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
+  owners: {
+    // There is no hook to invalidate the owners, so defaulting 0 disables the cache
+    ownersTtlSeconds: parseInt(process.env.OWNERS_TTL_MS ?? `${0}`),
+  },
   mappings: {
     history: {
       maxNestedTransfers: parseInt(

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -54,6 +54,7 @@ describe('Transaction API Manager Tests', () => {
       .build();
     const expirationTimeInSeconds = faker.number.int();
     const notFoundExpireTimeSeconds = faker.number.int();
+    const ownersTtlSeconds = faker.number.int();
     configurationServiceMock.getOrThrow.mockImplementation((key) => {
       if (key === 'safeTransaction.useVpcUrl') return useVpcUrl;
       else if (key === 'expirationTimeInSeconds.default')
@@ -64,6 +65,8 @@ describe('Transaction API Manager Tests', () => {
         return notFoundExpireTimeSeconds;
       else if (key === 'expirationTimeInSeconds.notFound.token')
         return notFoundExpireTimeSeconds;
+      else if (key === 'owners.ownersTtlSeconds') return ownersTtlSeconds;
+
       throw new Error(`Unexpected key: ${key}`);
     });
     configApiMock.getChain.mockResolvedValue(chain);

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -43,12 +43,14 @@ describe('TransactionApi', () => {
   let service: TransactionApi;
   let defaultExpirationTimeInSeconds: number;
   let notFoundExpireTimeSeconds: number;
+  let ownersTtlSeconds: number;
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     defaultExpirationTimeInSeconds = faker.number.int();
     notFoundExpireTimeSeconds = faker.number.int();
+    ownersTtlSeconds = faker.number.int();
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'expirationTimeInSeconds.default') {
         return defaultExpirationTimeInSeconds;
@@ -61,6 +63,9 @@ describe('TransactionApi', () => {
       }
       if (key === 'expirationTimeInSeconds.notFound.token') {
         return notFoundExpireTimeSeconds;
+      }
+      if (key === 'owners.ownersTtlSeconds') {
+        return ownersTtlSeconds;
       }
       throw Error(`Unexpected key: ${key}`);
     });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -31,6 +31,7 @@ export class TransactionApi implements ITransactionApi {
   private readonly defaultNotFoundExpirationTimeSeconds: number;
   private readonly tokenNotFoundExpirationTimeSeconds: number;
   private readonly contractNotFoundExpirationTimeSeconds: number;
+  private readonly ownersExpirationTimeSeconds: number;
 
   constructor(
     private readonly chainId: string,
@@ -57,6 +58,8 @@ export class TransactionApi implements ITransactionApi {
       this.configurationService.getOrThrow<number>(
         'expirationTimeInSeconds.notFound.contract',
       );
+    this.ownersExpirationTimeSeconds =
+      this.configurationService.getOrThrow<number>('owners.ownersTtlSeconds');
   }
 
   async getDataDecoded(args: {
@@ -651,7 +654,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   // Important: there is no hook which invalidates this endpoint,
-  // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
+  // Therefore, this data will live in cache until [ownersExpirationTimeSeconds]
   async getSafesByOwner(ownerAddress: string): Promise<SafeList> {
     try {
       const cacheDir = CacheRouter.getSafesByOwnerCacheDir({
@@ -663,7 +666,7 @@ export class TransactionApi implements ITransactionApi {
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
-        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        expireTimeSeconds: this.ownersExpirationTimeSeconds,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -44,6 +44,6 @@ describe('Get safes by owner e2e test', () => {
       });
 
     const cacheContent = await redisClient.hGet(ownerCacheKey, '');
-    expect(cacheContent).not.toBeNull();
+    expect(cacheContent).toBeNull();
   });
 });

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -19,3 +19,5 @@ process.env.POSTGRES_PASSWORD = 'postgres';
 // For E2E tests, connect to the test cache
 process.env.REDIS_HOST = '127.0.0.1';
 process.env.REDIS_PORT = '6379';
+
+process.env.OWNERS_TTL_MS = '0';


### PR DESCRIPTION
## Summary

Resolves #1183

As there is no hook to invalidate the owners cache, the data is/was potentially stale. This was causing an issue client-side with newly created Safes.

This adds a new custom TTL for owners. It defaults to `0`, effectively disabling the cache but we will monitor this implementation to decide whether we should keep/remove caching.

## Changes

- Adds `owners.ownersTtlSeconds`, defaulting to `0`