### PR TITLE
Add optional debugging logs when retrieving transactions history

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -175,6 +175,7 @@ export default (): ReturnType<typeof configuration> => ({
     locking: true,
     relay: true,
     swapsDecoding: true,
+    historyDebugLogs: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -171,6 +171,8 @@ export default () => ({
     locking: process.env.FF_LOCKING?.toLowerCase() === 'true',
     relay: process.env.FF_RELAY?.toLowerCase() === 'true',
     swapsDecoding: process.env.FF_SWAPS_DECODING?.toLowerCase() === 'true',
+    historyDebugLogs:
+      process.env.FF_HISTORY_DEBUG_LOGS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -7,6 +7,7 @@ import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { INetworkService } from '@/datasources/network/network.service.interface';
 import { ILoggingService } from '@/logging/logging.interface';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 
 const mockLoggingService: jest.MockedObjectDeep<ILoggingService> = {
   info: jest.fn(),
@@ -24,15 +25,19 @@ const mockNetworkService = jest.mocked(networkService);
 describe('CacheFirstDataSource', () => {
   let cacheFirstDataSource: CacheFirstDataSource;
   let fakeCacheService: FakeCacheService;
+  let fakeConfigurationService: FakeConfigurationService;
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.useFakeTimers();
     fakeCacheService = new FakeCacheService();
+    fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set('features.historyDebugLogs', true);
     cacheFirstDataSource = new CacheFirstDataSource(
       fakeCacheService,
       mockNetworkService,
       mockLoggingService,
+      fakeConfigurationService,
     );
   });
 
@@ -231,6 +236,7 @@ describe('CacheFirstDataSource', () => {
       mockCache,
       mockNetworkService,
       mockLoggingService,
+      fakeConfigurationService,
     );
 
     const targetUrl = faker.internet.url({ appendSlash: false });
@@ -274,6 +280,7 @@ describe('CacheFirstDataSource', () => {
       mockCache,
       mockNetworkService,
       mockLoggingService,
+      fakeConfigurationService,
     );
 
     const targetUrl = faker.internet.url({ appendSlash: false });


### PR DESCRIPTION
## Summary
This PR adds optional debugging logs when retrieving the transactions history from the Safe Transaction Service (i.e.: when querying the `all-transactions` endpoint).

The result logs would have the following format:
```
{
    "level": "info",
    "message": {
        "cacheField": "undefined_true_false_20_0",
        "cacheKey": "11155111_all_transactions_0x2a73e61bd15b25B6958b4D...",
        "timestamp": 1710862749974,
        "txHashes": [
            {
                "safeTxHash": "0x556310bb...",
                "txType": "multisig"
            },
            {
                "safeTxHash": "0xa097de04...",
                "txType": "multisig"
            },
            ...
            {
                "safeTxHash": "0x3e17412c...",
                "txType": "multisig"
            },
            {
                "safeTxHash": "0x1b2e5143...",
                "txType": "multisig"
            }
        ],
        "type": "cache_write"
    },
    "request_id": "714788c1-1302-4231-b0bb-c916d5e553fb",
    "timestamp": "2024-03-19T15:39:09.974Z"
}
```

## Changes
- Adds `FF_HISTORY_DEBUG_LOGS` to (de)activate the logging.
- Implements a private function (`logTransactionsCacheWrite`) to log transactions following the above format.
