### PR TITLE
Normalize Ethereum addresses

### DIFF
--- a/src/datasources/account/account.datasource.spec.ts
+++ b/src/datasources/account/account.datasource.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '@/domain/account/entities/account.entity';
 import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
 import { verificationCodeBuilder } from '@/domain/account/entities/__tests__/verification-code.builder';
+import { getAddress } from 'viem';
 
 const DB_CHAIN_ID_MAX_VALUE = 2147483647;
 
@@ -46,9 +47,9 @@ describe('Account DataSource Tests', () => {
 
   it('saves account successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -79,9 +80,9 @@ describe('Account DataSource Tests', () => {
 
   it('saving account with same email throws', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -111,9 +112,9 @@ describe('Account DataSource Tests', () => {
 
   it('updates email verification successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const newCode = code + 1;
@@ -145,9 +146,9 @@ describe('Account DataSource Tests', () => {
 
   it('setting email verification code on verified emails throws', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const newCode = code + 1;
@@ -181,9 +182,9 @@ describe('Account DataSource Tests', () => {
 
   it('sets verification sent date successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const sentOn = faker.date.recent();
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
@@ -210,8 +211,8 @@ describe('Account DataSource Tests', () => {
 
   it('setting verification code throws on unknown accounts', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
-    const signer = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.number.int({ max: 999998 });
     const newCode = code + 1;
     const newCodeGenerationDate = faker.date.recent();
@@ -229,8 +230,8 @@ describe('Account DataSource Tests', () => {
 
   it('updating email verification fails on unknown accounts', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
-    const signer = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const signer = getAddress(faker.finance.ethereumAddress());
 
     await expect(
       target.verifyEmail({
@@ -243,12 +244,12 @@ describe('Account DataSource Tests', () => {
 
   it('gets only verified email addresses associated with a given safe address', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const verifiedAccounts: [Account, VerificationCode][] = [
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', true)
           .build(),
         verificationCodeBuilder().build(),
@@ -256,7 +257,7 @@ describe('Account DataSource Tests', () => {
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', true)
           .build(),
         verificationCodeBuilder().build(),
@@ -266,7 +267,7 @@ describe('Account DataSource Tests', () => {
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', false)
           .build(),
         verificationCodeBuilder().build(),
@@ -274,7 +275,7 @@ describe('Account DataSource Tests', () => {
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', false)
           .build(),
         verificationCodeBuilder().build(),
@@ -320,12 +321,12 @@ describe('Account DataSource Tests', () => {
 
   it('gets all email addresses associated with a given safe address', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const verifiedAccounts: [Account, VerificationCode][] = [
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', true)
           .build(),
         verificationCodeBuilder().build(),
@@ -333,7 +334,7 @@ describe('Account DataSource Tests', () => {
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', true)
           .build(),
         verificationCodeBuilder().build(),
@@ -343,7 +344,7 @@ describe('Account DataSource Tests', () => {
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', false)
           .build(),
         verificationCodeBuilder().build(),
@@ -351,7 +352,7 @@ describe('Account DataSource Tests', () => {
       [
         accountBuilder()
           .with('chainId', chainId)
-          .with('safeAddress', safeAddress)
+          .with('safeAddress', getAddress(safeAddress))
           .with('isVerified', false)
           .build(),
         verificationCodeBuilder().build(),
@@ -399,9 +400,9 @@ describe('Account DataSource Tests', () => {
 
   it('deletes accounts successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.number.int({ max: 999998 }).toString();
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -432,8 +433,8 @@ describe('Account DataSource Tests', () => {
 
   it('deleting a non-existent account throws', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
-    const signer = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const signer = getAddress(faker.finance.ethereumAddress());
 
     await expect(
       target.deleteAccount({
@@ -446,10 +447,10 @@ describe('Account DataSource Tests', () => {
 
   it('update from previously unverified emails successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const prevEmailAddress = new EmailAddress(faker.internet.email());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const unsubscriptionToken = faker.string.uuid();
 
     await target.createAccount({
@@ -481,10 +482,10 @@ describe('Account DataSource Tests', () => {
 
   it('update from previously verified emails successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const prevEmailAddress = new EmailAddress(faker.internet.email());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const unsubscriptionToken = faker.string.uuid();
     await target.createAccount({
       chainId,
@@ -520,9 +521,9 @@ describe('Account DataSource Tests', () => {
 
   it('updating a non-existent account throws', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE });
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const unsubscriptionToken = faker.string.uuid();
 
     await expect(
@@ -538,9 +539,9 @@ describe('Account DataSource Tests', () => {
 
   it('Has zero subscriptions when creating new account', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -565,9 +566,9 @@ describe('Account DataSource Tests', () => {
 
   it('subscribes to category', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -604,9 +605,9 @@ describe('Account DataSource Tests', () => {
 
   it('unsubscribes from a category successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -664,9 +665,9 @@ describe('Account DataSource Tests', () => {
 
   it('unsubscribes from a non-existent category', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -692,9 +693,9 @@ describe('Account DataSource Tests', () => {
 
   it('unsubscribes with wrong token', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();
@@ -731,9 +732,9 @@ describe('Account DataSource Tests', () => {
 
   it('unsubscribes from all categories successfully', async () => {
     const chainId = faker.number.int({ max: DB_CHAIN_ID_MAX_VALUE }).toString();
-    const safeAddress = faker.finance.ethereumAddress();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
     const emailAddress = new EmailAddress(faker.internet.email());
-    const signer = faker.finance.ethereumAddress();
+    const signer = getAddress(faker.finance.ethereumAddress());
     const code = faker.string.numeric({ length: 6 });
     const codeGenerationDate = faker.date.recent();
     const unsubscriptionToken = faker.string.uuid();

--- a/src/domain/account/entities/__tests__/account.builder.ts
+++ b/src/domain/account/entities/__tests__/account.builder.ts
@@ -4,13 +4,14 @@ import {
   Account,
   EmailAddress,
 } from '@/domain/account/entities/account.entity';
+import { getAddress } from 'viem';
 
 export function accountBuilder(): IBuilder<Account> {
   return new Builder<Account>()
     .with('chainId', faker.string.numeric())
     .with('emailAddress', new EmailAddress(faker.internet.email()))
     .with('isVerified', faker.datatype.boolean())
-    .with('safeAddress', faker.finance.ethereumAddress())
-    .with('signer', faker.finance.ethereumAddress())
+    .with('safeAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('signer', getAddress(faker.finance.ethereumAddress()))
     .with('unsubscriptionToken', faker.string.uuid());
 }

--- a/src/domain/account/entities/account.entity.ts
+++ b/src/domain/account/entities/account.entity.ts
@@ -8,8 +8,8 @@ export interface Account {
   chainId: string;
   emailAddress: EmailAddress;
   isVerified: boolean;
-  safeAddress: string;
-  signer: string;
+  safeAddress: `0x${string}`;
+  signer: `0x${string}`;
   unsubscriptionToken: string;
 }
 

--- a/src/domain/interfaces/account.datasource.interface.ts
+++ b/src/domain/interfaces/account.datasource.interface.ts
@@ -19,8 +19,8 @@ export interface IAccountDataSource {
    */
   getAccount(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<Account>;
 
   /**
@@ -33,14 +33,14 @@ export interface IAccountDataSource {
    */
   getAccounts(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     onlyVerified: boolean;
   }): Promise<Account[]>;
 
   getAccountVerificationCode(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<VerificationCode>;
 
   /**
@@ -55,9 +55,9 @@ export interface IAccountDataSource {
    */
   createAccount(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     emailAddress: EmailAddress;
-    signer: string;
+    signer: `0x${string}`;
     code: string;
     codeGenerationDate: Date;
     unsubscriptionToken: string;
@@ -76,8 +76,8 @@ export interface IAccountDataSource {
    */
   setEmailVerificationCode(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
     code: string;
     codeGenerationDate: Date;
   }): Promise<VerificationCode>;
@@ -92,8 +92,8 @@ export interface IAccountDataSource {
    */
   setEmailVerificationSentDate(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
     sentOn: Date;
   }): Promise<VerificationCode>;
 
@@ -108,8 +108,8 @@ export interface IAccountDataSource {
    */
   verifyEmail(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<void>;
 
   /**
@@ -123,8 +123,8 @@ export interface IAccountDataSource {
    */
   deleteAccount(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<Account>;
 
   /**
@@ -141,9 +141,9 @@ export interface IAccountDataSource {
    */
   updateAccountEmail(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     emailAddress: EmailAddress;
-    signer: string;
+    signer: `0x${string}`;
     unsubscriptionToken: string;
   }): Promise<Account>;
 
@@ -156,8 +156,8 @@ export interface IAccountDataSource {
    */
   getSubscriptions(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<Subscription[]>;
 
   /**
@@ -172,8 +172,8 @@ export interface IAccountDataSource {
    */
   subscribe(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
     notificationTypeKey: string;
   }): Promise<Subscription[]>;
 

--- a/src/domain/subscriptions/subscription.repository.ts
+++ b/src/domain/subscriptions/subscription.repository.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
 import { ISubscriptionRepository } from '@/domain/subscriptions/subscription.repository.interface';
 import { Subscription } from '@/domain/account/entities/subscription.entity';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class SubscriptionRepository implements ISubscriptionRepository {
@@ -17,7 +18,13 @@ export class SubscriptionRepository implements ISubscriptionRepository {
     safeAddress: string;
     signer: string;
   }): Promise<Subscription[]> {
-    return this.accountDataSource.getSubscriptions(args);
+    const safeAddress = getAddress(args.safeAddress);
+    const signer = getAddress(args.signer);
+    return this.accountDataSource.getSubscriptions({
+      chainId: args.chainId,
+      safeAddress,
+      signer,
+    });
   }
 
   subscribe(args: {
@@ -26,7 +33,14 @@ export class SubscriptionRepository implements ISubscriptionRepository {
     signer: string;
     notificationTypeKey: string;
   }): Promise<Subscription[]> {
-    return this.accountDataSource.subscribe(args);
+    const safeAddress = getAddress(args.safeAddress);
+    const signer = getAddress(args.signer);
+    return this.accountDataSource.subscribe({
+      chainId: args.chainId,
+      safeAddress,
+      signer,
+      notificationTypeKey: args.notificationTypeKey,
+    });
   }
 
   unsubscribe(args: {

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -29,6 +29,7 @@ import {
   EmailAddress,
 } from '@/domain/account/entities/account.entity';
 import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
+import { getAddress } from 'viem';
 
 const verificationCodeTtlMs = 100;
 
@@ -87,7 +88,12 @@ describe('Email controller edit email tests', () => {
     await app.close();
   });
 
-  it('edits email successfully', async () => {
+  it.each([
+    // non-checksummed address
+    { safeAddress: faker.finance.ethereumAddress() },
+    // checksummed address
+    { safeAddress: getAddress(faker.finance.ethereumAddress()) },
+  ])('edits email successfully', async ({ safeAddress }) => {
     const chain = chainBuilder().build();
     const prevEmailAddress = faker.internet.email();
     const emailAddress = faker.internet.email();
@@ -95,7 +101,7 @@ describe('Email controller edit email tests', () => {
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const signerAddress = signer.address;
-    const safe = safeBuilder().build();
+    const safe = safeBuilder().with('address', safeAddress).build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     networkService.get.mockImplementation((url) => {
@@ -113,7 +119,7 @@ describe('Email controller edit email tests', () => {
         .with('chainId', chain.chainId)
         .with('signer', signerAddress)
         .with('isVerified', true)
-        .with('safeAddress', safe.address)
+        .with('safeAddress', getAddress(safe.address))
         .with('emailAddress', new EmailAddress(prevEmailAddress))
         .build(),
     );
@@ -139,7 +145,8 @@ describe('Email controller edit email tests', () => {
     expect(accountDataSource.updateAccountEmail).toHaveBeenCalledWith({
       chainId: chain.chainId,
       emailAddress: new EmailAddress(emailAddress),
-      safeAddress: safe.address,
+      // Should always call with the checksummed address
+      safeAddress: getAddress(safe.address),
       signer: signerAddress,
       unsubscriptionToken: expect.any(String),
     });
@@ -148,7 +155,8 @@ describe('Email controller edit email tests', () => {
       chainId: chain.chainId,
       code: expect.any(String),
       signer: signerAddress,
-      safeAddress: safe.address,
+      // Should always call with the checksummed address
+      safeAddress: getAddress(safe.address),
       codeGenerationDate: expect.any(Date),
     });
     expect(
@@ -157,7 +165,8 @@ describe('Email controller edit email tests', () => {
     expect(accountDataSource.setEmailVerificationSentDate).toHaveBeenCalledWith(
       {
         chainId: chain.chainId,
-        safeAddress: safe.address,
+        // Should always call with the checksummed address
+        safeAddress: getAddress(safe.address),
         signer: signerAddress,
         sentOn: expect.any(Date),
       },
@@ -202,6 +211,43 @@ describe('Email controller edit email tests', () => {
       .expect({
         statusCode: 409,
         message: 'Email address matches that of the Safe owner.',
+      });
+
+    expect(accountDataSource.updateAccountEmail).toHaveBeenCalledTimes(0);
+    expect(accountDataSource.setEmailVerificationCode).toHaveBeenCalledTimes(0);
+    expect(
+      accountDataSource.setEmailVerificationSentDate,
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns 422 if Safe address is not a valid Ethereum address', async () => {
+    const chain = chainBuilder().build();
+    const emailAddress = faker.internet.email();
+    const timestamp = jest.now();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const signerAddress = signer.address;
+    const invalidSafeAddress = faker.word.sample();
+    const message = `email-edit-${chain.chainId}-${invalidSafeAddress}-${emailAddress}-${signerAddress}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
+    accountDataSource.getAccount.mockResolvedValue({
+      emailAddress: new EmailAddress(emailAddress),
+    } as Account);
+
+    await request(app.getHttpServer())
+      .put(
+        `/v1/chains/${chain.chainId}/safes/${invalidSafeAddress}/emails/${signer.address}`,
+      )
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .send({
+        emailAddress,
+      })
+      .expect(422)
+      .expect({
+        message: `Address "${invalidSafeAddress}" is invalid.`,
+        error: 'Unprocessable Entity',
+        statusCode: 422,
       });
 
     expect(accountDataSource.updateAccountEmail).toHaveBeenCalledTimes(0);

--- a/src/routes/email/email.controller.get-email.spec.ts
+++ b/src/routes/email/email.controller.get-email.spec.ts
@@ -20,6 +20,7 @@ import { IAccountDataSource } from '@/domain/interfaces/account.datasource.inter
 import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
 import { faker } from '@faker-js/faker';
 import { AccountDoesNotExistError } from '@/domain/account/errors/account-does-not-exist.error';
+import { getAddress } from 'viem';
 
 describe('Email controller get email tests', () => {
   let app: INestApplication;
@@ -56,24 +57,33 @@ describe('Email controller get email tests', () => {
     await app.close();
   });
 
-  it('Retrieves email if correctly authenticated', async () => {
+  it.each([
+    // non-checksummed address
+    {
+      safeAddress: faker.finance.ethereumAddress(),
+    },
+    // checksummed address
+    {
+      safeAddress: getAddress(faker.finance.ethereumAddress()),
+    },
+  ])('Retrieves email if correctly authenticated', async ({ safeAddress }) => {
     const chain = chainBuilder().build();
-    const safe = safeBuilder().build();
+    const safe = safeBuilder().with('address', safeAddress).build();
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const timestamp = Date.now();
-    const message = `email-retrieval-${chain.chainId}-${safe.address}-${signer.address}-${timestamp}`;
+    const message = `email-retrieval-${chain.chainId}-${safeAddress}-${signer.address}-${timestamp}`;
     const signature = await signer.signMessage({ message });
     const account = accountBuilder()
       .with('signer', signer.address)
       .with('chainId', chain.chainId)
-      .with('safeAddress', safe.address)
+      .with('safeAddress', getAddress(safe.address))
       .build();
     accountDataSource.getAccount.mockResolvedValue(account);
 
     await request(app.getHttpServer())
       .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/emails/${signer.address}`,
+        `/v1/chains/${chain.chainId}/safes/${safeAddress}/emails/${signer.address}`,
       )
       .set('Safe-Wallet-Signature', signature)
       .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
@@ -86,7 +96,8 @@ describe('Email controller get email tests', () => {
     expect(accountDataSource.getAccount).toHaveBeenCalledTimes(1);
     expect(accountDataSource.getAccount).toHaveBeenCalledWith({
       chainId: chain.chainId.toString(),
-      safeAddress: safe.address.toString(),
+      // Should always call with the checksummed address
+      safeAddress: getAddress(safeAddress),
       signer: signer.address,
     });
   });
@@ -116,6 +127,31 @@ describe('Email controller get email tests', () => {
     expect(accountDataSource.getAccount).toHaveBeenCalledTimes(0);
   });
 
+  it('returns 422 if Safe address is not a valid Ethereum address', async () => {
+    const chain = chainBuilder().build();
+    const invalidSafeAddress = faker.word.sample();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const timestamp = Date.now();
+    const message = `email-retrieval-${chain.chainId}-${invalidSafeAddress}-${signer.address}-${timestamp}`;
+    const signature = await signer.signMessage({ message });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${invalidSafeAddress}/emails/${signer.address}`,
+      )
+      .set('Safe-Wallet-Signature', signature)
+      .set('Safe-Wallet-Signature-Timestamp', timestamp.toString())
+      .expect(422)
+      .expect({
+        message: `Address "${invalidSafeAddress}" is invalid.`,
+        error: 'Unprocessable Entity',
+        statusCode: 422,
+      });
+
+    expect(accountDataSource.getAccount).toHaveBeenCalledTimes(0);
+  });
+
   it('Returns 403 if signature expired', async () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
@@ -127,7 +163,7 @@ describe('Email controller get email tests', () => {
     const account = accountBuilder()
       .with('signer', signer.address)
       .with('chainId', chain.chainId)
-      .with('safeAddress', safe.address)
+      .with('safeAddress', getAddress(safe.address))
       .build();
     accountDataSource.getAccount.mockResolvedValue(account);
 

--- a/src/routes/email/email.controller.resend-verification.spec.ts
+++ b/src/routes/email/email.controller.resend-verification.spec.ts
@@ -16,6 +16,8 @@ import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { INestApplication } from '@nestjs/common';
 import { accountBuilder } from '@/domain/account/entities/__tests__/account.builder';
 import { verificationCodeBuilder } from '@/domain/account/entities/__tests__/verification-code.builder';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
 
 const resendLockWindowMs = 100;
 const ttlMs = 1000;
@@ -66,7 +68,12 @@ describe('Email controller resend verification tests', () => {
     await app.close();
   });
 
-  it('resends email verification successfully', async () => {
+  it.each([
+    // non-checksummed address
+    { safeAddress: faker.finance.ethereumAddress() },
+    // checksummed address
+    { safeAddress: getAddress(faker.finance.ethereumAddress()) },
+  ])('resends email verification successfully', async ({ safeAddress }) => {
     const account = accountBuilder().with('isVerified', false).build();
     const verificationCode = verificationCodeBuilder()
       .with('generatedOn', new Date())
@@ -84,7 +91,7 @@ describe('Email controller resend verification tests', () => {
     jest.advanceTimersByTime(resendLockWindowMs);
     await request(app.getHttpServer())
       .post(
-        `/v1/chains/${account.chainId}/safes/${account.safeAddress}/emails/${account.signer}/verify-resend`,
+        `/v1/chains/${account.chainId}/safes/${safeAddress}/emails/${account.signer}/verify-resend`,
       )
       .expect(202)
       .expect({});
@@ -96,6 +103,12 @@ describe('Email controller resend verification tests', () => {
     expect(
       accountDataSource.setEmailVerificationSentDate,
     ).toHaveBeenCalledTimes(1);
+    expect(accountDataSource.getAccount).toHaveBeenCalledWith({
+      chainId: account.chainId,
+      // Should always call with the checksummed address
+      safeAddress: getAddress(safeAddress),
+      signer: account.signer,
+    });
   });
 
   it('triggering email resend within lock window returns 202', async () => {

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -1,6 +1,11 @@
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { IAccountRepository } from '@/domain/account/account.repository.interface';
 import { Email } from '@/routes/email/entities/email.entity';
+import { InvalidAddressError } from 'viem';
 
 @Injectable()
 export class EmailService {
@@ -8,13 +13,22 @@ export class EmailService {
     @Inject(IAccountRepository) private readonly repository: IAccountRepository,
   ) {}
 
+  private _mapInvalidAddressError(e: unknown): never {
+    if (e instanceof InvalidAddressError) {
+      throw new UnprocessableEntityException(e.shortMessage);
+    }
+    throw e;
+  }
+
   async saveEmail(args: {
     chainId: string;
     safeAddress: string;
     emailAddress: string;
     signer: string;
   }): Promise<void> {
-    return this.repository.createAccount(args);
+    return this.repository
+      .createAccount(args)
+      .catch((e) => this._mapInvalidAddressError(e));
   }
 
   async resendVerification(args: {
@@ -22,7 +36,9 @@ export class EmailService {
     safeAddress: string;
     signer: string;
   }): Promise<void> {
-    return this.repository.resendEmailVerification(args);
+    return this.repository
+      .resendEmailVerification(args)
+      .catch((e) => this._mapInvalidAddressError(e));
   }
 
   async verifyEmailAddress(args: {
@@ -31,7 +47,9 @@ export class EmailService {
     signer: string;
     code: string;
   }): Promise<void> {
-    return this.repository.verifyEmailAddress(args);
+    return this.repository
+      .verifyEmailAddress(args)
+      .catch((e) => this._mapInvalidAddressError(e));
   }
 
   async deleteEmail(args: {
@@ -39,7 +57,9 @@ export class EmailService {
     safeAddress: string;
     signer: string;
   }): Promise<void> {
-    return this.repository.deleteAccount(args);
+    return this.repository
+      .deleteAccount(args)
+      .catch((e) => this._mapInvalidAddressError(e));
   }
 
   async editEmail(args: {
@@ -48,7 +68,9 @@ export class EmailService {
     signer: string;
     emailAddress: string;
   }): Promise<void> {
-    return this.repository.editEmail(args);
+    return this.repository
+      .editEmail(args)
+      .catch((e) => this._mapInvalidAddressError(e));
   }
 
   async getEmail(args: {
@@ -56,7 +78,10 @@ export class EmailService {
     safeAddress: string;
     signer: string;
   }): Promise<Email> {
-    const account = await this.repository.getAccount(args);
+    const account = await this.repository
+      .getAccount(args)
+      .catch((e) => this._mapInvalidAddressError(e));
+
     return new Email(account.emailAddress.value, account.isVerified);
   }
 }


### PR DESCRIPTION
- Normalizes Ethereum addresses in the `AccountRepository` – this avoids that the same address is represented in different ways (thus resulting in duplicate entries).
- The normalization step for Ethereum addresses results in a checksummed address.
- The `InvalidAddressError` error mapping was added to `EmailService` – an exception filter was considered but this results in the wrong status code being logged in `RouteLoggerInterceptor` since it's neither an instance of `HttpException` nor  `DataSourceError`.