### PR TITLE
Extend ICacheService interface by storing incrementable numeric values

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -59,7 +59,7 @@ describe('FakeCacheService', () => {
     expect(target.keyCount()).toBe(0);
   });
 
-  it('increments the value of a key', async () => {
+  it('creates a missing key and increments its value', async () => {
     const key = faker.string.alphanumeric();
     const firstResult = await target.incrementAndGet(key, undefined);
     expect(firstResult).toEqual(1);
@@ -70,5 +70,16 @@ describe('FakeCacheService', () => {
     }
 
     expect(results).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  it('increments the value of an existing key', async () => {
+    const key = faker.string.alphanumeric();
+    const initialValue = faker.number.int({ min: 100 });
+    target.initNumericalValue(key, initialValue);
+
+    for (let i = 1; i <= 5; i++) {
+      const result = await target.incrementAndGet(key, undefined);
+      expect(result).toEqual(initialValue + i);
+    }
   });
 });

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -75,7 +75,11 @@ describe('FakeCacheService', () => {
   it('increments the value of an existing key', async () => {
     const key = faker.string.alphanumeric();
     const initialValue = faker.number.int({ min: 100 });
-    target.initNumericalValue(key, initialValue);
+    await target.set(
+      new CacheDir(key, ''),
+      initialValue,
+      faker.number.int({ min: 1 }),
+    );
 
     for (let i = 1; i <= 5; i++) {
       const result = await target.increment(key, undefined);

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -61,12 +61,12 @@ describe('FakeCacheService', () => {
 
   it('creates a missing key and increments its value', async () => {
     const key = faker.string.alphanumeric();
-    const firstResult = await target.incrementAndGet(key, undefined);
+    const firstResult = await target.increment(key, undefined);
     expect(firstResult).toEqual(1);
 
     const results: number[] = [];
     for (let i = 0; i < 5; i++) {
-      results.push(await target.incrementAndGet(key, undefined));
+      results.push(await target.increment(key, undefined));
     }
 
     expect(results).toEqual([2, 3, 4, 5, 6]);
@@ -78,7 +78,7 @@ describe('FakeCacheService', () => {
     target.initNumericalValue(key, initialValue);
 
     for (let i = 1; i <= 5; i++) {
-      const result = await target.incrementAndGet(key, undefined);
+      const result = await target.increment(key, undefined);
       expect(result).toEqual(initialValue + i);
     }
   });

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -58,4 +58,17 @@ describe('FakeCacheService', () => {
 
     expect(target.keyCount()).toBe(0);
   });
+
+  it('increments the value of a key', async () => {
+    const key = faker.string.alphanumeric();
+    const firstResult = await target.incrementAndGet(key, undefined);
+    expect(firstResult).toEqual(1);
+
+    const results: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      results.push(await target.incrementAndGet(key, undefined));
+    }
+
+    expect(results).toEqual([2, 3, 4, 5, 6]);
+  });
 });

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -41,7 +41,7 @@ export class FakeCacheService implements ICacheService {
 
   set(
     cacheDir: CacheDir,
-    value: string | number, // this changed
+    value: string | number,
     expireTimeSeconds: number | undefined,
   ): Promise<void> {
     if (!expireTimeSeconds || expireTimeSeconds <= 0) {

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -56,7 +56,7 @@ export class FakeCacheService implements ICacheService {
     return Promise.resolve();
   }
 
-  incrementAndGet(
+  increment(
     cacheKey: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     expireTimeSeconds: number | undefined,

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -2,7 +2,7 @@ import { ICacheService } from '@/datasources/cache/cache.service.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
 export class FakeCacheService implements ICacheService {
-  private cache: Record<string, Record<string, string>> = {};
+  private cache: Record<string, Record<string, string> | number> = {};
   private isReady: boolean = true;
 
   ping(): Promise<unknown> {
@@ -34,7 +34,9 @@ export class FakeCacheService implements ICacheService {
   get(cacheDir: CacheDir): Promise<string | undefined> {
     const fields = this.cache[cacheDir.key];
     if (fields === undefined) return Promise.resolve(undefined);
-    return Promise.resolve(this.cache[cacheDir.key][cacheDir.field]);
+    return Promise.resolve(
+      (this.cache[cacheDir.key] as Record<string, string>)[cacheDir.field],
+    );
   }
 
   set(
@@ -49,7 +51,21 @@ export class FakeCacheService implements ICacheService {
     if (fields === undefined) {
       this.cache[cacheDir.key] = {};
     }
-    this.cache[cacheDir.key][cacheDir.field] = value;
+    (this.cache[cacheDir.key] as Record<string, string>)[cacheDir.field] =
+      value;
     return Promise.resolve();
+  }
+
+  incrementAndGet(
+    cacheKey: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    expireTimeSeconds: number | undefined,
+  ): Promise<number> {
+    if (!this.cache[cacheKey]) {
+      this.cache[cacheKey] = 1;
+    } else {
+      this.cache[cacheKey] = ++(this.cache[cacheKey] as number);
+    }
+    return Promise.resolve(this.cache[cacheKey] as number);
   }
 }

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -68,4 +68,8 @@ export class FakeCacheService implements ICacheService {
     }
     return Promise.resolve(this.cache[cacheKey] as number);
   }
+
+  initNumericalValue(cacheKey: string, value: number): void {
+    this.cache[cacheKey] = value;
+  }
 }

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -41,10 +41,14 @@ export class FakeCacheService implements ICacheService {
 
   set(
     cacheDir: CacheDir,
-    value: string,
+    value: string | number, // this changed
     expireTimeSeconds: number | undefined,
   ): Promise<void> {
     if (!expireTimeSeconds || expireTimeSeconds <= 0) {
+      return Promise.resolve();
+    }
+    if (typeof value === 'number') {
+      this.cache[cacheDir.key] = value;
       return Promise.resolve();
     }
     const fields = this.cache[cacheDir.key];
@@ -67,9 +71,5 @@ export class FakeCacheService implements ICacheService {
       this.cache[cacheKey] = ++(this.cache[cacheKey] as number);
     }
     return Promise.resolve(this.cache[cacheKey] as number);
-  }
-
-  initNumericalValue(cacheKey: string, value: number): void {
-    this.cache[cacheKey] = value;
   }
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -13,7 +13,7 @@ export interface ICacheService {
 
   deleteByKey(key: string): Promise<number>;
 
-  incrementAndGet(
+  increment(
     cacheKey: string,
     expireTimeSeconds: number | undefined,
   ): Promise<number>;

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -12,4 +12,9 @@ export interface ICacheService {
   get(cacheDir: CacheDir): Promise<string | undefined>;
 
   deleteByKey(key: string): Promise<number>;
+
+  incrementAndGet(
+    cacheKey: string,
+    expireTimeSeconds: number | undefined,
+  ): Promise<number>;
 }

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -149,15 +149,12 @@ describe('RedisCacheService', () => {
   it('creates a missing key and increments its value', async () => {
     const expireTime = faker.number.int({ min: 1 });
     const key = faker.string.alphanumeric();
-    const firstResult = await redisCacheService.incrementAndGet(
-      key,
-      expireTime,
-    );
+    const firstResult = await redisCacheService.increment(key, expireTime);
     expect(firstResult).toEqual(1);
 
     const results: number[] = [];
     for (let i = 0; i < 5; i++) {
-      results.push(await redisCacheService.incrementAndGet(key, expireTime));
+      results.push(await redisCacheService.increment(key, expireTime));
     }
 
     const ttl = await redisClient.ttl(key);
@@ -173,7 +170,7 @@ describe('RedisCacheService', () => {
     await redisClient.set(key, initialValue, { EX: expireTime });
 
     for (let i = 1; i <= 5; i++) {
-      const result = await redisCacheService.incrementAndGet(key, undefined);
+      const result = await redisCacheService.increment(key, undefined);
       expect(result).toEqual(initialValue + i);
     }
 

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -149,16 +149,11 @@ describe('RedisCacheService', () => {
   it('creates a missing key and increments its value', async () => {
     const expireTime = faker.number.int({ min: 1 });
     const key = faker.string.alphanumeric();
-    const firstResult = await redisCacheService.increment(key, expireTime);
-    expect(firstResult).toEqual(1);
 
-    const results: number[] = [];
-    for (let i = 0; i < 5; i++) {
-      results.push(await redisCacheService.increment(key, expireTime));
-    }
+    const firstResult = await redisCacheService.increment(key, expireTime);
 
     const ttl = await redisClient.ttl(key);
-    expect(results).toEqual([2, 3, 4, 5, 6]);
+    expect(firstResult).toEqual(1);
     expect(ttl).toBeGreaterThan(0);
     expect(ttl).toBeLessThanOrEqual(expireTime);
   });

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -70,15 +70,16 @@ export class RedisCacheService
     return result;
   }
 
-  async incrementAndGet(
+  async increment(
     cacheKey: string,
     expireTimeSeconds: number | undefined,
   ): Promise<number> {
-    const result = await this.client.incr(cacheKey);
+    const transaction = this.client.multi().incr(cacheKey);
     if (expireTimeSeconds !== undefined && expireTimeSeconds > 0) {
-      await this.client.expire(cacheKey, expireTimeSeconds, 'NX');
+      transaction.expire(cacheKey, expireTimeSeconds, 'NX');
     }
-    return result;
+    const [incrRes] = await transaction.get(cacheKey).exec();
+    return Number(incrRes);
   }
 
   /**

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -70,6 +70,17 @@ export class RedisCacheService
     return result;
   }
 
+  async incrementAndGet(
+    cacheKey: string,
+    expireTimeSeconds: number | undefined,
+  ): Promise<number> {
+    const result = await this.client.incr(cacheKey);
+    if (expireTimeSeconds !== undefined && expireTimeSeconds > 0) {
+      await this.client.expire(cacheKey, expireTimeSeconds, 'NX');
+    }
+    return result;
+  }
+
   /**
    * Constructs a prefixed key string.
    *


### PR DESCRIPTION
## Summary
This adds a new functionality to `ICacheService` interface: setting keys on the underlying cache that hold `number` values and can be incremented sequentially.

## Changes
- Adds `ICacheService.incrementAndGet` function. It also adds the function code on each implementation class. 
