### PR TITLE
Generify, validate and inject relay env. vars. into Docker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,11 +22,16 @@
 # The API Key to be used. If none is set, balances cannot be retrieved using this provider.
 #ZERION_API_KEY=
 
-# Relay Provider - Gelato API
+# Relay Provider
 # FF_RELAY=
-# The API key to be used for a specific chain
-# GELATO_API_KEY_GNOSIS_CHAIN=
-# GELATO_API_KEY_SEPOLIA=
+# The relay provider to be used.
+# (default='https://api.gelato.digital')
+# RELAY_PROVIDER_API_BASE_URI=
+# (default=5)
+# RELAY_THROTTLE_LIMIT=
+# The API key to be used per chain.
+# RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN=
+# RELAY_PROVIDER_API_KEY_SEPOLIA=
 
 # The cache TTL for each token price datapoint.
 #BALANCES_TTL_SECONDS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: ${EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX-example_template_unknown_recovery_tx}
       EMAIL_TEMPLATE_RECOVERY_TX: ${EMAIL_TEMPLATE_RECOVERY_TX-example_template_recovery_tx}
       EMAIL_TEMPLATE_VERIFICATION_CODE: ${EMAIL_TEMPLATE_VERIFICATION_CODE-example_template_verification_code}
+      RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: ${RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN-example_api_key}
+      RELAY_PROVIDER_API_KEY_SEPOLIA: ${RELAY_PROVIDER_API_KEY_SEPOLIA-example_api_key}
     depends_on:
       - redis
       - db

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -17,6 +17,8 @@ describe('Configuration validator', () => {
     EMAIL_TEMPLATE_RECOVERY_TX: faker.string.alphanumeric(),
     EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
     EMAIL_TEMPLATE_VERIFICATION_CODE: faker.string.alphanumeric(),
+    RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),
+    RELAY_PROVIDER_API_KEY_SEPOLIA: faker.string.uuid(),
   };
 
   it('should bypass this validation on test environment', () => {
@@ -44,6 +46,8 @@ describe('Configuration validator', () => {
     { key: 'EMAIL_TEMPLATE_RECOVERY_TX' },
     { key: 'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX' },
     { key: 'EMAIL_TEMPLATE_VERIFICATION_CODE' },
+    { key: 'RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN' },
+    { key: 'RELAY_PROVIDER_API_KEY_SEPOLIA' },
   ])(
     'should detect that $key is missing in the configuration in production environment',
     ({ key }) => {
@@ -70,6 +74,8 @@ describe('Configuration validator', () => {
         EMAIL_TEMPLATE_RECOVERY_TX: faker.string.alphanumeric(),
         EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
         EMAIL_TEMPLATE_VERIFICATION_CODE: faker.string.alphanumeric(),
+        RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),
+        RELAY_PROVIDER_API_KEY_SEPOLIA: faker.string.uuid(),
       }),
     ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
   });

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -19,6 +19,8 @@ const configurationSchema: Schema = {
     EMAIL_TEMPLATE_RECOVERY_TX: { type: 'string' },
     EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: { type: 'string' },
     EMAIL_TEMPLATE_VERIFICATION_CODE: { type: 'string' },
+    RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: { type: 'string' },
+    RELAY_PROVIDER_API_KEY_SEPOLIA: { type: 'string' },
   },
   required: [
     'AUTH_TOKEN',
@@ -32,6 +34,8 @@ const configurationSchema: Schema = {
     'EMAIL_TEMPLATE_RECOVERY_TX',
     'EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX',
     'EMAIL_TEMPLATE_VERIFICATION_CODE',
+    'RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN',
+    'RELAY_PROVIDER_API_KEY_SEPOLIA',
   ],
 };
 

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -192,8 +192,8 @@ export default () => ({
       process.env.RELAY_PROVIDER_API_BASE_URI || 'https://api.gelato.digital',
     limit: parseInt(process.env.RELAY_THROTTLE_LIMIT ?? `${5}`),
     apiKey: {
-      100: process.env.GELATO_API_KEY_GNOSIS_CHAIN,
-      11155111: process.env.GELATO_API_KEY_SEPOLIA,
+      100: process.env.RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN,
+      11155111: process.env.RELAY_PROVIDER_API_KEY_SEPOLIA,
     },
   },
   safeConfig: {


### PR DESCRIPTION
## Summary

This prepares the relay env. vars. for release by: generifying their names, validating them and injecting them into the Docker compose file.

## Changes

- All references to "Gelato" in env. vars have been changed to "Relay provider".
  - `GELATO_API_KEY_GNOSIS_CHAIN` -> `RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN`
  - `GELATO_API_KEY_SEPOLIA` -> `RELAY_PROVIDER_API_KEY_SEPOLIA`
- Validation of the env. vars has been added.
- They are injected in the `docker-compose.yml` file.