### PR TITLE
Move `proposer` from `executionInfo` to `detailedExecutionInfo`

### DIFF
--- a/src/routes/transactions/entities/multisig-execution-info.entity.ts
+++ b/src/routes/transactions/entities/multisig-execution-info.entity.ts
@@ -14,21 +14,17 @@ export class MultisigExecutionInfo extends ExecutionInfo {
   confirmationsSubmitted: number;
   @ApiPropertyOptional({ type: AddressInfo, isArray: true, nullable: true })
   missingSigners: AddressInfo[] | null;
-  @ApiProperty()
-  proposer!: AddressInfo | null;
 
   constructor(
     nonce: number,
     confirmationsRequired: number,
     confirmationsSubmitted: number,
     missingSigners: AddressInfo[] | null,
-    proposer: AddressInfo | null,
   ) {
     super(ExecutionInfoType.Multisig);
     this.nonce = nonce;
     this.confirmationsRequired = confirmationsRequired;
     this.confirmationsSubmitted = confirmationsSubmitted;
     this.missingSigners = missingSigners;
-    this.proposer = proposer;
   }
 }

--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -56,6 +56,8 @@ export class MultisigExecutionDetails extends ExecutionDetails {
   gasTokenInfo: Token | null;
   @ApiProperty()
   trusted: boolean;
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
+  proposer!: AddressInfo | null;
 
   constructor(
     submittedAt: number,
@@ -73,6 +75,7 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     rejectors: AddressInfo[],
     gasTokenInfo: Token | null,
     trusted: boolean,
+    proposer: AddressInfo | null,
   ) {
     super(ExecutionDetailsType.Multisig);
     this.submittedAt = submittedAt;
@@ -90,5 +93,6 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     this.rejectors = rejectors;
     this.gasTokenInfo = gasTokenInfo;
     this.trusted = trusted;
+    this.proposer = proposer;
   }
 }

--- a/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
+++ b/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
@@ -43,5 +43,6 @@ export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDet
     .with('confirmations', confirmations)
     .with('rejectors', faker.helpers.arrayElements(signers, MIN_SIGNERS))
     .with('gasTokenInfo', tokenBuilder().build())
-    .with('trusted', faker.datatype.boolean());
+    .with('trusted', faker.datatype.boolean())
+    .with('proposer', signers[0]);
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -83,6 +83,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         rejectors: [],
         gasTokenInfo,
         trusted: transaction.trusted,
+        proposer: new AddressInfo(transaction.proposer!),
       }),
     );
   });
@@ -146,6 +147,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         rejectors: expectedRejectors,
         gasTokenInfo: null,
         trusted: transaction.trusted,
+        proposer: new AddressInfo(transaction.proposer!),
       }),
     );
   });
@@ -211,6 +213,36 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         rejectors: expectedRejectors,
         gasTokenInfo: null,
         trusted: transaction.trusted,
+        proposer: new AddressInfo(transaction.proposer!),
+      }),
+    );
+  });
+
+  it('should return a MultisigExecutionDetails object with no proposer if not present', async () => {
+    const chainId = faker.string.numeric();
+    const safe = safeBuilder().build();
+    const transaction = multisigTransactionBuilder()
+      .with('safe', safe.address)
+      .with('proposer', null)
+      .build();
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    safeRepository.getMultisigTransactions.mockResolvedValue(
+      pageBuilder<MultisigTransaction>().with('results', []).build(),
+    );
+    const gasTokenInfo = tokenBuilder().build();
+    tokenRepository.getToken.mockResolvedValue(gasTokenInfo);
+
+    const actual = await mapper.mapMultisigExecutionDetails(
+      chainId,
+      transaction,
+      safe,
+    );
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        type: 'MULTISIG',
+        proposer: null,
       }),
     );
   });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -42,6 +42,9 @@ export class MultisigTransactionExecutionDetailsMapper {
               confirmation.submissionDate.getTime(),
             ),
         );
+    const proposer = transaction.proposer
+      ? new AddressInfo(transaction.proposer)
+      : null;
 
     const [gasTokenInfo, executor, refundReceiver, rejectors] =
       await Promise.all([
@@ -77,6 +80,7 @@ export class MultisigTransactionExecutionDetailsMapper {
       rejectors,
       gasTokenInfo,
       transaction.trusted,
+      proposer,
     );
   }
 

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -14,53 +14,6 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     mapper = new MultisigTransactionExecutionInfoMapper();
   });
 
-  it('should return a MultiSigExecutionInfo with no proposer', () => {
-    const safe = safeBuilder().build();
-    const transaction = multisigTransactionBuilder()
-      .with('proposer', null)
-      .build();
-
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.Success,
-    );
-
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        Number(transaction.confirmations?.length),
-        null,
-        null,
-      ),
-    );
-  });
-
-  it('should return a MultiSigExecutionInfo with proposer', () => {
-    const safe = safeBuilder().build();
-    const proposer = faker.finance.ethereumAddress();
-    const transaction = multisigTransactionBuilder()
-      .with('proposer', proposer)
-      .build();
-
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.Success,
-    );
-
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        Number(transaction.confirmations?.length),
-        null,
-        new AddressInfo(proposer),
-      ),
-    );
-  });
-
   it('should return a MultiSigExecutionInfo with no missing signers', () => {
     const safe = safeBuilder().build();
     const proposer = faker.finance.ethereumAddress();
@@ -80,16 +33,13 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
         transaction.confirmationsRequired,
         Number(transaction.confirmations?.length),
         null,
-        new AddressInfo(proposer),
       ),
     );
   });
 
   it('should return a MultiSigExecutionInfo with no missing signers and zero confirmations', () => {
     const safe = safeBuilder().build();
-    const proposer = faker.finance.ethereumAddress();
     const transaction = multisigTransactionBuilder()
-      .with('proposer', proposer)
       .with('confirmations', null)
       .build();
 
@@ -105,17 +55,13 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
         transaction.confirmationsRequired,
         0,
         null,
-        new AddressInfo(proposer),
       ),
     );
   });
 
   it('should return a MultiSigExecutionInfo with empty missing signers', () => {
     const safe = safeBuilder().with('owners', []).build();
-    const proposer = faker.finance.ethereumAddress();
-    const transaction = multisigTransactionBuilder()
-      .with('proposer', proposer)
-      .build();
+    const transaction = multisigTransactionBuilder().build();
 
     const executionInfo = mapper.mapExecutionInfo(
       transaction,
@@ -129,18 +75,17 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
         transaction.confirmationsRequired,
         Number(transaction.confirmations?.length),
         [],
-        new AddressInfo(proposer),
       ),
     );
   });
 
   it('should return a MultiSigExecutionInfo with all safe owners as missing signers', () => {
-    const proposer = faker.finance.ethereumAddress();
-    const transaction = multisigTransactionBuilder()
-      .with('proposer', proposer)
-      .build();
+    const transaction = multisigTransactionBuilder().build();
     const safe = safeBuilder()
-      .with('owners', [proposer, faker.finance.ethereumAddress()])
+      .with('owners', [
+        faker.finance.ethereumAddress(),
+        faker.finance.ethereumAddress(),
+      ])
       .build();
 
     const executionInfo = mapper.mapExecutionInfo(
@@ -155,19 +100,17 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
         transaction.confirmationsRequired,
         Number(transaction.confirmations?.length),
         safe.owners.map((address) => new AddressInfo(address)),
-        new AddressInfo(proposer),
       ),
     );
   });
 
   it('should return a MultiSigExecutionInfo with some safe owners as missing signers', () => {
-    const proposer = faker.finance.ethereumAddress();
     const confirmations = [
-      confirmationBuilder().with('owner', proposer).build(),
+      confirmationBuilder().build(),
       confirmationBuilder().build(),
     ];
     const transaction = multisigTransactionBuilder()
-      .with('proposer', proposer)
+      .with('proposer', confirmations[0].owner)
       .with('confirmations', confirmations)
       .build();
     const safe = safeBuilder()
@@ -186,7 +129,6 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
         transaction.confirmationsRequired,
         Number(transaction.confirmations?.length),
         [new AddressInfo(safe.owners[1])],
-        new AddressInfo(proposer),
       ),
     );
   });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.ts
@@ -22,7 +22,6 @@ export class MultisigTransactionExecutionInfoMapper {
       transaction.confirmationsRequired,
       transaction?.confirmations?.length || 0,
       missingSigners,
-      transaction.proposer ? new AddressInfo(transaction.proposer) : null,
     );
   }
 


### PR DESCRIPTION
## Summary

This moves the [recently added `proposer`
](https://github.com/safe-global/safe-client-gateway/pull/1217), from the `executionInfo` to the `detailedExecutionInfo` of a multisig transaction

## Motivation

1. The `proposer` is not required in the transactions list (where only `executionInfo` is returned).
2. Semantically, `proposer` matches the other properties of `detailedExecutionInfo`.

## Changes

- `proposer` removed from `executionInfo`
- `proposer` added to `detailedExecutionInfo`
- Associated tests updated