### PR TITLE
Change OpenAPI resource location

### DIFF
--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -25,7 +25,7 @@ function configureSwagger(app: INestApplication): void {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('index.html', app, document, {
+  SwaggerModule.setup('api', app, document, {
     customfavIcon: '/favicon.png',
     customSiteTitle: 'Safe Client Gateway',
     customCss: `.topbar-wrapper img { content:url(\'logo.svg\'); }`,

--- a/src/routes/root/root.controller.spec.ts
+++ b/src/routes/root/root.controller.spec.ts
@@ -30,7 +30,7 @@ describe('Root Controller tests', () => {
       .get(`/`)
       .expect(302)
       .expect((res) => {
-        expect(res.get('location')).toBe('/index.html');
+        expect(res.get('location')).toBe('/api');
       });
   });
 });

--- a/src/routes/root/root.controller.spec.ts
+++ b/src/routes/root/root.controller.spec.ts
@@ -25,7 +25,7 @@ describe('Root Controller tests', () => {
     await app.init();
   });
 
-  it('should redirect / to /index.html', async () => {
+  it('should redirect / to /api', async () => {
     await request(app.getHttpServer())
       .get(`/`)
       .expect(302)

--- a/src/routes/root/root.controller.ts
+++ b/src/routes/root/root.controller.ts
@@ -1,12 +1,12 @@
-import { Controller, Get, Res } from '@nestjs/common';
+import { Controller, Get, Redirect } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
-import { Response } from 'express';
 
 @Controller()
 @ApiExcludeController()
 export class RootController {
   @Get()
-  getIndex(@Res() res: Response): void {
-    return res.redirect('/index.html');
+  @Redirect('/api', 302)
+  redirectApi(): void {
+    // This method is intentionally left blank because @Redirect() handles the response
   }
 }


### PR DESCRIPTION
## Summary

- By serving the Swagger UI via `index.html` we removed the PetStore demo Swagger interface that was also being served under the same location. See 94ee10d2fd1f9e83dde88a74a94a99de74f9278b.
- However, the OpenAPI schema (JSON format) stopped being served with that change (previously available under `/-json`)

## Changes

- Therefore, we now serve the Swagger UI under `/api`. The redirect from `/` was adjusted to redirect to `/api`.
  * Additionally, the `PetStore` is not served under `index.html`.
  * `index.html` now returns a 404 – as there is no resource under that path.
  * The Open API JSON schema can now be found in `/api-json`.