### PR TITLE
Add support for decoding Swap Orders in Multisends

### DIFF
--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -1,7 +1,6 @@
 import { SwapOrderMapper } from '@/routes/transactions/mappers/common/swap-order.mapper';
 import { SwapsRepository } from '@/domain/swaps/swaps.repository';
 import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
-import { CustomTransactionMapper } from '@/routes/transactions/mappers/common/custom-transaction.mapper';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import { faker } from '@faker-js/faker';
 import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
@@ -12,9 +11,6 @@ import {
   FulfilledSwapOrderTransactionInfo,
 } from '@/routes/transactions/entities/swap-order-info.entity';
 import { getAddress } from 'viem';
-import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
-import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { ILoggingService } from '@/logging/logging.interface';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 
 const swapsRepository = {
@@ -32,17 +28,6 @@ const tokenRepository = {
 } as jest.MockedObjectDeep<ITokenRepository>;
 
 const tokenRepositoryMock = jest.mocked(tokenRepository);
-
-const customTransactionMapper = {
-  mapCustomTransaction: jest.fn(),
-} as jest.MockedObjectDeep<CustomTransactionMapper>;
-
-const customTransactionMapperMock = jest.mocked(customTransactionMapper);
-
-const loggingService = {
-  warn: jest.fn(),
-} as jest.MockedObjectDeep<ILoggingService>;
-const loggingServiceMock = jest.mocked(loggingService);
 
 const configurationService = {
   getOrThrow: jest.fn(),
@@ -67,8 +52,6 @@ describe('Swap Order Mapper tests', () => {
       swapsRepositoryMock,
       setPreSignatureDecoderMock,
       tokenRepositoryMock,
-      customTransactionMapperMock,
-      loggingServiceMock,
       configurationServiceMock,
     );
   });
@@ -94,7 +77,9 @@ describe('Swap Order Mapper tests', () => {
       return Promise.reject(new Error(`Token ${address} not found.`));
     });
 
-    const result = await target.mapSwapOrder(chainId, transaction, 0);
+    const result = await target.mapSwapOrder(chainId, {
+      data: transaction.data as `0x${string}`,
+    });
 
     const surplus = asDecimal(order.executedSurplusFee!, buyToken.decimals!);
     const expectedSurplus = `${surplus} ${buyToken.symbol}`;
@@ -150,7 +135,9 @@ describe('Swap Order Mapper tests', () => {
         return Promise.reject(new Error(`Token ${address} not found.`));
       });
 
-      const result = await target.mapSwapOrder(chainId, transaction, 0);
+      const result = await target.mapSwapOrder(chainId, {
+        data: transaction.data as `0x${string}`,
+      });
 
       const ratio =
         asDecimal(order.sellAmount, sellToken.decimals!) /
@@ -182,32 +169,20 @@ describe('Swap Order Mapper tests', () => {
     },
   );
 
-  it(`should map to custom order if getOrder throws an error`, async () => {
+  it(`should throw if getOrder throws an error`, async () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder().build();
-    const dataSize = 0;
     const orderUid = faker.string.hexadecimal({ length: 112 }) as `0x${string}`;
     setPreSignatureDecoderMock.getOrderUid.mockReturnValue(orderUid);
-    swapsRepositoryMock.getOrder.mockRejectedValue(
-      new Error('Order not found'),
-    );
-    const customTransaction = new CustomTransactionInfo(
-      new AddressInfo(faker.finance.ethereumAddress()),
-      dataSize.toString(),
-      transaction.value,
-      null,
-      null,
-      false,
-      null,
-      null,
-    );
-    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
-      customTransaction,
-    );
+    const error = new Error('Order not found');
+    swapsRepositoryMock.getOrder.mockRejectedValue(error);
 
-    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+    await expect(
+      target.mapSwapOrder(chainId, {
+        data: transaction.data as `0x${string}`,
+      }),
+    ).rejects.toThrow(error);
 
-    expect(result).toBe(customTransaction);
     expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
     expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
       transaction.data,
@@ -217,110 +192,44 @@ describe('Swap Order Mapper tests', () => {
       chainId,
       expect.any(String),
     );
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledTimes(1);
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
   });
 
-  it('should map to custom order if transaction data is null', async () => {
-    const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder().with('data', null).build();
-    const dataSize = 0;
-    const customTransaction = new CustomTransactionInfo(
-      new AddressInfo(faker.finance.ethereumAddress()),
-      dataSize.toString(),
-      transaction.value,
-      null,
-      null,
-      false,
-      null,
-      null,
-    );
-    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
-      customTransaction,
-    );
-
-    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
-
-    expect(result).toBe(customTransaction);
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledTimes(1);
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
-    expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(0);
-    expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(0);
-  });
-
-  it(`should map to custom transaction if order id is null`, async () => {
+  it(`should throw if order id is null`, async () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder().build();
-    const dataSize = 0;
     setPreSignatureDecoderMock.getOrderUid.mockReturnValue(null);
-    const customTransaction = new CustomTransactionInfo(
-      new AddressInfo(faker.finance.ethereumAddress()),
-      dataSize.toString(),
-      transaction.value,
-      null,
-      null,
-      false,
-      null,
-      null,
-    );
-    setPreSignatureDecoderMock.getOrderUid.mockReturnValue(null);
-    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
-      customTransaction,
-    );
 
-    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+    await expect(
+      target.mapSwapOrder(chainId, {
+        data: transaction.data as `0x${string}`,
+      }),
+    ).rejects.toThrow('Order UID not found in transaction data');
 
-    expect(result).toBe(customTransaction);
     expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
     expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
       transaction.data,
     );
     expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(0);
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledTimes(1);
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
   });
 
-  it('should map to custom transaction if token data is not available', async () => {
+  it('should throw if token data is not available', async () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder().build();
-    const dataSize = 0;
     const order = orderBuilder().build();
     setPreSignatureDecoderMock.getOrderUid.mockReturnValue(
       order.uid as `0x${string}`,
-    );
-    const customTransaction = new CustomTransactionInfo(
-      new AddressInfo(faker.finance.ethereumAddress()),
-      dataSize.toString(),
-      transaction.value,
-      null,
-      null,
-      false,
-      null,
-      null,
-    );
-    customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
-      customTransaction,
     );
     tokenRepositoryMock.getToken.mockRejectedValue(
       new Error('Token not found'),
     );
     swapsRepositoryMock.getOrder.mockResolvedValue(order);
 
-    const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+    await expect(
+      target.mapSwapOrder(chainId, {
+        data: transaction.data as `0x${string}`,
+      }),
+    ).rejects.toThrow('Token not found');
 
-    expect(result).toBe(customTransaction);
     expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
     expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
       transaction.data,
@@ -330,20 +239,13 @@ describe('Swap Order Mapper tests', () => {
       chainId,
       order.uid,
     );
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledTimes(1);
-    expect(
-      customTransactionMapperMock.mapCustomTransaction,
-    ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
   });
 
   it.each(['fulfilled', 'open', 'cancelled', 'expired'])(
-    'should map to custom transaction if order kind is unknown',
+    'should throw if %s order kind is unknown',
     async (status) => {
       const chainId = faker.string.numeric();
       const transaction = multisigTransactionBuilder().build();
-      const dataSize = 0;
       const buyToken = tokenBuilder().with('decimals', 0).build();
       const sellToken = tokenBuilder().build();
       const order = orderBuilder()
@@ -364,23 +266,13 @@ describe('Swap Order Mapper tests', () => {
         if (address === order.sellToken) return Promise.resolve(sellToken);
         return Promise.reject(new Error(`Token ${address} not found.`));
       });
-      const customTransaction = new CustomTransactionInfo(
-        new AddressInfo(faker.finance.ethereumAddress()),
-        dataSize.toString(),
-        transaction.value,
-        null,
-        null,
-        false,
-        null,
-        null,
-      );
-      customTransactionMapperMock.mapCustomTransaction.mockResolvedValue(
-        customTransaction,
-      );
 
-      const result = await target.mapSwapOrder(chainId, transaction, dataSize);
+      await expect(
+        target.mapSwapOrder(chainId, {
+          data: transaction.data as `0x${string}`,
+        }),
+      ).rejects.toThrow('Unknown order kind');
 
-      expect(result).toBe(customTransaction);
       expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledTimes(1);
       expect(setPreSignatureDecoderMock.getOrderUid).toHaveBeenCalledWith(
         transaction.data,
@@ -390,12 +282,6 @@ describe('Swap Order Mapper tests', () => {
         chainId,
         order.uid,
       );
-      expect(
-        customTransactionMapperMock.mapCustomTransaction,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        customTransactionMapperMock.mapCustomTransaction,
-      ).toHaveBeenCalledWith(transaction, dataSize, chainId, null, null);
     },
   );
 
@@ -442,7 +328,9 @@ describe('Swap Order Mapper tests', () => {
         return Promise.reject(new Error(`Token ${address} not found.`));
       });
 
-      const result = await target.mapSwapOrder(chainId, transaction, 0);
+      const result = await target.mapSwapOrder(chainId, {
+        data: transaction.data as `0x${string}`,
+      });
 
       expect(result).toMatchObject({
         filledPercentage: expected,

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -19,6 +19,10 @@ import { NativeCoinTransferMapper } from '@/routes/transactions/mappers/common/n
 import { SettingsChangeMapper } from '@/routes/transactions/mappers/common/settings-change.mapper';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import { SwapOrderMapper } from '@/routes/transactions/mappers/common/swap-order.mapper';
+import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
+import { isHex } from 'viem';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swap-order-info.entity';
 
 @Injectable()
 export class MultisigTransactionInfoMapper {
@@ -43,6 +47,7 @@ export class MultisigTransactionInfoMapper {
     @Inject(ITokenRepository) private readonly tokenRepository: TokenRepository,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
     private readonly dataDecodedParamHelper: DataDecodedParamHelper,
     private readonly customTransactionMapper: CustomTransactionMapper,
     private readonly settingsChangeMapper: SettingsChangeMapper,
@@ -52,6 +57,7 @@ export class MultisigTransactionInfoMapper {
     private readonly humanDescriptionMapper: HumanDescriptionMapper,
     private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
     private readonly swapOrderMapper: SwapOrderMapper,
+    private readonly multisendDecoder: MultiSendDecoder,
   ) {
     this.isRichFragmentsEnabled = this.configurationService.getOrThrow(
       'features.richFragments',
@@ -88,12 +94,11 @@ export class MultisigTransactionInfoMapper {
       ? richDecodedInfo
       : undefined;
 
-    if (this.isSwapsDecodingEnabled && this.isCoWSwapOrder(transaction)) {
-      return await this.swapOrderMapper.mapSwapOrder(
-        chainId,
-        transaction,
-        dataSize,
-      );
+    if (this.isSwapsDecodingEnabled) {
+      const swapOrder: SwapOrderTransactionInfo | null =
+        await this.mapSwapOrder(chainId, transaction);
+      // If the transaction is a swap order, we return it immediately
+      if (swapOrder) return swapOrder;
     }
 
     if (this.isCustomTransaction(value, dataSize, transaction.operation)) {
@@ -180,11 +185,71 @@ export class MultisigTransactionInfoMapper {
     );
   }
 
-  private isCoWSwapOrder(
-    transaction: MultisigTransaction | ModuleTransaction,
-  ): boolean {
+  private isSwapOrder(transaction: { data?: `0x${string}` }): boolean {
     if (!transaction.data) return false;
     return this.setPreSignatureDecoder.isSetPreSignature(transaction.data);
+  }
+
+  /**
+   * Maps a swap order transaction.
+   * If the transaction is not a swap order, it returns null.
+   *
+   * @param chainId
+   * @param transaction
+   * @private
+   */
+  private async mapSwapOrder(
+    chainId: string,
+    transaction: MultisigTransaction | ModuleTransaction,
+  ): Promise<SwapOrderTransactionInfo | null> {
+    if (!transaction?.data || !isHex(transaction.data)) {
+      return null;
+    }
+
+    const orderData: `0x${string}` | null = this.findSwapOrder(
+      transaction.data,
+    );
+
+    if (!orderData) {
+      return null;
+    }
+
+    try {
+      return await this.swapOrderMapper.mapSwapOrder(chainId, {
+        data: orderData,
+      });
+    } catch (error) {
+      // The transaction is a swap order, but we couldn't decode it successfully.
+      this.loggingService.warn(error);
+      return null;
+    }
+  }
+
+  /**
+   * Finds the swap order in the transaction data.
+   * The swap order can be in the transaction data directly or in the data of a Multisend transaction.
+   *
+   * @param data - The transaction data
+   * @private
+   * @returns The swap order if found, otherwise null
+   */
+  private findSwapOrder(data: `0x${string}`): `0x${string}` | null {
+    // The swap order can be in the transaction data directly
+    if (this.isSwapOrder({ data })) {
+      return data;
+    }
+    // or in the data of a multisend transaction
+    if (this.multisendDecoder.helpers.isMultiSend(data)) {
+      const transactions = this.multisendDecoder.mapMultiSendTransactions(data);
+      // TODO If we can build a sorted hash map of the transactions, we can avoid iterating all of them
+      //  as we know the pattern of a Swap Order.
+      for (const transaction of transactions) {
+        if (this.isSwapOrder(transaction)) {
+          return transaction.data;
+        }
+      }
+    }
+    return null;
   }
 
   private isCustomTransaction(

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -57,7 +57,7 @@ export class MultisigTransactionInfoMapper {
     private readonly humanDescriptionMapper: HumanDescriptionMapper,
     private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
     private readonly swapOrderMapper: SwapOrderMapper,
-    private readonly multisendDecoder: MultiSendDecoder,
+    private readonly multiSendDecoder: MultiSendDecoder,
   ) {
     this.isRichFragmentsEnabled = this.configurationService.getOrThrow(
       'features.richFragments',
@@ -239,8 +239,8 @@ export class MultisigTransactionInfoMapper {
       return data;
     }
     // or in the data of a multisend transaction
-    if (this.multisendDecoder.helpers.isMultiSend(data)) {
-      const transactions = this.multisendDecoder.mapMultiSendTransactions(data);
+    if (this.multiSendDecoder.helpers.isMultiSend(data)) {
+      const transactions = this.multiSendDecoder.mapMultiSendTransactions(data);
       // TODO If we can build a sorted hash map of the transactions, we can avoid iterating all of them
       //  as we know the pattern of a Swap Order.
       for (const transaction of transactions) {

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -30,6 +30,7 @@ import { TransactionsController } from '@/routes/transactions/transactions.contr
 import { TransactionsService } from '@/routes/transactions/transactions.service';
 import { SwapOrderMapperModule } from '@/routes/transactions/mappers/common/swap-order.mapper';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
 
 @Module({
   controllers: [TransactionsController],
@@ -44,6 +45,7 @@ import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pr
     ModuleTransactionDetailsMapper,
     ModuleTransactionMapper,
     ModuleTransactionStatusMapper,
+    MultiSendDecoder,
     MultisigTransactionDetailsMapper,
     MultisigTransactionExecutionDetailsMapper,
     MultisigTransactionExecutionInfoMapper,


### PR DESCRIPTION
- Swap Orders inside a Multisend should be decoded in the same way as regular ones.
- Detection of a Multisend order happens on the first level of transactions (i.e. it does not detect Swap transactions if a Multisend contains another Multisend).
- The `mapSwapOrder` function also changed:
  * It is no longer restricted to a `MultisigTransaction` or `ModuleTransaction` – this was done to support nested transactions which do not have all the properties of a Multisig or Module transactions.
  * It no longer maps to a `CustomTransactionInfo` – this is now a decision left for the callers. Instead, the promise is rejected if the swap transaction couldn't be decoded successfully.
