### PR TITLE
Move viem deprecated getFunctionSelector to toFunctionSelector

### DIFF
--- a/src/domain/human-description/human-description.repository.ts
+++ b/src/domain/human-description/human-description.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { getFunctionSelector } from 'viem';
+import { toFunctionSelector } from 'viem';
 import { HumanDescriptionTemplate } from '@/domain/human-description/entities/human-description-template.entity';
 import {
   FunctionSignatureHash,
@@ -22,7 +22,7 @@ export class HumanDescriptionRepository implements IHumanDescriptionRepository {
     const humanDescriptions = this.humanDescriptionApi.getDescriptions();
 
     for (const functionSignature in humanDescriptions) {
-      const selector = getFunctionSelector(functionSignature);
+      const selector = toFunctionSelector(functionSignature);
       this.templates[selector] = new HumanDescriptionTemplate(
         functionSignature,
         humanDescriptions[functionSignature],

--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
-import { getFunctionSelector, parseAbi } from 'viem';
+import { toFunctionSelector, parseAbi } from 'viem';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 
 export const abi = parseAbi([
@@ -15,7 +15,7 @@ export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
     super(abi);
-    this.setPreSignatureFunctionSelector = getFunctionSelector(abi[0]);
+    this.setPreSignatureFunctionSelector = toFunctionSelector(abi[0]);
   }
 
   /**


### PR DESCRIPTION
## Summary
The function `getFunctionSelector` was deprecated in `viem` 2.4.0. See: https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#minor-changes-4

## Changes
- Moves deprecated `getFunctionSelector` calls to `toFunctionSelector`.
