### PR TITLE
Fix Singleton.deployer schema requirement

### DIFF
--- a/src/domain/chains/entities/schemas/__tests__/singleton.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/singleton.schema.spec.ts
@@ -13,23 +13,20 @@ describe('SingletonSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it.each(['address' as const, 'deployer' as const])(
-    'should checksum %s',
-    (key) => {
-      const nonChecksummedAddress = faker.finance
-        .ethereumAddress()
-        .toLowerCase() as `0x${string}`;
-      const singleton = singletonBuilder()
-        .with(key, nonChecksummedAddress)
-        .build();
+  it.each(['address' as const])('should checksum %s', (key) => {
+    const nonChecksummedAddress = faker.finance
+      .ethereumAddress()
+      .toLowerCase() as `0x${string}`;
+    const singleton = singletonBuilder()
+      .with(key, nonChecksummedAddress)
+      .build();
 
-      const result = SingletonSchema.safeParse(singleton);
+    const result = SingletonSchema.safeParse(singleton);
 
-      expect(result.success && result.data[key]).toBe(
-        getAddress(nonChecksummedAddress),
-      );
-    },
-  );
+    expect(result.success && result.data[key]).toBe(
+      getAddress(nonChecksummedAddress),
+    );
+  });
 
   it.each<keyof Singleton>([
     'address',

--- a/src/domain/chains/entities/schemas/singleton.schema.ts
+++ b/src/domain/chains/entities/schemas/singleton.schema.ts
@@ -4,7 +4,7 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 export const SingletonSchema = z.object({
   address: AddressSchema,
   version: z.string(),
-  deployer: AddressSchema,
+  deployer: z.string(),
   deployedBlockNumber: z.number(),
   lastIndexedBlockNumber: z.number(),
   l2: z.boolean(),


### PR DESCRIPTION
- Changes the Singleton's requirement of `deployer` to be a string instead of an Ethereum address.