### PR TITLE
Pass network request arguments in an object

### DIFF
--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -78,19 +78,19 @@ describe('TenderlyApi', () => {
 
       await service.addContract(contract);
 
-      expect(mockNetworkService.post).toHaveBeenCalledWith(
-        `${tenderlyBaseUri}/api/v1/account/${tenderlyAccount}/project/${tenderlyProject}/address`,
-        {
+      expect(mockNetworkService.post).toHaveBeenCalledWith({
+        url: `${tenderlyBaseUri}/api/v1/account/${tenderlyAccount}/project/${tenderlyProject}/address`,
+        data: {
           address: contract.address,
           display_name: contract.displayName,
           network_id: contract.chainId,
         },
-        {
+        networkRequest: {
           headers: {
             'X-Access-Key': tenderlyApiKey,
           },
         },
-      );
+      });
     });
 
     it('should forward error', async () => {
@@ -126,15 +126,14 @@ describe('TenderlyApi', () => {
 
       await service.deleteContract(contract);
 
-      expect(mockNetworkService.delete).toHaveBeenCalledWith(
-        `${tenderlyBaseUri}/api/v1/account/${tenderlyAccount}/project/${tenderlyProject}/contract/${contract.chainId}/${contract.address}`,
-        undefined,
-        {
+      expect(mockNetworkService.delete).toHaveBeenCalledWith({
+        url: `${tenderlyBaseUri}/api/v1/account/${tenderlyAccount}/project/${tenderlyProject}/contract/${contract.chainId}/${contract.address}`,
+        networkRequest: {
           headers: {
             'X-Access-Key': tenderlyApiKey,
           },
         },
-      );
+      });
     });
 
     it('should forward error', async () => {

--- a/src/datasources/alerts-api/tenderly-api.service.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.ts
@@ -47,19 +47,19 @@ export class TenderlyApi implements IAlertsApi {
   async addContract(contract: AlertsRegistration): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/account/${this.account}/project/${this.project}/address`;
-      await this.networkService.post(
+      await this.networkService.post({
         url,
-        {
+        data: {
           address: contract.address,
           display_name: contract.displayName,
           network_id: contract.chainId,
         },
-        {
+        networkRequest: {
           headers: {
             [TenderlyApi.HEADER]: this.apiKey,
           },
         },
-      );
+      });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
@@ -73,9 +73,12 @@ export class TenderlyApi implements IAlertsApi {
   async deleteContract(contract: AlertsDeletion): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/account/${this.account}/project/${this.project}/contract/${contract.chainId}/${contract.address}`;
-      await this.networkService.delete(url, undefined, {
-        headers: {
-          [TenderlyApi.HEADER]: this.apiKey,
+      await this.networkService.delete({
+        url,
+        networkRequest: {
+          headers: {
+            [TenderlyApi.HEADER]: this.apiKey,
+          },
         },
       });
     } catch (error) {

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -164,9 +164,9 @@ describe('CoingeckoAPI', () => {
     expect(assetPrice).toEqual([
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
-    expect(mockNetworkService.get).toHaveBeenCalledWith(
-      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      {
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
@@ -175,7 +175,7 @@ describe('CoingeckoAPI', () => {
           vs_currencies: lowerCaseFiatCode,
         },
       },
-    );
+    });
     expect(mockCacheService.get).toHaveBeenCalledTimes(1);
     expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
     expect(mockCacheService.set).toHaveBeenCalledTimes(1);
@@ -227,15 +227,15 @@ describe('CoingeckoAPI', () => {
     expect(assetPrice).toEqual([
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
-    expect(mockNetworkService.get).toHaveBeenCalledWith(
-      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      {
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
         params: {
           contract_addresses: tokenAddress,
           vs_currencies: lowerCaseFiatCode,
         },
       },
-    );
+    });
     expect(mockCacheService.get).toHaveBeenCalledTimes(1);
     expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
     expect(mockCacheService.set).toHaveBeenCalledTimes(1);
@@ -287,9 +287,9 @@ describe('CoingeckoAPI', () => {
       { [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice } },
       { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
     ]);
-    expect(mockNetworkService.get).toHaveBeenCalledWith(
-      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      {
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
@@ -302,7 +302,7 @@ describe('CoingeckoAPI', () => {
           vs_currencies: lowerCaseFiatCode,
         },
       },
-    );
+    });
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
@@ -406,9 +406,9 @@ describe('CoingeckoAPI', () => {
         (i) => Object.keys(i)[0],
       ),
     );
-    expect(mockNetworkService.get).toHaveBeenCalledWith(
-      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      {
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
@@ -417,7 +417,7 @@ describe('CoingeckoAPI', () => {
           vs_currencies: lowerCaseFiatCode,
         },
       },
-    );
+    });
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
@@ -513,9 +513,9 @@ describe('CoingeckoAPI', () => {
         (i) => Object.keys(i)[0],
       ),
     );
-    expect(mockNetworkService.get).toHaveBeenCalledWith(
-      `${coingeckoBaseUri}/simple/token_price/${chainName}`,
-      {
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
@@ -524,7 +524,7 @@ describe('CoingeckoAPI', () => {
           vs_currencies: lowerCaseFiatCode,
         },
       },
-    );
+    });
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -261,16 +261,19 @@ export class CoingeckoApi implements IPricesApi {
   }): Promise<AssetPrice> {
     try {
       const url = `${this.baseUrl}/simple/token_price/${args.chainName}`;
-      const { data } = await this.networkService.get<AssetPrice>(url, {
-        params: {
-          vs_currencies: args.fiatCode,
-          contract_addresses: args.tokenAddresses.join(','),
-        },
-        ...(this.apiKey && {
-          headers: {
-            [CoingeckoApi.COINGECKO_API_HEADER]: this.apiKey,
+      const { data } = await this.networkService.get<AssetPrice>({
+        url,
+        networkRequest: {
+          params: {
+            vs_currencies: args.fiatCode,
+            contract_addresses: args.tokenAddresses.join(','),
           },
-        }),
+          ...(this.apiKey && {
+            headers: {
+              [CoingeckoApi.COINGECKO_API_HEADER]: this.apiKey,
+            },
+          }),
+        },
       });
       return data;
     } catch (error) {

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -113,10 +113,10 @@ export class ZerionBalancesApi implements IBalancesApi {
           sort: 'value',
         },
       };
-      const { data } = await this.networkService.get<ZerionBalances>(
+      const { data } = await this.networkService.get<ZerionBalances>({
         url,
         networkRequest,
-      );
+      });
       await this.cacheService.set(
         cacheDir,
         JSON.stringify(data.data),
@@ -168,10 +168,10 @@ export class ZerionBalancesApi implements IBalancesApi {
             ...(pageAfter && { 'page[after]': pageAfter }),
           },
         };
-        const { data } = await this.networkService.get<ZerionCollectibles>(
+        const { data } = await this.networkService.get<ZerionCollectibles>({
           url,
           networkRequest,
-        );
+        });
         await this.cacheService.set(
           cacheDir,
           JSON.stringify(data),

--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -45,7 +45,7 @@ describe('CacheFirstDataSource', () => {
     const cacheDir = new CacheDir(faker.word.sample(), faker.word.sample());
     const notFoundExpireTimeSeconds = faker.number.int();
     const data = JSON.parse(fakeJson());
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.resolve({ data, status: 200 });
@@ -80,7 +80,7 @@ describe('CacheFirstDataSource', () => {
       invalidationTimeMs.toString(),
       faker.number.int({ min: 1 }),
     );
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.resolve({ data, status: 200 });
@@ -114,7 +114,7 @@ describe('CacheFirstDataSource', () => {
       invalidationTimeMs.toString(),
       faker.number.int({ min: 1 }),
     );
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.resolve({ data, status: 200 });
@@ -142,7 +142,7 @@ describe('CacheFirstDataSource', () => {
     const notFoundExpireTimeSeconds = faker.number.int();
     const rawJson = fakeJson();
     await fakeCacheService.set(cacheDir, rawJson, faker.number.int({ min: 1 }));
-    mockNetworkService.get.mockImplementation((url) =>
+    mockNetworkService.get.mockImplementation(({ url }) =>
       Promise.reject(`Unexpected request to ${url}`),
     );
 
@@ -163,7 +163,7 @@ describe('CacheFirstDataSource', () => {
       status: 404,
     } as Response);
     const notFoundExpireTimeSeconds = faker.number.int();
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.reject(expectedError);
@@ -192,7 +192,7 @@ describe('CacheFirstDataSource', () => {
     const expectedError = new NetworkResponseError(new URL(targetUrl), {
       status: 404,
     } as Response);
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.reject(expectedError);
@@ -240,7 +240,7 @@ describe('CacheFirstDataSource', () => {
       status: 404,
     } as Response);
     mockCache.get.mockResolvedValue(undefined);
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.reject(expectedError);
@@ -283,7 +283,7 @@ describe('CacheFirstDataSource', () => {
     } as Response);
     const notFoundExpireTimeSeconds = faker.number.int();
     mockCache.get.mockResolvedValue(undefined);
-    mockNetworkService.get.mockImplementation((url) => {
+    mockNetworkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case targetUrl:
           return Promise.reject(expectedError);

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -99,10 +99,10 @@ export class CacheFirstDataSource {
     const { key, field } = args.cacheDir;
     this.loggingService.debug({ type: 'cache_miss', key, field });
     const startTimeMs = Date.now();
-    const { data } = await this.networkService.get<T>(
-      args.url,
-      args.networkRequest,
-    );
+    const { data } = await this.networkService.get<T>({
+      url: args.url,
+      networkRequest: args.networkRequest,
+    });
 
     const shouldBeCached = await this._shouldBeCached(key, startTimeMs);
     if (shouldBeCached) {

--- a/src/datasources/email-api/pushwoosh-api.service.spec.ts
+++ b/src/datasources/email-api/pushwoosh-api.service.spec.ts
@@ -106,9 +106,9 @@ describe('PushwooshApi', () => {
       await service.createMessage(createEmailMessageDto);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        `${pushwooshBaseUri}/json/1.3/createEmailMessage`,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: `${pushwooshBaseUri}/json/1.3/createEmailMessage`,
+        data: {
           request: {
             application: pushwooshApplicationCode,
             auth: pushwooshApiKey,
@@ -126,7 +126,7 @@ describe('PushwooshApi', () => {
             ],
           },
         },
-      );
+      });
     });
 
     it('should create a new unique (using emailMessageId field) message', async () => {
@@ -144,9 +144,9 @@ describe('PushwooshApi', () => {
       await service.createMessage(createEmailMessageDto);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        `${pushwooshBaseUri}/json/1.3/createEmailMessage`,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: `${pushwooshBaseUri}/json/1.3/createEmailMessage`,
+        data: {
           request: {
             application: pushwooshApplicationCode,
             auth: pushwooshApiKey,
@@ -165,7 +165,7 @@ describe('PushwooshApi', () => {
             ],
           },
         },
-      );
+      });
     });
   });
 
@@ -195,15 +195,15 @@ describe('PushwooshApi', () => {
       await service.deleteEmailAddress({ emailAddress });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        `${pushwooshBaseUri}/json/1.3/deleteEmail`,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: `${pushwooshBaseUri}/json/1.3/deleteEmail`,
+        data: {
           request: {
             application: pushwooshApplicationCode,
             email: emailAddress,
           },
         },
-      );
+      });
     });
   });
 });

--- a/src/datasources/email-api/pushwoosh-api.service.ts
+++ b/src/datasources/email-api/pushwoosh-api.service.ts
@@ -45,25 +45,29 @@ export class PushwooshApi implements IEmailApi {
   ): Promise<void> {
     try {
       const url = `${this.baseUri}/json/1.3/createEmailMessage`;
-      await this.networkService.post(url, {
-        request: {
-          application: this.applicationCode, // application code, should exist on Pushwoosh
-          auth: this.apiKey,
-          notifications: [
-            {
-              send_date: 'now',
-              email_template: createEmailMessageDto.template, // template code, should exist on Pushwoosh
-              devices: createEmailMessageDto.to,
-              use_auto_registration: true, // auto-register email addresses while sending
-              subject: [{ default: createEmailMessageDto.subject }],
-              dynamic_content_placeholders: createEmailMessageDto.substitutions, // key-value template substitutions
-              from: { name: this.fromName, email: this.fromEmail },
-              // optional unique identifier to avoid messages duplication
-              ...(createEmailMessageDto.emailMessageId && {
-                transactionId: createEmailMessageDto.emailMessageId,
-              }),
-            },
-          ],
+      await this.networkService.post({
+        url,
+        data: {
+          request: {
+            application: this.applicationCode, // application code, should exist on Pushwoosh
+            auth: this.apiKey,
+            notifications: [
+              {
+                send_date: 'now',
+                email_template: createEmailMessageDto.template, // template code, should exist on Pushwoosh
+                devices: createEmailMessageDto.to,
+                use_auto_registration: true, // auto-register email addresses while sending
+                subject: [{ default: createEmailMessageDto.subject }],
+                dynamic_content_placeholders:
+                  createEmailMessageDto.substitutions, // key-value template substitutions
+                from: { name: this.fromName, email: this.fromEmail },
+                // optional unique identifier to avoid messages duplication
+                ...(createEmailMessageDto.emailMessageId && {
+                  transactionId: createEmailMessageDto.emailMessageId,
+                }),
+              },
+            ],
+          },
         },
       });
     } catch (error) {
@@ -74,10 +78,13 @@ export class PushwooshApi implements IEmailApi {
   async deleteEmailAddress(args: { emailAddress: string }): Promise<void> {
     try {
       const url = `${this.baseUri}/json/1.3/deleteEmail`;
-      await this.networkService.post(url, {
-        request: {
-          application: this.applicationCode,
-          email: args.emailAddress,
+      await this.networkService.post({
+        url,
+        data: {
+          request: {
+            application: this.applicationCode,
+            email: args.emailAddress,
+          },
         },
       });
     } catch (error) {

--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -61,15 +61,15 @@ describe('LockingApi', () => {
 
       await service.getLockingHistory({ safeAddress });
 
-      expect(mockNetworkService.get).toHaveBeenCalledWith(
-        `${lockingBaseUri}/api/v1/all-events/${safeAddress}`,
-        {
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/all-events/${safeAddress}`,
+        networkRequest: {
           params: {
             limit: undefined,
             offset: undefined,
           },
         },
-      );
+      });
     });
 
     it('should forward pagination queries', async () => {
@@ -90,15 +90,15 @@ describe('LockingApi', () => {
 
       await service.getLockingHistory({ safeAddress, limit, offset });
 
-      expect(mockNetworkService.get).toHaveBeenCalledWith(
-        `${lockingBaseUri}/api/v1/all-events/${safeAddress}`,
-        {
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/all-events/${safeAddress}`,
+        networkRequest: {
           params: {
             limit,
             offset,
           },
         },
-      );
+      });
     });
 
     it('should forward error', async () => {

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -40,10 +40,13 @@ export class LockingApi implements ILockingApi {
   }): Promise<Page<LockingEvent>> {
     try {
       const url = `${this.baseUri}/api/v1/all-events/${args.safeAddress}`;
-      const { data } = await this.networkService.get<Page<LockingEvent>>(url, {
-        params: {
-          limit: args.limit,
-          offset: args.offset,
+      const { data } = await this.networkService.get<Page<LockingEvent>>({
+        url,
+        networkRequest: {
+          params: {
+            limit: args.limit,
+            offset: args.offset,
+          },
         },
       });
       return data;

--- a/src/datasources/network/fetch.network.service.spec.ts
+++ b/src/datasources/network/fetch.network.service.spec.ts
@@ -28,7 +28,7 @@ describe('FetchNetworkService', () => {
     it(`get uses GET method`, async () => {
       const url = faker.internet.url({ appendSlash: false });
 
-      await target.get(url);
+      await target.get({ url });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(`${url}/`, {
@@ -38,14 +38,14 @@ describe('FetchNetworkService', () => {
 
     it(`get calls fetch get with request`, async () => {
       const url = faker.internet.url({ appendSlash: false });
-      const request: NetworkRequest = {
+      const networkRequest: NetworkRequest = {
         params: { some_query_param: 'query_param' },
         headers: {
           test: 'value',
         },
       };
 
-      await target.get(url, request);
+      await target.get({ url, networkRequest });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(
@@ -61,7 +61,7 @@ describe('FetchNetworkService', () => {
 
     it(`get should remove empty strings, null and undefined query params from the request`, async () => {
       const url = faker.internet.url({ appendSlash: false });
-      const request: NetworkRequest = {
+      const networkRequest: NetworkRequest = {
         params: {
           boolean: true,
           falsy_boolean: false,
@@ -75,7 +75,7 @@ describe('FetchNetworkService', () => {
         },
       };
 
-      await target.get(url, request);
+      await target.get({ url, networkRequest });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(
@@ -98,7 +98,7 @@ describe('FetchNetworkService', () => {
       );
       fetchClientMock.mockRejectedValueOnce(error);
 
-      await expect(target.get(url)).rejects.toThrow(error);
+      await expect(target.get({ url })).rejects.toThrow(error);
 
       expect(loggingService.debug).toHaveBeenCalledTimes(1);
       expect(loggingService.debug).toHaveBeenCalledWith({
@@ -118,7 +118,7 @@ describe('FetchNetworkService', () => {
       const url = faker.internet.url({ appendSlash: false });
       const data = { [faker.word.sample()]: faker.string.alphanumeric() };
 
-      await target.post(url, data);
+      await target.post({ url, data });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(`${url}/`, {
@@ -133,14 +133,14 @@ describe('FetchNetworkService', () => {
     it(`post calls fetch with request`, async () => {
       const url = faker.internet.url({ appendSlash: false });
       const data = { [faker.word.sample()]: faker.string.alphanumeric() };
-      const request: NetworkRequest = {
+      const networkRequest: NetworkRequest = {
         params: { some_query_param: 'query_param' },
         headers: {
           test: 'value',
         },
       };
 
-      await target.post(url, data, request);
+      await target.post({ url, data, networkRequest });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(
@@ -168,7 +168,7 @@ describe('FetchNetworkService', () => {
       );
       fetchClientMock.mockRejectedValueOnce(error);
 
-      await expect(target.post(url, {})).rejects.toThrow(error);
+      await expect(target.post({ url, data: {} })).rejects.toThrow(error);
 
       expect(loggingService.debug).toHaveBeenCalledTimes(1);
       expect(loggingService.debug).toHaveBeenCalledWith({
@@ -187,7 +187,7 @@ describe('FetchNetworkService', () => {
     it(`delete uses DELETE method`, async () => {
       const url = faker.internet.url({ appendSlash: false });
 
-      await target.delete(url);
+      await target.delete({ url });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(`${url}/`, {
@@ -198,14 +198,14 @@ describe('FetchNetworkService', () => {
     it(`delete calls fetch with request`, async () => {
       const url = faker.internet.url({ appendSlash: false });
       const data = { [faker.word.sample()]: faker.string.alphanumeric() };
-      const request: NetworkRequest = {
+      const networkRequest: NetworkRequest = {
         params: { some_query_param: 'query_param' },
         headers: {
           test: 'value',
         },
       };
 
-      await target.delete(url, data, request);
+      await target.delete({ url, data, networkRequest });
 
       expect(fetchClientMock).toHaveBeenCalledTimes(1);
       expect(fetchClientMock).toHaveBeenCalledWith(
@@ -233,7 +233,7 @@ describe('FetchNetworkService', () => {
       );
       fetchClientMock.mockRejectedValueOnce(error);
 
-      await expect(target.delete(url)).rejects.toThrow(error);
+      await expect(target.delete({ url })).rejects.toThrow(error);
 
       expect(loggingService.debug).toHaveBeenCalledTimes(1);
       expect(loggingService.debug).toHaveBeenCalledWith({

--- a/src/datasources/network/fetch.network.service.ts
+++ b/src/datasources/network/fetch.network.service.ts
@@ -18,16 +18,16 @@ export class FetchNetworkService implements INetworkService {
     private readonly loggingService: ILoggingService,
   ) {}
 
-  async get<T>(
-    baseUrl: string,
-    { params, ...options }: NetworkRequest = {},
-  ): Promise<NetworkResponse<T>> {
-    const url = this.buildUrl(baseUrl, params);
+  async get<T>(args: {
+    url: string;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>> {
+    const url = this.buildUrl(args.url, args.networkRequest?.params);
     const startTimeMs = performance.now();
     try {
       return await this.client<T>(url, {
         method: 'GET',
-        ...options,
+        headers: args.networkRequest?.headers,
       });
     } catch (error) {
       this.logErrorResponse(error, performance.now() - startTimeMs);
@@ -35,20 +35,20 @@ export class FetchNetworkService implements INetworkService {
     }
   }
 
-  async post<T>(
-    baseUrl: string,
-    data: object,
-    { params, headers }: NetworkRequest = {},
-  ): Promise<NetworkResponse<T>> {
-    const url = this.buildUrl(baseUrl, params);
+  async post<T>(args: {
+    url: string;
+    data: object;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>> {
+    const url = this.buildUrl(args.url, args.networkRequest?.params);
     const startTimeMs = performance.now();
     try {
       return await this.client<T>(url, {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: JSON.stringify(args.data),
         headers: {
           'Content-Type': 'application/json',
-          ...headers,
+          ...(args.networkRequest?.headers ?? {}),
         },
       });
     } catch (error) {
@@ -57,15 +57,17 @@ export class FetchNetworkService implements INetworkService {
     }
   }
 
-  async delete<T>(
-    baseUrl: string,
-    data?: object,
-    { params, headers }: NetworkRequest = {},
-  ): Promise<NetworkResponse<T>> {
-    const url = this.buildUrl(baseUrl, params);
+  async delete<T>(args: {
+    url: string;
+    data?: object;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>> {
+    const url = this.buildUrl(args.url, args.networkRequest?.params);
     const startTimeMs = performance.now();
 
-    if (data) {
+    let headers = args.networkRequest?.headers;
+
+    if (args.data) {
       headers ??= {};
       headers['Content-Type'] = 'application/json';
     }
@@ -73,8 +75,8 @@ export class FetchNetworkService implements INetworkService {
     try {
       return await this.client<T>(url, {
         method: 'DELETE',
-        ...(data && {
-          body: JSON.stringify(data),
+        ...(args.data && {
+          body: JSON.stringify(args.data),
         }),
         headers,
       });

--- a/src/datasources/network/network.service.interface.ts
+++ b/src/datasources/network/network.service.interface.ts
@@ -4,20 +4,20 @@ import { NetworkResponse } from '@/datasources/network/entities/network.response
 export const NetworkService = Symbol('INetworkService');
 
 export interface INetworkService {
-  get<T>(
-    url: string,
-    networkRequest?: NetworkRequest,
-  ): Promise<NetworkResponse<T>>;
+  get<T>(args: {
+    url: string;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>>;
 
-  post<T>(
-    url: string,
-    data: object,
-    networkRequest?: NetworkRequest,
-  ): Promise<NetworkResponse<T>>;
+  post<T>(args: {
+    url: string;
+    data: object;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>>;
 
-  delete<T>(
-    url: string,
-    data?: object,
-    networkRequest?: NetworkRequest,
-  ): Promise<NetworkResponse<T>>;
+  delete<T>(args: {
+    url: string;
+    data?: object;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>>;
 }

--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -68,15 +68,15 @@ describe('GelatoApi', () => {
         gasLimit: null,
       });
 
-      expect(mockNetworkService.post).toHaveBeenCalledWith(
-        `${baseUri}/relays/v2/sponsored-call`,
-        {
+      expect(mockNetworkService.post).toHaveBeenCalledWith({
+        url: `${baseUri}/relays/v2/sponsored-call`,
+        data: {
           sponsorApiKey: apiKey,
           chainId,
           target: address,
           data,
         },
-      );
+      });
     });
 
     it('should add a gas buffer if a gas limit is provided', async () => {
@@ -101,16 +101,16 @@ describe('GelatoApi', () => {
         gasLimit,
       });
 
-      expect(mockNetworkService.post).toHaveBeenCalledWith(
-        `${baseUri}/relays/v2/sponsored-call`,
-        {
+      expect(mockNetworkService.post).toHaveBeenCalledWith({
+        url: `${baseUri}/relays/v2/sponsored-call`,
+        data: {
           sponsorApiKey: apiKey,
           chainId,
           target: address,
           data,
           gasLimit: (gasLimit + BigInt(150_000)).toString(),
         },
-      );
+      });
     });
 
     it('should throw if there is no API key preset', async () => {

--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -42,14 +42,17 @@ export class GelatoApi implements IRelayApi {
 
     try {
       const url = `${this.baseUri}/relays/v2/sponsored-call`;
-      const { data } = await this.networkService.post<{ taskId: string }>(url, {
-        sponsorApiKey,
-        chainId: args.chainId,
-        target: args.to,
-        data: args.data,
-        ...(args.gasLimit && {
-          gasLimit: this.getRelayGasLimit(args.gasLimit).toString(),
-        }),
+      const { data } = await this.networkService.post<{ taskId: string }>({
+        url,
+        data: {
+          sponsorApiKey,
+          chainId: args.chainId,
+          target: args.to,
+          data: args.data,
+          ...(args.gasLimit && {
+            gasLimit: this.getRelayGasLimit(args.gasLimit).toString(),
+          }),
+        },
       });
       return data;
     } catch (error) {

--- a/src/datasources/swaps-api/cowswap-api.service.ts
+++ b/src/datasources/swaps-api/cowswap-api.service.ts
@@ -13,7 +13,7 @@ export class CowSwapApi implements ISwapsApi {
   async getOrder(uid: string): Promise<Order> {
     try {
       const url = `${this.baseUrl}/api/v1/orders/${uid}`;
-      const { data } = await this.networkService.get<Order>(url);
+      const { data } = await this.networkService.get<Order>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -108,9 +108,12 @@ describe('TransactionApi', () => {
 
       expect(actual).toBe(decodedData);
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(getDataDecodedUrl, {
-        data,
-        to,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: getDataDecodedUrl,
+        data: {
+          data,
+          to,
+        },
       });
     });
 
@@ -141,9 +144,12 @@ describe('TransactionApi', () => {
       );
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(getDataDecodedUrl, {
-        data,
-        to,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: getDataDecodedUrl,
+        data: {
+          data,
+          to,
+        },
       });
     });
   });
@@ -479,9 +485,12 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postDelegateUrl, {
-        ...delegate,
-        signature,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postDelegateUrl,
+        data: {
+          ...delegate,
+          signature,
+        },
       });
     });
 
@@ -516,9 +525,12 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postDelegateUrl, {
-        ...delegate,
-        signature,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postDelegateUrl,
+        data: {
+          ...delegate,
+          signature,
+        },
       });
     });
   });
@@ -540,10 +552,13 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(deleteDelegateUrl, {
-        delegate: delegate.delegate,
-        delegator: delegate.delegator,
-        signature,
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteDelegateUrl,
+        data: {
+          delegate: delegate.delegate,
+          delegator: delegate.delegator,
+          signature,
+        },
       });
     });
 
@@ -578,10 +593,13 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(deleteDelegateUrl, {
-        delegate: delegate.delegate,
-        delegator: delegate.delegator,
-        signature,
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteDelegateUrl,
+        data: {
+          delegate: delegate.delegate,
+          delegator: delegate.delegator,
+          signature,
+        },
       });
     });
   });
@@ -603,14 +621,14 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(
-        deleteSafeDelegateUrl,
-        {
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteSafeDelegateUrl,
+        data: {
           delegate: delegate.delegate,
           safe: delegate.safe!,
           signature,
         },
-      );
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -644,14 +662,14 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(
-        deleteSafeDelegateUrl,
-        {
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteSafeDelegateUrl,
+        data: {
           delegate: delegate.delegate,
           safe: delegate.safe!,
           signature,
         },
-      );
+      });
     });
   });
 
@@ -982,8 +1000,11 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postConfirmationUrl, {
-        signature: signedSafeTxHash,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postConfirmationUrl,
+        data: {
+          signature: signedSafeTxHash,
+        },
       });
     });
 
@@ -1017,8 +1038,11 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postConfirmationUrl, {
-        signature: signedSafeTxHash,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postConfirmationUrl,
+        data: {
+          signature: signedSafeTxHash,
+        },
       });
     });
   });
@@ -1042,7 +1066,9 @@ describe('TransactionApi', () => {
 
       expect(actual).toBe(safesByModule);
       expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
-      expect(mockNetworkService.get).toHaveBeenCalledWith(getSafesByModuleUrl);
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: getSafesByModuleUrl,
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -1071,7 +1097,9 @@ describe('TransactionApi', () => {
       );
 
       expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
-      expect(mockNetworkService.get).toHaveBeenCalledWith(getSafesByModuleUrl);
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: getSafesByModuleUrl,
+      });
     });
   });
 
@@ -1470,8 +1498,11 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(deleteTransactionUrl, {
-        signature,
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteTransactionUrl,
+        data: {
+          signature,
+        },
       });
     });
 
@@ -1505,8 +1536,11 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(deleteTransactionUrl, {
-        signature,
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteTransactionUrl,
+        data: {
+          signature,
+        },
       });
     });
   });
@@ -1930,14 +1964,14 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        postDeviceRegistrationUrl,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postDeviceRegistrationUrl,
+        data: {
           ...device,
           safes,
           signatures,
         },
-      );
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -1970,8 +2004,11 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postConfirmationUrl, {
-        signature: signedSafeTxHash,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postConfirmationUrl,
+        data: {
+          signature: signedSafeTxHash,
+        },
       });
     });
   });
@@ -1988,9 +2025,9 @@ describe('TransactionApi', () => {
       await service.deleteDeviceRegistration(uuid);
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(
-        deleteDeviceRegistrationUrl,
-      );
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteDeviceRegistrationUrl,
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -2019,9 +2056,9 @@ describe('TransactionApi', () => {
       );
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(
-        deleteDeviceRegistrationUrl,
-      );
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteDeviceRegistrationUrl,
+      });
     });
   });
 
@@ -2038,9 +2075,9 @@ describe('TransactionApi', () => {
       await service.deleteSafeRegistration({ uuid, safeAddress });
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(
-        deleteSafeRegistrationUrl,
-      );
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteSafeRegistrationUrl,
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -2070,9 +2107,9 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(
-        deleteSafeRegistrationUrl,
-      );
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: deleteSafeRegistrationUrl,
+      });
     });
   });
 
@@ -2099,11 +2136,14 @@ describe('TransactionApi', () => {
 
       expect(actual).toBe(estimation);
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(getEstimationUrl, {
-        to,
-        value,
-        data,
-        operation,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: getEstimationUrl,
+        data: {
+          to,
+          value,
+          data,
+          operation,
+        },
       });
     });
 
@@ -2140,11 +2180,14 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(getEstimationUrl, {
-        to,
-        value,
-        data,
-        operation,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: getEstimationUrl,
+        data: {
+          to,
+          value,
+          data,
+          operation,
+        },
       });
     });
   });
@@ -2308,13 +2351,13 @@ describe('TransactionApi', () => {
 
       const { safeTxHash, ...rest } = proposeTransactionDto;
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        postMultisigTransactionUrl,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postMultisigTransactionUrl,
+        data: {
           ...rest,
           contractTransactionHash: safeTxHash,
         },
-      );
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -2348,13 +2391,13 @@ describe('TransactionApi', () => {
 
       const { safeTxHash, ...rest } = proposeTransactionDto;
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        postMultisigTransactionUrl,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postMultisigTransactionUrl,
+        data: {
           ...rest,
           contractTransactionHash: safeTxHash,
         },
-      );
+      });
     });
   });
 
@@ -2378,10 +2421,13 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postMessageUrl, {
-        message,
-        safeAppId,
-        signature,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postMessageUrl,
+        data: {
+          message,
+          safeAppId,
+          signature,
+        },
       });
     });
 
@@ -2419,10 +2465,13 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(postMessageUrl, {
-        message,
-        safeAppId,
-        signature,
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postMessageUrl,
+        data: {
+          message,
+          safeAppId,
+          signature,
+        },
       });
     });
   });
@@ -2443,12 +2492,12 @@ describe('TransactionApi', () => {
       });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        postMessageSignatureUrl,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postMessageSignatureUrl,
+        data: {
           signature,
         },
-      );
+      });
     });
 
     const errorMessage = faker.word.words();
@@ -2481,12 +2530,12 @@ describe('TransactionApi', () => {
       ).rejects.toThrow(expected);
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
-      expect(networkService.post).toHaveBeenCalledWith(
-        postMessageSignatureUrl,
-        {
+      expect(networkService.post).toHaveBeenCalledWith({
+        url: postMessageSignatureUrl,
+        data: {
           signature,
         },
-      );
+      });
     });
   });
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -73,10 +73,12 @@ export class TransactionApi implements ITransactionApi {
     try {
       const url = `${this.baseUrl}/api/v1/data-decoder/`;
       const { data: dataDecoded } = await this.networkService.post<DataDecoded>(
-        url,
         {
-          data: args.data,
-          to: args.to,
+          url,
+          data: {
+            data: args.data,
+            to: args.to,
+          },
         },
       );
       return dataDecoded;
@@ -208,12 +210,15 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/delegates/`;
-      await this.networkService.post(url, {
-        safe: args.safeAddress,
-        delegate: args.delegate,
-        delegator: args.delegator,
-        signature: args.signature,
-        label: args.label,
+      await this.networkService.post({
+        url,
+        data: {
+          safe: args.safeAddress,
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+          label: args.label,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -227,10 +232,13 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<unknown> {
     try {
       const url = `${this.baseUrl}/api/v1/delegates/${args.delegate}`;
-      return await this.networkService.delete(url, {
-        delegate: args.delegate,
-        delegator: args.delegator,
-        signature: args.signature,
+      return await this.networkService.delete({
+        url,
+        data: {
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -244,10 +252,13 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<unknown> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/delegates/${args.delegate}`;
-      return await this.networkService.delete(url, {
-        delegate: args.delegate,
-        safe: args.safeAddress,
-        signature: args.signature,
+      return await this.networkService.delete({
+        url,
+        data: {
+          delegate: args.delegate,
+          safe: args.safeAddress,
+          signature: args.signature,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -366,8 +377,11 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<unknown> {
     try {
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${args.safeTxHash}/confirmations/`;
-      return await this.networkService.post(url, {
-        signature: args.addConfirmationDto.signedSafeTxHash,
+      return await this.networkService.post({
+        url,
+        data: {
+          signature: args.addConfirmationDto.signedSafeTxHash,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -377,7 +391,7 @@ export class TransactionApi implements ITransactionApi {
   async getSafesByModule(moduleAddress: string): Promise<SafeList> {
     try {
       const url = `${this.baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
-      const { data } = await this.networkService.get<SafeList>(url);
+      const { data } = await this.networkService.get<SafeList>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -527,8 +541,11 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/transactions/${args.safeTxHash}`;
-      await this.networkService.delete(url, {
-        signature: args.signature,
+      await this.networkService.delete({
+        url,
+        data: {
+          signature: args.signature,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -684,16 +701,19 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/notifications/devices/`;
-      await this.networkService.post(url, {
-        uuid: args.device.uuid,
-        cloudMessagingToken: args.device.cloudMessagingToken,
-        buildNumber: args.device.buildNumber,
-        bundle: args.device.bundle,
-        deviceType: args.device.deviceType,
-        version: args.device.version,
-        timestamp: args.device.timestamp,
-        safes: args.safes,
-        signatures: args.signatures,
+      await this.networkService.post({
+        url,
+        data: {
+          uuid: args.device.uuid,
+          cloudMessagingToken: args.device.cloudMessagingToken,
+          buildNumber: args.device.buildNumber,
+          bundle: args.device.bundle,
+          deviceType: args.device.deviceType,
+          version: args.device.version,
+          timestamp: args.device.timestamp,
+          safes: args.safes,
+          signatures: args.signatures,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -703,7 +723,7 @@ export class TransactionApi implements ITransactionApi {
   async deleteDeviceRegistration(uuid: string): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/notifications/devices/${uuid}`;
-      await this.networkService.delete(url);
+      await this.networkService.delete({ url });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
     }
@@ -715,7 +735,7 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/notifications/devices/${args.uuid}/safes/${args.safeAddress}`;
-      await this.networkService.delete(url);
+      await this.networkService.delete({ url });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
     }
@@ -727,15 +747,15 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<Estimation> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.address}/multisig-transactions/estimations/`;
-      const { data: estimation } = await this.networkService.post<Estimation>(
+      const { data: estimation } = await this.networkService.post<Estimation>({
         url,
-        {
+        data: {
           to: args.getEstimationDto.to,
           value: args.getEstimationDto.value,
           data: args.getEstimationDto.data,
           operation: args.getEstimationDto.operation,
         },
-      );
+      });
       return estimation;
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -794,21 +814,24 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<unknown> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.address}/multisig-transactions/`;
-      return await this.networkService.post(url, {
-        to: args.data.to,
-        value: args.data.value,
-        data: args.data.data,
-        operation: args.data.operation,
-        baseGas: args.data.baseGas,
-        gasPrice: args.data.gasPrice,
-        gasToken: args.data.gasToken,
-        refundReceiver: args.data.refundReceiver,
-        nonce: args.data.nonce,
-        safeTxGas: args.data.safeTxGas,
-        contractTransactionHash: args.data.safeTxHash,
-        sender: args.data.sender,
-        signature: args.data.signature,
-        origin: args.data.origin,
+      return await this.networkService.post({
+        url,
+        data: {
+          to: args.data.to,
+          value: args.data.value,
+          data: args.data.data,
+          operation: args.data.operation,
+          baseGas: args.data.baseGas,
+          gasPrice: args.data.gasPrice,
+          gasToken: args.data.gasToken,
+          refundReceiver: args.data.refundReceiver,
+          nonce: args.data.nonce,
+          safeTxGas: args.data.safeTxGas,
+          contractTransactionHash: args.data.safeTxHash,
+          sender: args.data.sender,
+          signature: args.data.signature,
+          origin: args.data.origin,
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -823,10 +846,13 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<Message> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/messages/`;
-      const { data } = await this.networkService.post<Message>(url, {
-        message: args.message,
-        safeAppId: args.safeAppId,
-        signature: args.signature,
+      const { data } = await this.networkService.post<Message>({
+        url,
+        data: {
+          message: args.message,
+          safeAppId: args.safeAppId,
+          signature: args.signature,
+        },
       });
       return data;
     } catch (error) {
@@ -840,8 +866,11 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<unknown> {
     try {
       const url = `${this.baseUrl}/api/v1/messages/${args.messageHash}/signatures/`;
-      const { data } = await this.networkService.post(url, {
-        signature: args.signature,
+      const { data } = await this.networkService.post({
+        url,
+        data: {
+          signature: args.signature,
+        },
       });
       return data;
     } catch (error) {

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -201,7 +201,7 @@ describe('Alerts (Unit)', () => {
             subscriptionBuilder().with('key', 'account_recovery').build(),
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -309,7 +309,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -416,7 +416,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -513,7 +513,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -641,7 +641,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -741,7 +741,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -863,7 +863,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -971,7 +971,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -1055,7 +1055,7 @@ describe('Alerts (Unit)', () => {
             accountRecoverySubscription,
           ]);
 
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -1182,7 +1182,7 @@ describe('Alerts (Unit)', () => {
           accountRecoverySubscription,
         ]);
 
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -1296,7 +1296,7 @@ describe('Alerts (Unit)', () => {
           accountRecoverySubscription,
         ]);
 
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -1399,7 +1399,7 @@ describe('Alerts (Unit)', () => {
           accountRecoverySubscription,
         ]);
 
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -1508,7 +1508,7 @@ describe('Alerts (Unit)', () => {
           subscriptionBuilder().build(),
         ]);
 
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -163,7 +163,7 @@ describe('Balances Controller (Unit)', () => {
         const apiKey = app
           .get(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -217,10 +217,12 @@ describe('Balances Controller (Unit)', () => {
           });
 
         expect(networkService.get.mock.calls.length).toBe(2);
-        expect(networkService.get.mock.calls[0][0]).toBe(
+        expect(networkService.get.mock.calls[0][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`,
         );
-        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+        expect(
+          networkService.get.mock.calls[0][0].networkRequest,
+        ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
@@ -228,7 +230,7 @@ describe('Balances Controller (Unit)', () => {
             sort: 'value',
           },
         });
-        expect(networkService.get.mock.calls[1][0]).toBe(
+        expect(networkService.get.mock.calls[1][0].url).toBe(
           `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
         );
       });
@@ -306,7 +308,7 @@ describe('Balances Controller (Unit)', () => {
         const apiKey = app
           .get(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -360,10 +362,12 @@ describe('Balances Controller (Unit)', () => {
           });
 
         expect(networkService.get.mock.calls.length).toBe(2);
-        expect(networkService.get.mock.calls[0][0]).toBe(
+        expect(networkService.get.mock.calls[0][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`,
         );
-        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+        expect(
+          networkService.get.mock.calls[0][0].networkRequest,
+        ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
@@ -371,7 +375,7 @@ describe('Balances Controller (Unit)', () => {
             sort: 'value',
           },
         });
-        expect(networkService.get.mock.calls[1][0]).toBe(
+        expect(networkService.get.mock.calls[1][0].url).toBe(
           `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
         );
       });
@@ -390,7 +394,7 @@ describe('Balances Controller (Unit)', () => {
             status: 500,
           } as Response,
         );
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
               return Promise.reject(error);
@@ -421,7 +425,7 @@ describe('Balances Controller (Unit)', () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
         const safeAddress = faker.finance.ethereumAddress();
         const currency = faker.finance.currencyCode();
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -487,7 +491,7 @@ describe('Balances Controller (Unit)', () => {
               .build(),
           ])
           .build();
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -557,7 +561,7 @@ describe('Balances Controller (Unit)', () => {
               .build(),
           ])
           .build();
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -105,7 +105,7 @@ describe('Balances Controller (Unit)', () => {
         [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
         [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
       };
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -184,19 +184,19 @@ describe('Balances Controller (Unit)', () => {
       // 4 Network calls are expected
       // (1. Chain data, 2. Balances, 3. Coingecko native coin, 4. Coingecko tokens)
       expect(networkService.get.mock.calls.length).toBe(4);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`,
       );
-      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[2][0]).toBe(
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chainName}`,
       );
-      expect(networkService.get.mock.calls[2][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -206,10 +206,10 @@ describe('Balances Controller (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[3][0]).toBe(
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[3][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
         params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
       });
@@ -237,7 +237,7 @@ describe('Balances Controller (Unit)', () => {
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
       };
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -263,7 +263,7 @@ describe('Balances Controller (Unit)', () => {
         .expect(200);
 
       // trusted and exclude_spam params are passed
-      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: {
           trusted,
           exclude_spam: excludeSpam,
@@ -290,7 +290,7 @@ describe('Balances Controller (Unit)', () => {
       const nativeCoinPriceProviderResponse = {
         [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
       };
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -356,7 +356,7 @@ describe('Balances Controller (Unit)', () => {
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
       };
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -402,16 +402,16 @@ describe('Balances Controller (Unit)', () => {
       // 3 Network calls are expected
       // (1. Chain data, 2. Balances, 3. Coingecko token)
       expect(networkService.get.mock.calls.length).toBe(3);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`,
       );
-      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[2][0]).toBe(
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chainName}`,
       );
     });
@@ -459,7 +459,7 @@ describe('Balances Controller (Unit)', () => {
           .getOrThrow(
             `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
           );
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -521,7 +521,7 @@ describe('Balances Controller (Unit)', () => {
             `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
           );
         const tokenPriceProviderResponse = 'notAnObject';
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -576,7 +576,7 @@ describe('Balances Controller (Unit)', () => {
         const safeAddress = faker.finance.ethereumAddress();
         const chainResponse = chainBuilder().with('chainId', chainId).build();
         const transactionServiceUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/`;
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
             return Promise.resolve({ data: chainResponse, status: 200 });
           } else if (url == transactionServiceUrl) {
@@ -608,7 +608,7 @@ describe('Balances Controller (Unit)', () => {
       const chainId = '1';
       const safeAddress = faker.finance.ethereumAddress();
       const chainResponse = chainBuilder().with('chainId', chainId).build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
           return Promise.resolve({ data: chainResponse, status: 200 });
         } else if (
@@ -642,7 +642,7 @@ describe('Balances Controller (Unit)', () => {
       const chain = chainBuilder().build();
       // So BalancesApiManager available currencies should include ['btc', 'eth', 'eur', 'usd']
       const pricesProviderFiatCodes = ['usd', 'eth', 'eur'];
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/1`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -666,7 +666,7 @@ describe('Balances Controller (Unit)', () => {
       const chain = chainBuilder().build();
       // So BalancesApiManager available currencies should include ['btc', 'eth', 'eur', 'usd']
       const pricesProviderFiatCodes = ['USD', 'ETH'];
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/1`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -688,7 +688,7 @@ describe('Balances Controller (Unit)', () => {
 
     it('should get an empty array of fiat currencies on failure', async () => {
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/1`:
             return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -142,7 +142,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -166,7 +166,7 @@ describe('Post Hook Events (Unit)', () => {
       type: 'SOME_TEST_TYPE_THAT_WE_DO_NOT_SUPPORT',
       safeTxHash: 'some-safe-tx-hash',
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/1`:
           return Promise.resolve({
@@ -227,7 +227,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -284,7 +284,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -341,7 +341,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -390,7 +390,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -448,7 +448,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -502,7 +502,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -551,7 +551,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -595,7 +595,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -664,7 +664,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -711,7 +711,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -137,15 +137,15 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains`,
-        {
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains`,
+        networkRequest: {
           params: {
             limit: PaginationData.DEFAULT_LIMIT,
             offset: PaginationData.DEFAULT_OFFSET,
           },
         },
-      );
+      });
     });
 
     it('Failure: network service fails', async () => {
@@ -163,15 +163,15 @@ describe('Chains Controller (Unit)', () => {
       });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains`,
-        {
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains`,
+        networkRequest: {
           params: {
             limit: PaginationData.DEFAULT_LIMIT,
             offset: PaginationData.DEFAULT_OFFSET,
           },
         },
-      );
+      });
     });
 
     it('Failure: received data is not valid', async () => {
@@ -196,15 +196,15 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains`,
-        {
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains`,
+        networkRequest: {
           params: {
             limit: PaginationData.DEFAULT_LIMIT,
             offset: PaginationData.DEFAULT_OFFSET,
           },
         },
-      );
+      });
     });
   });
 
@@ -303,13 +303,15 @@ describe('Chains Controller (Unit)', () => {
         .expect(backboneResponse);
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about`,
       );
-      expect(networkService.get.mock.calls[1][1]).toBe(undefined);
+      expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
+        undefined,
+      );
     });
 
     it('Validate the response', async () => {
@@ -336,13 +338,15 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about`,
       );
-      expect(networkService.get.mock.calls[1][1]).toBe(undefined);
+      expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
+        undefined,
+      );
     });
 
     it('Failure getting the chain', async () => {
@@ -363,10 +367,9 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains/1`,
-        undefined,
-      );
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains/1`,
+      });
     });
 
     it('Failure getting the backbone data', async () => {
@@ -391,13 +394,15 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about`,
       );
-      expect(networkService.get.mock.calls[1][1]).toBe(undefined);
+      expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
+        undefined,
+      );
     });
   });
 
@@ -432,13 +437,15 @@ describe('Chains Controller (Unit)', () => {
         .expect(masterCopiesResponse);
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about/singletons/`,
       );
-      expect(networkService.get.mock.calls[1][1]).toBe(undefined);
+      expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
+        undefined,
+      );
     });
 
     it('Failure getting the chain', async () => {
@@ -459,10 +466,9 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains/1`,
-        undefined,
-      );
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains/1`,
+      });
     });
 
     it('Should fail getting the master-copies data', async () => {
@@ -487,13 +493,15 @@ describe('Chains Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get.mock.calls[0][0]).toBe(
+      expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/1`,
       );
-      expect(networkService.get.mock.calls[1][0]).toBe(
+      expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about/singletons/`,
       );
-      expect(networkService.get.mock.calls[1][1]).toBe(undefined);
+      expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
+        undefined,
+      );
     });
 
     it('Should return validation error', async () => {

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -126,7 +126,7 @@ describe('Zerion Collectibles Controller', () => {
         const apiKey = app
           .get(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
@@ -231,10 +231,12 @@ describe('Zerion Collectibles Controller', () => {
           });
 
         expect(networkService.get.mock.calls.length).toBe(1);
-        expect(networkService.get.mock.calls[0][0]).toBe(
+        expect(networkService.get.mock.calls[0][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`,
         );
-        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+        expect(
+          networkService.get.mock.calls[0][0].networkRequest,
+        ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
@@ -264,7 +266,7 @@ describe('Zerion Collectibles Controller', () => {
         const apiKey = app
           .get(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
@@ -291,10 +293,12 @@ describe('Zerion Collectibles Controller', () => {
           });
 
         expect(networkService.get.mock.calls.length).toBe(1);
-        expect(networkService.get.mock.calls[0][0]).toBe(
+        expect(networkService.get.mock.calls[0][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`,
         );
-        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+        expect(
+          networkService.get.mock.calls[0][0].networkRequest,
+        ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
@@ -327,7 +331,7 @@ describe('Zerion Collectibles Controller', () => {
         const apiKey = app
           .get(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
@@ -354,10 +358,12 @@ describe('Zerion Collectibles Controller', () => {
           });
 
         expect(networkService.get.mock.calls.length).toBe(1);
-        expect(networkService.get.mock.calls[0][0]).toBe(
+        expect(networkService.get.mock.calls[0][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`,
         );
-        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+        expect(
+          networkService.get.mock.calls[0][0].networkRequest,
+        ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
@@ -389,7 +395,7 @@ describe('Zerion Collectibles Controller', () => {
         const apiKey = app
           .get(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
@@ -416,10 +422,12 @@ describe('Zerion Collectibles Controller', () => {
           });
 
         expect(networkService.get.mock.calls.length).toBe(1);
-        expect(networkService.get.mock.calls[0][0]).toBe(
+        expect(networkService.get.mock.calls[0][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`,
         );
-        expect(networkService.get.mock.calls[0][1]).toStrictEqual({
+        expect(
+          networkService.get.mock.calls[0][0].networkRequest,
+        ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
@@ -435,7 +443,7 @@ describe('Zerion Collectibles Controller', () => {
       it(`500 error response`, async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
         const safeAddress = faker.finance.ethereumAddress();
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.reject(new Error('test error'));

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -80,7 +80,7 @@ describe('Collectibles Controller (Unit)', () => {
         ])
         .build();
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
@@ -123,7 +123,7 @@ describe('Collectibles Controller (Unit)', () => {
         ])
         .build();
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
@@ -140,7 +140,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: {
           limit: 10,
           offset: 20,
@@ -167,7 +167,7 @@ describe('Collectibles Controller (Unit)', () => {
         ])
         .build();
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
@@ -184,7 +184,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: {
           limit: PaginationData.DEFAULT_LIMIT,
           offset: PaginationData.DEFAULT_OFFSET,
@@ -206,7 +206,7 @@ describe('Collectibles Controller (Unit)', () => {
           message: 'some collectibles error',
         },
       );
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
@@ -235,7 +235,7 @@ describe('Collectibles Controller (Unit)', () => {
       const transactionServiceError = new NetworkRequestError(
         new URL(transactionServiceUrl),
       );
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -58,7 +58,7 @@ describe('Contracts controller', () => {
     it('Success', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -78,7 +78,7 @@ describe('Contracts controller', () => {
     it('Failure: Config API fails', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.reject(new Error());
@@ -96,7 +96,7 @@ describe('Contracts controller', () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
       const transactionServiceUrl = `${chain.transactionService}/api/v1/contracts/${contract.address}`;
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -119,7 +119,7 @@ describe('Contracts controller', () => {
     it('should get a validation error', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -69,7 +69,7 @@ describe('Delegates controller', () => {
           delegateBuilder().with('safe', safe).build(),
         ])
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: chain, status: 200 });
         }
@@ -97,7 +97,7 @@ describe('Delegates controller', () => {
           { ...delegateBuilder().with('safe', safe).build(), label: true },
         ])
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: chain, status: 200 });
         }
@@ -126,7 +126,7 @@ describe('Delegates controller', () => {
         .with('previous', null)
         .with('results', [])
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: chain, status: 200 });
         }
@@ -156,12 +156,12 @@ describe('Delegates controller', () => {
     it('Success', async () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url === `${chain.transactionService}/api/v1/delegates/`
           ? Promise.resolve({ status: 201, data: {} })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -194,12 +194,12 @@ describe('Delegates controller', () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       createDelegateDto.safe = null;
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url === `${chain.transactionService}/api/v1/delegates/`
           ? Promise.resolve({ status: 201, data: {} })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -214,7 +214,7 @@ describe('Delegates controller', () => {
     it('Should return the tx-service error message', async () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -227,7 +227,7 @@ describe('Delegates controller', () => {
         } as Response,
         { message: 'Malformed body', status: 400 },
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url === transactionServiceUrl
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -246,7 +246,7 @@ describe('Delegates controller', () => {
     it('Should fail with An error occurred', async () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -255,7 +255,7 @@ describe('Delegates controller', () => {
       const error = new NetworkResponseError(new URL(transactionServiceUrl), {
         status: 503,
       } as Response);
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url === transactionServiceUrl
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -276,12 +276,12 @@ describe('Delegates controller', () => {
     it('Success', async () => {
       const deleteDelegateDto = deleteDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`
           ? Promise.resolve({ data: {}, status: 204 })
@@ -299,7 +299,7 @@ describe('Delegates controller', () => {
     it('Should return the tx-service error message', async () => {
       const deleteDelegateDto = deleteDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -312,7 +312,7 @@ describe('Delegates controller', () => {
         } as Response,
         { message: 'Malformed body', status: 400 },
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url === transactionServiceUrl
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -333,7 +333,7 @@ describe('Delegates controller', () => {
     it('Should fail with An error occurred', async () => {
       const deleteDelegateDto = deleteDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -342,7 +342,7 @@ describe('Delegates controller', () => {
       const error = new NetworkResponseError(new URL(transactionServiceUrl), {
         status: 503,
       } as Response);
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`
           ? Promise.reject(error)
@@ -406,12 +406,12 @@ describe('Delegates controller', () => {
     it('Success', async () => {
       const chain = chainBuilder().build();
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${deleteSafeDelegateDto.safe}/delegates/${deleteSafeDelegateDto.delegate}`
           ? Promise.resolve({ data: {}, status: 204 })
@@ -429,7 +429,7 @@ describe('Delegates controller', () => {
     it('Should return errors from provider', async () => {
       const chain = chainBuilder().build();
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -442,7 +442,7 @@ describe('Delegates controller', () => {
         } as Response,
         { message: 'Malformed body', status: 400 },
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url === transactionServiceUrl
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),

--- a/src/routes/email/email.controller.delete-email.spec.ts
+++ b/src/routes/email/email.controller.delete-email.spec.ts
@@ -129,7 +129,7 @@ describe('Email controller delete email tests', () => {
       .build();
     const message = `email-delete-${chain.chainId}-${safe.address}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -258,7 +258,7 @@ describe('Email controller delete email tests', () => {
       .build();
     const message = `email-delete-${chain.chainId}-${safe.address}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -104,7 +104,7 @@ describe('Email controller edit email tests', () => {
     const safe = safeBuilder().with('address', safeAddress).build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -184,7 +184,7 @@ describe('Email controller edit email tests', () => {
     const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -267,7 +267,7 @@ describe('Email controller edit email tests', () => {
     const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -314,7 +314,7 @@ describe('Email controller edit email tests', () => {
     const safe = safeBuilder().build();
     const message = `email-edit-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/email/email.controller.save-email.spec.ts
+++ b/src/routes/email/email.controller.save-email.spec.ts
@@ -95,7 +95,7 @@ describe('Email controller save email tests', () => {
       .build();
     const message = `email-register-${chain.chainId}-${safe.address}-${emailAddress}-${signerAddress}-${timestamp}`;
     const signature = await signer.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -245,7 +245,7 @@ describe('Email controller save email tests', () => {
       .build();
     const message = `email-register-${chain.chainId}-${safe.address}-${emailAddress}-${accountAddress}-${timestamp}`;
     const signature = await account.signMessage({ message });
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -68,7 +68,7 @@ describe('Estimations Controller (Unit)', () => {
       const safe = safeBuilder().build();
       const estimation = estimationBuilder().build();
       const lastTransaction = multisigTransactionBuilder().build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
         const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -89,7 +89,7 @@ describe('Estimations Controller (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.post.mockImplementation((url) => {
+      networkService.post.mockImplementation(({ url }) => {
         const estimationsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/estimations/`;
         return url === estimationsUrl
           ? Promise.resolve({ data: estimation, status: 200 })
@@ -143,7 +143,7 @@ describe('Estimations Controller (Unit)', () => {
     const lastTransaction = multisigTransactionBuilder()
       .with('nonce', faker.number.int({ min: 51 }))
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
@@ -164,7 +164,7 @@ describe('Estimations Controller (Unit)', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation, status: 200 })
@@ -196,7 +196,7 @@ describe('Estimations Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().with('nonce', faker.number.int()).build();
     const estimation = estimationBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
@@ -214,7 +214,7 @@ describe('Estimations Controller (Unit)', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation, status: 200 })
@@ -249,7 +249,7 @@ describe('Estimations Controller (Unit)', () => {
     const lastTransaction = multisigTransactionBuilder()
       .with('nonce', faker.number.int({ max: safe.nonce }))
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
@@ -270,7 +270,7 @@ describe('Estimations Controller (Unit)', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation, status: 200 })

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -88,7 +88,7 @@ describe('Locking (Unit)', () => {
         .with('previous', null)
         .with('next', null)
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
             return Promise.resolve({ data: lockingHistoryPage, status: 200 });
@@ -134,7 +134,7 @@ describe('Locking (Unit)', () => {
         .with('previous', null)
         .with('next', null)
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
             return Promise.resolve({ data: lockingHistoryPage, status: 200 });
@@ -162,7 +162,7 @@ describe('Locking (Unit)', () => {
         types: ['clientError', 'serverError'],
       });
       const errorMessage = faker.word.words();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
             return Promise.reject(

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -79,7 +79,7 @@ describe('Messages controller', () => {
           faker.number.int({ max: messageConfirmations.length }),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -146,7 +146,7 @@ describe('Messages controller', () => {
           faker.number.int({ max: messageConfirmations.length }),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -210,7 +210,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -277,7 +277,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -341,7 +341,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -405,7 +405,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -457,7 +457,7 @@ describe('Messages controller', () => {
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
       const page = pageBuilder().with('results', []).build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -502,7 +502,7 @@ describe('Messages controller', () => {
         .with('count', 1)
         .with('results', [messageToJson(message)])
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -588,7 +588,7 @@ describe('Messages controller', () => {
           messages.map((m) => messageToJson(m)),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -687,7 +687,7 @@ describe('Messages controller', () => {
           messages.map((m) => messageToJson(m)),
         )
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
@@ -750,12 +750,12 @@ describe('Messages controller', () => {
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
       const message = messageBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`
           ? Promise.resolve({ data: messageToJson(message), status: 200 })
@@ -773,7 +773,7 @@ describe('Messages controller', () => {
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
       const errorMessage = faker.word.words();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -784,7 +784,7 @@ describe('Messages controller', () => {
         { status: 400 } as Response,
         { message: errorMessage },
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url === transactionServiceUrl
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -829,12 +829,12 @@ describe('Messages controller', () => {
         data: { signature: faker.string.hexadecimal() },
         status: 200,
       };
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/messages/${message.messageHash}/signatures/`
           ? Promise.resolve(expectedResponse)
@@ -857,7 +857,7 @@ describe('Messages controller', () => {
         .with('created', faker.date.recent())
         .build();
       const errorMessage = faker.word.words();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -870,7 +870,7 @@ describe('Messages controller', () => {
         } as Response,
         { message: errorMessage },
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url === transactionServiceUrl
           ? Promise.reject(error)
           : Promise.reject(`No matching rule for url: ${url}`),

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -71,12 +71,12 @@ describe('Notifications Controller (Unit)', () => {
   describe('POST /register/notifications', () => {
     it('Success', async () => {
       const registerDeviceDto = buildInputDto();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -91,12 +91,12 @@ describe('Notifications Controller (Unit)', () => {
 
     it('Client errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url);
       });
-      networkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce(({ url }) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -108,7 +108,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -129,12 +129,12 @@ describe('Notifications Controller (Unit)', () => {
 
     it('Server errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce(({ url }) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -146,7 +146,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -165,12 +165,12 @@ describe('Notifications Controller (Unit)', () => {
 
     it('Both client and server errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url);
       });
-      networkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce(({ url }) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -182,7 +182,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce(({ url }) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -194,7 +194,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -216,22 +216,22 @@ describe('Notifications Controller (Unit)', () => {
 
     it('No status code errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce(({ url }) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(new Error())
           : rejectForUrl(url),
       );
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -254,12 +254,12 @@ describe('Notifications Controller (Unit)', () => {
       const uuid = faker.string.uuid();
       const chain = chainBuilder().build();
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}`;
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url === expectedProviderURL
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -270,13 +270,15 @@ describe('Notifications Controller (Unit)', () => {
         .expect(200)
         .expect({});
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(expectedProviderURL);
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: expectedProviderURL,
+      });
     });
 
     it('Failure: Config API fails', async () => {
       const uuid = faker.string.uuid();
       const chainId = faker.string.numeric();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chainId}`
           ? Promise.reject(new Error())
           : rejectForUrl(url),
@@ -291,12 +293,12 @@ describe('Notifications Controller (Unit)', () => {
     it('Failure: Transaction API fails', async () => {
       const uuid = faker.string.uuid();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/notifications/devices/${uuid}`
           ? Promise.reject(new Error())
@@ -316,12 +318,12 @@ describe('Notifications Controller (Unit)', () => {
       const safeAddress = faker.finance.ethereumAddress();
       const chain = chainBuilder().build();
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url === expectedProviderURL
           ? Promise.resolve({ data: {}, status: 200 })
           : rejectForUrl(url),
@@ -334,14 +336,16 @@ describe('Notifications Controller (Unit)', () => {
         .expect(200)
         .expect({});
       expect(networkService.delete).toHaveBeenCalledTimes(1);
-      expect(networkService.delete).toHaveBeenCalledWith(expectedProviderURL);
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: expectedProviderURL,
+      });
     });
 
     it('Failure: Config API fails', async () => {
       const uuid = faker.string.uuid();
       const safeAddress = faker.finance.ethereumAddress();
       const chainId = faker.string.numeric();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chainId}`
           ? Promise.reject(new Error())
           : rejectForUrl(url),
@@ -359,12 +363,12 @@ describe('Notifications Controller (Unit)', () => {
       const uuid = faker.string.uuid();
       const safeAddress = faker.finance.ethereumAddress();
       const chain = chainBuilder().build();
-      networkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain, status: 200 })
           : rejectForUrl(url),
       );
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`
           ? Promise.reject(new Error())

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -103,10 +103,9 @@ describe('Owners Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains/${chainId}`,
-        undefined,
-      );
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+      });
     });
 
     it('Failure: Transaction API fails', async () => {
@@ -136,14 +135,12 @@ describe('Owners Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains/${chainId}`,
-        undefined,
-      );
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${chainResponse.transactionService}/api/v1/owners/${ownerAddress}/safes/`,
-        undefined,
-      );
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+      });
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${chainResponse.transactionService}/api/v1/owners/${ownerAddress}/safes/`,
+      });
     });
 
     it('Failure: data validation fails', async () => {
@@ -198,7 +195,7 @@ describe('Owners Controller (Unit)', () => {
         faker.finance.ethereumAddress(),
       ];
 
-      networkService.get.mockImplementation((url: string) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains`: {
             return Promise.resolve({
@@ -255,7 +252,7 @@ describe('Owners Controller (Unit)', () => {
     it('Failure: Config API fails', async () => {
       const ownerAddress = faker.finance.ethereumAddress();
 
-      networkService.get.mockImplementation((url: string) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains`) {
           const error = new NetworkResponseError(
             new URL(`${safeConfigUrl}/api/v1/chains`),
@@ -277,10 +274,10 @@ describe('Owners Controller (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenCalledWith(
-        `${safeConfigUrl}/api/v1/chains`,
-        { params: { limit: undefined, offset: undefined } },
-      );
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${safeConfigUrl}/api/v1/chains`,
+        networkRequest: { params: { limit: undefined, offset: undefined } },
+      });
     });
 
     it('Failure: data validation fails', async () => {
@@ -296,7 +293,7 @@ describe('Owners Controller (Unit)', () => {
         faker.finance.ethereumAddress(),
       ];
 
-      networkService.get.mockImplementation((url: string) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains`: {
             return Promise.resolve({

--- a/src/routes/recovery/recovery.controller.spec.ts
+++ b/src/routes/recovery/recovery.controller.spec.ts
@@ -88,7 +88,7 @@ describe('Recovery (Unit)', () => {
       const message = `enable-recovery-alerts-${chain.chainId}-${safe.address}-${addRecoveryModuleDto.moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -99,7 +99,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.resolve({ status: 200, data: {} })
@@ -128,7 +128,7 @@ describe('Recovery (Unit)', () => {
       const message = `enable-recovery-alerts-${chain.chainId}-${safe.address}-${addRecoveryModuleDto.moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -163,7 +163,7 @@ describe('Recovery (Unit)', () => {
       const message = `enable-recovery-alerts-${chain.chainId}-${safe.address}-${addRecoveryModuleDto.moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -198,7 +198,7 @@ describe('Recovery (Unit)', () => {
       const message = `enable-recovery-alerts-${chain.chainId}-${safe.address}-${addRecoveryModuleDto.moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -209,7 +209,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.resolve({ status: 200, data: {} })
@@ -250,7 +250,7 @@ describe('Recovery (Unit)', () => {
         },
       );
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -261,7 +261,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.reject(error)
@@ -299,7 +299,7 @@ describe('Recovery (Unit)', () => {
         } as Response,
       );
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -310,7 +310,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
           ? Promise.reject(error)
@@ -339,7 +339,7 @@ describe('Recovery (Unit)', () => {
       const message = `disable-recovery-alerts-${chain.chainId}-${safe.address}-${moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -350,7 +350,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/contract/${chain.chainId}/${moduleAddress}`
           ? Promise.resolve({ status: 204, data: {} })
@@ -379,7 +379,7 @@ describe('Recovery (Unit)', () => {
       const message = `disable-recovery-alerts-${chain.chainId}-${safe.address}-${moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -390,7 +390,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/contract/${chain.chainId}/${moduleAddress}`
           ? Promise.resolve({ status: 204, data: {} })
@@ -421,7 +421,7 @@ describe('Recovery (Unit)', () => {
       const message = `disable-recovery-alerts-${chain.chainId}-${safe.address}-${moduleAddress}-${signer.address}-${timestamp}`;
       const signature = await signer.signMessage({ message });
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -432,7 +432,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/contract/${chain.chainId}/${moduleAddress}`
           ? Promise.resolve({ status: 204, data: {} })
@@ -473,7 +473,7 @@ describe('Recovery (Unit)', () => {
         },
       );
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -484,7 +484,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/contract/${chain.chainId}/${moduleAddress}`
           ? Promise.reject(error)
@@ -528,7 +528,7 @@ describe('Recovery (Unit)', () => {
         } as Response,
       );
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ status: 200, data: chain });
         }
@@ -539,7 +539,7 @@ describe('Recovery (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/contract/${chain.chainId}/${moduleAddress}`
           ? Promise.reject(error)

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -135,7 +135,7 @@ describe('Relay controller', () => {
                   .with('value', faker.number.bigInt())
                   .encode() as Hex;
                 const taskId = faker.string.uuid();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -146,7 +146,7 @@ describe('Relay controller', () => {
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
                 });
-                networkService.post.mockImplementation((url) => {
+                networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({ data: { taskId }, status: 200 });
@@ -175,7 +175,7 @@ describe('Relay controller', () => {
                 const gasLimit = faker.string.numeric({ exclude: '0' });
                 const data = execTransactionEncoder().encode() as Hex;
                 const taskId = faker.string.uuid();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -186,7 +186,7 @@ describe('Relay controller', () => {
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
                 });
-                networkService.post.mockImplementation((url) => {
+                networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({ data: { taskId }, status: 200 });
@@ -212,12 +212,12 @@ describe('Relay controller', () => {
                 const expectedGasLimit = (
                   BigInt(gasLimit) + BigInt(150_000)
                 ).toString();
-                expect(networkService.post).toHaveBeenCalledWith(
-                  `${relayUrl}/relays/v2/sponsored-call`,
-                  expect.objectContaining({
+                expect(networkService.post).toHaveBeenCalledWith({
+                  url: `${relayUrl}/relays/v2/sponsored-call`,
+                  data: expect.objectContaining({
                     gasLimit: expectedGasLimit,
                   }),
-                );
+                });
               });
 
               it.each([
@@ -255,7 +255,7 @@ describe('Relay controller', () => {
                     .with('data', execTransactionData)
                     .encode() as Hex;
                   const taskId = faker.string.uuid();
-                  networkService.get.mockImplementation((url) => {
+                  networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                         return Promise.resolve({ data: chain, status: 200 });
@@ -268,7 +268,7 @@ describe('Relay controller', () => {
                         );
                     }
                   });
-                  networkService.post.mockImplementation((url) => {
+                  networkService.post.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
@@ -305,7 +305,7 @@ describe('Relay controller', () => {
                   .with('data', execTransactionEncoder().encode())
                   .encode() as Hex;
                 const taskId = faker.string.uuid();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -316,7 +316,7 @@ describe('Relay controller', () => {
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
                 });
-                networkService.post.mockImplementation((url) => {
+                networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({ data: { taskId }, status: 200 });
@@ -373,7 +373,7 @@ describe('Relay controller', () => {
                   network: chainId,
                 })!.networkAddresses[chainId];
                 const taskId = faker.string.uuid();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -384,7 +384,7 @@ describe('Relay controller', () => {
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
                 });
-                networkService.post.mockImplementation((url) => {
+                networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({ data: { taskId }, status: 200 });
@@ -434,7 +434,7 @@ describe('Relay controller', () => {
               network: chainId,
             })!.networkAddresses[chainId];
             const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
+            networkService.get.mockImplementation(({ url }) => {
               switch (url) {
                 case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                   return Promise.resolve({ data: chain, status: 200 });
@@ -445,7 +445,7 @@ describe('Relay controller', () => {
                   return Promise.reject(`No matching rule for url: ${url}`);
               }
             });
-            networkService.post.mockImplementation((url) => {
+            networkService.post.mockImplementation(({ url }) => {
               switch (url) {
                 case `${relayUrl}/relays/v2/sponsored-call`:
                   return Promise.resolve({ data: { taskId }, status: 200 });
@@ -500,7 +500,7 @@ describe('Relay controller', () => {
                   network: chainId,
                 })!.networkAddresses[chainId];
                 const taskId = faker.string.uuid();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -511,7 +511,7 @@ describe('Relay controller', () => {
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
                 });
-                networkService.post.mockImplementation((url) => {
+                networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({ data: { taskId }, status: 200 });
@@ -562,7 +562,7 @@ describe('Relay controller', () => {
               network: chainId,
             })!.networkAddresses[chainId];
             const taskId = faker.string.uuid();
-            networkService.get.mockImplementation((url) => {
+            networkService.get.mockImplementation(({ url }) => {
               switch (url) {
                 case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                   return Promise.resolve({ data: chain, status: 200 });
@@ -573,7 +573,7 @@ describe('Relay controller', () => {
                   return Promise.reject(`No matching rule for url: ${url}`);
               }
             });
-            networkService.post.mockImplementation((url) => {
+            networkService.post.mockImplementation(({ url }) => {
               switch (url) {
                 case `${relayUrl}/relays/v2/sponsored-call`:
                   return Promise.resolve({ data: { taskId }, status: 200 });
@@ -624,7 +624,7 @@ describe('Relay controller', () => {
                     )
                     .encode();
                   const taskId = faker.string.uuid();
-                  networkService.get.mockImplementation((url) => {
+                  networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                         return Promise.resolve({ data: chain, status: 200 });
@@ -634,7 +634,7 @@ describe('Relay controller', () => {
                         );
                     }
                   });
-                  networkService.post.mockImplementation((url) => {
+                  networkService.post.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
@@ -681,7 +681,7 @@ describe('Relay controller', () => {
                     )
                     .encode();
                   const taskId = faker.string.uuid();
-                  networkService.get.mockImplementation((url) => {
+                  networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                         return Promise.resolve({ data: chain, status: 200 });
@@ -691,7 +691,7 @@ describe('Relay controller', () => {
                         );
                     }
                   });
-                  networkService.post.mockImplementation((url) => {
+                  networkService.post.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
@@ -744,7 +744,7 @@ describe('Relay controller', () => {
                     )
                     .encode();
                   const taskId = faker.string.uuid();
-                  networkService.get.mockImplementation((url) => {
+                  networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                         return Promise.resolve({ data: chain, status: 200 });
@@ -754,7 +754,7 @@ describe('Relay controller', () => {
                         );
                     }
                   });
-                  networkService.post.mockImplementation((url) => {
+                  networkService.post.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
@@ -801,7 +801,7 @@ describe('Relay controller', () => {
                     )
                     .encode();
                   const taskId = faker.string.uuid();
-                  networkService.get.mockImplementation((url) => {
+                  networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                         return Promise.resolve({ data: chain, status: 200 });
@@ -811,7 +811,7 @@ describe('Relay controller', () => {
                         );
                     }
                   });
-                  networkService.post.mockImplementation((url) => {
+                  networkService.post.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
@@ -883,7 +883,7 @@ describe('Relay controller', () => {
                 )
                 .encode();
               const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
+              networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                     return Promise.resolve({ data: chain, status: 200 });
@@ -891,7 +891,7 @@ describe('Relay controller', () => {
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
               });
-              networkService.post.mockImplementation((url) => {
+              networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
                     return Promise.resolve({ data: { taskId }, status: 200 });
@@ -930,7 +930,7 @@ describe('Relay controller', () => {
                   .with('to', safeAddress)
                   .with('value', faker.number.bigInt())
                   .encode() as Hex;
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -968,7 +968,7 @@ describe('Relay controller', () => {
                     erc20TransferEncoder().with('to', safeAddress).encode(),
                   )
                   .encode() as Hex;
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1002,7 +1002,7 @@ describe('Relay controller', () => {
                 const data = execTransactionEncoder()
                   .with('value', faker.number.bigInt())
                   .encode() as Hex;
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1059,7 +1059,7 @@ describe('Relay controller', () => {
                   network: chainId,
                 })!.networkAddresses[chainId];
                 const taskId = faker.string.uuid();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1070,7 +1070,7 @@ describe('Relay controller', () => {
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
                 });
-                networkService.post.mockImplementation((url) => {
+                networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({
@@ -1124,7 +1124,7 @@ describe('Relay controller', () => {
                   version,
                   network: chainId,
                 })!.networkAddresses[chainId];
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1175,7 +1175,7 @@ describe('Relay controller', () => {
                   version,
                   network: chainId,
                 })!.networkAddresses[chainId];
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1227,7 +1227,7 @@ describe('Relay controller', () => {
                   .encode();
                 // Unofficial MultiSend deployment
                 const to = faker.finance.ethereumAddress();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1275,7 +1275,7 @@ describe('Relay controller', () => {
                     setupEncoder().with('owners', owners).encode(),
                   )
                   .encode();
-                networkService.get.mockImplementation((url) => {
+                networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                       return Promise.resolve({ data: chain, status: 200 });
@@ -1337,7 +1337,7 @@ describe('Relay controller', () => {
           const safe = safeBuilder().build();
           const safeAddress = getAddress(safe.address);
           const data = erc20TransferEncoder().encode();
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -1377,7 +1377,7 @@ describe('Relay controller', () => {
                 .with('value', faker.number.bigInt())
                 .encode() as Hex;
               const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
+              networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                     return Promise.resolve({ data: chain, status: 200 });
@@ -1388,7 +1388,7 @@ describe('Relay controller', () => {
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
               });
-              networkService.post.mockImplementation((url) => {
+              networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
                     return Promise.resolve({ data: { taskId }, status: 200 });
@@ -1447,7 +1447,7 @@ describe('Relay controller', () => {
                 network: chainId,
               })!.networkAddresses[chainId];
               const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
+              networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                     return Promise.resolve({ data: chain, status: 200 });
@@ -1458,7 +1458,7 @@ describe('Relay controller', () => {
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
               });
-              networkService.post.mockImplementation((url) => {
+              networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
                     return Promise.resolve({ data: { taskId }, status: 200 });
@@ -1513,7 +1513,7 @@ describe('Relay controller', () => {
                 )
                 .encode();
               const taskId = faker.string.uuid();
-              networkService.get.mockImplementation((url) => {
+              networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                     return Promise.resolve({ data: chain, status: 200 });
@@ -1521,7 +1521,7 @@ describe('Relay controller', () => {
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
               });
-              networkService.post.mockImplementation((url) => {
+              networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
                     return Promise.resolve({ data: { taskId }, status: 200 });
@@ -1560,7 +1560,7 @@ describe('Relay controller', () => {
             .with('value', faker.number.bigInt())
             .encode() as Hex;
           const taskId = faker.string.uuid();
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -1572,7 +1572,7 @@ describe('Relay controller', () => {
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
           });
-          networkService.post.mockImplementation((url) => {
+          networkService.post.mockImplementation(({ url }) => {
             switch (url) {
               case `${relayUrl}/relays/v2/sponsored-call`:
                 return Promise.resolve({ data: { taskId }, status: 200 });
@@ -1618,7 +1618,7 @@ describe('Relay controller', () => {
             .with('value', faker.number.bigInt())
             .encode() as Hex;
           const taskId = faker.string.uuid();
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -1629,7 +1629,7 @@ describe('Relay controller', () => {
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
           });
-          networkService.post.mockImplementation((url) => {
+          networkService.post.mockImplementation(({ url }) => {
             switch (url) {
               case `${relayUrl}/relays/v2/sponsored-call`:
                 return Promise.resolve({ data: { taskId }, status: 200 });
@@ -1662,7 +1662,7 @@ describe('Relay controller', () => {
             .with('value', faker.number.bigInt())
             .encode() as Hex;
           const taskId = faker.string.uuid();
-          networkService.get.mockImplementation((url) => {
+          networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
                 return Promise.resolve({ data: chain, status: 200 });
@@ -1673,7 +1673,7 @@ describe('Relay controller', () => {
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
           });
-          networkService.post.mockImplementation((url) => {
+          networkService.post.mockImplementation(({ url }) => {
             switch (url) {
               case `${relayUrl}/relays/v2/sponsored-call`:
                 return Promise.resolve({ data: { taskId }, status: 200 });
@@ -1710,7 +1710,7 @@ describe('Relay controller', () => {
         const chain = chainBuilder().with('chainId', chainId).build();
         const safe = safeBuilder().build();
         const data = execTransactionEncoder().encode() as Hex;
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -1721,7 +1721,7 @@ describe('Relay controller', () => {
               return Promise.reject(`No matching rule for url: ${url}`);
           }
         });
-        networkService.post.mockImplementation((url) => {
+        networkService.post.mockImplementation(({ url }) => {
           switch (url) {
             case `${relayUrl}/relays/v2/sponsored-call`:
               return Promise.reject(new Error('Relayer error'));
@@ -1757,7 +1757,7 @@ describe('Relay controller', () => {
           .with('value', faker.number.bigInt())
           .encode() as Hex;
         const taskId = faker.string.uuid();
-        networkService.get.mockImplementation((url) => {
+        networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
@@ -1768,7 +1768,7 @@ describe('Relay controller', () => {
               return Promise.reject(`No matching rule for url: ${url}`);
           }
         });
-        networkService.post.mockImplementation((url) => {
+        networkService.post.mockImplementation(({ url }) => {
           switch (url) {
             case `${relayUrl}/relays/v2/sponsored-call`:
               return Promise.resolve({ data: { taskId }, status: 200 });

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -77,7 +77,7 @@ describe('Safe Apps Controller (Unit)', () => {
           )
           .build(),
       ];
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({ data: safeAppsResponse, status: 200 });
@@ -126,7 +126,7 @@ describe('Safe Apps Controller (Unit)', () => {
     it('Success with UNKNOWN accessControl', async () => {
       const chain = chainBuilder().build();
       const safeAppsResponse = [safeAppBuilder().build()];
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({
@@ -184,7 +184,7 @@ describe('Safe Apps Controller (Unit)', () => {
           .build(),
       ];
 
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({ data: safeAppsResponse, status: 200 });

--- a/src/routes/safes/safes.controller.nonces.spec.ts
+++ b/src/routes/safes/safes.controller.nonces.spec.ts
@@ -68,7 +68,7 @@ describe('Safes Controller Nonces (Unit)', () => {
       )
       .build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -105,7 +105,7 @@ describe('Safes Controller Nonces (Unit)', () => {
       )
       .build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -134,7 +134,7 @@ describe('Safes Controller Nonces (Unit)', () => {
     const safeInfo = safeBuilder().build();
     const multisigTransactionsPage = pageBuilder().with('results', []).build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -112,7 +112,7 @@ describe('Safes Controller (Unit)', () => {
       ])
       .build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -221,7 +221,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -274,7 +274,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -328,7 +328,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -383,7 +383,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -441,7 +441,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -492,7 +492,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -565,7 +565,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -616,7 +616,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -686,7 +686,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -738,7 +738,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -789,7 +789,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -840,7 +840,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -912,7 +912,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -986,7 +986,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1058,7 +1058,7 @@ describe('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1136,7 +1136,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1185,7 +1185,7 @@ describe('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1248,7 +1248,7 @@ describe('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1308,7 +1308,7 @@ describe('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1379,7 +1379,7 @@ describe('Safes Controller (Unit)', () => {
       ])
       .build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1432,7 +1432,7 @@ describe('Safes Controller (Unit)', () => {
 
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1491,7 +1491,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1566,7 +1566,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1618,7 +1618,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1665,7 +1665,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1718,7 +1718,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });
@@ -1766,7 +1766,7 @@ describe('Safes Controller (Unit)', () => {
     const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -91,7 +91,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         .build(),
     ];
     const rejectionTxsPage = pageBuilder().with('results', []).build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -123,7 +123,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       switch (url) {
         case postConfirmationUrl:

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -92,7 +92,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
       signature: faker.string.hexadecimal({ length: 16 }),
     };
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -104,7 +104,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    networkService.delete.mockImplementation((url) => {
+    networkService.delete.mockImplementation(({ url }) => {
       if (
         url ===
         `${chain.transactionService}/api/v1/transactions/${tx.safeTxHash}`
@@ -127,7 +127,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
       signature: faker.string.hexadecimal({ length: 16 }),
     };
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -139,7 +139,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    networkService.delete.mockImplementation((url) => {
+    networkService.delete.mockImplementation(({ url }) => {
       if (
         url ===
         `${chain.transactionService}/api/v1/transactions/${tx.safeTxHash}`
@@ -176,7 +176,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     };
 
     const tx = multisigTransactionBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -188,7 +188,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    networkService.delete.mockImplementation((url) => {
+    networkService.delete.mockImplementation(({ url }) => {
       if (
         url ===
         `${chain.transactionService}/api/v1/transactions/${tx.safeTxHash}`

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -76,7 +76,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const chainId = faker.string.numeric();
     const id = `module_${faker.string.uuid()}`;
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       if (url === getChainUrl) {
         const error = new NetworkResponseError(new URL(getChainUrl), {
           status: 500,
@@ -95,7 +95,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(1);
-    expect(networkService.get).toHaveBeenCalledWith(getChainUrl, undefined);
+    expect(networkService.get).toHaveBeenCalledWith({ url: getChainUrl });
   });
 
   it('Failure: Transaction API fails', async () => {
@@ -104,7 +104,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const moduleTransactionId = faker.string.uuid();
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${moduleTransactionId}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -132,11 +132,10 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(2);
-    expect(networkService.get).toHaveBeenCalledWith(getChainUrl, undefined);
-    expect(networkService.get).toHaveBeenCalledWith(
-      getModuleTransactionUrl,
-      undefined,
-    );
+    expect(networkService.get).toHaveBeenCalledWith({ url: getChainUrl });
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: getModuleTransactionUrl,
+    });
   });
 
   it('Get module transaction by ID should return 404', async () => {
@@ -147,7 +146,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${id}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -197,7 +196,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${moduleTransactionId}`;
     const getContractUrl = `${chain.transactionService}/api/v1/contracts/${moduleTransaction.to}`;
     const getModuleContractUrl = `${chain.transactionService}/api/v1/contracts/${moduleTransaction.module}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -267,7 +266,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getTransferUrl = `${chain.transactionService}/api/v1/transfer/${id}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -310,7 +309,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getTransferUrl = `${chain.transactionService}/api/v1/transfer/${transferId}`;
     const getFromContractUrl = `${chain.transactionService}/api/v1/contracts/${transfer.from}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${transfer.to}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -367,7 +366,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${txHash}/`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -451,7 +450,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
     const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${tx.to}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -618,7 +617,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
     const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${tx.to}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
@@ -786,7 +785,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -90,10 +90,9 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(1);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
   });
 
   it('Failure: Transaction API fails', async () => {
@@ -125,16 +124,15 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(2);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`,
-      expect.objectContaining({
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`,
+      networkRequest: expect.objectContaining({
         params: expect.objectContaining({ offset, limit }),
       }),
-    );
+    });
   });
 
   it('Failure: data validation fails', async () => {
@@ -196,7 +194,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('address', erc20Transfer.tokenAddress)
       .with('trusted', true)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -280,7 +278,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('address', erc20Transfer.tokenAddress)
       .with('trusted', trusted)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -363,7 +361,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('address', erc20Transfer.tokenAddress)
       .with('trusted', false)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -416,7 +414,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('type', TokenType.Erc721)
       .with('address', erc721Transfer.tokenAddress)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -490,7 +488,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('value', faker.number.int({ min: 1 }).toString())
       .with('transferId', 'e1015fc690')
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -78,10 +78,9 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(1);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
   });
 
   it('Failure: Transaction API fails', async () => {
@@ -109,10 +108,9 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(2);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
   });
 
   it('Failure: data page validation fails', async () => {
@@ -161,10 +159,9 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(2);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
   });
 
   it('Get module transaction successfully', async () => {

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -89,10 +89,9 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(1);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
   });
 
   it('Failure: Transaction API fails', async () => {
@@ -120,20 +119,19 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       });
 
     expect(networkService.get).toHaveBeenCalledTimes(2);
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`,
-      expect.objectContaining({
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`,
+      networkRequest: expect.objectContaining({
         params: expect.objectContaining({
           ordering: '-nonce',
           safe: safeAddress,
           trusted: true,
         }),
       }),
-    );
+    });
   });
 
   it('Failure: data validation fails', async () => {
@@ -223,7 +221,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .with('type', TokenType.Erc20)
       .with('address', multisigTransaction.to)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -346,7 +344,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         confirmationBuilder().build(),
       ])
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -443,7 +441,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
           .build(),
       )
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${domainTransaction.safe}/multisig-transactions/`;

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -66,7 +66,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
     const page = pageBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -168,7 +168,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       ) as MultisigTransaction,
     ];
 
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
@@ -362,7 +362,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .build(),
       ) as MultisigTransaction,
     ];
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
@@ -503,7 +503,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .build(),
       ) as MultisigTransaction,
     ];
-    networkService.get.mockImplementation((url, query) => {
+    networkService.get.mockImplementation(({ url, networkRequest }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
@@ -513,10 +513,10 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
-        if (!query?.params) {
+        if (!networkRequest?.params) {
           return Promise.reject('Query params not found');
         }
-        expect(query.params.trusted).toBe(false);
+        expect(networkRequest.params.trusted).toBe(false);
 
         return Promise.resolve({
           data: {

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -85,7 +85,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const chainResponse = chainBuilder().build();
     const dataDecodedResponse = dataDecodedBuilder().build();
     const contractResponse = contractBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -100,7 +100,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.resolve({ data: dataDecodedResponse, status: 200 });
@@ -152,7 +152,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const safeResponse = safeBuilder().with('address', safeAddress).build();
     const chainResponse = chainBuilder().build();
     const dataDecodedResponse = dataDecodedBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -167,7 +167,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.resolve({ data: dataDecodedResponse, status: 200 });
@@ -218,7 +218,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const safeResponse = safeBuilder().with('address', safeAddress).build();
     const chainResponse = chainBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -233,7 +233,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.reject({ error: 'Data cannot be decoded' });
@@ -299,7 +299,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const contractResponse = contractBuilder()
       .with('trustedForDelegateCall', true)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -314,7 +314,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.resolve({ data: dataDecodedResponse, status: 200 });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -86,7 +86,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     const transactions = pageBuilder().build();
     const token = tokenBuilder().build();
     const gasToken = tokenBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -119,7 +119,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
-    networkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation(({ url }) => {
       const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       switch (url) {
         case proposeTransactionUrl:

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -105,7 +105,7 @@ describe('Transactions History Controller (Unit)', () => {
   it('Failure: Config API fails', async () => {
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       if (url === getChainUrl) {
         const error = new NetworkResponseError(new URL(getChainUrl), {
@@ -129,7 +129,7 @@ describe('Transactions History Controller (Unit)', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       if (url === getChainUrl) {
@@ -156,7 +156,7 @@ describe('Transactions History Controller (Unit)', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const chain = chainBuilder().build();
     const page = pageBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       if (url === getChainUrl) {
@@ -196,7 +196,7 @@ describe('Transactions History Controller (Unit)', () => {
       results: [],
     };
     const creationTransaction = creationTransactionBuilder().build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -264,7 +264,7 @@ describe('Transactions History Controller (Unit)', () => {
       previous: null,
       results: [moduleTransaction, multisigTransaction, incomingTransaction],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -322,7 +322,7 @@ describe('Transactions History Controller (Unit)', () => {
       previous: null,
       results: [moduleTransaction],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -377,7 +377,7 @@ describe('Transactions History Controller (Unit)', () => {
         moduleTransactionToJson(moduleTransaction1),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -487,7 +487,7 @@ describe('Transactions History Controller (Unit)', () => {
       .with('type', TokenType.Erc20)
       .with('address', multisigTransaction.to)
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -635,7 +635,7 @@ describe('Transactions History Controller (Unit)', () => {
     const creationTransaction = creationTransactionBuilder()
       .with('created', new Date(moduleTransaction.executionDate))
       .build();
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -716,7 +716,7 @@ describe('Transactions History Controller (Unit)', () => {
       previous: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/?executed=false&limit=6&queued=true&trusted=true`,
       results: [moduleTransaction],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -745,13 +745,12 @@ describe('Transactions History Controller (Unit)', () => {
         expect(body.previous).toContain(clientPreviousCursor);
       });
 
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${safeConfigUrl}/api/v1/chains/${chainId}`,
-      undefined,
-    );
-    expect(networkService.get).toHaveBeenCalledWith(
-      `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`,
-      {
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
+    });
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`,
+      networkRequest: {
         params: {
           executed: true,
           offset: offset - 1,
@@ -761,7 +760,7 @@ describe('Transactions History Controller (Unit)', () => {
           safe: safeAddress,
         },
       },
-    );
+    });
   });
 
   it('Should limit the amount of nested transfers', async () => {
@@ -789,7 +788,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -853,7 +852,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -945,7 +944,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -1041,7 +1040,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -1129,7 +1128,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -1210,7 +1209,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -1286,7 +1285,7 @@ describe('Transactions History Controller (Unit)', () => {
         ),
       ],
     };
-    networkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;


### PR DESCRIPTION
## Summary

This changes the interfaces of network requests to accept arguments in an object as there are optional params th[at currently require being explicitly coded as `undefined`](https://github.com/safe-global/safe-client-gateway/pull/1241#discussion_r1511489549):

```ts
interface INetworkService {
  get<T>(args: {
    url: string;
    networkRequest?: NetworkRequest;
  }): Promise<NetworkResponse<T>>;

  post<T>(args: {
    url: string;
    data: object;
    networkRequest?: NetworkRequest;
  }): Promise<NetworkResponse<T>>;

  delete<T>(args: {
    url: string;
    data?: object;
    networkRequest?: NetworkRequest;
  }): Promise<NetworkResponse<T>>;
}
```

## Changes

- Change the `INetworkService` interface to accept arguments as objects and propagate in codebase
- Update test accordingly