### PR TITLE
Propagate Django error messages from Transaction Service

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -116,7 +116,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const data = faker.string.hexadecimal();
@@ -169,7 +169,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const getBackboneUrl = `${baseUrl}/api/v1/about`;
@@ -221,7 +221,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const getSingletonsUrl = `${baseUrl}/api/v1/about/singletons/`;
@@ -273,7 +273,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safe = safeBuilder().build();
@@ -342,7 +342,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const contract = faker.finance.ethereumAddress();
@@ -412,7 +412,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const delegate = delegateBuilder().build();
@@ -487,7 +487,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const delegate = delegateBuilder().build();
@@ -549,7 +549,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const delegate = delegateBuilder().build();
@@ -615,7 +615,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const delegate = delegateBuilder().build();
@@ -682,7 +682,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const transferId = faker.string.hexadecimal();
@@ -761,7 +761,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -889,7 +889,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -989,7 +989,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeTxHash = faker.string.hexadecimal();
@@ -1047,7 +1047,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const moduleAddress = faker.finance.ethereumAddress();
@@ -1100,7 +1100,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const moduleTransactionId = faker.string.hexadecimal();
@@ -1180,7 +1180,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const moduleTransaction = moduleTransactionBuilder().build();
@@ -1307,7 +1307,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const multisigTransaction = multisigTransactionBuilder().build();
@@ -1417,7 +1417,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const multisigTransaction = multisigTransactionBuilder().build();
@@ -1477,7 +1477,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeTxHash = faker.string.hexadecimal();
@@ -1549,7 +1549,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -1637,7 +1637,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -1730,7 +1730,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const token = tokenBuilder().build();
@@ -1795,7 +1795,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const limit = faker.number.int();
@@ -1866,7 +1866,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const owner = faker.finance.ethereumAddress();
@@ -1942,7 +1942,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeTxHash = faker.string.hexadecimal();
@@ -1995,7 +1995,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const uuid = faker.string.uuid();
@@ -2045,7 +2045,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const uuid = faker.string.uuid();
@@ -2109,7 +2109,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -2171,7 +2171,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const messageHash = faker.string.hexadecimal();
@@ -2242,7 +2242,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -2319,7 +2319,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -2387,7 +2387,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const safeAddress = faker.finance.ethereumAddress();
@@ -2453,7 +2453,7 @@ describe('TransactionApi', () => {
 
     const errorMessage = faker.word.words();
     it.each([
-      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const messageHash = faker.string.hexadecimal();

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -9,6 +9,20 @@ import { TransactionApi } from '@/datasources/transaction-api/transaction-api.se
 import { backboneBuilder } from '@/domain/backbone/entities/__tests__/backbone.builder';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
+import { singletonBuilder } from '@/domain/chains/entities/__tests__/singleton.builder';
+import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { delegateBuilder } from '@/domain/delegate/entities/__tests__/delegate.builder';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import { moduleTransactionBuilder } from '@/domain/safe/entities/__tests__/module-transaction.builder';
+import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
+import { creationTransactionBuilder } from '@/domain/safe/entities/__tests__/creation-transaction.builder';
+import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import { messageBuilder } from '@/domain/messages/entities/__tests__/message.builder';
+import { proposeTransactionDtoBuilder } from '@/routes/transactions/entities/__tests__/propose-transaction.dto.builder';
+import { erc20TransferBuilder } from '@/domain/safe/entities/__tests__/erc20-transfer.builder';
+import { DeviceType } from '@/domain/notifications/entities/device.entity';
 
 const dataSource = {
   get: jest.fn(),
@@ -26,20 +40,17 @@ const configurationService = {
 } as jest.MockedObjectDeep<IConfigurationService>;
 const mockConfigurationService = jest.mocked(configurationService);
 
-const httpErrorFactory = {
-  from: jest.fn(),
-} as jest.MockedObjectDeep<HttpErrorFactory>;
-const mockHttpErrorFactory = jest.mocked(httpErrorFactory);
-
 const networkService = jest.mocked({
   get: jest.fn(),
   post: jest.fn(),
+  delete: jest.fn(),
 } as jest.MockedObjectDeep<INetworkService>);
 const mockNetworkService = jest.mocked(networkService);
 
 describe('TransactionApi', () => {
   const chainId = '1';
   const baseUrl = faker.internet.url({ appendSlash: false });
+  let httpErrorFactory: HttpErrorFactory;
   let service: TransactionApi;
   let defaultExpirationTimeInSeconds: number;
   let notFoundExpireTimeSeconds: number;
@@ -48,6 +59,7 @@ describe('TransactionApi', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    httpErrorFactory = new HttpErrorFactory();
     defaultExpirationTimeInSeconds = faker.number.int();
     notFoundExpireTimeSeconds = faker.number.int();
     ownersTtlSeconds = faker.number.int();
@@ -76,99 +88,2431 @@ describe('TransactionApi', () => {
       mockDataSource,
       mockCacheService,
       mockConfigurationService,
-      mockHttpErrorFactory,
+      httpErrorFactory,
       mockNetworkService,
     );
   });
 
-  describe('Backbone', () => {
+  describe('getDataDecoded', () => {
+    it('should return the decoded data', async () => {
+      const data = faker.string.hexadecimal();
+      const to = faker.finance.ethereumAddress();
+      const getDataDecodedUrl = `${baseUrl}/api/v1/data-decoder/`;
+      const decodedData = dataDecodedBuilder().build();
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: decodedData,
+      });
+
+      const actual = await service.getDataDecoded({ data, to });
+
+      expect(actual).toBe(decodedData);
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(getDataDecodedUrl, {
+        data,
+        to,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const data = faker.string.hexadecimal();
+      const to = faker.finance.ethereumAddress();
+      const getDataDecodedUrl = `${baseUrl}/api/v1/data-decoder/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getDataDecodedUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getDataDecoded({ data, to })).rejects.toThrow(
+        expected,
+      );
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(getDataDecodedUrl, {
+        data,
+        to,
+      });
+    });
+  });
+
+  describe('getBackbone', () => {
     it('should return the backbone retrieved', async () => {
       const data = backboneBuilder().build();
+      const getBackboneUrl = `${baseUrl}/api/v1/about`;
+      const cacheDir = new CacheDir(`${chainId}_backbone`, '');
       mockDataSource.get.mockResolvedValueOnce(data);
 
       const actual = await service.getBackbone();
 
       expect(actual).toBe(data);
-      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getBackboneUrl,
+      });
     });
 
-    it('should forward error', async () => {
-      const expected = new DataSourceError('something happened');
-      mockHttpErrorFactory.from.mockReturnValue(expected);
-      mockDataSource.get.mockRejectedValueOnce(new Error('testErr'));
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const getBackboneUrl = `${baseUrl}/api/v1/about`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_backbone`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getBackboneUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
 
       await expect(service.getBackbone()).rejects.toThrow(expected);
 
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
-      expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getBackboneUrl,
+      });
     });
   });
 
-  describe('Safe', () => {
-    describe('getSafe', () => {
-      it('should return retrieved safe', async () => {
-        const safe = safeBuilder().build();
-        mockDataSource.get.mockResolvedValueOnce(safe);
+  describe('getSingletons', () => {
+    it('should return the singletons received', async () => {
+      const singletons = [singletonBuilder().build()];
+      const getSingletonsUrl = `${baseUrl}/api/v1/about/singletons/`;
+      const cacheDir = new CacheDir(`${chainId}_singletons`, '');
+      mockDataSource.get.mockResolvedValueOnce(singletons);
 
-        const actual = await service.getSafe(safe.address);
+      const actual = await service.getSingletons();
 
-        expect(actual).toBe(safe);
-        expect(mockDataSource.get).toHaveBeenCalledWith({
-          cacheDir: new CacheDir(`${chainId}_safe_${safe.address}`, ''),
-          url: `${baseUrl}/api/v1/safes/${safe.address}`,
-          notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
-          expireTimeSeconds: defaultExpirationTimeInSeconds,
-        });
-        expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
-      });
-
-      it('should map error on error', async () => {
-        const safe = safeBuilder().build();
-        const error = new Error('some error');
-        const expected = new DataSourceError('some data source error');
-        mockDataSource.get.mockRejectedValueOnce(error);
-        mockHttpErrorFactory.from.mockReturnValue(expected);
-
-        await expect(service.getSafe(safe.address)).rejects.toThrow(expected);
-        expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
+      expect(actual).toBe(singletons);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getSingletonsUrl,
       });
     });
 
-    describe('getSafesByModules', () => {
-      it('should return Safes with module enabled', async () => {
-        const moduleAddress = faker.finance.ethereumAddress();
-        const safesByModule = {
-          safes: [
-            faker.finance.ethereumAddress(),
-            faker.finance.ethereumAddress(),
-          ],
-        };
-        mockNetworkService.get.mockResolvedValueOnce({
-          data: safesByModule,
-          status: 200,
-        });
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const getSingletonsUrl = `${baseUrl}/api/v1/about/singletons/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_singletons`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getSingletonsUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
 
-        const actual = await service.getSafesByModule(moduleAddress);
+      await expect(service.getSingletons()).rejects.toThrow(expected);
 
-        expect(actual).toBe(safesByModule);
-        expect(mockNetworkService.get).toHaveBeenCalledWith(
-          `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`,
-        );
-        expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getSingletonsUrl,
+      });
+    });
+  });
+
+  describe('getSafe', () => {
+    it('should return retrieved safe', async () => {
+      const safe = safeBuilder().build();
+      const getSafeUrl = `${baseUrl}/api/v1/safes/${safe.address}`;
+      const cacheDir = new CacheDir(`${chainId}_safe_${safe.address}`, '');
+      mockDataSource.get.mockResolvedValueOnce(safe);
+
+      const actual = await service.getSafe(safe.address);
+
+      expect(actual).toBe(safe);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getSafeUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safe = safeBuilder().build();
+      const getSafeUrl = `${baseUrl}/api/v1/safes/${safe.address}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_safe_${safe.address}`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getSafeUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getSafe(safe.address)).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getSafeUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+      });
+    });
+  });
+
+  describe('clearSafe', () => {
+    it('should clear the Safe cache', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearSafe(safeAddress);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_safe_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getContract', () => {
+    it('should return retrieved contract', async () => {
+      const contract = contractBuilder().build();
+      const getContractUrl = `${baseUrl}/api/v1/contracts/${contract.address}`;
+      const cacheDir = new CacheDir(
+        `${chainId}_contract_${contract.address}`,
+        '',
+      );
+      mockDataSource.get.mockResolvedValueOnce(contract);
+
+      const actual = await service.getContract(contract.address);
+
+      expect(actual).toBe(contract);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getContractUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const contract = faker.finance.ethereumAddress();
+      const getContractUrl = `${baseUrl}/api/v1/contracts/${contract}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_contract_${contract}`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getContractUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getContract(contract)).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getContractUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+      });
+    });
+  });
+
+  describe('getDelegates', () => {
+    it('should return retrieved delegates', async () => {
+      const delegate = delegateBuilder().build();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const delegatesPage = pageBuilder().with('results', [delegate]).build();
+      const getDelegatesUrl = `${baseUrl}/api/v1/delegates/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_delegates_${delegate.safe}`,
+        `${delegate.delegate}_${delegate.delegator}_${delegate.label}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockResolvedValueOnce(delegatesPage);
+
+      const actual = await service.getDelegates({
+        ...delegate,
+        safeAddress: delegate.safe!,
+        limit,
+        offset,
       });
 
-      it('should map error on error', async () => {
-        const moduleAddress = faker.finance.ethereumAddress();
-        const error = new Error('some error');
-        const expected = new DataSourceError('some data source error');
-        mockNetworkService.get.mockRejectedValueOnce(error);
-        mockHttpErrorFactory.from.mockReturnValue(expected);
-
-        await expect(service.getSafesByModule(moduleAddress)).rejects.toThrow(
-          expected,
-        );
-        expect(httpErrorFactory.from).toHaveBeenCalledTimes(1);
+      expect(actual).toBe(delegatesPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getDelegatesUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        networkRequest: {
+          params: {
+            ...delegate,
+            limit,
+            offset,
+          },
+        },
       });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const delegate = delegateBuilder().build();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getDelegatesUrl = `${baseUrl}/api/v1/delegates/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_delegates_${delegate.safe}`,
+        `${delegate.delegate}_${delegate.delegator}_${delegate.label}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getDelegatesUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getDelegates({
+          ...delegate,
+          safeAddress: delegate.safe!,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getDelegatesUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        networkRequest: {
+          params: {
+            ...delegate,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('postDelegate', () => {
+    it('should post delegate', async () => {
+      const delegate = delegateBuilder().build();
+      const signature = faker.string.hexadecimal();
+      const postDelegateUrl = `${baseUrl}/api/v1/delegates/`;
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.postDelegate({
+        ...delegate,
+        safeAddress: delegate.safe!,
+        signature,
+      });
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postDelegateUrl, {
+        ...delegate,
+        signature,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const delegate = delegateBuilder().build();
+      const signature = faker.string.hexadecimal();
+      const postDelegateUrl = `${baseUrl}/api/v1/delegates/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(postDelegateUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.postDelegate({
+          ...delegate,
+          safeAddress: delegate.safe!,
+          signature,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postDelegateUrl, {
+        ...delegate,
+        signature,
+      });
+    });
+  });
+
+  describe('deleteDelegate', () => {
+    it('should delete delegate', async () => {
+      const delegate = delegateBuilder().build();
+      const signature = faker.string.hexadecimal();
+      const deleteDelegateUrl = `${baseUrl}/api/v1/delegates/${delegate.delegate}`;
+      networkService.delete.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.deleteDelegate({
+        delegate: delegate.delegate,
+        delegator: delegate.delegator,
+        signature,
+      });
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(deleteDelegateUrl, {
+        delegate: delegate.delegate,
+        delegator: delegate.delegator,
+        signature,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const delegate = delegateBuilder().build();
+      const signature = faker.string.hexadecimal();
+      const deleteDelegateUrl = `${baseUrl}/api/v1/delegates/${delegate.delegate}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.delete.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(deleteDelegateUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.deleteDelegate({
+          delegate: delegate.delegate,
+          delegator: delegate.delegator,
+          signature,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(deleteDelegateUrl, {
+        delegate: delegate.delegate,
+        delegator: delegate.delegator,
+        signature,
+      });
+    });
+  });
+
+  describe('deleteSafeDelegate', () => {
+    it('should delete Safe delegate', async () => {
+      const delegate = delegateBuilder().build();
+      const signature = faker.string.hexadecimal();
+      const deleteSafeDelegateUrl = `${baseUrl}/api/v1/safes/${delegate.safe}/delegates/${delegate.delegate}`;
+      networkService.delete.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.deleteSafeDelegate({
+        delegate: delegate.delegate,
+        safeAddress: delegate.safe!,
+        signature,
+      });
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(
+        deleteSafeDelegateUrl,
+        {
+          delegate: delegate.delegate,
+          safe: delegate.safe!,
+          signature,
+        },
+      );
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const delegate = delegateBuilder().build();
+      const signature = faker.string.hexadecimal();
+      const deleteSafeDelegateUrl = `${baseUrl}/api/v1/safes/${delegate.safe}/delegates/${delegate.delegate}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.delete.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(deleteSafeDelegateUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.deleteSafeDelegate({
+          delegate: delegate.delegate,
+          safeAddress: delegate.safe!,
+          signature,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(
+        deleteSafeDelegateUrl,
+        {
+          delegate: delegate.delegate,
+          safe: delegate.safe!,
+          signature,
+        },
+      );
+    });
+  });
+
+  describe('getTransfer', () => {
+    it('should return the transfer retrieved', async () => {
+      const transfer = erc20TransferBuilder().build();
+      const getTransferUrl = `${baseUrl}/api/v1/transfer/${transfer.transferId}`;
+      const cacheDir = new CacheDir(
+        `${chainId}_transfer_${transfer.transferId}`,
+        '',
+      );
+      networkService.get.mockResolvedValueOnce({
+        status: 200,
+        data: transfer,
+      });
+
+      const actual = await service.getTransfer(transfer.transferId);
+
+      expect(actual).toBe(actual);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTransferUrl,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const transferId = faker.string.hexadecimal();
+      const getTransferUrl = `${baseUrl}/api/v1/transfer/${transferId}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_transfer_${transferId}`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getTransferUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getTransfer(transferId)).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTransferUrl,
+      });
+    });
+  });
+
+  describe('getTransfers', () => {
+    it('should return the transfers retrieved', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const onlyErc20 = faker.datatype.boolean();
+      const onlyErc721 = faker.datatype.boolean();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const transfer = erc20TransferBuilder().build();
+      const transfersPage = pageBuilder().with('results', [transfer]).build();
+      const getTransfersUrl = `${baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_transfers_${safeAddress}`,
+        `${onlyErc20}_${onlyErc721}_${limit}_${offset}`,
+      );
+      networkService.get.mockResolvedValueOnce({
+        status: 200,
+        data: transfersPage,
+      });
+
+      const actual = await service.getTransfers({
+        safeAddress,
+        onlyErc20,
+        onlyErc721,
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(actual);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTransfersUrl,
+        networkRequest: {
+          params: {
+            erc20: onlyErc20,
+            erc721: onlyErc721,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const onlyErc20 = faker.datatype.boolean();
+      const onlyErc721 = faker.datatype.boolean();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getTransfersUrl = `${baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_transfers_${safeAddress}`,
+        `${onlyErc20}_${onlyErc721}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getTransfersUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getTransfers({
+          safeAddress,
+          onlyErc20,
+          onlyErc721,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTransfersUrl,
+        networkRequest: {
+          params: {
+            erc20: onlyErc20,
+            erc721: onlyErc721,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('clearTransfers', () => {
+    it('should clear the transfers cache', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearTransfers(safeAddress);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_transfers_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getIncomingTransfers', () => {
+    it('should return the incoming transfers retrieved', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const executionDateGte = faker.date.recent().toISOString();
+      const executionDateLte = faker.date.recent().toISOString();
+      const to = faker.finance.ethereumAddress();
+      const value = faker.string.numeric();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const incomingTransfer = erc20TransferBuilder()
+        .with('to', safeAddress)
+        .build();
+      const incomingTransfersPage = pageBuilder()
+        .with('results', [incomingTransfer])
+        .build();
+      const getIncomingTransfersUrl = `${baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_incoming_transfers_${safeAddress}`,
+        `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`,
+      );
+      networkService.get.mockResolvedValueOnce({
+        status: 200,
+        data: incomingTransfersPage,
+      });
+
+      const actual = await service.getIncomingTransfers({
+        safeAddress,
+        executionDateGte,
+        executionDateLte,
+        to,
+        value,
+        tokenAddress,
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(actual);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getIncomingTransfersUrl,
+        networkRequest: {
+          params: {
+            execution_date__gte: executionDateGte,
+            execution_date__lte: executionDateLte,
+            to,
+            value,
+            token_address: tokenAddress,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const executionDateGte = faker.date.recent().toISOString();
+      const executionDateLte = faker.date.recent().toISOString();
+      const to = faker.finance.ethereumAddress();
+      const value = faker.string.numeric();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getIncomingTransfersUrl = `${baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_incoming_transfers_${safeAddress}`,
+        `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getIncomingTransfersUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getIncomingTransfers({
+          safeAddress,
+          executionDateGte,
+          executionDateLte,
+          to,
+          value,
+          tokenAddress,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getIncomingTransfersUrl,
+        networkRequest: {
+          params: {
+            execution_date__gte: executionDateGte,
+            execution_date__lte: executionDateLte,
+            to,
+            value,
+            token_address: tokenAddress,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('clearIncomingTransfers', () => {
+    it('should clear the incoming transfers cache', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearIncomingTransfers(safeAddress);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_incoming_transfers_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('postConfirmation', () => {
+    it('should post confirmation', async () => {
+      const safeTxHash = faker.string.hexadecimal();
+      const signedSafeTxHash = faker.string.hexadecimal();
+      const postConfirmationUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.postConfirmation({
+        safeTxHash,
+        addConfirmationDto: { signedSafeTxHash },
+      });
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postConfirmationUrl, {
+        signature: signedSafeTxHash,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeTxHash = faker.string.hexadecimal();
+      const signedSafeTxHash = faker.string.hexadecimal();
+      const postConfirmationUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(postConfirmationUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.postConfirmation({
+          safeTxHash,
+          addConfirmationDto: { signedSafeTxHash },
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postConfirmationUrl, {
+        signature: signedSafeTxHash,
+      });
+    });
+  });
+
+  describe('getSafesByModules', () => {
+    it('should return Safes with module enabled', async () => {
+      const moduleAddress = faker.finance.ethereumAddress();
+      const safesByModule = {
+        safes: [
+          faker.finance.ethereumAddress(),
+          faker.finance.ethereumAddress(),
+        ],
+      };
+      const getSafesByModuleUrl = `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: safesByModule,
+        status: 200,
+      });
+
+      const actual = await service.getSafesByModule(moduleAddress);
+
+      expect(actual).toBe(safesByModule);
+      expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+      expect(mockNetworkService.get).toHaveBeenCalledWith(getSafesByModuleUrl);
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const moduleAddress = faker.finance.ethereumAddress();
+      const getSafesByModuleUrl = `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      mockNetworkService.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getSafesByModuleUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getSafesByModule(moduleAddress)).rejects.toThrow(
+        expected,
+      );
+
+      expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+      expect(mockNetworkService.get).toHaveBeenCalledWith(getSafesByModuleUrl);
+    });
+  });
+
+  describe('getModuleTransaction', () => {
+    it('should return the module transaction retrieved', async () => {
+      const moduleTransactionId = faker.string.hexadecimal();
+      const moduleTransaction = moduleTransactionBuilder().build();
+      const getModuleTransactionUrl = `${baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
+      const cacheDir = new CacheDir(
+        `${chainId}_module_transaction_${moduleTransactionId}`,
+        '',
+      );
+      mockDataSource.get.mockResolvedValueOnce(moduleTransaction);
+
+      const actual = await service.getModuleTransaction(moduleTransactionId);
+
+      expect(actual).toBe(moduleTransaction);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getModuleTransactionUrl,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const moduleTransactionId = faker.string.hexadecimal();
+      const getModuleTransactionUrl = `${baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_module_transaction_${moduleTransactionId}`,
+        '',
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getModuleTransactionUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getModuleTransaction(moduleTransactionId),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getModuleTransactionUrl,
+      });
+    });
+  });
+
+  describe('getModuleTransactions', () => {
+    it('should return the module transactions retrieved', async () => {
+      const moduleTransaction = moduleTransactionBuilder().build();
+      const moduleTransactionsPage = pageBuilder()
+        .with('results', [moduleTransaction])
+        .build();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getModuleTransactionsUrl = `${baseUrl}/api/v1/safes/${moduleTransaction.safe}/module-transactions/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_module_transactions_${moduleTransaction.safe}`,
+        `${moduleTransaction.to}_${moduleTransaction.module}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockResolvedValueOnce(moduleTransactionsPage);
+
+      const actual = await service.getModuleTransactions({
+        safeAddress: moduleTransaction.safe,
+        to: moduleTransaction.to,
+        module: moduleTransaction.module,
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(moduleTransactionsPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getModuleTransactionsUrl,
+        networkRequest: {
+          params: {
+            to: moduleTransaction.to,
+            module: moduleTransaction.module,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const moduleTransaction = moduleTransactionBuilder().build();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getModuleTransactionsUrl = `${baseUrl}/api/v1/safes/${moduleTransaction.safe}/module-transactions/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_module_transactions_${moduleTransaction.safe}`,
+        `${moduleTransaction.to}_${moduleTransaction.module}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getModuleTransactionsUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getModuleTransactions({
+          safeAddress: moduleTransaction.safe,
+          to: moduleTransaction.to,
+          module: moduleTransaction.module,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getModuleTransactionsUrl,
+        networkRequest: {
+          params: {
+            to: moduleTransaction.to,
+            module: moduleTransaction.module,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('clearModuleTransactions', () => {
+    it('should clear the module transactions cache', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearModuleTransactions(safeAddress);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_module_transactions_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getMultisigTransactions', () => {
+    it('should return the multisig transactions retrieved', async () => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+      const multisigTransactionsPage = pageBuilder()
+        .with('results', [multisigTransaction])
+        .build();
+      const ordering = faker.word.noun();
+      const executedDateGte = faker.date.recent().toISOString();
+      const executedDateLte = faker.date.recent().toISOString();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getMultisigTransactionsUrl = `${baseUrl}/api/v1/safes/${multisigTransaction.safe}/multisig-transactions/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_multisig_transactions_${multisigTransaction.safe}`,
+        `${ordering}_${multisigTransaction.isExecuted}_${multisigTransaction.trusted}_${executedDateGte}_${executedDateLte}_${multisigTransaction.to}_${multisigTransaction.value}_${multisigTransaction.nonce}_${multisigTransaction.nonce}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockResolvedValueOnce(multisigTransactionsPage);
+
+      const actual = await service.getMultisigTransactions({
+        safeAddress: multisigTransaction.safe,
+        ordering,
+        executed: multisigTransaction.isExecuted,
+        trusted: multisigTransaction.trusted,
+        executionDateGte: executedDateGte,
+        executionDateLte: executedDateLte,
+        to: multisigTransaction.to,
+        value: multisigTransaction.value,
+        nonce: multisigTransaction.nonce.toString(),
+        nonceGte: multisigTransaction.nonce,
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(multisigTransactionsPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMultisigTransactionsUrl,
+        networkRequest: {
+          params: {
+            safe: multisigTransaction.safe,
+            ordering,
+            executed: multisigTransaction.isExecuted,
+            trusted: multisigTransaction.trusted,
+            execution_date__gte: executedDateGte,
+            execution_date__lte: executedDateLte,
+            to: multisigTransaction.to,
+            value: multisigTransaction.value,
+            nonce: multisigTransaction.nonce.toString(),
+            nonce__gte: multisigTransaction.nonce,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+      const ordering = faker.word.noun();
+      const executedDateGte = faker.date.recent().toISOString();
+      const executedDateLte = faker.date.recent().toISOString();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getMultisigTransactionsUrl = `${baseUrl}/api/v1/safes/${multisigTransaction.safe}/multisig-transactions/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_multisig_transactions_${multisigTransaction.safe}`,
+        `${ordering}_${multisigTransaction.isExecuted}_${multisigTransaction.trusted}_${executedDateGte}_${executedDateLte}_${multisigTransaction.to}_${multisigTransaction.value}_${multisigTransaction.nonce}_${multisigTransaction.nonce}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getMultisigTransactionsUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getMultisigTransactions({
+          safeAddress: multisigTransaction.safe,
+          ordering,
+          executed: multisigTransaction.isExecuted,
+          trusted: multisigTransaction.trusted,
+          executionDateGte: executedDateGte,
+          executionDateLte: executedDateLte,
+          to: multisigTransaction.to,
+          value: multisigTransaction.value,
+          nonce: multisigTransaction.nonce.toString(),
+          nonceGte: multisigTransaction.nonce,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMultisigTransactionsUrl,
+        networkRequest: {
+          params: {
+            safe: multisigTransaction.safe,
+            ordering,
+            executed: multisigTransaction.isExecuted,
+            trusted: multisigTransaction.trusted,
+            execution_date__gte: executedDateGte,
+            execution_date__lte: executedDateLte,
+            to: multisigTransaction.to,
+            value: multisigTransaction.value,
+            nonce: multisigTransaction.nonce.toString(),
+            nonce__gte: multisigTransaction.nonce,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('clearMultisigTransactions', () => {
+    it('should clear the multisig transactions cache', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearMultisigTransactions(safeAddress);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_multisig_transactions_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getMultisigTransaction', () => {
+    it('should return the multisig transaction retrieved', async () => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+      const getMultisigTransactionUrl = `${baseUrl}/api/v1/multisig-transactions/${multisigTransaction.safeTxHash}/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${multisigTransaction.safeTxHash}`,
+        '',
+      );
+      mockDataSource.get.mockResolvedValueOnce(multisigTransaction);
+
+      const actual = await service.getMultisigTransaction(
+        multisigTransaction.safeTxHash,
+      );
+
+      expect(actual).toBe(multisigTransaction);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMultisigTransactionUrl,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+      const getMultisigTransactionUrl = `${baseUrl}/api/v1/multisig-transactions/${multisigTransaction.safeTxHash}/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${multisigTransaction.safeTxHash}`,
+        '',
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getMultisigTransactionUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getMultisigTransaction(multisigTransaction.safeTxHash),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMultisigTransactionUrl,
+      });
+    });
+  });
+
+  describe('deleteTransaction', () => {
+    it('should delete a transaction', async () => {
+      const safeTxHash = faker.string.hexadecimal();
+      const signature = faker.string.hexadecimal();
+      const deleteTransactionUrl = `${baseUrl}/api/v1/transactions/${safeTxHash}`;
+      networkService.delete.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.deleteTransaction({
+        safeTxHash,
+        signature,
+      });
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(deleteTransactionUrl, {
+        signature,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeTxHash = faker.string.hexadecimal();
+      const signature = faker.string.hexadecimal();
+      const deleteTransactionUrl = `${baseUrl}/api/v1/transactions/${safeTxHash}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.delete.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(deleteTransactionUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.deleteTransaction({
+          safeTxHash,
+          signature,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(deleteTransactionUrl, {
+        signature,
+      });
+    });
+  });
+
+  describe('clearMultisigTransaction', () => {
+    it('should clear the multisig transaction cache', async () => {
+      const safeTxHash = faker.string.hexadecimal();
+
+      await service.clearMultisigTransaction(safeTxHash);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_multisig_transaction_${safeTxHash}`,
+      );
+    });
+  });
+
+  describe('getCreationTransaction', () => {
+    it('should return the creation transaction retrieved', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const creationTransaction = creationTransactionBuilder().build();
+      const getCreationTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/creation/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_creation_transaction_${safeAddress}`,
+        '',
+      );
+      mockDataSource.get.mockResolvedValueOnce(creationTransaction);
+
+      const actual = await service.getCreationTransaction(safeAddress);
+
+      expect(actual).toBe(creationTransaction);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getCreationTransactionUrl,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const getCreationTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/creation/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_creation_transaction_${safeAddress}`,
+        '',
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getCreationTransactionUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getCreationTransaction(safeAddress)).rejects.toThrow(
+        expected,
+      );
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getCreationTransactionUrl,
+      });
+    });
+  });
+
+  describe('getAllTransactions', () => {
+    it('should return all transactions retrieved', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const ordering = faker.word.noun();
+      const executed = faker.datatype.boolean();
+      const queued = faker.datatype.boolean();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const multisigTransaction = multisigTransactionBuilder().build();
+      const creationTransaction = creationTransactionBuilder().build();
+      const allTransactionsPage = pageBuilder()
+        .with('results', [multisigTransaction, creationTransaction])
+        .build();
+      const getAllTransactionsUrl = `${baseUrl}/api/v1/safes/${safeAddress}/all-transactions/`;
+      const cacheDir = new CacheDir(
+        `${chainId}_all_transactions_${safeAddress}`,
+        `${ordering}_${executed}_${queued}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockResolvedValueOnce(allTransactionsPage);
+
+      const actual = await service.getAllTransactions({
+        safeAddress,
+        ordering,
+        executed,
+        queued,
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(allTransactionsPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getAllTransactionsUrl,
+        networkRequest: {
+          params: {
+            safe: safeAddress,
+            ordering,
+            executed,
+            queued,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const ordering = faker.word.noun();
+      const executed = faker.datatype.boolean();
+      const queued = faker.datatype.boolean();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getAllTransactionsUrl = `${baseUrl}/api/v1/safes/${safeAddress}/all-transactions/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_all_transactions_${safeAddress}`,
+        `${ordering}_${executed}_${queued}_${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getAllTransactionsUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getAllTransactions({
+          safeAddress,
+          ordering,
+          executed,
+          queued,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getAllTransactionsUrl,
+        networkRequest: {
+          params: {
+            safe: safeAddress,
+            ordering,
+            executed,
+            queued,
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('clearAllTransactions', () => {
+    it('should clear the all transactions cache', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearAllTransactions(safeAddress);
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_all_transactions_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getToken', () => {
+    it('should return the token retrieved', async () => {
+      const token = tokenBuilder().build();
+      const getTokenUrl = `${baseUrl}/api/v1/tokens/${token.address}`;
+      const cacheDir = new CacheDir(`${chainId}_token_${token.address}`, '');
+      mockDataSource.get.mockResolvedValueOnce(token);
+
+      const actual = await service.getToken(token.address);
+
+      expect(actual).toBe(token);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTokenUrl,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const token = tokenBuilder().build();
+      const getTokenUrl = `${baseUrl}/api/v1/tokens/${token.address}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_token_${token.address}`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getTokenUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getToken(token.address)).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTokenUrl,
+      });
+    });
+  });
+
+  describe('getTokens', () => {
+    it('should return the token retrieved', async () => {
+      const token = tokenBuilder().build();
+      const tokensPage = pageBuilder().with('results', [token]).build();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getTokensUrl = `${baseUrl}/api/v1/tokens/`;
+      const cacheDir = new CacheDir(`${chainId}_tokens`, `${limit}_${offset}`);
+      mockDataSource.get.mockResolvedValueOnce(tokensPage);
+
+      const actual = await service.getTokens({
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(tokensPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTokensUrl,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getTokensUrl = `${baseUrl}/api/v1/tokens/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_tokens`, `${limit}_${offset}`);
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getTokensUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getTokens({
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getTokensUrl,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('getSafesByOwner', () => {
+    it('should return retrieved safe', async () => {
+      const owner = faker.finance.ethereumAddress();
+      const safeList = {
+        safes: [
+          faker.finance.ethereumAddress(),
+          faker.finance.ethereumAddress(),
+        ],
+      };
+      const getSafesByOwnerUrl = `${baseUrl}/api/v1/owners/${owner}/safes/`;
+      const cacheDir = new CacheDir(`${chainId}_owner_safes_${owner}`, '');
+      mockDataSource.get.mockResolvedValueOnce(safeList);
+
+      const actual = await service.getSafesByOwner(owner);
+
+      expect(actual).toBe(safeList);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getSafesByOwnerUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: ownersTtlSeconds,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const owner = faker.finance.ethereumAddress();
+      const getSafesByOwnerUrl = `${baseUrl}/api/v1/owners/${owner}/safes/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_owner_safes_${owner}`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getSafesByOwnerUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getSafesByOwner(owner)).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getSafesByOwnerUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: ownersTtlSeconds,
+      });
+    });
+  });
+
+  describe('postDeviceRegistration', () => {
+    it('should post device registration', async () => {
+      const device = {
+        uuid: faker.string.uuid(),
+        cloudMessagingToken: faker.string.uuid(),
+        buildNumber: faker.system.semver(),
+        deviceType: faker.helpers.arrayElement(Object.values(DeviceType)),
+        version: faker.system.semver(),
+        timestamp: faker.date.recent().toISOString(),
+        bundle: faker.word.noun(),
+      };
+      const safes = [
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+      ];
+      const signatures = [
+        faker.string.hexadecimal(),
+        faker.string.hexadecimal(),
+      ];
+      const postDeviceRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/`;
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.postDeviceRegistration({
+        device,
+        safes,
+        signatures,
+      });
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(
+        postDeviceRegistrationUrl,
+        {
+          ...device,
+          safes,
+          signatures,
+        },
+      );
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeTxHash = faker.string.hexadecimal();
+      const signedSafeTxHash = faker.string.hexadecimal();
+      const postConfirmationUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(postConfirmationUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.postConfirmation({
+          safeTxHash,
+          addConfirmationDto: { signedSafeTxHash },
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postConfirmationUrl, {
+        signature: signedSafeTxHash,
+      });
+    });
+  });
+
+  describe('deleteDeviceRegistration', () => {
+    it('should delete device registration', async () => {
+      const uuid = faker.string.uuid();
+      const deleteDeviceRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/${uuid}`;
+      networkService.delete.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.deleteDeviceRegistration(uuid);
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(
+        deleteDeviceRegistrationUrl,
+      );
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const uuid = faker.string.uuid();
+      const deleteDeviceRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/${uuid}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.delete.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(deleteDeviceRegistrationUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.deleteDeviceRegistration(uuid)).rejects.toThrow(
+        expected,
+      );
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(
+        deleteDeviceRegistrationUrl,
+      );
+    });
+  });
+
+  describe('deleteSafeRegistration', () => {
+    it('should delete Safe registration', async () => {
+      const uuid = faker.string.uuid();
+      const safeAddress = faker.finance.ethereumAddress();
+      const deleteSafeRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
+      networkService.delete.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.deleteSafeRegistration({ uuid, safeAddress });
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(
+        deleteSafeRegistrationUrl,
+      );
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const uuid = faker.string.uuid();
+      const safeAddress = faker.finance.ethereumAddress();
+      const deleteSafeRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.delete.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(deleteSafeRegistrationUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.deleteSafeRegistration({ uuid, safeAddress }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.delete).toHaveBeenCalledTimes(1);
+      expect(networkService.delete).toHaveBeenCalledWith(
+        deleteSafeRegistrationUrl,
+      );
+    });
+  });
+
+  describe('getEstimation', () => {
+    it('should return the estimation received', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const to = faker.finance.ethereumAddress();
+      const value = faker.string.numeric();
+      const data = faker.string.hexadecimal();
+      const operation = faker.helpers.arrayElement([0, 1] as const);
+      const estimation = {
+        safeTxGas: faker.string.numeric(),
+      };
+      const getEstimationUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/estimations/`;
+      networkService.post.mockResolvedValueOnce({
+        data: estimation,
+        status: 200,
+      });
+
+      const actual = await service.getEstimation({
+        address: safeAddress,
+        getEstimationDto: { to, value, data, operation },
+      });
+
+      expect(actual).toBe(estimation);
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(getEstimationUrl, {
+        to,
+        value,
+        data,
+        operation,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const to = faker.finance.ethereumAddress();
+      const value = faker.string.numeric();
+      const data = faker.string.hexadecimal();
+      const operation = faker.helpers.arrayElement([0, 1] as const);
+      const getEstimationUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/estimations/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getEstimationUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getEstimation({
+          address: safeAddress,
+          getEstimationDto: { to, value, data, operation },
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(getEstimationUrl, {
+        to,
+        value,
+        data,
+        operation,
+      });
+    });
+  });
+
+  describe('getMessageByHash', () => {
+    it('should return the message hash received', async () => {
+      const messageHash = faker.string.hexadecimal();
+      const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}`;
+      const message = messageBuilder().build();
+      const cacheDir = new CacheDir(`${chainId}_message_${messageHash}`, '');
+      mockDataSource.get.mockResolvedValueOnce(message);
+
+      const actual = await service.getMessageByHash(messageHash);
+
+      expect(actual).toBe(message);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMessageByHashUrl,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const messageHash = faker.string.hexadecimal();
+      const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_message_${messageHash}`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getMessageByHashUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(service.getMessageByHash(messageHash)).rejects.toThrow(
+        expected,
+      );
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMessageByHashUrl,
+      });
+    });
+  });
+
+  describe('getMessagesBySafe', () => {
+    it('should return the message hash received', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getMessageBySafeUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
+      const message = messageBuilder().build();
+      const cacheDir = new CacheDir(
+        `${chainId}_messages_${safeAddress}`,
+        `${limit}_${offset}`,
+      );
+      mockDataSource.get.mockResolvedValueOnce(message);
+
+      const actual = await service.getMessagesBySafe({
+        safeAddress,
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(message);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMessageBySafeUrl,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+      const getMessageBySafeUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(
+        `${chainId}_messages_${safeAddress}`,
+        `${limit}_${offset}`,
+      );
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getMessageBySafeUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getMessagesBySafe({
+          safeAddress,
+          limit,
+          offset,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        url: getMessageBySafeUrl,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+  });
+
+  describe('postMultisigTransaction', () => {
+    it('should post multisig transaction', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const proposeTransactionDto = proposeTransactionDtoBuilder().build();
+      const postMultisigTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.postMultisigTransaction({
+        address: safeAddress,
+        data: proposeTransactionDto,
+      });
+
+      const { safeTxHash, ...rest } = proposeTransactionDto;
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(
+        postMultisigTransactionUrl,
+        {
+          ...rest,
+          contractTransactionHash: safeTxHash,
+        },
+      );
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const proposeTransactionDto = proposeTransactionDtoBuilder().build();
+      const postMultisigTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(postMultisigTransactionUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.postMultisigTransaction({
+          address: safeAddress,
+          data: proposeTransactionDto,
+        }),
+      ).rejects.toThrow(expected);
+
+      const { safeTxHash, ...rest } = proposeTransactionDto;
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(
+        postMultisigTransactionUrl,
+        {
+          ...rest,
+          contractTransactionHash: safeTxHash,
+        },
+      );
+    });
+  });
+
+  describe('postMessage', () => {
+    it('should post message', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const message = faker.word.words();
+      const safeAppId = faker.number.int();
+      const signature = faker.string.hexadecimal();
+      const postMessageUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.postMessage({
+        safeAddress,
+        message,
+        safeAppId,
+        signature,
+      });
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postMessageUrl, {
+        message,
+        safeAppId,
+        signature,
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const message = faker.word.words();
+      const safeAppId = faker.number.int();
+      const signature = faker.string.hexadecimal();
+      const postMessageUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(postMessageUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.postMessage({
+          safeAddress,
+          message,
+          safeAppId,
+          signature,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(postMessageUrl, {
+        message,
+        safeAppId,
+        signature,
+      });
+    });
+  });
+
+  describe('postMessageSignature', () => {
+    it('should post message', async () => {
+      const messageHash = faker.string.hexadecimal();
+      const signature = faker.string.hexadecimal();
+      const postMessageSignatureUrl = `${baseUrl}/api/v1/messages/${messageHash}/signatures/`;
+      networkService.post.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      await service.postMessageSignature({
+        messageHash,
+        signature,
+      });
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(
+        postMessageSignatureUrl,
+        {
+          signature,
+        },
+      );
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Django', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const messageHash = faker.string.hexadecimal();
+      const signature = faker.string.hexadecimal();
+      const postMessageSignatureUrl = `${baseUrl}/api/v1/messages/${messageHash}/signatures/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      networkService.post.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(postMessageSignatureUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.postMessageSignature({
+          messageHash,
+          signature,
+        }),
+      ).rejects.toThrow(expected);
+
+      expect(networkService.post).toHaveBeenCalledTimes(1);
+      expect(networkService.post).toHaveBeenCalledWith(
+        postMessageSignatureUrl,
+        {
+          signature,
+        },
+      );
+    });
+  });
+
+  describe('clearMessagesBySafe', () => {
+    it('should clear the messages cache by Safe address', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+
+      await service.clearMessagesBySafe({ safeAddress });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_messages_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('clearMessagesByHash', () => {
+    it('should clear the message cache by messages hash', async () => {
+      const messageHash = faker.string.hexadecimal();
+
+      await service.clearMessagesByHash({ messageHash });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_message_${messageHash}`,
+      );
     });
   });
 });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -3,6 +3,7 @@ import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.sourc
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { INetworkService } from '@/datasources/network/network.service.interface';
 import { Backbone } from '@/domain/backbone/entities/backbone.entity';
 import { Singleton } from '@/domain/chains/entities/singleton.entity';
@@ -25,6 +26,7 @@ import { Transfer } from '@/domain/safe/entities/transfer.entity';
 import { Token } from '@/domain/tokens/entities/token.entity';
 import { AddConfirmationDto } from '@/domain/transactions/entities/add-confirmation.dto.entity';
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
+import { get } from 'lodash';
 
 export class TransactionApi implements ITransactionApi {
   private readonly defaultExpirationTimeInSeconds: number;
@@ -77,7 +79,7 @@ export class TransactionApi implements ITransactionApi {
       );
       return dataDecoded;
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -94,7 +96,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -111,7 +113,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -129,7 +131,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -157,7 +159,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -191,7 +193,7 @@ export class TransactionApi implements ITransactionApi {
         },
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -212,7 +214,7 @@ export class TransactionApi implements ITransactionApi {
         label: args.label,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -229,7 +231,7 @@ export class TransactionApi implements ITransactionApi {
         signature: args.signature,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -246,7 +248,7 @@ export class TransactionApi implements ITransactionApi {
         signature: args.signature,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -266,7 +268,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -298,7 +300,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -344,7 +346,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -366,7 +368,7 @@ export class TransactionApi implements ITransactionApi {
         signature: args.addConfirmationDto.signedSafeTxHash,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -376,7 +378,7 @@ export class TransactionApi implements ITransactionApi {
       const { data } = await this.networkService.get<SafeList>(url);
       return data;
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -398,7 +400,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -430,7 +432,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -485,7 +487,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -513,7 +515,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -527,7 +529,7 @@ export class TransactionApi implements ITransactionApi {
         signature: args.signature,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -557,7 +559,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -592,7 +594,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -620,7 +622,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -649,7 +651,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -669,7 +671,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.ownersExpirationTimeSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -692,7 +694,7 @@ export class TransactionApi implements ITransactionApi {
         signatures: args.signatures,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -701,7 +703,7 @@ export class TransactionApi implements ITransactionApi {
       const url = `${this.baseUrl}/api/v1/notifications/devices/${uuid}`;
       await this.networkService.delete(url);
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -713,7 +715,7 @@ export class TransactionApi implements ITransactionApi {
       const url = `${this.baseUrl}/api/v1/notifications/devices/${args.uuid}/safes/${args.safeAddress}`;
       await this.networkService.delete(url);
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -734,7 +736,7 @@ export class TransactionApi implements ITransactionApi {
       );
       return estimation;
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -752,7 +754,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -780,7 +782,7 @@ export class TransactionApi implements ITransactionApi {
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -807,7 +809,7 @@ export class TransactionApi implements ITransactionApi {
         origin: args.data.origin,
       });
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -826,7 +828,7 @@ export class TransactionApi implements ITransactionApi {
       });
       return data;
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -841,7 +843,7 @@ export class TransactionApi implements ITransactionApi {
       });
       return data;
     } catch (error) {
-      throw this.httpErrorFactory.from(error);
+      throw this.httpErrorFactory.from(this.mapError(error));
     }
   }
 
@@ -859,5 +861,18 @@ export class TransactionApi implements ITransactionApi {
       messageHash: args.messageHash,
     });
     await this.cacheService.deleteByKey(key);
+  }
+
+  private mapError(error: unknown): unknown {
+    if (error instanceof NetworkResponseError) {
+      // Map Django error as "standard" error message if present
+      const djangoError = get(error.data, 'nonFieldErrors[0]');
+      if (djangoError) {
+        return new NetworkResponseError(error.url, error.response, {
+          message: djangoError,
+        });
+      }
+    }
+    return error;
   }
 }

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -29,6 +29,8 @@ import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-tr
 import { get } from 'lodash';
 
 export class TransactionApi implements ITransactionApi {
+  private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
+
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
   private readonly tokenNotFoundExpirationTimeSeconds: number;
@@ -865,11 +867,11 @@ export class TransactionApi implements ITransactionApi {
 
   private mapError(error: unknown): unknown {
     if (error instanceof NetworkResponseError) {
-      // Map Django error as "standard" error message if present
-      const djangoError = get(error.data, 'nonFieldErrors[0]');
-      if (djangoError) {
+      const errors = get(error.data, TransactionApi.ERROR_ARRAY_PATH);
+      if (errors) {
         return new NetworkResponseError(error.url, error.response, {
-          message: djangoError,
+          // We only return the first error message so as to be a string
+          message: errors[0],
         });
       }
     }


### PR DESCRIPTION
## Summary

This adds an error mapper to the `TransactionApi` service that maps Django error messages (`nonFieldErrors[0]`) if present to be the "standard" error `message`.

## Changes

- Add `TransactionApi['mapError']` and use it within all calls
- Add test coverage for `TransactionApi`