### PR TITLE
Add SetPreSignatureDecoder

### DIFF
--- a/src/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder.ts
+++ b/src/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder.ts
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker';
+import { encodeFunctionData, Hex } from 'viem';
+import { Builder } from '@/__tests__/builder';
+import { IEncoder } from '@/__tests__/encoder-builder';
+import { abi } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+
+type SetPreSignatureArgs = {
+  orderUid: `0x${string}`;
+  signed: boolean;
+};
+
+class SetPreSignatureEncoder<T extends SetPreSignatureArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): Hex {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi,
+      functionName: 'setPreSignature',
+      args: [args.orderUid, args.signed],
+    });
+  }
+}
+
+export function setPreSignatureEncoder(): SetPreSignatureEncoder<SetPreSignatureArgs> {
+  return new SetPreSignatureEncoder()
+    .with(
+      'orderUid',
+      faker.string.hexadecimal({ length: 112 }) as `0x${string}`,
+    )
+    .with('signed', faker.datatype.boolean());
+}

--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.spec.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.spec.ts
@@ -2,13 +2,19 @@ import { Hex } from 'viem';
 import { faker } from '@faker-js/faker';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import { setPreSignatureEncoder } from '@/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder';
+import { ILoggingService } from '@/logging/logging.interface';
+
+const loggingService = {
+  debug: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+const loggingServiceMock = jest.mocked(loggingService);
 
 describe('SetPreSignatureDecoder', () => {
   let target: SetPreSignatureDecoder;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    target = new SetPreSignatureDecoder();
+    target = new SetPreSignatureDecoder(loggingServiceMock);
   });
 
   it('decodes a setPreSignature function call correctly', () => {

--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.spec.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.spec.ts
@@ -1,0 +1,30 @@
+import { Hex } from 'viem';
+import { faker } from '@faker-js/faker';
+import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+import { setPreSignatureEncoder } from '@/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder';
+
+describe('SetPreSignatureDecoder', () => {
+  let target: SetPreSignatureDecoder;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    target = new SetPreSignatureDecoder();
+  });
+
+  it('decodes a setPreSignature function call correctly', () => {
+    const encoder = setPreSignatureEncoder();
+    const args = encoder.build();
+    const data = encoder.encode();
+
+    expect(target.decodeFunctionData({ data })).toEqual({
+      functionName: 'setPreSignature',
+      args: [args.orderUid, args.signed],
+    });
+  });
+
+  it('throws if the function call cannot be decoded', () => {
+    const data = faker.string.hexadecimal({ length: 138 }) as Hex;
+
+    expect(() => target.decodeFunctionData({ data })).toThrow();
+  });
+});

--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
+import { getFunctionSelector, isHex, parseAbi } from 'viem';
+
+export const abi = parseAbi([
+  'function setPreSignature(bytes calldata orderUid, bool signed)',
+]);
+
+@Injectable()
+export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
+  private readonly setPreSignatureFunctionSelector: `0x${string}`;
+
+  constructor() {
+    super(abi);
+    this.setPreSignatureFunctionSelector = getFunctionSelector(abi[0]);
+  }
+
+  /**
+   * Gets the Order UID associated with the provided transaction data.
+   *
+   * @param data - the transaction data for the setPreSignature call
+   * @returns {`0x${string}`} the order UID or null if the data does not represent a setPreSignature transaction
+   */
+  getOrderUid(data: `0x${string}`): `0x${string}` | null {
+    if (!data.startsWith(this.setPreSignatureFunctionSelector)) return null;
+    const { functionName, args } = this.decodeFunctionData({ data });
+    if (functionName !== 'setPreSignature') return null;
+    if (!args || !args[0] || typeof args[0] !== 'string' || !isHex(args[0]))
+      return null;
+    return args[0];
+  }
+}


### PR DESCRIPTION
Adds the `SetPreSignatureDecoder`, a decoder helper which can be used to retrieve a CoW Swap Order UID from any `setPreSignature` transaction.

This represent preliminary work for https://github.com/safe-global/safe-client-gateway/issues/1198. With the ability to retrieve the Order UID (this PR) and the integration of the CoW Swap API done in https://github.com/safe-global/safe-client-gateway/pull/1233, the CGW components can now retrieve the data of CoW Swap orders and map the respective data to be rendered to the clients.