### PR TITLE
Fix missing path `safeAddress` param on Swagger locking docs

### DIFF
--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -9,7 +9,6 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { Controller, Get, Param } from '@nestjs/common';
 import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
-import { z } from 'zod';
 
 @ApiTags('locking')
 @Controller({
@@ -23,7 +22,7 @@ export class LockingController {
   @Get('/leaderboard/:safeAddress')
   async getRank(
     @Param('safeAddress', new ValidationPipe(AddressSchema))
-    safeAddress: z.infer<typeof AddressSchema>,
+    safeAddress: `0x${string}`,
   ): Promise<Rank> {
     return this.lockingService.getRank(safeAddress);
   }
@@ -51,7 +50,7 @@ export class LockingController {
   @Get('/:safeAddress/history')
   async getLockingHistory(
     @Param('safeAddress', new ValidationPipe(AddressSchema))
-    safeAddress: z.infer<typeof AddressSchema>,
+    safeAddress: `0x${string}`,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<LockingEventPage> {


### PR DESCRIPTION
## Summary

The `{safeAddress}` path params for the locking endpoints were not showing on Swagger. This explicitly defines the types of the params so that they now appear in the docs and can be tested:

![image](https://github.com/safe-global/safe-client-gateway/assets/20442784/9af54774-ddd0-49ba-bade-e814b86d480b)

![image](https://github.com/safe-global/safe-client-gateway/assets/20442784/cf8576f7-1655-4cad-889c-ca93cb58c631)

## Changes

- Switch from Zod's inferral to explicit `0x${string}` type