### PR TITLE
Add Swap Order UID to SwapOrderTransactionInfo

### DIFF
--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -36,6 +36,9 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
   @ApiProperty({ enum: [TransactionInfoType.SwapOrder] })
   override type: TransactionInfoType.SwapOrder;
 
+  @ApiProperty({ description: 'The order UID' })
+  orderUid: string;
+
   @ApiProperty({ enum: ['open', 'fulfilled', 'cancelled', 'expired'] })
   status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
 
@@ -58,6 +61,7 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
   filledPercentage: string;
 
   protected constructor(args: {
+    orderUid: string;
     status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
     orderKind: 'buy' | 'sell';
     sellToken: TokenInfo;
@@ -66,6 +70,7 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
     filledPercentage: string;
   }) {
     super(TransactionInfoType.SwapOrder, null, null);
+    this.orderUid = args.orderUid;
     this.type = TransactionInfoType.SwapOrder;
     this.status = args.status;
     this.orderKind = args.orderKind;
@@ -96,6 +101,7 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
   executionPriceLabel: string;
 
   constructor(args: {
+    orderUid: string;
     orderKind: 'buy' | 'sell';
     sellToken: TokenInfo;
     buyToken: TokenInfo;
@@ -123,6 +129,7 @@ export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
   limitPriceLabel: string;
 
   constructor(args: {
+    orderUid: string;
     status: 'open' | 'cancelled' | 'expired';
     orderKind: 'buy' | 'sell';
     sellToken: TokenInfo;

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -93,6 +93,7 @@ describe('Swap Order Mapper tests', () => {
     expect(result).toBeInstanceOf(FulfilledSwapOrderTransactionInfo);
     expect(result).toEqual({
       type: 'SwapOrder',
+      orderUid: order.uid,
       status: 'fulfilled',
       orderKind: order.kind,
       sellToken: {
@@ -145,6 +146,7 @@ describe('Swap Order Mapper tests', () => {
       expect(result).toBeInstanceOf(DefaultSwapOrderTransactionInfo);
       expect(result).toEqual({
         type: 'SwapOrder',
+        orderUid: order.uid,
         status: order.status,
         orderKind: order.kind,
         sellToken: {

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -208,6 +208,7 @@ export class SwapOrderMapper {
       : null;
 
     return new FulfilledSwapOrderTransactionInfo({
+      orderUid: args.order.uid,
       orderKind: args.order.kind,
       sellToken: args.sellToken.toTokenInfo(),
       buyToken: args.buyToken.toTokenInfo(),
@@ -246,6 +247,7 @@ export class SwapOrderMapper {
         `${args.order.status} orders should not be mapped as default orders. Order UID = ${args.order.uid}`,
       );
     return new DefaultSwapOrderTransactionInfo({
+      orderUid: args.order.uid,
       status: args.order.status,
       orderKind: args.order.kind,
       sellToken: args.sellToken.toTokenInfo(),


### PR DESCRIPTION
`SwapOrderTransactionInfo` now contains the respective `orderUid` (required field).
