### PR TITLE
Redirect legacy relay route using `chainId` from `body`

### DIFF
--- a/src/routes/relay/entities/relay.legacy.dto.entity.ts
+++ b/src/routes/relay/entities/relay.legacy.dto.entity.ts
@@ -1,0 +1,6 @@
+export class RelayLegacyDto {
+  chainId!: string;
+  to!: string;
+  data!: string;
+  gasLimit!: string | null;
+}

--- a/src/routes/relay/entities/schemas/relay.legacy.dto.schema.ts
+++ b/src/routes/relay/entities/schemas/relay.legacy.dto.schema.ts
@@ -1,0 +1,17 @@
+import { RelayLegacyDto } from '@/routes/relay/entities/relay.legacy.dto.entity';
+import { JSONSchemaType } from 'ajv';
+
+export const RELAY_LEGACY_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/relay/relay.legacy.dto.json';
+
+export const relayLegacyDtoSchema: JSONSchemaType<RelayLegacyDto> = {
+  $id: RELAY_LEGACY_DTO_SCHEMA_ID,
+  type: 'object',
+  properties: {
+    chainId: { type: 'string' },
+    to: { type: 'string' },
+    data: { type: 'string' },
+    gasLimit: { oneOf: [{ type: 'string' }, { type: 'null', nullable: true }] },
+  },
+  required: ['chainId', 'to', 'data'],
+};

--- a/src/routes/relay/pipes/relay.legacy.validation.pipe.ts
+++ b/src/routes/relay/pipes/relay.legacy.validation.pipe.ts
@@ -1,0 +1,29 @@
+import { RelayLegacyDto } from '@/routes/relay/entities/relay.legacy.dto.entity';
+import {
+  RELAY_LEGACY_DTO_SCHEMA_ID,
+  relayLegacyDtoSchema,
+} from '@/routes/relay/entities/schemas/relay.legacy.dto.schema';
+import { GenericValidator } from '@/validation/providers/generic.validator';
+import { JsonSchemaService } from '@/validation/providers/json-schema.service';
+import { Injectable, PipeTransform } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+
+@Injectable()
+export class RelayLegacyDtoValidationPipe
+  implements PipeTransform<unknown, RelayLegacyDto>
+{
+  private readonly isValid: ValidateFunction<RelayLegacyDto>;
+
+  constructor(
+    private readonly genericValidator: GenericValidator,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValid = this.jsonSchemaService.getSchema(
+      RELAY_LEGACY_DTO_SCHEMA_ID,
+      relayLegacyDtoSchema,
+    );
+  }
+  transform(data: unknown): RelayLegacyDto {
+    return this.genericValidator.validate(this.isValid, data);
+  }
+}

--- a/src/routes/relay/relay.legacy.controller.spec.ts
+++ b/src/routes/relay/relay.legacy.controller.spec.ts
@@ -59,8 +59,9 @@ describe('Relay controller', () => {
         const data = faker.string.hexadecimal();
 
         await request(app.getHttpServer())
-          .post(`/v1/relay/${chainId}`)
+          .post(`/v1/relay`)
           .send({
+            chainId,
             to: safeAddress,
             data,
           })

--- a/src/routes/relay/relay.legacy.controller.ts
+++ b/src/routes/relay/relay.legacy.controller.ts
@@ -1,17 +1,34 @@
-import { Controller, Post, Get, HttpStatus, Res, Param } from '@nestjs/common';
+import { RelayLegacyDto } from '@/routes/relay/entities/relay.legacy.dto.entity';
+import { RelayLegacyDtoValidationPipe } from '@/routes/relay/pipes/relay.legacy.validation.pipe';
+import {
+  Controller,
+  Post,
+  Get,
+  HttpStatus,
+  Res,
+  Param,
+  Body,
+} from '@nestjs/common';
 import { Response } from 'express';
 
 @Controller({
   version: '1',
-  path: 'relay/:chainId',
+  path: 'relay',
 })
 export class RelayLegacyController {
   @Post()
-  relay(@Param('chainId') chainId: string, @Res() res: Response): void {
-    res.redirect(HttpStatus.PERMANENT_REDIRECT, `/v1/chains/${chainId}/relay`);
+  relay(
+    @Body(RelayLegacyDtoValidationPipe)
+    relayLegacyDto: RelayLegacyDto,
+    @Res() res: Response,
+  ): void {
+    res.redirect(
+      HttpStatus.PERMANENT_REDIRECT,
+      `/v1/chains/${relayLegacyDto.chainId}/relay`,
+    );
   }
 
-  @Get(':safeAddress')
+  @Get('/:chainId/:safeAddress')
   getRelaysRemaining(
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,


### PR DESCRIPTION
## Summary

The legacy relay route was incorrect, assuming that the `chainId` was present in it. It is/was, however, in the body. This updates the route and redirection, adding the correct validation to ensure correctness.

## Changes

- Update legacy relay route to be `/v1/relay` and redirect with `body.chainId`
- Add associated validation
- Update relevant tests