### PR TITLE
Change type and validate `Rank['position']` as a `number`

### DIFF
--- a/src/domain/locking/entities/__tests__/rank.builder.ts
+++ b/src/domain/locking/entities/__tests__/rank.builder.ts
@@ -6,7 +6,7 @@ import { getAddress } from 'viem';
 export function rankBuilder(): IBuilder<Rank> {
   return new Builder<Rank>()
     .with('holder', getAddress(faker.finance.ethereumAddress()))
-    .with('position', faker.string.numeric())
+    .with('position', faker.number.int())
     .with('lockedAmount', faker.string.numeric())
     .with('unlockedAmount', faker.string.numeric())
     .with('withdrawnAmount', faker.string.numeric());

--- a/src/domain/locking/entities/schemas/__tests__/rank.schema.spec.ts
+++ b/src/domain/locking/entities/schemas/__tests__/rank.schema.spec.ts
@@ -42,7 +42,7 @@ describe('RankSchema', () => {
         },
         {
           code: 'invalid_type',
-          expected: 'string',
+          expected: 'number',
           received: 'undefined',
           path: ['position'],
           message: 'Required',

--- a/src/domain/locking/entities/schemas/rank.schema.ts
+++ b/src/domain/locking/entities/schemas/rank.schema.ts
@@ -5,7 +5,7 @@ import { NumericStringSchema } from '@/validation/entities/schemas/numeric-strin
 
 export const RankSchema = z.object({
   holder: AddressSchema,
-  position: NumericStringSchema,
+  position: z.number(),
   lockedAmount: NumericStringSchema,
   unlockedAmount: NumericStringSchema,
   withdrawnAmount: NumericStringSchema,

--- a/src/routes/locking/entities/rank.entity.ts
+++ b/src/routes/locking/entities/rank.entity.ts
@@ -5,7 +5,7 @@ export class Rank implements DomainRank {
   @ApiProperty()
   holder!: `0x${string}`;
   @ApiProperty()
-  position!: string;
+  position!: number;
   @ApiProperty()
   lockedAmount!: string;
   @ApiProperty()


### PR DESCRIPTION
## Summary

This changes the type and validation of `Rank['position']` from a numeric string to a number.

## Changes

- Change `position` validation in `RankSchema`
- Propagate type changes upwards and across tests