### PR TITLE
Implement ICacheReadiness for FakeCacheService

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -1,7 +1,8 @@
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { ICacheReadiness } from '@/domain/interfaces/cache-readiness.interface';
 
-export class FakeCacheService implements ICacheService {
+export class FakeCacheService implements ICacheService, ICacheReadiness {
   private cache: Record<string, Record<string, string> | number> = {};
   private isReady: boolean = true;
 


### PR DESCRIPTION
The `FakeCacheService` already had the functionality of `ICacheReadiness` without declaring its respective implementation – see the `ping()` method.