### PR TITLE
Remove unused `HEX_PATTERN`

### DIFF
--- a/src/validation/patterns.ts
+++ b/src/validation/patterns.ts
@@ -1,1 +1,0 @@
-export const HEX_PATTERN = '0[x][0-9a-fA-F]+';


### PR DESCRIPTION
## Summary

This removes the `HEX_PATTERN` (and with it `/src/validation/pattern`) as it is not being used.