### PR TITLE
Simplify `Operation` entity

### DIFF
--- a/src/domain/safe/entities/operation.entity.ts
+++ b/src/domain/safe/entities/operation.entity.ts
@@ -1,6 +1,4 @@
-export const CALL_OPERATION = 0;
-export const DELEGATE_OPERATION = 1;
-
-export type Call = typeof CALL_OPERATION;
-export type Delegate = typeof DELEGATE_OPERATION;
-export type Operation = Call | Delegate;
+export enum Operation {
+  CALL = 0,
+  DELEGATE = 1,
+}

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -9,7 +9,7 @@ import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { safeAppBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app.builder';
-import { CALL_OPERATION } from '@/domain/safe/entities/operation.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 import {
   moduleTransactionBuilder,
   toJson as moduleTransactionToJson,
@@ -188,7 +188,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .with('safe', safe.address)
       .with('data', null)
       .with('value', '0xf')
-      .with('operation', CALL_OPERATION)
+      .with('operation', Operation.CALL)
       .with('isSuccessful', true)
       .build();
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -244,7 +244,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             value: moduleTransaction.value,
             hexData: moduleTransaction.data,
             dataDecoded: moduleTransaction.dataDecoded,
-            operation: CALL_OPERATION,
+            operation: Operation.CALL,
             addressInfoIndex: null,
             trustedDelegateCallTarget: null,
           },

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -12,10 +12,7 @@ import {
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
 } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
-import {
-  CALL_OPERATION,
-  DELEGATE_OPERATION,
-} from '@/domain/safe/entities/operation.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
@@ -84,7 +81,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
 
   it('should preview a transaction', async () => {
     const previewTransactionDto = previewTransactionDtoBuilder()
-      .with('operation', CALL_OPERATION)
+      .with('operation', Operation.CALL)
       .build();
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
@@ -152,7 +149,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
 
   it('should preview a transaction with an unknown "to" address', async () => {
     const previewTransactionDto = previewTransactionDtoBuilder()
-      .with('operation', CALL_OPERATION)
+      .with('operation', Operation.CALL)
       .build();
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
@@ -219,7 +216,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
 
   it('should preview a transaction even if the data cannot be decoded', async () => {
     const previewTransactionDto = previewTransactionDtoBuilder()
-      .with('operation', CALL_OPERATION)
+      .with('operation', Operation.CALL)
       .build();
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
@@ -285,7 +282,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
 
   it('should preview a transaction with a nested call', async () => {
     const previewTransactionDto = previewTransactionDtoBuilder()
-      .with('operation', DELEGATE_OPERATION)
+      .with('operation', Operation.DELEGATE)
       .build();
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();

--- a/src/routes/transactions/entities/schemas/__tests__/preview-transaction.dto.schema.spec.ts
+++ b/src/routes/transactions/entities/schemas/__tests__/preview-transaction.dto.schema.spec.ts
@@ -61,36 +61,13 @@ describe('PreviewTransactionDtoSchema', () => {
           path: ['value'],
           message: 'Required',
         },
+        // @ts-expect-error - enum values cannot be inferred by zod (zod-based error)
         {
-          code: 'invalid_union',
-          unionErrors: [
-            {
-              issues: [
-                // @ts-expect-error - zod cannot infer literal (zod-based error)
-                {
-                  code: 'invalid_literal',
-                  expected: 0,
-                  path: ['operation'],
-                  message: 'Invalid literal value, expected 0',
-                },
-              ],
-              name: 'ZodError',
-            },
-            {
-              issues: [
-                // @ts-expect-error - zod cannot infer literal (zod-based error)
-                {
-                  code: 'invalid_literal',
-                  expected: 1,
-                  path: ['operation'],
-                  message: 'Invalid literal value, expected 1',
-                },
-              ],
-              name: 'ZodError',
-            },
-          ],
+          expected: '0 | 1',
+          received: 'undefined',
+          code: 'invalid_type',
           path: ['operation'],
-          message: 'Invalid input',
+          message: 'Required',
         },
       ]),
     );

--- a/src/routes/transactions/entities/schemas/preview-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/preview-transaction.dto.schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 
 export const PreviewTransactionDtoSchema = z.object({
   to: AddressSchema,
   data: HexSchema.nullish().default(null),
   value: z.string(),
-  // TODO: Reference Operation enum
-  operation: z.literal(0).or(z.literal(1)),
+  operation: z.nativeEnum(Operation),
 });

--- a/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
+++ b/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
-import { DELEGATE_OPERATION } from '@/domain/safe/entities/operation.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 
 @Injectable()
 export class DataDecodedParamHelper {
@@ -73,7 +73,7 @@ export class DataDecodedParamHelper {
       (param) =>
         Array.isArray(param.valueDecoded) &&
         param.valueDecoded.some(
-          (innerParam) => innerParam?.operation === DELEGATE_OPERATION,
+          (innerParam) => innerParam?.operation === Operation.DELEGATE,
         ),
     );
   }

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
@@ -5,7 +5,7 @@ import {
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
 } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
-import { DELEGATE_OPERATION } from '@/domain/safe/entities/operation.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
@@ -56,7 +56,7 @@ describe('Transaction Data Mapper (Unit)', () => {
 
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
-        DELEGATE_OPERATION,
+        Operation.DELEGATE,
         faker.finance.ethereumAddress(),
         null,
       );

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -2,10 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { isEmpty } from 'lodash';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
-import {
-  DELEGATE_OPERATION,
-  Operation,
-} from '@/domain/safe/entities/operation.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
@@ -79,7 +76,7 @@ export class TransactionDataMapper {
     to: string,
     dataDecoded: DataDecoded | null,
   ): Promise<boolean | null> {
-    if (operation !== DELEGATE_OPERATION) return null;
+    if (operation !== Operation.DELEGATE) return null;
 
     let contract: Contract;
     try {


### PR DESCRIPTION
## Summary

This applies 1ebbadfa4a0de17ec5417785c91460b244969784 which simplifies the `Operation` entity and associated types into a singular enum.

## Changes

- Condense `Operation` entity into an enum and propagate changes