### PR TITLE
Encode mock event hashes

### DIFF
--- a/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
+++ b/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
@@ -1,13 +1,14 @@
 import { IEncoder } from '@/__tests__/encoder-builder';
 import { faker } from '@faker-js/faker';
 import {
-  decodeAbiParameters,
   encodeAbiParameters,
   encodeEventTopics,
   getAddress,
   Hex,
+  keccak256,
   parseAbi,
   parseAbiParameters,
+  toBytes,
 } from 'viem';
 import { Builder } from '@/__tests__/builder';
 
@@ -63,13 +64,12 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
 }
 
 export function transactionAddedEventBuilder(): TransactionAddedEventBuilder<TransactionAddedEventArgs> {
-  const [checksummedTxHash] = decodeAbiParameters(
-    parseAbiParameters('bytes32 txHash'),
-    faker.string.hexadecimal({ length: 64 }) as Hex,
-  );
   return new TransactionAddedEventBuilder()
     .with('queueNonce', faker.number.bigInt())
-    .with('txHash', checksummedTxHash)
+    .with(
+      'txHash',
+      keccak256(toBytes(faker.string.hexadecimal({ length: 64 }))),
+    )
     .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('value', BigInt(0))
     .with('data', '0x')

--- a/src/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder.ts
+++ b/src/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { encodeFunctionData, Hex } from 'viem';
+import {  encodeFunctionData, Hex, keccak256,  toBytes } from 'viem';
 import { Builder } from '@/__tests__/builder';
 import { IEncoder } from '@/__tests__/encoder-builder';
 import { abi } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
@@ -28,7 +28,7 @@ export function setPreSignatureEncoder(): SetPreSignatureEncoder<SetPreSignature
   return new SetPreSignatureEncoder()
     .with(
       'orderUid',
-      faker.string.hexadecimal({ length: 112 }) as `0x${string}`,
+      keccak256(toBytes(faker.string.hexadecimal({ length: 112 }))),
     )
     .with('signed', faker.datatype.boolean());
 }

--- a/src/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder.ts
+++ b/src/domain/swaps/contracts/__tests__/encoders/set-pre-signature-encoder.builder.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import {  encodeFunctionData, Hex, keccak256,  toBytes } from 'viem';
+import { encodeFunctionData, Hex, keccak256, toBytes } from 'viem';
 import { Builder } from '@/__tests__/builder';
 import { IEncoder } from '@/__tests__/encoder-builder';
 import { abi } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';


### PR DESCRIPTION
## Summary

The [latest version of `viem`](https://github.com/safe-global/safe-client-gateway/commit/6dbd8b458c2d63831eecc912a213263482abb1eb) returns "checksummed" hashes from events. Our `SetPreSignatureEncoder` was returning a lowercase hash which is incorrect. This hashes the `orderUuid` correctly.

The `txHash` within `transactionAddedEventBuilder` was being "checksummed" with a workaround. This adjusts the logic to mirror that of the above.