### PR TITLE
Improve Order OpenAPI documentation

### DIFF
--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -9,13 +9,19 @@ import {
 } from '@nestjs/swagger';
 
 export class TokenInfo {
-  @ApiPropertyOptional({ type: String, nullable: true })
+  @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description: 'The token logo',
+  })
   logo: string | null;
 
-  @ApiProperty()
+  @ApiProperty({ description: 'The token symbol' })
   symbol: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'The token amount in decimal format',
+  })
   amount: string;
 
   constructor(args: { logo: string | null; symbol: string; amount: string }) {
@@ -27,19 +33,22 @@ export class TokenInfo {
 
 @ApiExtraModels(TokenInfo)
 export abstract class SwapOrderTransactionInfo extends TransactionInfo {
-  @ApiProperty()
+  @ApiProperty({ enum: [TransactionInfoType.SwapOrder] })
+  override type: TransactionInfoType.SwapOrder;
+
+  @ApiProperty({ enum: ['open', 'fulfilled', 'cancelled', 'expired'] })
   status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
 
-  @ApiProperty()
+  @ApiProperty({ enum: ['buy', 'sell'] })
   orderKind: 'buy' | 'sell';
 
-  @ApiProperty()
+  @ApiProperty({ description: 'The sell token of the order' })
   sellToken: TokenInfo;
 
-  @ApiProperty()
+  @ApiProperty({ description: 'The buy token of the order' })
   buyToken: TokenInfo;
 
-  @ApiProperty()
+  @ApiProperty({ description: 'The timestamp when the order expires' })
   expiresTimestamp: number;
 
   protected constructor(args: {
@@ -50,6 +59,7 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
     expiresTimestamp: number;
   }) {
     super(TransactionInfoType.SwapOrder, null, null);
+    this.type = TransactionInfoType.SwapOrder;
     this.status = args.status;
     this.orderKind = args.orderKind;
     this.sellToken = args.sellToken;
@@ -60,10 +70,21 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
 
 @ApiExtraModels(TokenInfo)
 export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
-  @ApiPropertyOptional({ type: String, nullable: true })
+  @ApiProperty({ enum: ['fulfilled'] })
+  override status: 'fulfilled';
+
+  @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description:
+      'The surplus label is in the format of "$executedSurplusFee $tokenSymbol"',
+  })
   surplusLabel: string | null;
 
-  @ApiProperty()
+  @ApiProperty({
+    description:
+      'The execution price label is in the format of "1 $sellTokenSymbol = $ratio $buyTokenSymbol"',
+  })
   executionPriceLabel: string;
 
   constructor(args: {
@@ -75,6 +96,7 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
     executionPriceLabel: string;
   }) {
     super({ ...args, status: 'fulfilled' });
+    this.status = 'fulfilled';
     this.surplusLabel = args.surplusFeeLabel;
     this.executionPriceLabel = args.executionPriceLabel;
   }
@@ -82,7 +104,13 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
 
 @ApiExtraModels(TokenInfo)
 export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
-  @ApiProperty()
+  @ApiProperty({ enum: ['open', 'cancelled', 'expired'] })
+  override status: 'open' | 'cancelled' | 'expired';
+
+  @ApiProperty({
+    description:
+      'The limit price label is in the format of "1 $sellTokenSymbol = $limitPriceLabel $buyTokenSymbol"',
+  })
   limitPriceLabel: string;
 
   constructor(args: {
@@ -93,7 +121,8 @@ export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
     expiresTimestamp: number;
     limitPriceLabel: string;
   }) {
-    super({ ...args });
+    super(args);
+    this.status = args.status;
     this.limitPriceLabel = args.limitPriceLabel;
   }
 }

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -13,7 +13,10 @@ import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity
 import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
 import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
-import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swap-order-info.entity';
+import {
+  DefaultSwapOrderTransactionInfo,
+  FulfilledSwapOrderTransactionInfo,
+} from '@/routes/transactions/entities/swap-order-info.entity';
 
 @ApiExtraModels(
   CreationTransactionInfo,
@@ -22,7 +25,8 @@ import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swap-or
   TransferTransactionInfo,
   ModuleExecutionInfo,
   MultisigExecutionInfo,
-  SwapOrderTransactionInfo,
+  FulfilledSwapOrderTransactionInfo,
+  DefaultSwapOrderTransactionInfo,
 )
 export class Transaction {
   @ApiProperty()
@@ -36,7 +40,8 @@ export class Transaction {
       { $ref: getSchemaPath(CreationTransactionInfo) },
       { $ref: getSchemaPath(CustomTransactionInfo) },
       { $ref: getSchemaPath(SettingsChangeTransaction) },
-      { $ref: getSchemaPath(SwapOrderTransactionInfo) },
+      { $ref: getSchemaPath(DefaultSwapOrderTransactionInfo) },
+      { $ref: getSchemaPath(FulfilledSwapOrderTransactionInfo) },
       { $ref: getSchemaPath(TransferTransactionInfo) },
     ],
   })


### PR DESCRIPTION
- Improves the documentation for the order related entities (`DefaultSwapOrderTransactionInfo` and `FulfilledSwapOrderTransactionInfo`)
- Uses the concrete entities instead of the abstract one (`SwapOrderTransactionInfo`) – this is what the clients expect, and we don't lose the schema information by using an abstract class.
- Adds a description to the relevant properties.
- Overrides the abstract class properties (e.g.: `type` and `status`) to provide the concrete values to be expected from the concrete implementation.
