### PR TITLE
Change Tenderly endpoint to add a contract

### DIFF
--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -68,38 +68,24 @@ describe('TenderlyApi', () => {
       return `${chain}:${safeAddress}:${moduleAddress}`;
     };
 
-    const contracts: Array<AlertsRegistration> = [
-      {
-        address: faker.finance.ethereumAddress(),
-        displayName: fakeDisplayName(),
-        chainId: faker.string.numeric(),
-      },
-      {
-        address: faker.finance.ethereumAddress(),
-        displayName: fakeDisplayName(),
-        chainId: faker.string.numeric(),
-      },
-      {
-        address: faker.finance.ethereumAddress(),
-        displayName: fakeDisplayName(),
-        chainId: faker.string.numeric(),
-      },
-    ];
+    const contract: AlertsRegistration = {
+      address: faker.finance.ethereumAddress(),
+      displayName: fakeDisplayName(),
+      chainId: faker.string.numeric(),
+    };
 
-    await service.addContracts(contracts);
+    await service.addContract(contract);
 
     expect(mockNetworkService.post).toHaveBeenCalledWith(
-      `${tenderlyBaseUri}/api/v2/accounts/${tenderlyAccount}/projects/${tenderlyProject}/contracts`,
+      `${tenderlyBaseUri}/api/v1/account/${tenderlyAccount}/project/${tenderlyProject}/address`,
       {
         headers: {
           'X-Access-Key': tenderlyApiKey,
         },
         params: {
-          contracts: contracts.map((contract) => ({
-            address: contract.address,
-            display_name: contract.displayName,
-            network_id: contract.chainId,
-          })),
+          address: contract.address,
+          display_name: contract.displayName,
+          network_id: contract.chainId,
         },
       },
     );
@@ -118,9 +104,12 @@ describe('TenderlyApi', () => {
     );
     mockNetworkService.post.mockRejectedValueOnce(error);
 
-    await expect(service.addContracts([])).rejects.toThrow(
-      new DataSourceError('Unexpected error', status),
-    );
+    await expect(
+      service.addContract({
+        address: faker.finance.ethereumAddress(),
+        chainId: faker.string.numeric(),
+      }),
+    ).rejects.toThrow(new DataSourceError('Unexpected error', status));
 
     expect(mockNetworkService.post).toHaveBeenCalledTimes(1);
   });

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -33,19 +33,17 @@ export class TenderlyApi implements IAlertsApi {
       this.configurationService.getOrThrow<string>('alerts.project');
   }
 
-  async addContracts(contracts: Array<AlertsRegistration>): Promise<void> {
+  async addContract(contract: AlertsRegistration): Promise<void> {
     try {
-      const url = `${this.baseUrl}/api/v2/accounts/${this.account}/projects/${this.project}/contracts`;
+      const url = `${this.baseUrl}/api/v1/account/${this.account}/project/${this.project}/address`;
       await this.networkService.post(url, {
         headers: {
           [TenderlyApi.HEADER]: this.apiKey,
         },
         params: {
-          contracts: contracts.map((contract) => ({
-            address: contract.address,
-            display_name: contract.displayName,
-            network_id: contract.chainId,
-          })),
+          address: contract.address,
+          display_name: contract.displayName,
+          network_id: contract.chainId,
         },
       });
     } catch (error) {

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -33,6 +33,16 @@ export class TenderlyApi implements IAlertsApi {
       this.configurationService.getOrThrow<string>('alerts.project');
   }
 
+  /**
+   * Add a smart contract to a Tenderly project.
+   *
+   * Note: If a contract is unverified on both Tenderly and external providers like Etherscan,
+   * Blockscout, or Routescan, it will be added to the project as unverified. However, if the
+   * contract is verified on an external provider, Tenderly will retrieve and apply the
+   * verification, subsequently adding the verified contract to the project.
+   *
+   * @see https://docs.tenderly.co/reference/api#tag/Contracts/operation/addContractToProject
+   */
   async addContract(contract: AlertsRegistration): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/account/${this.account}/project/${this.project}/address`;

--- a/src/domain/alerts/alerts.repository.interface.ts
+++ b/src/domain/alerts/alerts.repository.interface.ts
@@ -5,10 +5,10 @@ export const IAlertsRepository = Symbol('IAlertsRepository');
 
 export interface IAlertsRepository {
   /**
-   * Adds the {@link contracts} to the Alerts provider
-   * @param contracts - the network-specific {@link AlertsRegistration} to add
+   * Adds the {@link contract} to the Alerts provider
+   * @param contract - the network-specific {@link AlertsRegistration} to add
    */
-  addContracts(contracts: Array<AlertsRegistration>): Promise<void>;
+  addContract(contract: AlertsRegistration): Promise<void>;
 
   /**
    * Parses and notifies the user about the {@link log} from the Alerts provider

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -47,8 +47,8 @@ export class AlertsRepository implements IAlertsRepository {
     private readonly subscriptionRepository: ISubscriptionRepository,
   ) {}
 
-  async addContracts(contracts: Array<AlertsRegistration>): Promise<void> {
-    await this.alertsApi.addContracts(contracts);
+  async addContract(contract: AlertsRegistration): Promise<void> {
+    await this.alertsApi.addContract(contract);
   }
 
   async handleAlertLog(chainId: string, log: AlertLog): Promise<void> {

--- a/src/domain/interfaces/alerts-api.interface.ts
+++ b/src/domain/interfaces/alerts-api.interface.ts
@@ -3,5 +3,5 @@ import { AlertsRegistration } from '@/domain/alerts/entities/alerts.entity';
 export const IAlertsApi = Symbol('IAlertsApi');
 
 export interface IAlertsApi {
-  addContracts(contracts: Array<AlertsRegistration>): Promise<void>;
+  addContract(contract: AlertsRegistration): Promise<void>;
 }

--- a/src/routes/recovery/recovery.controller.spec.ts
+++ b/src/routes/recovery/recovery.controller.spec.ts
@@ -76,7 +76,7 @@ describe('Recovery (Unit)', () => {
 
       networkService.post.mockImplementation((url) =>
         url ===
-        `${alertsUrl}/api/v2/accounts/${alertsAccount}/projects/${alertsProject}/contracts`
+        `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.resolve({ status: 200, data: {} })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
@@ -105,7 +105,7 @@ describe('Recovery (Unit)', () => {
       const safeAddress = faker.finance.ethereumAddress();
       const error = new NetworkResponseError(
         new URL(
-          `${alertsUrl}/api/v2/accounts/${alertsAccount}/projects/${alertsProject}/contracts`,
+          `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`,
         ),
         {
           status: 400,
@@ -118,7 +118,7 @@ describe('Recovery (Unit)', () => {
 
       networkService.post.mockImplementation((url) =>
         url ===
-        `${alertsUrl}/api/v2/accounts/${alertsAccount}/projects/${alertsProject}/contracts`
+        `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),
       );
@@ -142,7 +142,7 @@ describe('Recovery (Unit)', () => {
       });
       const error = new NetworkResponseError(
         new URL(
-          `${alertsUrl}/api/v2/accounts/${alertsAccount}/projects/${alertsProject}/contracts`,
+          `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`,
         ),
         {
           status: statusCode,
@@ -151,7 +151,7 @@ describe('Recovery (Unit)', () => {
 
       networkService.post.mockImplementation((url) =>
         url ===
-        `${alertsUrl}/api/v2/accounts/${alertsAccount}/projects/${alertsProject}/contracts`
+        `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),
       );

--- a/src/routes/recovery/recovery.service.ts
+++ b/src/routes/recovery/recovery.service.ts
@@ -21,6 +21,6 @@ export class RecoveryService {
       address: args.addRecoveryModuleDto.moduleAddress,
       displayName: `${args.chainId}:${args.safeAddress}:${args.addRecoveryModuleDto.moduleAddress}`,
     };
-    await this.alertsRepository.addContracts([contract]);
+    await this.alertsRepository.addContract(contract);
   }
 }


### PR DESCRIPTION
## Summary

This changes the endpoint from Tenderly used to add a contract from one that supports multiple addresses, to one that supports one.

## Motivation

1. We are only using this endpoint to add recovery modules, which there is only one of when activating it on a Safe.
2. The singular address endpoint is the only one specified in the [API documentation](https://docs.tenderly.co/reference/api#tag/Contracts/operation/addContractToProject).
