### PR TITLE
Add `proposer` to `MultisigExecutionInfo`

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -41,6 +41,7 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
         appendSlash: false,
       })}", "name": "${faker.word.words()}"}`,
     )
+    .with('proposer', faker.finance.ethereumAddress())
     .with('refundReceiver', faker.finance.ethereumAddress())
     .with('safe', faker.finance.ethereumAddress())
     .with('safeTxGas', faker.number.int())

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -29,6 +29,7 @@ export type MultisigTransaction = {
   nonce: number;
   operation: Operation;
   origin: string | null;
+  proposer: string | null;
   refundReceiver: string | null;
   safe: string;
   safeTxGas: number | null;

--- a/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
@@ -42,6 +42,7 @@ export const multisigTransactionSchema: Schema = {
     safeTxGas: { type: 'number', nullable: true, default: null },
     baseGas: { type: 'number', nullable: true, default: null },
     gasPrice: { type: 'string', nullable: true, default: null },
+    proposer: { type: 'string', nullable: true, default: null },
     refundReceiver: { type: 'string', nullable: true, default: null },
     nonce: { type: 'number' },
     executionDate: {

--- a/src/routes/transactions/entities/multisig-execution-info.entity.ts
+++ b/src/routes/transactions/entities/multisig-execution-info.entity.ts
@@ -14,17 +14,21 @@ export class MultisigExecutionInfo extends ExecutionInfo {
   confirmationsSubmitted: number;
   @ApiPropertyOptional({ type: AddressInfo, isArray: true, nullable: true })
   missingSigners: AddressInfo[] | null;
+  @ApiProperty()
+  proposer!: AddressInfo | null;
 
   constructor(
     nonce: number,
     confirmationsRequired: number,
     confirmationsSubmitted: number,
     missingSigners: AddressInfo[] | null,
+    proposer: AddressInfo | null,
   ) {
     super(ExecutionInfoType.Multisig);
     this.nonce = nonce;
     this.confirmationsRequired = confirmationsRequired;
     this.confirmationsSubmitted = confirmationsSubmitted;
     this.missingSigners = missingSigners;
+    this.proposer = proposer;
   }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -19,6 +19,7 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const transaction = multisigTransactionBuilder()
       .with('proposer', null)
       .build();
+
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,
@@ -42,6 +43,7 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const transaction = multisigTransactionBuilder()
       .with('proposer', proposer)
       .build();
+
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,
@@ -65,6 +67,7 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const transaction = multisigTransactionBuilder()
       .with('proposer', proposer)
       .build();
+
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,
@@ -89,6 +92,7 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
       .with('proposer', proposer)
       .with('confirmations', null)
       .build();
+
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,
@@ -112,6 +116,7 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const transaction = multisigTransactionBuilder()
       .with('proposer', proposer)
       .build();
+
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,
@@ -137,6 +142,7 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     const safe = safeBuilder()
       .with('owners', [proposer, faker.finance.ethereumAddress()])
       .build();
+
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -62,7 +62,9 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
   it('should return a MultiSigExecutionInfo with no missing signers', () => {
     const safe = safeBuilder().build();
     const proposer = faker.finance.ethereumAddress();
-    const transaction = multisigTransactionBuilder().build();
+    const transaction = multisigTransactionBuilder()
+      .with('proposer', proposer)
+      .build();
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
       safe,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.ts
@@ -22,6 +22,7 @@ export class MultisigTransactionExecutionInfoMapper {
       transaction.confirmationsRequired,
       transaction?.confirmations?.length || 0,
       missingSigners,
+      transaction.proposer ? new AddressInfo(transaction.proposer) : null,
     );
   }
 


### PR DESCRIPTION
## Summary

This adds the `MultisigTransaction['proposer']` from the Transaction Service as `MultisigExecutionInfo['proposer']` (`AddressInfo`) for the client to reference for deletion. (Only the proposer can delete a transaction.)

## Changes

- Add `proposer` to `MultisigTransaction` entity (`null` pre-deletion integration)
- Add validation for `proposer` to `multisigTransactionSchema`
- Forward `proposer` in `MultisigTransactionExecutionInfoMapper['mapExecutionInfo']`
- Add `proposer` to `multisigTransactionBuilder`
- Add/update associated tests