### PR TITLE
Improve `NetworkResponseError` error message propagation

### DIFF
--- a/src/datasources/errors/http-error-factory.spec.ts
+++ b/src/datasources/errors/http-error-factory.spec.ts
@@ -8,13 +8,34 @@ import { faker } from '@faker-js/faker';
 describe('HttpErrorFactory', () => {
   const httpErrorFactory: HttpErrorFactory = new HttpErrorFactory();
 
-  it('should create an DataSourceError when there is an error with the response', async () => {
+  it('should create a DataSourceError with a Django error', async () => {
     const httpError = new NetworkResponseError(
       new URL(faker.internet.url()),
       {
         status: faker.internet.httpStatusCode({
           types: ['serverError', 'clientError'],
         }),
+        statusText: faker.word.words(),
+      } as Response,
+      { nonFieldErrors: [faker.word.words()], message: faker.word.words() },
+    );
+
+    const actual = httpErrorFactory.from(httpError);
+
+    expect(actual.code).toBe(httpError.response.status);
+    expect(actual.message).toBe(
+      (httpError.data as { nonFieldErrors: Array<string> }).nonFieldErrors[0],
+    );
+  });
+
+  it('should create a DataSourceError with a standard error message if there is no Django error', async () => {
+    const httpError = new NetworkResponseError(
+      new URL(faker.internet.url()),
+      {
+        status: faker.internet.httpStatusCode({
+          types: ['serverError', 'clientError'],
+        }),
+        statusText: faker.word.words(),
       } as Response,
       { message: faker.word.words() },
     );
@@ -27,7 +48,34 @@ describe('HttpErrorFactory', () => {
     );
   });
 
-  it('should create an DataSourceError with 503 status when there is an error with the request URL', async () => {
+  it('should create a DataSourceError with the statusText if there is no Django/standard error', async () => {
+    const httpError = new NetworkResponseError(new URL(faker.internet.url()), {
+      status: faker.internet.httpStatusCode({
+        types: ['serverError', 'clientError'],
+      }),
+      statusText: faker.word.words(),
+    } as Response);
+
+    const actual = httpErrorFactory.from(httpError);
+
+    expect(actual.code).toBe(httpError.response.status);
+    expect(actual.message).toBe(httpError.response.statusText);
+  });
+
+  it('should create a DataSourceError with a standard error message if there is no Django/standard error or statusText', async () => {
+    const httpError = new NetworkResponseError(new URL(faker.internet.url()), {
+      status: faker.internet.httpStatusCode({
+        types: ['serverError', 'clientError'],
+      }),
+    } as Response);
+
+    const actual = httpErrorFactory.from(httpError);
+
+    expect(actual.code).toBe(httpError.response.status);
+    expect(actual.message).toBe('An error occurred');
+  });
+
+  it('should create a DataSourceError with 503 status when there is an error with the request URL', async () => {
     const httpError = new NetworkRequestError(null, undefined);
 
     const actual = httpErrorFactory.from(httpError);
@@ -48,7 +96,7 @@ describe('HttpErrorFactory', () => {
     expect(actual.message).toBe('Service unavailable');
   });
 
-  it('should create an DataSourceError with 503 status when an arbitrary error happens', async () => {
+  it('should create a DataSourceError with 503 status when an arbitrary error happens', async () => {
     const errMessage = 'Service unavailable';
     const randomError = new Error();
 

--- a/src/datasources/errors/http-error-factory.ts
+++ b/src/datasources/errors/http-error-factory.ts
@@ -16,7 +16,7 @@ import { get } from 'lodash';
 export class HttpErrorFactory {
   from(source: unknown): DataSourceError {
     if (source instanceof NetworkResponseError) {
-      const errorMessage = get(source, 'data.message', 'An error occurred');
+      const errorMessage = this.getNetworkResponseErrorMessage(source);
       return new DataSourceError(errorMessage, source.response.status);
     } else {
       return new DataSourceError(
@@ -24,5 +24,14 @@ export class HttpErrorFactory {
         HttpStatus.SERVICE_UNAVAILABLE,
       );
     }
+  }
+
+  private getNetworkResponseErrorMessage(source: NetworkResponseError): string {
+    return (
+      get(source, 'data.nonFieldErrors[0]') || // Django error
+      get(source, 'data.message') ||
+      get(source, 'response.statusText') ||
+      'An error occurred'
+    );
   }
 }


### PR DESCRIPTION
## Summary

This improves the propagation of `NetworkResponseError` messages in the following order:

1. Django `nonFieldErrors[0]`
2. Standard error `message`
3. Response `statusText`
4. Default of `"An error occurred"

## Changes

- Adds new `HttpErrorFactory['getNetworkResponseErrorMessage']` method returning the above "ranked" error messages.

## Notes

The above can be tested by trying to delete transactions that were proposed _before_ deleteion was possible.