### PR TITLE
Add additional timestamps to transaction history logs

### DIFF
--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -209,7 +209,7 @@ export class CacheFirstDataSource {
       type: 'cache_write',
       cacheKey: cacheDir.key,
       cacheField: cacheDir.field,
-      cacheWriteTime: new Date(Date.now()),
+      cacheWriteTime: new Date(),
       requestStartTime: new Date(requestStartTime),
       txHashes:
         isArray(data?.results) && // no validation executed yet at this point

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -137,6 +137,7 @@ export class CacheFirstDataSource {
         args.url.includes('all-transactions')
       ) {
         this.logTransactionsCacheWrite(
+          startTimeMs,
           args.cacheDir,
           data as Page<Transaction>,
         );
@@ -200,6 +201,7 @@ export class CacheFirstDataSource {
    * TODO: remove this function after debugging.
    */
   private logTransactionsCacheWrite(
+    requestStartTime: number,
     cacheDir: CacheDir,
     data: Page<Transaction>,
   ): void {
@@ -207,7 +209,8 @@ export class CacheFirstDataSource {
       type: 'cache_write',
       cacheKey: cacheDir.key,
       cacheField: cacheDir.field,
-      timestamp: Date.now(),
+      cacheWriteTime: new Date(Date.now()),
+      requestStartTime: new Date(requestStartTime),
       txHashes:
         isArray(data?.results) && // no validation executed yet at this point
         data.results.map((transaction) => {


### PR DESCRIPTION
## Summary

## Changes
- Adds an additional field (`requestStartTime`) to the transactions history `cache_write` log.
- Renames `timestamp` to `cacheWriteTime` to clarify the field's purpose.