### PR TITLE
Remove duplicate eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,6 @@ module.exports = {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/consistent-type-assertions': [
       'warn',


### PR DESCRIPTION
We were setting the `@typescript-eslint/no-explicit-any` rule twice: `off` and `error`. This leaves the `error` rule only (the active one).
