### PR TITLE
Allow relaying of all ERC-20 methods

### DIFF
--- a/src/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder.ts
+++ b/src/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder.ts
@@ -30,3 +30,61 @@ export function erc20TransferEncoder(): Erc20TransferEncoder<Erc20TransferArgs> 
     .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('value', faker.number.bigInt());
 }
+
+// transferFrom
+
+type Erc20TransferFromArgs = {
+  sender: Hex;
+  recipient: Hex;
+  amount: bigint;
+};
+
+class Erc20TransferFromEncoder<T extends Erc20TransferFromArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): Hex {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'transferFrom',
+      args: [args.sender, args.recipient, args.amount],
+    });
+  }
+}
+
+export function erc20TransferFromEncoder(): Erc20TransferFromEncoder<Erc20TransferFromArgs> {
+  return new Erc20TransferFromEncoder()
+    .with('sender', getAddress(faker.finance.ethereumAddress()))
+    .with('recipient', getAddress(faker.finance.ethereumAddress()))
+    .with('amount', faker.number.bigInt());
+}
+
+// transferFrom
+
+type Erc20ApproveArgs = {
+  spender: Hex;
+  amount: bigint;
+};
+
+class Erc20ApproveEncoder<T extends Erc20ApproveArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): Hex {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'approve',
+      args: [args.spender, args.amount],
+    });
+  }
+}
+
+export function erc20ApproveEncoder(): Erc20ApproveEncoder<Erc20ApproveArgs> {
+  return new Erc20ApproveEncoder()
+    .with('spender', getAddress(faker.finance.ethereumAddress()))
+    .with('amount', faker.number.bigInt());
+}

--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -469,6 +469,29 @@ describe('LimitAddressesMapper', () => {
             );
           });
 
+          // approve (execTransaction)
+          it('should throw when trying to call an ERC-20 method on the Safe', async () => {
+            const safe = safeBuilder().build();
+            const safeAddress = getAddress(safe.address);
+            const data = execTransactionEncoder()
+              .with('to', safeAddress)
+              .with('data', erc20ApproveEncoder().encode())
+              .encode() as Hex;
+            // Official mastercopy
+            mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+            await expect(
+              target.getLimitAddresses({
+                version,
+                chainId,
+                data,
+                to: safeAddress,
+              }),
+            ).rejects.toThrow(
+              'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+            );
+          });
+
           // Unofficial mastercopy
           it('should throw when the mastercopy is not official', async () => {
             const safe = safeBuilder().build();

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -141,8 +141,6 @@ export class LimitAddressesMapper {
       });
     }
 
-    // Other ERC-20 methods are valid if they are...
-
     // Only transaction to other party is valid
     const toSelf = execTransactionArgs.to === args.to;
     if (!toSelf) {
@@ -185,6 +183,7 @@ export class LimitAddressesMapper {
   }
 
   private isValidErc20Transfer(args: { to: string; data: Hex }): boolean {
+    // Can throw but called after this.erc20Decoder.helpers.isTransfer
     const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
       data: args.data,
     });
@@ -200,6 +199,7 @@ export class LimitAddressesMapper {
   }
 
   private isValidErc20TransferFrom(args: { to: string; data: Hex }): boolean {
+    // Can throw but called after this.erc20Decoder.helpers.isTransferFrom
     const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
       data: args.data,
     });

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -33,7 +33,11 @@ import {
   setupEncoder,
   swapOwnerEncoder,
 } from '@/domain/contracts/__tests__/encoders/safe-encoder.builder';
-import { erc20TransferEncoder } from '@/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder';
+import {
+  erc20ApproveEncoder,
+  erc20TransferEncoder,
+  erc20TransferFromEncoder,
+} from '@/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder';
 import {
   multiSendEncoder,
   multiSendTransactionsEncoder,
@@ -222,9 +226,14 @@ describe('Relay controller', () => {
 
               it.each([
                 [
-                  'sending ERC-20 tokens to another party',
+                  '`transfer`ing ERC-20 tokens to another party',
                   erc20TransferEncoder().encode(),
                 ],
+                [
+                  '`transferFrom`ing ERC-20 tokens to another party',
+                  erc20TransferFromEncoder().encode(),
+                ],
+                ['`approve`ing ERC-20 tokens', erc20ApproveEncoder().encode()],
                 ['cancelling a transaction', '0x' as const],
                 [
                   'making an addOwnerWithThreshold call',
@@ -958,7 +967,7 @@ describe('Relay controller', () => {
               });
 
               // transfer (execTransaction)
-              it('should return 422 sending ERC-20 tokens to self', async () => {
+              it('should return 422 `transfer`ing ERC-20 tokens to self', async () => {
                 const chain = chainBuilder().with('chainId', chainId).build();
                 const safe = safeBuilder().build();
                 const safeAddress = getAddress(safe.address);
@@ -966,6 +975,87 @@ describe('Relay controller', () => {
                   .with(
                     'data',
                     erc20TransferEncoder().with('to', safeAddress).encode(),
+                  )
+                  .encode() as Hex;
+                networkService.get.mockImplementation(({ url }) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      return Promise.reject(`No matching rule for url: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+                    statusCode: 422,
+                  });
+              });
+
+              // transferFrom (execTransaction)
+              it('should return 422 `transferFrom`ing ERC-20 tokens to self', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const data = execTransactionEncoder()
+                  .with(
+                    'data',
+                    erc20TransferFromEncoder()
+                      .with('recipient', safeAddress)
+                      .encode(),
+                  )
+                  .encode() as Hex;
+                networkService.get.mockImplementation(({ url }) => {
+                  switch (url) {
+                    case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+                      return Promise.resolve({ data: chain, status: 200 });
+                    case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+                      // Official mastercopy
+                      return Promise.resolve({ data: safe, status: 200 });
+                    default:
+                      return Promise.reject(`No matching rule for url: ${url}`);
+                  }
+                });
+
+                await request(app.getHttpServer())
+                  .post(`/v1/chains/${chain.chainId}/relay`)
+                  .send({
+                    version,
+                    to: safeAddress,
+                    data,
+                  })
+                  .expect(422)
+                  .expect({
+                    message:
+                      'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+                    statusCode: 422,
+                  });
+              });
+
+              it('should return 422 `transferFrom`ing ERC-20 tokens from sender to sender as recipient', async () => {
+                const chain = chainBuilder().with('chainId', chainId).build();
+                const safe = safeBuilder().build();
+                const safeAddress = getAddress(safe.address);
+                const recipient = getAddress(faker.finance.ethereumAddress());
+                const data = execTransactionEncoder()
+                  .with(
+                    'data',
+                    erc20TransferFromEncoder()
+                      .with('sender', recipient)
+                      .with('recipient', recipient)
+                      .encode(),
                   )
                   .encode() as Hex;
                 networkService.get.mockImplementation(({ url }) => {


### PR DESCRIPTION
## Summary

This facilitates the relaying of _all_ ERC-20 methods, with validation of `transfer` and `transferFrom` methods:

- `transfer` transactions that are being executed to 'self' (the Safe) _cannot_ be relayed.
- `transferFrom` transactions that are being executed to 'self' or transferring from the `sender` to `receiver` _cannot_ be relayed.

## Motivation

We were previous _only_ allowing "valid" `transfer` relays. It was otherwise [not possible to relay other methods](https://github.com/safe-global/safe-client-gateway/blob/main/src/domain/relay/limit-addresses.mapper.ts#L144).

This is an inherent bug that was ported over from the relay service - it was [_only_ validating `transfer` calldata](https://github.com/safe-global/safe-gelato-relay-service/blob/main/src/routes/relay/entities/schema/transactions/exec-transaction.ts#L41). Other methods were able to relay as they passed the ['self'-validation](https://github.com/safe-global/safe-gelato-relay-service/blob/main/src/routes/relay/entities/schema/transactions/exec-transaction.ts#L47-L48).

Note: although there is no validation of `transferFrom` on the relay service, adding it aligns with that of `transfer`.

## Changes

- Add validation of `transferFrom` relays
- Allow relay of other methods of ERC-20
- Add respective `IEncoder`s for mocking calldata
- Add test coverage