### PR TITLE
Scaffold locking API data source

### DIFF
--- a/src/datasources/locking-api/locking-api.module.ts
+++ b/src/datasources/locking-api/locking-api.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
+import { LockingApi } from '@/datasources/locking-api/locking-api.service';
+
+@Global()
+@Module({
+  providers: [{ provide: ILockingApi, useClass: LockingApi }],
+  exports: [ILockingApi],
+})
+export class LockingApiModule {}

--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -1,0 +1,7 @@
+describe('LockingApi', () => {
+  it.todo('getRank');
+
+  it.todo('getLeaderboard');
+
+  it.todo('getLockingHistory');
+});

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -1,4 +1,4 @@
-import { Page } from '@/routes/common/entities/page.entity';
+import { Page } from '@/domain/entities/page.entity';
 import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -1,3 +1,4 @@
+import { Page } from '@/domain/entities/page.entity';
 import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
@@ -8,7 +9,7 @@ export class LockingApi implements ILockingApi {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Array<Rank>> {
+  }): Promise<Page<Array<Rank>>> {
     throw new Error('Method not implemented.');
   }
 
@@ -17,7 +18,7 @@ export class LockingApi implements ILockingApi {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Array<LockingEvent>> {
+  }): Promise<Page<Array<LockingEvent>>> {
     throw new Error('Method not implemented.');
   }
 }

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -9,7 +9,7 @@ export class LockingApi implements ILockingApi {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Page<Array<Rank>>> {
+  }): Promise<Page<Rank>> {
     throw new Error('Method not implemented.');
   }
 
@@ -18,7 +18,7 @@ export class LockingApi implements ILockingApi {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Page<Array<LockingEvent>>> {
+  }): Promise<Page<LockingEvent>> {
     throw new Error('Method not implemented.');
   }
 }

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -4,16 +4,20 @@ import { Rank } from '@/domain/locking/entities/rank.entity';
 
 export class LockingApi implements ILockingApi {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getRank(_safeAddress: string): Promise<Rank> {
-    throw new Error('Method not implemented.');
-  }
-
-  async getLeaderboard(): Promise<Array<Rank>> {
+  async getLeaderboard(args: {
+    safeAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Array<Rank>> {
     throw new Error('Method not implemented.');
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getLockingHistory(_safeAddress: string): Promise<Array<LockingEvent>> {
+  async getLockingHistory(args: {
+    safeAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Array<LockingEvent>> {
     throw new Error('Method not implemented.');
   }
 }

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -1,0 +1,19 @@
+import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
+import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
+import { Rank } from '@/domain/locking/entities/rank.entity';
+
+export class LockingApi implements ILockingApi {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getRank(_safeAddress: string): Promise<Rank> {
+    throw new Error('Method not implemented.');
+  }
+
+  async getLeaderboard(): Promise<Array<Rank>> {
+    throw new Error('Method not implemented.');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getLockingHistory(_safeAddress: string): Promise<Array<LockingEvent>> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -1,4 +1,4 @@
-import { Page } from '@/domain/entities/page.entity';
+import { Page } from '@/routes/common/entities/page.entity';
 import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -1,4 +1,4 @@
-import { Page } from '@/routes/common/entities/page.entity';
+import { Page } from '@/domain/entities/page.entity';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
 

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -9,11 +9,11 @@ export interface ILockingApi {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Page<Array<Rank>>>;
+  }): Promise<Page<Rank>>;
 
   getLockingHistory(args: {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Page<Array<LockingEvent>>>;
+  }): Promise<Page<LockingEvent>>;
 }

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -1,0 +1,12 @@
+import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
+import { Rank } from '@/domain/locking/entities/rank.entity';
+
+export const ILockingApi = Symbol('ILockingApi');
+
+export interface ILockingApi {
+  getRank(safeAddress: string): Promise<Rank>;
+
+  getLeaderboard(): Promise<Array<Rank>>;
+
+  getLockingHistory(safeAddress: string): Promise<Array<LockingEvent>>;
+}

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -1,3 +1,4 @@
+import { Page } from '@/domain/entities/page.entity';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
 
@@ -8,11 +9,11 @@ export interface ILockingApi {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Array<Rank>>;
+  }): Promise<Page<Array<Rank>>>;
 
   getLockingHistory(args: {
     safeAddress?: string;
     limit?: number;
     offset?: number;
-  }): Promise<Array<LockingEvent>>;
+  }): Promise<Page<Array<LockingEvent>>>;
 }

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -4,9 +4,15 @@ import { Rank } from '@/domain/locking/entities/rank.entity';
 export const ILockingApi = Symbol('ILockingApi');
 
 export interface ILockingApi {
-  getRank(safeAddress: string): Promise<Rank>;
+  getLeaderboard(args: {
+    safeAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Array<Rank>>;
 
-  getLeaderboard(): Promise<Array<Rank>>;
-
-  getLockingHistory(safeAddress: string): Promise<Array<LockingEvent>>;
+  getLockingHistory(args: {
+    safeAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Array<LockingEvent>>;
 }

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -1,4 +1,4 @@
-import { Page } from '@/domain/entities/page.entity';
+import { Page } from '@/routes/common/entities/page.entity';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
 

--- a/src/domain/locking/entities/locking-event.entity.ts
+++ b/src/domain/locking/entities/locking-event.entity.ts
@@ -1,0 +1,28 @@
+export type LockingEvent = LockEvent | UnlockEvent | WithdrawEvent;
+
+export enum LockType {
+  LOCK = 'LOCK',
+  UNLOCK = 'UNLOCK',
+  WITHDRAW = 'WITHDRAW',
+}
+
+export type LockEvent = {
+  type: LockType.LOCK;
+  amount: string;
+  executedAt: string;
+};
+
+export type UnlockEvent = {
+  type: LockType.UNLOCK;
+  amount: string;
+  executedAt: string;
+  unlockIndex: number;
+  unlockedAt: string;
+};
+
+export type WithdrawEvent = {
+  type: LockType.WITHDRAW;
+  amount: string;
+  executedAt: string;
+  unlockIndex: number;
+};

--- a/src/domain/locking/entities/locking-event.entity.ts
+++ b/src/domain/locking/entities/locking-event.entity.ts
@@ -16,7 +16,7 @@ export type UnlockEvent = {
   type: LockType.UNLOCK;
   amount: string;
   executedAt: string;
-  unlockIndex: number;
+  unlockIndex: string;
   unlockedAt: string;
 };
 
@@ -24,5 +24,5 @@ export type WithdrawEvent = {
   type: LockType.WITHDRAW;
   amount: string;
   executedAt: string;
-  unlockIndex: number;
+  unlockIndex: string;
 };

--- a/src/domain/locking/entities/rank.entity.ts
+++ b/src/domain/locking/entities/rank.entity.ts
@@ -1,6 +1,5 @@
 export type Rank = {
   address: string;
   rank: string;
-  amount: string;
-  boost: string;
+  lockedAmount: string;
 };

--- a/src/domain/locking/entities/rank.entity.ts
+++ b/src/domain/locking/entities/rank.entity.ts
@@ -1,0 +1,6 @@
+export type Rank = {
+  address: string;
+  rank: string;
+  amount: string;
+  boost: string;
+};


### PR DESCRIPTION
## Summary

This adds a scaffold for the locking API data source. The methods are not implemented, but the types are according to agreed proposal

## Changes

- Add `ILockingApi`-based `LockingApi` service:
  - `getLeaderboard`
  - `getLockingHistory`