### PR TITLE
Change relay-related errors to throw client-side errors

### DIFF
--- a/src/domain/relay/errors/invalid-multisend.error.ts
+++ b/src/domain/relay/errors/invalid-multisend.error.ts
@@ -1,10 +1,9 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { UnprocessableEntityException } from '@nestjs/common';
 
-export class InvalidMultiSendError extends HttpException {
+export class InvalidMultiSendError extends UnprocessableEntityException {
   constructor() {
     super(
       'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
-      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/invalid-multisend.error.ts
+++ b/src/domain/relay/errors/invalid-multisend.error.ts
@@ -1,7 +1,10 @@
-export class InvalidMultiSendError extends Error {
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class InvalidMultiSendError extends HttpException {
   constructor() {
     super(
       'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
+      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/invalid-transfer.error.ts
+++ b/src/domain/relay/errors/invalid-transfer.error.ts
@@ -1,7 +1,10 @@
-export class InvalidTransferError extends Error {
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class InvalidTransferError extends HttpException {
   constructor() {
     super(
       'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/invalid-transfer.error.ts
+++ b/src/domain/relay/errors/invalid-transfer.error.ts
@@ -1,10 +1,9 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { UnprocessableEntityException } from '@nestjs/common';
 
-export class InvalidTransferError extends HttpException {
+export class InvalidTransferError extends UnprocessableEntityException {
   constructor() {
     super(
       'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
-      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/relay-limit-reached.error.ts
+++ b/src/domain/relay/errors/relay-limit-reached.error.ts
@@ -1,6 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { Hex } from 'viem';
 
-export class RelayLimitReachedError extends Error {
+export class RelayLimitReachedError extends HttpException {
   constructor(
     readonly address: Hex,
     readonly current: number,
@@ -8,6 +9,7 @@ export class RelayLimitReachedError extends Error {
   ) {
     super(
       `Relay limit reached for ${address} | current: ${current} | limit: ${limit}`,
+      HttpStatus.TOO_MANY_REQUESTS,
     );
   }
 }

--- a/src/domain/relay/errors/unofficial-master-copy.error.ts
+++ b/src/domain/relay/errors/unofficial-master-copy.error.ts
@@ -1,10 +1,9 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { UnprocessableEntityException } from '@nestjs/common';
 
-export class UnofficialMasterCopyError extends HttpException {
+export class UnofficialMasterCopyError extends UnprocessableEntityException {
   constructor() {
     super(
       'Safe attempting to relay is not official. Only official Safe singletons are supported.',
-      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/unofficial-master-copy.error.ts
+++ b/src/domain/relay/errors/unofficial-master-copy.error.ts
@@ -1,7 +1,10 @@
-export class UnofficialMasterCopyError extends Error {
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class UnofficialMasterCopyError extends HttpException {
   constructor() {
     super(
       'Safe attempting to relay is not official. Only official Safe singletons are supported.',
+      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/unofficial-multisend.error.ts
+++ b/src/domain/relay/errors/unofficial-multisend.error.ts
@@ -1,7 +1,10 @@
-export class UnofficialMultiSendError extends Error {
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class UnofficialMultiSendError extends HttpException {
   constructor() {
     super(
       'MultiSend contract is not official. Only official MultiSend contracts are supported.',
+      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/unofficial-multisend.error.ts
+++ b/src/domain/relay/errors/unofficial-multisend.error.ts
@@ -1,10 +1,9 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { UnprocessableEntityException } from '@nestjs/common';
 
-export class UnofficialMultiSendError extends HttpException {
+export class UnofficialMultiSendError extends UnprocessableEntityException {
   constructor() {
     super(
       'MultiSend contract is not official. Only official MultiSend contracts are supported.',
-      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/unofficial-proxy-factory.error.ts
+++ b/src/domain/relay/errors/unofficial-proxy-factory.error.ts
@@ -1,10 +1,9 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { UnprocessableEntityException } from '@nestjs/common';
 
-export class UnofficialProxyFactoryError extends HttpException {
+export class UnofficialProxyFactoryError extends UnprocessableEntityException {
   constructor() {
     super(
       'ProxyFactory contract is not official. Only official ProxyFactory contracts are supported.',
-      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }

--- a/src/domain/relay/errors/unofficial-proxy-factory.error.ts
+++ b/src/domain/relay/errors/unofficial-proxy-factory.error.ts
@@ -1,7 +1,10 @@
-export class UnofficialProxyFactoryError extends Error {
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class UnofficialProxyFactoryError extends HttpException {
   constructor() {
     super(
       'ProxyFactory contract is not official. Only official ProxyFactory contracts are supported.',
+      HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }
 }


### PR DESCRIPTION
## Summary

This changes the relay-specific errors from extending `Error`s to `HttpException`/`UnprocessableEntityException`s in order to specify a `status`. By specifying the `status`, the `RouteLoggerInteceptor` [can extract it](https://github.com/safe-global/safe-client-gateway/blob/ee37f48916d392d9d69a6f6ffdca9192ab06b948/src/routes/common/interceptors/route-logger.interceptor.ts#L67).

## Changes

The following exceptions have been changed to extend `HttpException`s with a `HttpStatus` or `UnprocessableEntityException` accordingly:

- `InvalidMultiSendError`
- `InvalidTransferError`
- `RelayLimitReachedError`
- `UnofficialMasterCopyError`
- `UnofficialMultiSendError`
- `UnofficialProxyFactoryError`