### PR TITLE
Add support for decoding CoW Swap orders

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -174,6 +174,7 @@ export default (): ReturnType<typeof configuration> => ({
     zerionBalancesChainIds: ['137'],
     locking: true,
     relay: true,
+    swapsDecoding: true,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -170,6 +170,7 @@ export default () => ({
       process.env.FF_ZERION_BALANCES_CHAIN_IDS?.split(',') ?? [],
     locking: process.env.FF_LOCKING?.toLowerCase() === 'true',
     relay: process.env.FF_RELAY?.toLowerCase() === 'true',
+    swapsDecoding: process.env.FF_SWAPS_DECODING?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
@@ -19,6 +19,14 @@ export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
   }
 
   /**
+   * Checks if the provided transaction data is a setPreSignature call.
+   * @param data - the transaction data
+   */
+  isSetPreSignature(data: string): boolean {
+    return data.startsWith(this.setPreSignatureFunctionSelector);
+  }
+
+  /**
    * Gets the Order UID associated with the provided transaction data.
    *
    * @param data - the transaction data for the setPreSignature call
@@ -26,7 +34,7 @@ export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
    */
   getOrderUid(data: `0x${string}`): `0x${string}` | null {
     try {
-      if (!data.startsWith(this.setPreSignatureFunctionSelector)) return null;
+      if (!this.isSetPreSignature(data)) return null;
       const { args } = this.decodeFunctionData({ data });
       return args[0];
     } catch (e) {

--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -16,7 +16,13 @@ export function orderBuilder(): IBuilder<Order> {
     .with('sellAmount', faker.number.bigInt({ min: 1 }))
     .with('buyAmount', faker.number.bigInt({ min: 1 }))
     .with('validTo', faker.date.future().getTime())
-    .with('appData', faker.string.hexadecimal())
+    .with(
+      'appData',
+      JSON.stringify({
+        version: faker.system.semver(),
+        metadata: {},
+      }),
+    )
     .with('feeAmount', faker.number.bigInt({ min: 1 }))
     .with('kind', faker.helpers.arrayElement(['buy', 'sell']))
     .with('partiallyFillable', faker.datatype.boolean())
@@ -40,7 +46,7 @@ export function orderBuilder(): IBuilder<Order> {
     .with('creationDate', faker.date.recent())
     .with('class', faker.helpers.arrayElement(['market', 'limit', 'liquidity']))
     .with('owner', getAddress(faker.finance.ethereumAddress()))
-    .with('uid', faker.string.uuid())
+    .with('uid', faker.string.hexadecimal({ length: 112 }))
     .with(
       'availableBalance',
       faker.datatype.boolean() ? faker.number.bigInt({ min: 1 }) : null,
@@ -66,7 +72,9 @@ export function orderBuilder(): IBuilder<Order> {
       'ethflowData',
       faker.datatype.boolean()
         ? {
-            refundTxHash: faker.string.hexadecimal(),
+            refundTxHash: faker.datatype.boolean()
+              ? faker.string.hexadecimal()
+              : null,
             userValidTo: faker.date.future().getTime(),
           }
         : null,

--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -1,0 +1,101 @@
+import { Order } from '@/domain/swaps/entities/order.entity';
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+export function orderBuilder(): IBuilder<Order> {
+  return new Builder<Order>()
+    .with('sellToken', getAddress(faker.finance.ethereumAddress()))
+    .with('buyToken', getAddress(faker.finance.ethereumAddress()))
+    .with(
+      'receiver',
+      faker.datatype.boolean()
+        ? getAddress(faker.finance.ethereumAddress())
+        : null,
+    )
+    .with('sellAmount', faker.number.bigInt({ min: 1 }))
+    .with('buyAmount', faker.number.bigInt({ min: 1 }))
+    .with('validTo', faker.date.future().getTime())
+    .with('appData', faker.string.hexadecimal())
+    .with('feeAmount', faker.number.bigInt({ min: 1 }))
+    .with('kind', faker.helpers.arrayElement(['buy', 'sell']))
+    .with('partiallyFillable', faker.datatype.boolean())
+    .with(
+      'sellTokenBalance',
+      faker.helpers.arrayElement(['erc20', 'internal', 'external']),
+    )
+    .with('buyTokenBalance', faker.helpers.arrayElement(['erc20', 'internal']))
+    .with(
+      'signingScheme',
+      faker.helpers.arrayElement(['eip712', 'ethsign', 'presign', 'eip1271']),
+    )
+    .with('signature', faker.string.hexadecimal())
+    .with(
+      'from',
+      faker.datatype.boolean()
+        ? getAddress(faker.finance.ethereumAddress())
+        : null,
+    )
+    .with('quoteId', faker.datatype.boolean() ? faker.number.int() : null)
+    .with('creationDate', faker.date.recent())
+    .with('class', faker.helpers.arrayElement(['market', 'limit', 'liquidity']))
+    .with('owner', getAddress(faker.finance.ethereumAddress()))
+    .with('uid', faker.string.uuid())
+    .with(
+      'availableBalance',
+      faker.datatype.boolean() ? faker.number.bigInt({ min: 1 }) : null,
+    )
+    .with('executedSellAmount', faker.number.bigInt({ min: 1 }))
+    .with('executedSellAmountBeforeFees', faker.number.bigInt({ min: 1 }))
+    .with('executedBuyAmount', faker.number.bigInt({ min: 1 }))
+    .with('executedFeeAmount', faker.number.bigInt({ min: 1 }))
+    .with('invalidated', faker.datatype.boolean())
+    .with(
+      'status',
+      faker.helpers.arrayElement([
+        'presignaturePending',
+        'open',
+        'fulfilled',
+        'cancelled',
+        'expired',
+      ]),
+    )
+    .with('fullFeeAmount', faker.number.bigInt({ min: 1 }))
+    .with('isLiquidityOrder', faker.datatype.boolean())
+    .with(
+      'ethflowData',
+      faker.datatype.boolean()
+        ? {
+            refundTxHash: faker.string.hexadecimal(),
+            userValidTo: faker.date.future().getTime(),
+          }
+        : null,
+    )
+    .with(
+      'onchainUser',
+      faker.datatype.boolean()
+        ? getAddress(faker.finance.ethereumAddress())
+        : null,
+    )
+    .with(
+      'onchainOrderData',
+      faker.datatype.boolean()
+        ? {
+            sender: getAddress(faker.finance.ethereumAddress()),
+            placementError: faker.helpers.arrayElement([
+              'QuoteNotFound',
+              'ValidToTooFarInFuture',
+              'PreValidationError',
+            ]),
+          }
+        : null,
+    )
+    .with(
+      'executedSurplusFee',
+      faker.datatype.boolean() ? faker.number.bigInt({ min: 1 }) : null,
+    )
+    .with(
+      'fullAppData',
+      faker.datatype.boolean() ? faker.string.hexadecimal() : null,
+    );
+}

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/swagger';
 
 export class TokenInfo {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   logo: string | null;
 
   @ApiProperty()
@@ -60,7 +60,7 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
 
 @ApiExtraModels(TokenInfo)
 export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   surplus: string | null;
 
   @ApiProperty()

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -61,29 +61,29 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
 @ApiExtraModels(TokenInfo)
 export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
   @ApiPropertyOptional({ type: String, nullable: true })
-  surplus: string | null;
+  surplusLabel: string | null;
 
   @ApiProperty()
-  executionPrice: string;
+  executionPriceLabel: string;
 
   constructor(args: {
     orderKind: 'buy' | 'sell';
     sellToken: TokenInfo;
     buyToken: TokenInfo;
     expiresTimestamp: number;
-    surplus: string | null;
-    executionPrice: string;
+    surplusFeeLabel: string | null;
+    executionPriceLabel: string;
   }) {
     super({ ...args, status: 'fulfilled' });
-    this.surplus = args.surplus;
-    this.executionPrice = args.executionPrice;
+    this.surplusLabel = args.surplusFeeLabel;
+    this.executionPriceLabel = args.executionPriceLabel;
   }
 }
 
 @ApiExtraModels(TokenInfo)
 export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
   @ApiProperty()
-  limitPriceDescription: string;
+  limitPriceLabel: string;
 
   constructor(args: {
     status: 'open' | 'cancelled' | 'expired';
@@ -91,9 +91,9 @@ export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
     sellToken: TokenInfo;
     buyToken: TokenInfo;
     expiresTimestamp: number;
-    limitPriceDescription: string;
+    limitPriceLabel: string;
   }) {
     super({ ...args });
-    this.limitPriceDescription = args.limitPriceDescription;
+    this.limitPriceLabel = args.limitPriceLabel;
   }
 }

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -1,0 +1,99 @@
+import {
+  TransactionInfo,
+  TransactionInfoType,
+} from '@/routes/transactions/entities/transaction-info.entity';
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
+
+export class TokenInfo {
+  @ApiPropertyOptional()
+  logo: string | null;
+
+  @ApiProperty()
+  symbol: string;
+
+  @ApiProperty()
+  amount: string;
+
+  constructor(args: { logo: string | null; symbol: string; amount: string }) {
+    this.logo = args.logo;
+    this.symbol = args.symbol;
+    this.amount = args.amount;
+  }
+}
+
+@ApiExtraModels(TokenInfo)
+export abstract class SwapOrderTransactionInfo extends TransactionInfo {
+  @ApiProperty()
+  status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
+
+  @ApiProperty()
+  orderKind: 'buy' | 'sell';
+
+  @ApiProperty()
+  sellToken: TokenInfo;
+
+  @ApiProperty()
+  buyToken: TokenInfo;
+
+  @ApiProperty()
+  expiresTimestamp: number;
+
+  protected constructor(args: {
+    status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
+    orderKind: 'buy' | 'sell';
+    sellToken: TokenInfo;
+    buyToken: TokenInfo;
+    expiresTimestamp: number;
+  }) {
+    super(TransactionInfoType.SwapOrder, null, null);
+    this.status = args.status;
+    this.orderKind = args.orderKind;
+    this.sellToken = args.sellToken;
+    this.buyToken = args.buyToken;
+    this.expiresTimestamp = args.expiresTimestamp;
+  }
+}
+
+@ApiExtraModels(TokenInfo)
+export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
+  @ApiPropertyOptional()
+  surplus: string | null;
+
+  @ApiProperty()
+  executionPrice: string;
+
+  constructor(args: {
+    orderKind: 'buy' | 'sell';
+    sellToken: TokenInfo;
+    buyToken: TokenInfo;
+    expiresTimestamp: number;
+    surplus: string | null;
+    executionPrice: string;
+  }) {
+    super({ ...args, status: 'fulfilled' });
+    this.surplus = args.surplus;
+    this.executionPrice = args.executionPrice;
+  }
+}
+
+@ApiExtraModels(TokenInfo)
+export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
+  @ApiProperty()
+  limitPriceDescription: string;
+
+  constructor(args: {
+    status: 'open' | 'cancelled' | 'expired';
+    orderKind: 'buy' | 'sell';
+    sellToken: TokenInfo;
+    buyToken: TokenInfo;
+    expiresTimestamp: number;
+    limitPriceDescription: string;
+  }) {
+    super({ ...args });
+    this.limitPriceDescription = args.limitPriceDescription;
+  }
+}

--- a/src/routes/transactions/entities/transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transaction-info.entity.ts
@@ -6,6 +6,7 @@ export enum TransactionInfoType {
   Custom = 'Custom',
   SettingsChange = 'SettingsChange',
   Transfer = 'Transfer',
+  SwapOrder = 'SwapOrder',
 }
 
 export class TransactionInfo {

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -13,6 +13,7 @@ import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity
 import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
 import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swap-order-info.entity';
 
 @ApiExtraModels(
   CreationTransactionInfo,
@@ -21,6 +22,7 @@ import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer
   TransferTransactionInfo,
   ModuleExecutionInfo,
   MultisigExecutionInfo,
+  SwapOrderTransactionInfo,
 )
 export class Transaction {
   @ApiProperty()
@@ -34,6 +36,7 @@ export class Transaction {
       { $ref: getSchemaPath(CreationTransactionInfo) },
       { $ref: getSchemaPath(CustomTransactionInfo) },
       { $ref: getSchemaPath(SettingsChangeTransaction) },
+      { $ref: getSchemaPath(SwapOrderTransactionInfo) },
       { $ref: getSchemaPath(TransferTransactionInfo) },
     ],
   })

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -1,0 +1,340 @@
+import { SwapOrderMapper } from '@/routes/transactions/mappers/common/swap-order.mapper';
+import { SwapsRepository } from '@/domain/swaps/swaps.repository';
+import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
+import { CustomTransactionMapper } from '@/routes/transactions/mappers/common/custom-transaction.mapper';
+import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+import { faker } from '@faker-js/faker';
+import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
+import { orderBuilder } from '@/domain/swaps/entities/__tests__/order.builder';
+import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import {
+  DefaultSwapOrderTransactionInfo,
+  FulfilledSwapOrderTransactionInfo,
+} from '@/routes/transactions/entities/swap-order-info.entity';
+import { getAddress } from 'viem';
+import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { ILoggingService } from '@/logging/logging.interface';
+
+const swapsRepository = {
+  getOrder: jest.fn(),
+} as jest.MockedObjectDeep<SwapsRepository>;
+const swapsRepositoryMock = jest.mocked(swapsRepository);
+
+const setPreSignatureDecoder = {
+  getOrderUid: jest.fn(),
+} as jest.MockedObjectDeep<SetPreSignatureDecoder>;
+const setPreSignatureDecoderMock = jest.mocked(setPreSignatureDecoder);
+
+const tokenRepository = {
+  getToken: jest.fn(),
+} as jest.MockedObjectDeep<ITokenRepository>;
+
+const tokenRepositoryMock = jest.mocked(tokenRepository);
+
+const customTransactionMapper = {
+  mapCustomTransaction: jest.fn(),
+} as jest.MockedObjectDeep<CustomTransactionMapper>;
+
+const customTransactionMapperMock = jest.mocked(customTransactionMapper);
+
+const loggingService = {
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+const loggingServiceMock = jest.mocked(loggingService);
+
+function asDecimal(amount: number | bigint, decimals: number): number {
+  return Number(amount) / 10 ** decimals;
+}
+
+describe('Swap Order Mapper tests', () => {
+  let target: SwapOrderMapper;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    target = new SwapOrderMapper(
+      swapsRepositoryMock,
+      setPreSignatureDecoderMock,
+      tokenRepositoryMock,
+      customTransactionMapperMock,
+      loggingServiceMock,
+    );
+  });
+
+  it('should map fulfilled swap orders successfully', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().build();
+    const buyToken = tokenBuilder().with('decimals', 0).build();
+    const sellToken = tokenBuilder().build();
+    const order = orderBuilder()
+      .with('status', 'fulfilled')
+      .with('buyToken', getAddress(buyToken.address))
+      .with('sellToken', getAddress(sellToken.address))
+      .with('executedSurplusFee', faker.number.bigInt())
+      .build();
+    setPreSignatureDecoderMock.getOrderUid.mockReturnValue(
+      order.uid as `0x${string}`,
+    );
+    swapsRepositoryMock.getOrder.mockResolvedValue(order);
+    tokenRepositoryMock.getToken.mockImplementation(({ address }) => {
+      if (address === order.buyToken) return Promise.resolve(buyToken);
+      if (address === order.sellToken) return Promise.resolve(sellToken);
+      return Promise.reject(new Error(`Token ${address} not found.`));
+    });
+
+    const result = await target.mapSwapOrder(chainId, transaction, 0);
+
+    const surplus = asDecimal(order.executedSurplusFee!, buyToken.decimals!);
+    const expectedSurplus = `${surplus} ${buyToken.symbol}`;
+    const executionRatio =
+      asDecimal(order.executedSellAmount, sellToken.decimals!) /
+      asDecimal(order.executedBuyAmount, buyToken.decimals!);
+    const expectedExecutionPrice = `1 ${sellToken.symbol} = ${executionRatio} ${buyToken.symbol}`;
+    expect(result).toBeInstanceOf(FulfilledSwapOrderTransactionInfo);
+    expect(result).toEqual({
+      type: 'SwapOrder',
+      status: 'fulfilled',
+      orderKind: order.kind,
+      sellToken: {
+        amount: `${asDecimal(order.sellAmount, sellToken.decimals!)}`,
+        logo: sellToken.logoUri,
+        symbol: sellToken.symbol,
+      },
+      buyToken: {
+        amount: `${asDecimal(order.buyAmount, buyToken.decimals!)}`,
+        logo: buyToken.logoUri,
+        symbol: buyToken.symbol,
+      },
+      expiresTimestamp: order.validTo,
+      surplus: expectedSurplus,
+      executionPrice: expectedExecutionPrice,
+      humanDescription: null,
+      richDecodedInfo: null,
+    });
+  });
+
+  it.each(['open', 'cancelled', 'expired'])(
+    'should map %s swap orders successfully',
+    async (orderStatus) => {
+      const chainId = faker.string.numeric();
+      const transaction = multisigTransactionBuilder().build();
+      const buyToken = tokenBuilder().with('decimals', 0).build();
+      const sellToken = tokenBuilder().build();
+      const order = orderBuilder()
+        .with('status', orderStatus as 'open' | 'cancelled' | 'expired')
+        .with('buyToken', getAddress(buyToken.address))
+        .with('sellToken', getAddress(sellToken.address))
+        .build();
+      setPreSignatureDecoderMock.getOrderUid.mockReturnValue(
+        order.uid as `0x${string}`,
+      );
+      swapsRepositoryMock.getOrder.mockResolvedValue(order);
+      tokenRepositoryMock.getToken.mockImplementation(({ address }) => {
+        if (address === order.buyToken) return Promise.resolve(buyToken);
+        if (address === order.sellToken) return Promise.resolve(sellToken);
+        return Promise.reject(new Error(`Token ${address} not found.`));
+      });
+
+      const result = await target.mapSwapOrder(chainId, transaction, 0);
+
+      const ratio =
+        asDecimal(order.sellAmount, sellToken.decimals!) /
+        asDecimal(order.buyAmount, buyToken.decimals!);
+      const expectedLimitPriceDescription = `1 ${sellToken.symbol} = ${ratio} ${buyToken.symbol}`;
+      expect(result).toBeInstanceOf(DefaultSwapOrderTransactionInfo);
+      expect(result).toEqual({
+        type: 'SwapOrder',
+        status: order.status,
+        orderKind: order.kind,
+        sellToken: {
+          amount: `${asDecimal(order.sellAmount, sellToken.decimals!)}`,
+          logo: sellToken.logoUri,
+          symbol: sellToken.symbol,
+        },
+        buyToken: {
+          amount: `${asDecimal(order.buyAmount, buyToken.decimals!)}`,
+          logo: buyToken.logoUri,
+          symbol: buyToken.symbol,
+        },
+        expiresTimestamp: order.validTo,
+        limitPriceDescription: expectedLimitPriceDescription,
+        humanDescription: null,
+        richDecodedInfo: null,
+      });
+    },
+  );
+
+  it('should map to custom order if transaction data is null', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().with('data', null).build();
+    const dataSize = 0;
+    const customTransaction = new CustomTransactionInfo(
+      new AddressInfo(faker.finance.ethereumAddress()),
+      dataSize.toString(),
+      transaction.value,
+      null,
+      null,
+      false,
+      null,
+      null,
+    );
+    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
+      customTransaction,
+    );
+
+    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+
+    expect(result).toBe(customTransaction);
+    expect(
+      customTransactionMapperMock.mapCustomTransaction,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      customTransactionMapperMock.mapCustomTransaction,
+    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
+    expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(0);
+    expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(0);
+  });
+
+  it(`should map to custom transaction if order id is null`, async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().build();
+    const dataSize = 0;
+    setPreSignatureDecoderMock.getOrderUid.mockReturnValue(null);
+    const customTransaction = new CustomTransactionInfo(
+      new AddressInfo(faker.finance.ethereumAddress()),
+      dataSize.toString(),
+      transaction.value,
+      null,
+      null,
+      false,
+      null,
+      null,
+    );
+    setPreSignatureDecoderMock.getOrderUid.mockReturnValue(null);
+    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
+      customTransaction,
+    );
+
+    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+
+    expect(result).toBe(customTransaction);
+    expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
+    expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
+      transaction.data,
+    );
+    expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(0);
+    expect(
+      customTransactionMapperMock.mapCustomTransaction,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      customTransactionMapperMock.mapCustomTransaction,
+    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
+  });
+
+  it('should map to custom transaction if token data is not available', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().build();
+    const dataSize = 0;
+    const order = orderBuilder().build();
+    setPreSignatureDecoderMock.getOrderUid.mockReturnValue(
+      order.uid as `0x${string}`,
+    );
+    const customTransaction = new CustomTransactionInfo(
+      new AddressInfo(faker.finance.ethereumAddress()),
+      dataSize.toString(),
+      transaction.value,
+      null,
+      null,
+      false,
+      null,
+      null,
+    );
+    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
+      customTransaction,
+    );
+    tokenRepositoryMock.getToken.mockRejectedValue(
+      new Error('Token not found'),
+    );
+    swapsRepositoryMock.getOrder.mockResolvedValue(order);
+
+    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+
+    expect(result).toBe(customTransaction);
+    expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
+    expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
+      transaction.data,
+    );
+    expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(1);
+    expect(swapsRepositoryMock.getOrder).toHaveBeenCalledWith(
+      chainId,
+      order.uid,
+    );
+    expect(
+      customTransactionMapperMock.mapCustomTransaction,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      customTransactionMapperMock.mapCustomTransaction,
+    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
+  });
+
+  it.each(['fulfilled', 'open', 'cancelled', 'expired'])(
+    'should map to custom transaction if order kind is unknown',
+    async (status) => {
+      const chainId = faker.string.numeric();
+      const transaction = multisigTransactionBuilder().build();
+      const dataSize = 0;
+      const buyToken = tokenBuilder().with('decimals', 0).build();
+      const sellToken = tokenBuilder().build();
+      const order = orderBuilder()
+        .with(
+          'status',
+          status as 'fulfilled' | 'open' | 'cancelled' | 'expired',
+        )
+        .with('buyToken', getAddress(buyToken.address))
+        .with('sellToken', getAddress(sellToken.address))
+        .with('kind', 'unknown')
+        .build();
+      setPreSignatureDecoderMock.getOrderUid.mockReturnValue(
+        order.uid as `0x${string}`,
+      );
+      swapsRepositoryMock.getOrder.mockResolvedValue(order);
+      tokenRepositoryMock.getToken.mockImplementation(({ address }) => {
+        if (address === order.buyToken) return Promise.resolve(buyToken);
+        if (address === order.sellToken) return Promise.resolve(sellToken);
+        return Promise.reject(new Error(`Token ${address} not found.`));
+      });
+      const customTransaction = new CustomTransactionInfo(
+        new AddressInfo(faker.finance.ethereumAddress()),
+        dataSize.toString(),
+        transaction.value,
+        null,
+        null,
+        false,
+        null,
+        null,
+      );
+      customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
+        customTransaction,
+      );
+
+      const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+
+      expect(result).toBe(customTransaction);
+      expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
+      expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
+        transaction.data,
+      );
+      expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(1);
+      expect(swapsRepositoryMock.getOrder).toHaveBeenCalledWith(
+        chainId,
+        order.uid,
+      );
+      expect(
+        customTransactionMapperMock.mapCustomTransaction,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        customTransactionMapperMock.mapCustomTransaction,
+      ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
+    },
+  );
+});

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -106,8 +106,8 @@ describe('Swap Order Mapper tests', () => {
         symbol: buyToken.symbol,
       },
       expiresTimestamp: order.validTo,
-      surplus: expectedSurplus,
-      executionPrice: expectedExecutionPrice,
+      surplusLabel: expectedSurplus,
+      executionPriceLabel: expectedExecutionPrice,
       humanDescription: null,
       richDecodedInfo: null,
     });
@@ -157,7 +157,7 @@ describe('Swap Order Mapper tests', () => {
           symbol: buyToken.symbol,
         },
         expiresTimestamp: order.validTo,
-        limitPriceDescription: expectedLimitPriceDescription,
+        limitPriceLabel: expectedLimitPriceDescription,
         humanDescription: null,
         richDecodedInfo: null,
       });

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -1,0 +1,239 @@
+import { Inject, Injectable, Module } from '@nestjs/common';
+import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
+import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
+import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+import { isHex } from 'viem';
+import {
+  DefaultSwapOrderTransactionInfo,
+  FulfilledSwapOrderTransactionInfo,
+  SwapOrderTransactionInfo,
+  TokenInfo,
+} from '@/routes/transactions/entities/swap-order-info.entity';
+import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
+import { CustomTransactionMapper } from '@/routes/transactions/mappers/common/custom-transaction.mapper';
+import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import { Token } from '@/domain/tokens/entities/token.entity';
+import { SwapsRepository } from '@/domain/swaps/swaps.repository';
+import { SwapsModule } from '@/domain/swaps/swaps.module';
+import { AddressInfoModule } from '@/routes/common/address-info/address-info.module';
+import { Order } from '@/domain/swaps/entities/order.entity';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+
+/**
+ * Represents the amount of a token in a swap order.
+ */
+class TokenAmount {
+  readonly token: Token & {
+    decimals: number;
+  };
+  private readonly amount: bigint;
+  private readonly executedAmount: bigint;
+
+  constructor(args: { token: Token; amount: bigint; executedAmount: bigint }) {
+    if (args.token.decimals === null)
+      throw new Error(`Token ${args.token.address} has no decimals set.`);
+
+    this.token = { ...args.token, decimals: args.token.decimals };
+    this.amount = args.amount;
+    this.executedAmount = args.executedAmount;
+  }
+
+  getAmount(): number {
+    return asDecimal(this.amount, this.token.decimals);
+  }
+
+  getExecutedAmount(): number {
+    return asDecimal(this.executedAmount, this.token.decimals);
+  }
+
+  toTokenInfo(): TokenInfo {
+    return new TokenInfo({
+      amount: this.getAmount().toString(),
+      symbol: this.token.symbol,
+      logo: this.token.logoUri,
+    });
+  }
+}
+
+function asDecimal(amount: number | bigint, decimals: number): number {
+  return Number(amount) / 10 ** decimals;
+}
+
+@Injectable()
+export class SwapOrderMapper {
+  constructor(
+    private readonly swapsRepository: SwapsRepository,
+    private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
+    @Inject(ITokenRepository)
+    private readonly tokenRepository: ITokenRepository,
+    private readonly customTransactionMapper: CustomTransactionMapper,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async mapSwapOrder(
+    chainId: string,
+    transaction: MultisigTransaction | ModuleTransaction,
+    dataSize: number,
+  ): Promise<SwapOrderTransactionInfo | CustomTransactionInfo> {
+    if (!isHex(transaction.data)) {
+      return this._mapUnknownOrderStatus(chainId, transaction, dataSize);
+    }
+
+    const orderUid: `0x${string}` | null =
+      this.setPreSignatureDecoder.getOrderUid(transaction.data);
+    if (!orderUid) {
+      return this._mapUnknownOrderStatus(chainId, transaction, dataSize);
+    }
+    const order = await this.swapsRepository.getOrder(chainId, orderUid);
+
+    try {
+      const [buyToken, sellToken] = await Promise.all([
+        this.tokenRepository.getToken({
+          chainId,
+          address: order.buyToken,
+        }),
+        this.tokenRepository.getToken({
+          chainId,
+          address: order.sellToken,
+        }),
+      ]);
+
+      const buyTokenAmount = new TokenAmount({
+        token: buyToken,
+        amount: order.buyAmount,
+        executedAmount: order.executedBuyAmount,
+      });
+      const sellTokenAmount = new TokenAmount({
+        token: sellToken,
+        amount: order.sellAmount,
+        executedAmount: order.executedSellAmount,
+      });
+
+      switch (order.status) {
+        case 'fulfilled':
+          return this._mapFulfilledOrderStatus({
+            buyToken: buyTokenAmount,
+            sellToken: sellTokenAmount,
+            order,
+          });
+        case 'open':
+        case 'cancelled':
+        case 'expired':
+          return this._mapDefaultOrderStatus({
+            buyToken: buyTokenAmount,
+            sellToken: sellTokenAmount,
+            order,
+          });
+        default:
+          return this._mapUnknownOrderStatus(chainId, transaction, dataSize);
+      }
+    } catch (e) {
+      this.loggingService.warn(e);
+      return this.customTransactionMapper.mapCustomTransaction(
+        transaction,
+        dataSize,
+        chainId,
+        null,
+        null,
+      );
+    }
+  }
+
+  private _mapUnknownOrderStatus(
+    chainId: string,
+    transaction: MultisigTransaction | ModuleTransaction,
+    dataSize: number,
+  ): Promise<CustomTransactionInfo> {
+    return this.customTransactionMapper.mapCustomTransaction(
+      transaction,
+      dataSize,
+      chainId,
+      null,
+      null,
+    );
+  }
+
+  private _getExecutionPrice(
+    sellToken: TokenAmount,
+    buyToken: TokenAmount,
+  ): string {
+    const ratio = sellToken.getExecutedAmount() / buyToken.getExecutedAmount();
+    return `1 ${sellToken.token.symbol} = ${ratio} ${buyToken.token.symbol}`;
+  }
+
+  private _getLimitPrice(
+    sellToken: TokenAmount,
+    buyToken: TokenAmount,
+  ): string {
+    const ratio = sellToken.getAmount() / buyToken.getAmount();
+    return `1 ${sellToken.token.symbol} = ${ratio} ${buyToken.token.symbol}`;
+  }
+
+  private _mapFulfilledOrderStatus(args: {
+    buyToken: TokenAmount;
+    sellToken: TokenAmount;
+    order: Order;
+  }): SwapOrderTransactionInfo {
+    if (args.order.kind === 'unknown') {
+      throw new Error('Unknown order kind');
+    }
+    const surplusFee: string | null = args.order.executedSurplusFee
+      ? this._getExecutedSurplusFee(
+          args.order.executedSurplusFee,
+          args.buyToken.token,
+        )
+      : null;
+
+    return new FulfilledSwapOrderTransactionInfo({
+      orderKind: args.order.kind,
+      sellToken: args.sellToken.toTokenInfo(),
+      buyToken: args.buyToken.toTokenInfo(),
+      expiresTimestamp: args.order.validTo,
+      surplus: surplusFee,
+      executionPrice: this._getExecutionPrice(args.sellToken, args.buyToken),
+    });
+  }
+
+  private _getExecutedSurplusFee(
+    executedSurplusFee: bigint,
+    token: Token & { decimals: number },
+  ): string | null {
+    const surplus = asDecimal(executedSurplusFee, token.decimals);
+    return `${surplus} ${token.symbol}`;
+  }
+
+  private _mapDefaultOrderStatus(args: {
+    buyToken: TokenAmount;
+    sellToken: TokenAmount;
+    order: Order;
+  }): SwapOrderTransactionInfo {
+    if (args.order.kind === 'unknown') {
+      throw new Error('Unknown order kind');
+    }
+    if (
+      args.order.status === 'fulfilled' ||
+      args.order.status === 'presignaturePending' ||
+      args.order.status === 'unknown'
+    )
+      throw new Error(
+        `${args.order.status} orders should not be mapped as default orders. Order UID = ${args.order.uid}`,
+      );
+    return new DefaultSwapOrderTransactionInfo({
+      status: args.order.status,
+      orderKind: args.order.kind,
+      sellToken: args.sellToken.toTokenInfo(),
+      buyToken: args.buyToken.toTokenInfo(),
+      expiresTimestamp: args.order.validTo,
+      limitPriceDescription: this._getLimitPrice(args.sellToken, args.buyToken),
+    });
+  }
+}
+
+@Module({
+  // TODO AddressInfoModule is not needed in this module but it is required by the CustomTransactionMapper.
+  //  The CustomTransactionMapper (module to be created) should be the one providing it instead.
+  imports: [SwapsModule, AddressInfoModule],
+  providers: [SwapOrderMapper, SetPreSignatureDecoder, CustomTransactionMapper],
+  exports: [SwapOrderMapper],
+})
+export class SwapOrderMapperModule {}

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -197,7 +197,7 @@ export class SwapOrderMapper {
   private _getExecutedSurplusFee(
     executedSurplusFee: bigint,
     token: Token & { decimals: number },
-  ): string | null {
+  ): string {
     const surplus = asDecimal(executedSurplusFee, token.decimals);
     return `${surplus} ${token.symbol}`;
   }

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -84,9 +84,9 @@ export class SwapOrderMapper {
     if (!orderUid) {
       return this._mapUnknownOrderStatus(chainId, transaction, dataSize);
     }
-    const order = await this.swapsRepository.getOrder(chainId, orderUid);
 
     try {
+      const order = await this.swapsRepository.getOrder(chainId, orderUid);
       const [buyToken, sellToken] = await Promise.all([
         this.tokenRepository.getToken({
           chainId,
@@ -153,7 +153,7 @@ export class SwapOrderMapper {
     );
   }
 
-  private _getExecutionPrice(
+  private _getExecutionPriceLabel(
     sellToken: TokenAmount,
     buyToken: TokenAmount,
   ): string {
@@ -161,7 +161,7 @@ export class SwapOrderMapper {
     return `1 ${sellToken.token.symbol} = ${ratio} ${buyToken.token.symbol}`;
   }
 
-  private _getLimitPrice(
+  private _getLimitPriceLabel(
     sellToken: TokenAmount,
     buyToken: TokenAmount,
   ): string {
@@ -177,8 +177,8 @@ export class SwapOrderMapper {
     if (args.order.kind === 'unknown') {
       throw new Error('Unknown order kind');
     }
-    const surplusFee: string | null = args.order.executedSurplusFee
-      ? this._getExecutedSurplusFee(
+    const surplusFeeLabel: string | null = args.order.executedSurplusFee
+      ? this._getExecutedSurplusFeeLabel(
           args.order.executedSurplusFee,
           args.buyToken.token,
         )
@@ -189,12 +189,15 @@ export class SwapOrderMapper {
       sellToken: args.sellToken.toTokenInfo(),
       buyToken: args.buyToken.toTokenInfo(),
       expiresTimestamp: args.order.validTo,
-      surplus: surplusFee,
-      executionPrice: this._getExecutionPrice(args.sellToken, args.buyToken),
+      surplusFeeLabel: surplusFeeLabel,
+      executionPriceLabel: this._getExecutionPriceLabel(
+        args.sellToken,
+        args.buyToken,
+      ),
     });
   }
 
-  private _getExecutedSurplusFee(
+  private _getExecutedSurplusFeeLabel(
     executedSurplusFee: bigint,
     token: Token & { decimals: number },
   ): string {
@@ -224,7 +227,7 @@ export class SwapOrderMapper {
       sellToken: args.sellToken.toTokenInfo(),
       buyToken: args.buyToken.toTokenInfo(),
       expiresTimestamp: args.order.validTo,
-      limitPriceDescription: this._getLimitPrice(args.sellToken, args.buyToken),
+      limitPriceLabel: this._getLimitPriceLabel(args.sellToken, args.buyToken),
     });
   }
 }

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -28,10 +28,12 @@ import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/tran
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
 import { TransactionsController } from '@/routes/transactions/transactions.controller';
 import { TransactionsService } from '@/routes/transactions/transactions.service';
+import { SwapOrderMapperModule } from '@/routes/transactions/mappers/common/swap-order.mapper';
+import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 
 @Module({
   controllers: [TransactionsController],
-  imports: [AddressInfoModule, DataDecodedModule],
+  imports: [AddressInfoModule, DataDecodedModule, SwapOrderMapperModule],
   providers: [
     CreationTransactionMapper,
     CustomTransactionMapper,
@@ -52,6 +54,7 @@ import { TransactionsService } from '@/routes/transactions/transactions.service'
     QueuedItemsMapper,
     SafeAppInfoMapper,
     SettingsChangeMapper,
+    SetPreSignatureDecoder,
     TransactionDataMapper,
     TransactionPreviewMapper,
     TransactionsHistoryMapper,


### PR DESCRIPTION
Part of #1198

- Adds `SwapOrderMapper` – this mapper will attempt to decode transactions that represent a `preSignature` CoW Swap order.
- Successful decoding depends on multiple conditions. If any of the following conditions occurs, the transaction is mapped to a custom transaction instead (i.e.: without any decoding in place):
  * Transaction data is null
  * Order UID cannot be retrieved
  * Buy or Sell token info cannot be retrieved
  * Unsupported order statuses (statuses which are not `fulfilled`, `open`, `cancelled` or `expired`).
- Adds an `orderBuilder` to support creating multiple instances of `Order` with different properties.
- The decoding of CoW Swap orders is only available if `FF_SWAPS_DECODING` is enabled.
