### PR TITLE
Add Explorer URI for Order

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -224,5 +224,6 @@ export default (): ReturnType<typeof configuration> => ({
       100: faker.internet.url(),
       11155111: faker.internet.url(),
     },
+    explorerBaseUri: faker.internet.url(),
   },
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -235,5 +235,7 @@ export default () => ({
       100: 'https://api.cow.fi/xdai',
       11155111: 'https://api.cow.fi/sepolia',
     },
+    explorerBaseUri:
+      process.env.SWAPS_EXPLORER_URI || 'https://explorer.cow.fi/',
   },
 });

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -60,6 +60,9 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
   })
   filledPercentage: string;
 
+  @ApiProperty({ description: 'The URL to the explorer page of the order' })
+  explorerUrl: URL;
+
   protected constructor(args: {
     orderUid: string;
     status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
@@ -68,6 +71,7 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
     buyToken: TokenInfo;
     expiresTimestamp: number;
     filledPercentage: string;
+    explorerUrl: URL;
   }) {
     super(TransactionInfoType.SwapOrder, null, null);
     this.orderUid = args.orderUid;
@@ -78,6 +82,7 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
     this.buyToken = args.buyToken;
     this.expiresTimestamp = args.expiresTimestamp;
     this.filledPercentage = args.filledPercentage;
+    this.explorerUrl = args.explorerUrl;
   }
 }
 
@@ -109,6 +114,7 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
     surplusFeeLabel: string | null;
     executionPriceLabel: string;
     filledPercentage: string;
+    explorerUrl: URL;
   }) {
     super({ ...args, status: 'fulfilled' });
     this.status = 'fulfilled';
@@ -137,6 +143,7 @@ export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
     expiresTimestamp: number;
     limitPriceLabel: string;
     filledPercentage: string;
+    explorerUrl: URL;
   }) {
     super(args);
     this.status = args.status;


### PR DESCRIPTION
- Each decoded order now has a url, `explorerUrl`, which leads to the Swap Order Explorer web page.
- The base URL can be configured via `SWAPS_EXPLORER_URI`. The default value is `https://explorer.cow.fi/`.

Note: The `https://explorer.cow.fi/orders/<id>` is chain agnostic i.e.: given an Order UID, there's a redirection from that order id page to the chain one (e.g.: `/sepolia/orders/<id>`).
