### PR TITLE
Add headers to `DELETE` requests

### DIFF
--- a/src/datasources/network/fetch.network.service.spec.ts
+++ b/src/datasources/network/fetch.network.service.spec.ts
@@ -190,9 +190,35 @@ describe('FetchNetworkService', () => {
       await target.delete(url);
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
-      expect(fetchClientMock).toHaveBeenCalledWith(url, {
+      expect(fetchClientMock).toHaveBeenCalledWith(`${url}/`, {
         method: 'DELETE',
       });
+    });
+
+    it(`delete calls fetch with request`, async () => {
+      const url = faker.internet.url({ appendSlash: false });
+      const data = { [faker.word.sample()]: faker.string.alphanumeric() };
+      const request: NetworkRequest = {
+        params: { some_query_param: 'query_param' },
+        headers: {
+          test: 'value',
+        },
+      };
+
+      await target.delete(url, data, request);
+
+      expect(fetchClientMock).toHaveBeenCalledTimes(1);
+      expect(fetchClientMock).toHaveBeenCalledWith(
+        `${url}/?some_query_param=query_param`,
+        {
+          method: 'DELETE',
+          headers: {
+            test: 'value',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(data),
+        },
+      );
     });
 
     it(`delete logs response error`, async () => {

--- a/src/datasources/network/fetch.network.service.ts
+++ b/src/datasources/network/fetch.network.service.ts
@@ -57,15 +57,25 @@ export class FetchNetworkService implements INetworkService {
     }
   }
 
-  async delete<T>(url: string, data?: object): Promise<NetworkResponse<T>> {
+  async delete<T>(
+    baseUrl: string,
+    data?: object,
+    { params, headers }: NetworkRequest = {},
+  ): Promise<NetworkResponse<T>> {
+    const url = this.buildUrl(baseUrl, params);
     const startTimeMs = performance.now();
     try {
       return await this.client<T>(url, {
         method: 'DELETE',
-        ...(data && {
+        ...((headers || data) && {
           headers: {
-            'Content-Type': 'application/json',
+            ...(data && {
+              'Content-Type': 'application/json',
+            }),
+            ...(headers && headers),
           },
+        }),
+        ...(data && {
           body: JSON.stringify(data),
         }),
       });

--- a/src/datasources/network/fetch.network.service.ts
+++ b/src/datasources/network/fetch.network.service.ts
@@ -64,20 +64,19 @@ export class FetchNetworkService implements INetworkService {
   ): Promise<NetworkResponse<T>> {
     const url = this.buildUrl(baseUrl, params);
     const startTimeMs = performance.now();
+
+    if (data) {
+      headers ??= {};
+      headers['Content-Type'] = 'application/json';
+    }
+
     try {
       return await this.client<T>(url, {
         method: 'DELETE',
-        ...((headers || data) && {
-          headers: {
-            ...(data && {
-              'Content-Type': 'application/json',
-            }),
-            ...(headers && headers),
-          },
-        }),
         ...(data && {
           body: JSON.stringify(data),
         }),
+        headers,
       });
     } catch (error) {
       this.logErrorResponse(error, performance.now() - startTimeMs);

--- a/src/datasources/network/network.service.interface.ts
+++ b/src/datasources/network/network.service.interface.ts
@@ -15,5 +15,9 @@ export interface INetworkService {
     networkRequest?: NetworkRequest,
   ): Promise<NetworkResponse<T>>;
 
-  delete<T>(url: string, data?: object): Promise<NetworkResponse<T>>;
+  delete<T>(
+    url: string,
+    data?: object,
+    networkRequest?: NetworkRequest,
+  ): Promise<NetworkResponse<T>>;
 }


### PR DESCRIPTION
## Summary

This passes any specified headers to `DELETE` requests.

## Changes

- Update `FetchNetworkService['delete']` to forward headers