### PR TITLE
Set Order UID type to 0x string

### DIFF
--- a/src/domain/swaps/swaps.repository.e2e-spec.ts
+++ b/src/domain/swaps/swaps.repository.e2e-spec.ts
@@ -129,7 +129,10 @@ describe('CowSwap E2E tests', () => {
     describe(`Chain ID ${chainId}`, () => {
       Object.entries(transactions).forEach(([orderId, expectedObject]) => {
         it(`Transaction ID: ${orderId}`, async () => {
-          const actual: Order = await repository.getOrder(chainId, orderId);
+          const actual: Order = await repository.getOrder(
+            chainId,
+            orderId as `0x${string}`,
+          );
 
           expect(actual).toEqual(expectedObject);
         });

--- a/src/domain/swaps/swaps.repository.ts
+++ b/src/domain/swaps/swaps.repository.ts
@@ -11,7 +11,7 @@ export class SwapsRepository {
     private readonly orderValidator: OrderValidator,
   ) {}
 
-  async getOrder(chainId: string, orderUid: string): Promise<Order> {
+  async getOrder(chainId: string, orderUid: `0x${string}`): Promise<Order> {
     const api = this.swapsApiFactory.get(chainId);
     const order = await api.getOrder(orderUid);
     return this.orderValidator.validate(order);


### PR DESCRIPTION
Sets the order UID type to prefixed `0x` which is its expected format.