### PR TITLE
Make Zerion balances icons nullable

### DIFF
--- a/src/datasources/balances-api/entities/zerion-balance.entity.ts
+++ b/src/datasources/balances-api/entities/zerion-balance.entity.ts
@@ -7,7 +7,7 @@ export interface ZerionFungibleInfo {
   name: string | null;
   symbol: string | null;
   description: string | null;
-  icon: { url: string | null };
+  icon: { url: string | null } | null;
   implementations: ZerionImplementation[];
 }
 

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -235,7 +235,7 @@ export class ZerionBalancesApi implements IBalancesApi {
         name: fungible_info.name ?? '',
         symbol: fungible_info.symbol ?? '',
         decimals: quantity.decimals,
-        logoUri: fungible_info.icon.url ?? '',
+        logoUri: fungible_info.icon?.url ?? '',
       },
       balance: quantity.int,
     };

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -206,7 +206,7 @@ describe('Balances Controller (Unit)', () => {
                     decimals: 15,
                     symbol: erc20TokenFungibleInfo.symbol,
                     name: erc20TokenFungibleInfo.name,
-                    logoUri: erc20TokenFungibleInfo.icon.url,
+                    logoUri: erc20TokenFungibleInfo.icon?.url,
                   },
                   balance: '12000000000000000',
                   fiatBalance: '20.002',
@@ -252,6 +252,7 @@ describe('Balances Controller (Unit)', () => {
           ])
           .build();
         const erc20TokenFungibleInfo = zerionFungibleInfoBuilder()
+          .with('icon', null)
           .with('implementations', [
             zerionImplementationBuilder().with('chain_id', chainName).build(),
             zerionImplementationBuilder().build(),
@@ -348,7 +349,7 @@ describe('Balances Controller (Unit)', () => {
                     decimals: 15,
                     symbol: erc20TokenFungibleInfo.symbol,
                     name: erc20TokenFungibleInfo.name,
-                    logoUri: erc20TokenFungibleInfo.icon.url,
+                    logoUri: '',
                   },
                   balance: '12000000000000000',
                   fiatBalance: '20000000000000000',


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `ZerionFungibleInfo` definition, as the `icon` was marked as required by mistake. 
Docs: https://developers.zerion.io/reference/listwalletpositions

## Changes
- Makes `ZerionFungibleInfo.icon` nullable.
