### PR TITLE
Fix Zerion API collectibles pagination on null next page

### DIFF
--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -276,7 +276,7 @@ export class ZerionBalancesApi implements IBalancesApi {
     // Zerion does not provide a "previous" cursor.
     return {
       count: null,
-      next: this._decodeZerionPagination(next ?? ''),
+      next: next ? this._decodeZerionPagination(next) : null,
       previous: null,
       results: this._mapCollectibles(data),
     };

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -74,6 +74,7 @@ describe('Zerion Collectibles Controller', () => {
         const aNFTName = faker.string.sample();
         const aUrl = faker.internet.url({ appendSlash: false });
         const zerionApiCollectiblesResponse = zerionCollectiblesBuilder()
+          .with('links', { next: null })
           .with('data', [
             zerionCollectibleBuilder()
               .with(
@@ -143,7 +144,7 @@ describe('Zerion Collectibles Controller', () => {
           .expect(({ body }) => {
             expect(body).toMatchObject({
               count: null,
-              next: expect.any(String),
+              next: null,
               previous: null,
               results: [
                 {


### PR DESCRIPTION
## Summary
This PR fixes a bug in the NFT retrieval from Zerion API. The cases where the next page is `null` (end of the paginated list of items) were incorrectly handled.

## Changes
- Changes the implementation of `ZerionBalancesApi._buildCollectiblesPage` to call `ZerionBalancesApi._decodeZerionPagination` when `next` is not `null` only.