### PR TITLE
Refactor cache-write functions

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -17,7 +17,7 @@ const mockCacheFirstDataSource = jest.mocked({
 const mockCacheService = jest.mocked({
   deleteByKey: jest.fn(),
   get: jest.fn(),
-  set: jest.fn(),
+  setWithExpiration: jest.fn(),
 } as jest.MockedObjectDeep<ICacheService>);
 
 const mockNetworkService = jest.mocked({
@@ -178,8 +178,8 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.get).toHaveBeenCalledTimes(1);
     expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
-    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.set).toHaveBeenCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledWith(
       expectedCacheDir,
       JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
       pricesCacheTtlSeconds,
@@ -238,8 +238,8 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.get).toHaveBeenCalledTimes(1);
     expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
-    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.set).toHaveBeenCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledWith(
       expectedCacheDir,
       JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
       pricesCacheTtlSeconds,
@@ -322,8 +322,8 @@ describe('CoingeckoAPI', () => {
         '',
       ),
     );
-    expect(mockCacheService.set).toHaveBeenCalledTimes(3);
-    expect(mockCacheService.set).toHaveBeenCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledTimes(3);
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledWith(
       new CacheDir(
         `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
@@ -333,7 +333,7 @@ describe('CoingeckoAPI', () => {
       }),
       pricesCacheTtlSeconds,
     );
-    expect(mockCacheService.set).toHaveBeenCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledWith(
       new CacheDir(
         `${chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
@@ -343,7 +343,7 @@ describe('CoingeckoAPI', () => {
       }),
       pricesCacheTtlSeconds,
     );
-    expect(mockCacheService.set).toHaveBeenCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledWith(
       new CacheDir(
         `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
@@ -437,8 +437,8 @@ describe('CoingeckoAPI', () => {
         '',
       ),
     );
-    expect(mockCacheService.set).toHaveBeenCalledTimes(2);
-    expect(mockCacheService.set).toHaveBeenNthCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledTimes(2);
+    expect(mockCacheService.setWithExpiration).toHaveBeenNthCalledWith(
       1,
       new CacheDir(
         `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
@@ -449,7 +449,7 @@ describe('CoingeckoAPI', () => {
       }),
       pricesCacheTtlSeconds,
     );
-    expect(mockCacheService.set).toHaveBeenNthCalledWith(
+    expect(mockCacheService.setWithExpiration).toHaveBeenNthCalledWith(
       2,
       new CacheDir(
         `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
@@ -544,16 +544,20 @@ describe('CoingeckoAPI', () => {
         '',
       ),
     );
-    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.set.mock.calls[0][1]).toEqual(
+    expect(mockCacheService.setWithExpiration).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.setWithExpiration.mock.calls[0][1]).toEqual(
       JSON.stringify({ [thirdTokenAddress]: { [lowerCaseFiatCode]: null } }),
     );
-    expect(mockCacheService.set.mock.calls[0][2]).toBeGreaterThanOrEqual(
+    expect(
+      mockCacheService.setWithExpiration.mock.calls[0][2],
+    ).toBeGreaterThanOrEqual(
       (fakeConfigurationService.get(
         'balances.providers.safe.prices.notFoundPriceTtlSeconds',
       ) as number) - CoingeckoApi.notFoundTtlRangeSeconds,
     );
-    expect(mockCacheService.set.mock.calls[0][2]).toBeLessThanOrEqual(
+    expect(
+      mockCacheService.setWithExpiration.mock.calls[0][2],
+    ).toBeLessThanOrEqual(
       (fakeConfigurationService.get(
         'balances.providers.safe.prices.notFoundPriceTtlSeconds',
       ) as number) + CoingeckoApi.notFoundTtlRangeSeconds,

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -242,7 +242,7 @@ export class CoingeckoApi implements IPricesApi {
         const price: AssetPrice = validPrice
           ? { [tokenAddress]: { [args.fiatCode]: validPrice } }
           : { [tokenAddress]: { [args.fiatCode]: null } };
-        await this.cacheService.set(
+        await this.cacheService.setWithExpiration(
           CacheRouter.getTokenPriceCacheDir({ ...args, tokenAddress }),
           JSON.stringify(price),
           validPrice

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -15,8 +15,9 @@ describe('FakeCacheService', () => {
       faker.string.alphanumeric(),
     );
     const value = faker.string.alphanumeric();
+    const expireTimeSeconds = faker.number.int({ min: 1 });
 
-    await target.set(cacheDir, value, 0);
+    await target.setWithExpiration(cacheDir, value, expireTimeSeconds);
 
     await expect(target.get(cacheDir)).resolves.toBe(value);
     expect(target.keyCount()).toBe(1);
@@ -29,8 +30,9 @@ describe('FakeCacheService', () => {
     const field = faker.string.alphanumeric();
     const cacheDir = new CacheDir(key, field);
     const value = faker.string.alphanumeric();
+    const expireTimeSeconds = faker.number.int({ min: 1 });
 
-    await target.set(cacheDir, value, 0);
+    await target.setWithExpiration(cacheDir, value, expireTimeSeconds);
     await target.deleteByKey(key);
 
     await expect(target.get(cacheDir)).resolves.toBe(undefined);
@@ -39,19 +41,5 @@ describe('FakeCacheService', () => {
     ).resolves.toBe(now.toString());
     expect(target.keyCount()).toBe(1);
     jest.useRealTimers();
-  });
-
-  it('clears keys', async () => {
-    const actions: Promise<void>[] = [];
-    for (let i = 0; i < 5; i++) {
-      actions.push(
-        target.set(new CacheDir(`key${i}`, `field${i}`), `value${i}`, 0),
-      );
-    }
-
-    await Promise.all(actions);
-    target.clear();
-
-    expect(target.keyCount()).toBe(0);
   });
 });

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -106,7 +106,7 @@ export class CacheFirstDataSource {
 
     const shouldBeCached = await this._shouldBeCached(key, startTimeMs);
     if (shouldBeCached) {
-      await this.cacheService.set(
+      await this.cacheService.setWithExpiration(
         args.cacheDir,
         JSON.stringify(data),
         args.expireTimeSeconds,
@@ -153,7 +153,7 @@ export class CacheFirstDataSource {
     error: NetworkResponseError,
     notFoundExpireTimeSeconds?: number,
   ): Promise<void> {
-    return this.cacheService.set(
+    return this.cacheService.setWithExpiration(
       cacheDir,
       JSON.stringify({
         data: error.data,

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -3,11 +3,13 @@ import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 export const CacheService = Symbol('ICacheService');
 
 export interface ICacheService {
-  set(
+  setWithExpiration(
     cacheDir: CacheDir,
     value: string,
     expireTimeSeconds?: number,
   ): Promise<void>;
+
+  set(cacheDir: CacheDir, value: string): Promise<void>;
 
   get(cacheDir: CacheDir): Promise<string | undefined>;
 

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -61,7 +61,7 @@ describe('RedisCacheService with a Key Prefix', () => {
     const value = fakeJson();
     const expireTime = faker.number.int();
 
-    await redisCacheService.set(cacheDir, value, expireTime);
+    await redisCacheService.setWithExpiration(cacheDir, value, expireTime);
 
     expect(redisClientTypeMock.hSet).toHaveBeenCalledWith(
       `${keyPrefix}-${cacheDir.key}`,

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -59,7 +59,7 @@ describe('RedisCacheService', () => {
     );
     const value = fakeJson();
 
-    await redisCacheService.set(cacheDir, value, undefined);
+    await redisCacheService.setWithExpiration(cacheDir, value, undefined);
 
     const storedValue = await redisClient.hGet(cacheDir.key, cacheDir.field);
     expect(storedValue).toBeNull();
@@ -73,7 +73,7 @@ describe('RedisCacheService', () => {
     const value = fakeJson();
     const expireTime = faker.number.int();
 
-    await redisCacheService.set(cacheDir, value, expireTime);
+    await redisCacheService.setWithExpiration(cacheDir, value, expireTime);
 
     const storedValue = await redisClient.hGet(cacheDir.key, cacheDir.field);
     const ttl = await redisClient.ttl(cacheDir.key);
@@ -90,7 +90,7 @@ describe('RedisCacheService', () => {
 
     // Expiration time out of range to force an error
     await expect(
-      redisCacheService.set(cacheDir, '', Number.MAX_VALUE + 1),
+      redisCacheService.setWithExpiration(cacheDir, '', Number.MAX_VALUE + 1),
     ).rejects.toThrow();
 
     const storedValue = await redisClient.hGet(cacheDir.key, cacheDir.field);

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -16,7 +16,7 @@ const mockDataSource = jest.mocked(dataSource);
 
 const cacheService = {
   deleteByKey: jest.fn(),
-  set: jest.fn(),
+  setWithExpiration: jest.fn(),
 } as jest.MockedObjectDeep<ICacheService>;
 const mockCacheService = jest.mocked(cacheService);
 

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -17,7 +17,7 @@ const mockDataSource = jest.mocked(dataSource);
 
 const cacheService = {
   deleteByKey: jest.fn(),
-  set: jest.fn(),
+  setWithExpiration: jest.fn(),
 } as jest.MockedObjectDeep<ICacheService>;
 const mockCacheService = jest.mocked(cacheService);
 

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -217,7 +217,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_safe_balances_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -270,7 +274,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_multisig_transactions_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -323,7 +331,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_multisig_transaction_${payload.safeTxHash}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -368,7 +380,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_safe_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -422,7 +438,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_safe_collectibles_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -472,7 +492,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_transfers_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -517,7 +541,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_incoming_transfers_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -557,7 +585,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_module_transactions_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -622,7 +654,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_all_transactions_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -665,7 +701,11 @@ describe('Post Hook Events (Unit)', () => {
       `${chainId}_messages_${safeAddress}`,
       faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -699,7 +739,11 @@ describe('Post Hook Events (Unit)', () => {
   ])('$type clears chain', async (payload) => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(`${chainId}_chain`, '');
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       chainId: chainId,
       ...payload,
@@ -721,7 +765,11 @@ describe('Post Hook Events (Unit)', () => {
   ])('$type clears chains', async (payload) => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(`chains`, '');
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       chainId: chainId,
       ...payload,
@@ -743,7 +791,11 @@ describe('Post Hook Events (Unit)', () => {
   ])('$type clears safe apps', async (payload) => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(`${chainId}_safe_apps`, '');
-    await fakeCacheService.set(cacheDir, faker.string.alpha());
+    await fakeCacheService.setWithExpiration(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
     const data = {
       chainId: chainId,
       ...payload,


### PR DESCRIPTION
## Summary
Before this PR, `ICacheService.set` had two main implementations in the service: `FakeCacheService` and `RedisCacheService`.

The implementation of these classes was different. For `FakeCacheService`:
- If the optional `expireTimeSeconds` parameter was **not set**, the value provided was set with no TTL.
- If the optional `expireTimeSeconds` parameter was **set**, the value provided was set with no TTL.
So, in `FakeCacheService`, the optional parameter `expireTimeSeconds` was meaningless, the implementation was not taking it into consideration.

## Changes
