### PR TITLE
Add Chain.chainLogoUri default value

### DIFF
--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -58,7 +58,7 @@ export const ChainSchema = z.object({
   chainName: z.string(),
   description: z.string(),
   // TODO: Make required when deemed stable on config service
-  chainLogoUri: z.string().url().optional().nullable(),
+  chainLogoUri: z.string().url().optional().nullable().default(null),
   l2: z.boolean(),
   isTestnet: z.boolean(),
   shortName: z.string(),


### PR DESCRIPTION
## Changes
- Add `Chain.chainLogoUri` `null` default value when the field is not defined.