### PR TITLE
Rename owners TTL env. var.

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -174,7 +174,7 @@ export default () => ({
   },
   owners: {
     // There is no hook to invalidate the owners, so defaulting 0 disables the cache
-    ownersTtlSeconds: parseInt(process.env.OWNERS_TTL_MS ?? `${0}`),
+    ownersTtlSeconds: parseInt(process.env.OWNERS_TTL_SECONDS ?? `${0}`),
   },
   mappings: {
     history: {

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -20,4 +20,4 @@ process.env.POSTGRES_PASSWORD = 'postgres';
 process.env.REDIS_HOST = '127.0.0.1';
 process.env.REDIS_PORT = '6379';
 
-process.env.OWNERS_TTL_MS = '0';
+process.env.OWNERS_TTL_SECONDS = '0';


### PR DESCRIPTION
## Summary

This renames the owners TTL env. var. to signify that the value is in seconds, not milliseconds.

## Changes

- Rename `OWNERS_TTL_MS` to `OWNERS_TTL_SECONDS`