### PR TITLE
Update locking API network interface

### DIFF
--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -27,7 +27,7 @@ export class LockingApi implements ILockingApi {
   async getRank(safeAddress: `0x${string}`): Promise<Rank> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;
-      const { data } = await this.networkService.get<Rank>(url);
+      const { data } = await this.networkService.get<Rank>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -40,10 +40,13 @@ export class LockingApi implements ILockingApi {
   }): Promise<Page<Rank>> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard`;
-      const { data } = await this.networkService.get<Page<Rank>>(url, {
-        params: {
-          limit: args.limit,
-          offset: args.offset,
+      const { data } = await this.networkService.get<Page<Rank>>({
+        url,
+        networkRequest: {
+          params: {
+            limit: args.limit,
+            offset: args.offset,
+          },
         },
       });
       return data;

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -74,7 +74,7 @@ describe('Locking (Unit)', () => {
   describe('GET rank', () => {
     it('should get the rank', async () => {
       const rank = rankBuilder().build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard/${rank.holder}`:
             return Promise.resolve({ data: rank, status: 200 });
@@ -106,7 +106,7 @@ describe('Locking (Unit)', () => {
     it('should validate the response', async () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const rank = { invalid: 'rank' };
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
             return Promise.resolve({ data: rank, status: 200 });
@@ -134,7 +134,7 @@ describe('Locking (Unit)', () => {
         types: ['clientError', 'serverError'],
       });
       const errorMessage = faker.word.words();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
             return Promise.reject(
@@ -166,7 +166,7 @@ describe('Locking (Unit)', () => {
       const leaderboard = pageBuilder()
         .with('results', [rankBuilder().build()])
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard`:
             return Promise.resolve({ data: leaderboard, status: 200 });
@@ -192,7 +192,7 @@ describe('Locking (Unit)', () => {
       const leaderboard = pageBuilder()
         .with('results', [{ invalid: 'rank' }])
         .build();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard`:
             return Promise.resolve({ data: leaderboard, status: 200 });
@@ -219,7 +219,7 @@ describe('Locking (Unit)', () => {
         types: ['clientError', 'serverError'],
       });
       const errorMessage = faker.word.words();
-      networkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard`:
             return Promise.reject(


### PR DESCRIPTION
## Summary

This updates the `LockingApi` methods to align with the [new networking interface](https://github.com/safe-global/safe-client-gateway/pull/1251) that requires object arguments to fix `build`.

## Changes

- Update `LockingApi['getRank']`
- Update `LockingApi['getLeaderboard']`