### PR TITLE
Clarify transfers to self in relaying error message

### DIFF
--- a/src/domain/relay/errors/invalid-transfer.error.ts
+++ b/src/domain/relay/errors/invalid-transfer.error.ts
@@ -1,7 +1,7 @@
 export class InvalidTransferError extends Error {
   constructor() {
     super(
-      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+      'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
     );
   }
 }

--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -343,7 +343,7 @@ describe('LimitAddressesMapper', () => {
                 to: safeAddress,
               }),
             ).rejects.toThrow(
-              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+              'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
             );
           });
 
@@ -368,7 +368,7 @@ describe('LimitAddressesMapper', () => {
                 to: safeAddress,
               }),
             ).rejects.toThrow(
-              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+              'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
             );
           });
 
@@ -882,7 +882,7 @@ describe('LimitAddressesMapper', () => {
                 to,
               }),
             ).rejects.toThrow(
-              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+              'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
             );
           });
 
@@ -912,7 +912,7 @@ describe('LimitAddressesMapper', () => {
                 to,
               }),
             ).rejects.toThrow(
-              'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+              'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
             );
 
             expect(PROXY_FACTORY_VERSIONS[chainId].includes(version)).toBe(
@@ -940,7 +940,7 @@ describe('LimitAddressesMapper', () => {
             to: safeAddress,
           }),
         ).rejects.toThrow(
-          'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+          'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
         );
       });
 

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -952,7 +952,7 @@ describe('Relay controller', () => {
                   .expect(422)
                   .expect({
                     message:
-                      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                      'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
                     statusCode: 422,
                   });
               });
@@ -990,7 +990,7 @@ describe('Relay controller', () => {
                   .expect(422)
                   .expect({
                     message:
-                      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                      'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
                     statusCode: 422,
                   });
               });
@@ -1294,7 +1294,7 @@ describe('Relay controller', () => {
                   .expect(422)
                   .expect({
                     message:
-                      'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                      'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
                     statusCode: 422,
                   });
               });
@@ -1359,7 +1359,7 @@ describe('Relay controller', () => {
             .expect(422)
             .expect({
               message:
-                'Invalid transfer. The proposed transfer is not an execTransaction, multiSend, or createProxyWithNonce call.',
+                'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
               statusCode: 422,
             });
         });


### PR DESCRIPTION
## Summary

This adjusts the error message of invalid relays to include information regarding transfers to self, which are invalid (as [it is unclear](https://github.com/safe-global/safe-ios/issues/3395#issuecomment-1978825516)).

## Changes

- Change `InvalidTransferError['message']` to: "Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call."