### PR TITLE
Change rank route

### DIFF
--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -85,7 +85,7 @@ describe('Locking (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/${rank.holder}`)
+        .get(`/v1/locking/leaderboard/rank/${rank.holder}`)
         .expect(200)
         .expect(rank);
     });
@@ -94,7 +94,7 @@ describe('Locking (Unit)', () => {
       const safeAddress = faker.string.alphanumeric();
 
       await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/${safeAddress}`)
+        .get(`/v1/locking/leaderboard/rank/${safeAddress}`)
         .expect(422)
         .expect({
           statusCode: 422,
@@ -117,7 +117,7 @@ describe('Locking (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/${safeAddress}`)
+        .get(`/v1/locking/leaderboard/rank/${safeAddress}`)
         .expect(500)
         .expect({
           statusCode: 500,
@@ -149,7 +149,7 @@ describe('Locking (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/${safeAddress}`)
+        .get(`/v1/locking/leaderboard/rank/${safeAddress}`)
         .expect(statusCode)
         .expect({
           message: errorMessage,

--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -19,7 +19,7 @@ export class LockingController {
   constructor(private readonly lockingService: LockingService) {}
 
   @ApiOkResponse({ type: Rank })
-  @Get('/leaderboard/:safeAddress')
+  @Get('/leaderboard/rank/:safeAddress')
   async getRank(
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: `0x${string}`,


### PR DESCRIPTION
## Summary

This changes the locking rank route from `/leaderboard/:safeAddress` to `/leaderboard/rank/:safeAddress`.

## Motivation

If we want to extend `/leaderboard/*`, it would currently not be possible.
