### PR TITLE
Make expireTimeSeconds non-optional

### DIFF
--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -6,7 +6,7 @@ export interface ICacheService {
   set(
     cacheDir: CacheDir,
     value: string,
-    expireTimeSeconds?: number,
+    expireTimeSeconds: number | undefined,
   ): Promise<void>;
 
   get(cacheDir: CacheDir): Promise<string | undefined>;

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -71,6 +71,7 @@ describe('RedisCacheService with a Key Prefix', () => {
     expect(redisClientTypeMock.expire).toHaveBeenCalledWith(
       `${keyPrefix}-${cacheDir.key}`,
       expireTime,
+      'NX',
     );
   });
 
@@ -102,6 +103,7 @@ describe('RedisCacheService with a Key Prefix', () => {
     expect(redisClientTypeMock.expire).toHaveBeenCalledWith(
       `${keyPrefix}-invalidationTimeMs:${key}`,
       defaultExpirationTimeInSeconds,
+      'NX',
     );
     jest.useRealTimers();
   });

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -52,7 +52,7 @@ describe('RedisCacheService', () => {
     );
   });
 
-  it('Setting key without setting expireTimeSeconds does not store the value', async () => {
+  it('Setting key with undefined expireTimeSeconds stores the respective value', async () => {
     const cacheDir = new CacheDir(
       faker.string.alphanumeric(),
       faker.string.sample(),
@@ -62,7 +62,7 @@ describe('RedisCacheService', () => {
     await redisCacheService.set(cacheDir, value, undefined);
 
     const storedValue = await redisClient.hGet(cacheDir.key, cacheDir.field);
-    expect(storedValue).toBeNull();
+    expect(storedValue).toBe(value);
   });
 
   it('Setting key with expireTimeSeconds does store the value with the provided TTL', async () => {

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -94,7 +94,8 @@ export class RelayRepository {
     const currentCount = await this.getRelayCount(args);
     const incremented = currentCount + 1;
     const cacheDir = this.getRelayCacheKey(args);
-    return this.cacheService.set(cacheDir, incremented.toString());
+    // TODO extract expiration time to a configurable variable
+    return this.cacheService.set(cacheDir, incremented.toString(), 60 * 60);
   }
 
   private getRelayCacheKey(args: {


### PR DESCRIPTION
- Makes the `expireTimeSeconds` of `ICacheService.set` a required parameter, thus reducing the likelihood of forgetting setting it (in most use cases, we want to set the expiration time).
- Setting the expiration time to `undefined` does not set the expiration time of the key, but the key will still be cached.
- Previously, if the key was `undefined` or not greater than 0, we would not save any entry in the cache. This can be confusing to the callers who might expect that calling `set` on the Cache actually sets a cache entry.
- If `set` is called multiple times on a specific cache entry, its TTL does not change (`NX` option). This option can be expanded in the future so that more control is given to the caller.