### PR TITLE
Implement proposed return types of leaderboard

### DIFF
--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -27,11 +27,9 @@ export class LockingApi implements ILockingApi {
   async getRank(safeAddress: `0x${string}`): Promise<Rank> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;
-      console.log('=>', url);
       const { data } = await this.networkService.get<Rank>(url);
       return data;
     } catch (error) {
-      console.log('=>', error);
       throw this.httpErrorFactory.from(error);
     }
   }

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -24,13 +24,34 @@ export class LockingApi implements ILockingApi {
       this.configurationService.getOrThrow<string>('locking.baseUri');
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getRank(safeAddress: `0x${string}`): Promise<Rank> {
+    try {
+      const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;
+      console.log('=>', url);
+      const { data } = await this.networkService.get<Rank>(url);
+      return data;
+    } catch (error) {
+      console.log('=>', error);
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getLeaderboard(args: {
-    safeAddress?: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<Rank>> {
-    throw new Error('Method not implemented.');
+    try {
+      const url = `${this.baseUri}/api/v1/leaderboard`;
+      const { data } = await this.networkService.get<Page<Rank>>(url, {
+        params: {
+          limit: args.limit,
+          offset: args.offset,
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
   }
 
   async getLockingHistory(args: {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -5,8 +5,9 @@ import { Rank } from '@/domain/locking/entities/rank.entity';
 export const ILockingApi = Symbol('ILockingApi');
 
 export interface ILockingApi {
+  getRank(safeAddress: `0x${string}`): Promise<Rank>;
+
   getLeaderboard(args: {
-    safeAddress?: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<Rank>>;

--- a/src/domain/locking/entities/__tests__/rank.builder.ts
+++ b/src/domain/locking/entities/__tests__/rank.builder.ts
@@ -1,0 +1,13 @@
+import { IBuilder, Builder } from '@/__tests__/builder';
+import { Rank } from '@/domain/locking/entities/rank.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+export function rankBuilder(): IBuilder<Rank> {
+  return new Builder<Rank>()
+    .with('holder', getAddress(faker.finance.ethereumAddress()))
+    .with('position', faker.string.numeric())
+    .with('lockedAmount', faker.string.numeric())
+    .with('unlockedAmount', faker.string.numeric())
+    .with('withdrawnAmount', faker.string.numeric());
+}

--- a/src/domain/locking/entities/schemas/__tests__/rank.schema.spec.ts
+++ b/src/domain/locking/entities/schemas/__tests__/rank.schema.spec.ts
@@ -1,0 +1,74 @@
+import { rankBuilder } from '@/domain/locking/entities/__tests__/rank.builder';
+import { RankSchema } from '@/domain/locking/entities/schemas/rank.schema';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { ZodError } from 'zod';
+
+describe('RankSchema', () => {
+  it('should validate a valid rank', () => {
+    const rank = rankBuilder().build();
+
+    const result = RankSchema.safeParse(rank);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should checksum the holder', () => {
+    const nonChecksummedAddress = faker.finance
+      .ethereumAddress()
+      .toLowerCase() as `0x${string}`;
+    const rank = rankBuilder().with('holder', nonChecksummedAddress).build();
+
+    const result = RankSchema.safeParse(rank);
+
+    expect(result.success && result.data.holder).toBe(
+      getAddress(nonChecksummedAddress),
+    );
+  });
+
+  it('should not validate an invalid rank', () => {
+    const rank = { invalid: 'rank' };
+
+    const result = RankSchema.safeParse(rank);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['holder'],
+          message: 'Required',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['position'],
+          message: 'Required',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['lockedAmount'],
+          message: 'Required',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['unlockedAmount'],
+          message: 'Required',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['withdrawnAmount'],
+          message: 'Required',
+        },
+      ]),
+    );
+  });
+});

--- a/src/domain/locking/entities/schemas/rank.schema.ts
+++ b/src/domain/locking/entities/schemas/rank.schema.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod';
 import { buildZodPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
-// TODO: Add and test once defined
-export const RankSchema = z.object({});
+export const RankSchema = z.object({
+  holder: AddressSchema,
+  position: NumericStringSchema,
+  lockedAmount: NumericStringSchema,
+  unlockedAmount: NumericStringSchema,
+  withdrawnAmount: NumericStringSchema,
+});
 
 export const RankPageSchema = buildZodPageSchema(RankSchema);

--- a/src/domain/locking/locking.repository.interface.ts
+++ b/src/domain/locking/locking.repository.interface.ts
@@ -5,7 +5,7 @@ import { Rank } from '@/domain/locking/entities/rank.entity';
 export const ILockingRepository = Symbol('ILockingRepository');
 
 export interface ILockingRepository {
-  getRank(safeAddress: string): Promise<Rank>;
+  getRank(safeAddress: `0x${string}`): Promise<Rank>;
 
   getLeaderboard(args: {
     limit?: number;

--- a/src/domain/locking/locking.repository.ts
+++ b/src/domain/locking/locking.repository.ts
@@ -17,9 +17,9 @@ export class LockingRepository implements ILockingRepository {
     private readonly lockingApi: ILockingApi,
   ) {}
 
-  async getRank(safeAddress: string): Promise<Rank> {
-    const rank = await this.lockingApi.getLeaderboard({ safeAddress });
-    return RankSchema.parse(rank.results[0]);
+  async getRank(safeAddress: `0x${string}`): Promise<Rank> {
+    const rank = await this.lockingApi.getRank(safeAddress);
+    return RankSchema.parse(rank);
   }
 
   async getLeaderboard(args: {

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -27,6 +27,7 @@ import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { getAddress } from 'viem';
+import { rankBuilder } from '@/domain/locking/entities/__tests__/rank.builder';
 
 describe('Locking (Unit)', () => {
   let app: INestApplication;
@@ -70,9 +71,180 @@ describe('Locking (Unit)', () => {
     await app.close();
   });
 
-  it.todo('GET rank');
+  describe('GET rank', () => {
+    it('should get the rank', async () => {
+      const rank = rankBuilder().build();
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard/${rank.holder}`:
+            return Promise.resolve({ data: rank, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
 
-  it.todo('GET leaderboard');
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard/${rank.holder}`)
+        .expect(200)
+        .expect(rank);
+    });
+
+    it('should validate the Safe address in URL', async () => {
+      const safeAddress = faker.string.alphanumeric();
+
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard/${safeAddress}`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          path: [],
+          message: 'Invalid input',
+        });
+    });
+
+    it('should validate the response', async () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const rank = { invalid: 'rank' };
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
+            return Promise.resolve({ data: rank, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard/${safeAddress}`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['holder'],
+          message: 'Required',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard/${safeAddress}`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
+  describe('GET leaderboard', () => {
+    it('should get the leaderboard', async () => {
+      const leaderboard = pageBuilder()
+        .with('results', [rankBuilder().build()])
+        .build();
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.resolve({ data: leaderboard, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard`)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            count: leaderboard.count,
+            next: expect.any(String),
+            previous: expect.any(String),
+            results: leaderboard.results,
+          });
+        });
+    });
+
+    it('should validate the response', async () => {
+      const leaderboard = pageBuilder()
+        .with('results', [{ invalid: 'rank' }])
+        .build();
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.resolve({ data: leaderboard, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['results', 0, 'holder'],
+          message: 'Required',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/api/v1/leaderboard`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/locking/leaderboard`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
 
   describe('GET locking history', () => {
     it('should get locking history', async () => {

--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -19,8 +19,11 @@ import { z } from 'zod';
 export class LockingController {
   constructor(private readonly lockingService: LockingService) {}
 
-  @Get('/:safeAddress/rank')
-  async getRank(@Param('safeAddress') safeAddress: string): Promise<Rank> {
+  @Get('/leaderboard/:safeAddress')
+  async getRank(
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: z.infer<typeof AddressSchema>,
+  ): Promise<Rank> {
     return this.lockingService.getRank(safeAddress);
   }
 

--- a/src/routes/locking/locking.service.ts
+++ b/src/routes/locking/locking.service.ts
@@ -15,7 +15,7 @@ export class LockingService {
     private readonly lockingRepository: ILockingRepository,
   ) {}
 
-  async getRank(safeAddress: string): Promise<Rank> {
+  async getRank(safeAddress: `0x${string}`): Promise<Rank> {
     return this.lockingRepository.getRank(safeAddress);
   }
 


### PR DESCRIPTION
## Summary

This updates the locking service to include the leaderboard functionality for a provided address and list in accordance with the proposed service.

## Changes

- Define structure of `RankSchema` and add test coverage
- Add `ILockingService['getRank']`
- Update `ILockingService['getLeaderboard']`
- Add associated test coverage to the controller