### PR TITLE
Add `AuthApiModule` datasource

### DIFF
--- a/src/datasources/auth-api/auth-api.module.ts
+++ b/src/datasources/auth-api/auth-api.module.ts
@@ -1,0 +1,9 @@
+import { SiweApi } from '@/datasources/auth-api/siwe-api.service';
+import { IAuthApi } from '@/domain/interfaces/auth-api.interface';
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [{ provide: IAuthApi, useClass: SiweApi }],
+  exports: [IAuthApi],
+})
+export class AuthApiModule {}

--- a/src/datasources/auth-api/siwe-api.service.spec.ts
+++ b/src/datasources/auth-api/siwe-api.service.spec.ts
@@ -1,0 +1,61 @@
+import { SiweApi } from '@/datasources/auth-api/siwe-api.service';
+import { toSignableSiweMessage } from '@/datasources/auth-api/utils/to-signable-siwe-message';
+import { siweMessageBuilder } from '@/domain/auth/entities/__tests__/siwe-message.builder';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+
+const mockLoggingService = {
+  debug: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+describe('SiweApiService', () => {
+  let service: SiweApi;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    service = new SiweApi(mockLoggingService);
+  });
+
+  describe('generateNonce', () => {
+    it('should return an alphanumeric string of at least 8 characters', () => {
+      const nonce = service.generateNonce();
+      expect(nonce).toMatch(/^[a-zA-Z0-9]{8,}$/);
+    });
+  });
+
+  describe('verifyMessage', () => {
+    it('should return true if the message is verified', async () => {
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const message = siweMessageBuilder()
+        .with('address', signer.address)
+        .build();
+      const signature = await signer.signMessage({
+        message: toSignableSiweMessage(message),
+      });
+
+      await expect(
+        service.verifyMessage({
+          message,
+          signature,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it('should return false if the message is not verified', async () => {
+      const message = siweMessageBuilder().build();
+      const signature = faker.string.hexadecimal({
+        length: 132,
+      }) as `0x${string}`;
+
+      await expect(
+        service.verifyMessage({
+          message,
+          signature,
+        }),
+      ).resolves.toBe(false);
+    });
+  });
+});

--- a/src/datasources/auth-api/siwe-api.service.ts
+++ b/src/datasources/auth-api/siwe-api.service.ts
@@ -1,0 +1,43 @@
+import { toSignableSiweMessage } from '@/datasources/auth-api/utils/to-signable-siwe-message';
+import { SiweMessage } from '@/domain/auth/entities/siwe-message.entity';
+import { IAuthApi } from '@/domain/interfaces/auth-api.interface';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
+import { Inject, Injectable } from '@nestjs/common';
+import { verifyMessage } from 'viem';
+
+@Injectable()
+export class SiweApi implements IAuthApi {
+  constructor(
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
+  ) {}
+
+  /**
+   * Returns a string-based nonce of at least 8 alphanumeric characters
+   * according to the EIP-4361 (SiWe) standard.
+   *
+   * @see https://eips.ethereum.org/EIPS/eip-4361#message-fields
+   */
+  generateNonce(): string {
+    return crypto.randomUUID().replace(/-/g, '');
+  }
+
+  async verifyMessage(args: {
+    message: SiweMessage;
+    signature: `0x${string}`;
+  }): Promise<boolean> {
+    const message = toSignableSiweMessage(args.message);
+    try {
+      return await verifyMessage({
+        address: args.message.address,
+        message,
+        signature: args.signature,
+      });
+    } catch (e) {
+      this.loggingService.debug(
+        `Failed to verify SiWe message. message=${message}, error=${e}`,
+      );
+      return false;
+    }
+  }
+}

--- a/src/datasources/auth-api/utils/__tests__/to-signable-siwe-message.spec.ts
+++ b/src/datasources/auth-api/utils/__tests__/to-signable-siwe-message.spec.ts
@@ -1,0 +1,328 @@
+import { toSignableSiweMessage } from '@/datasources/auth-api/utils/to-signable-siwe-message';
+import { siweMessageBuilder } from '@/domain/auth/entities/__tests__/siwe-message.builder';
+import { faker } from '@faker-js/faker';
+
+describe('toSignableSiweMessage', () => {
+  it('should return a signable message with all fields', () => {
+    const message = siweMessageBuilder()
+      .with('resources', [
+        faker.internet.url(),
+        faker.internet.url(),
+        faker.internet.url(),
+      ])
+      .build();
+
+    const result = toSignableSiweMessage(message);
+
+    // Origin is built correctly from scheme and domain
+    expect(result)
+      .toBe(`${message.scheme}://${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+
+${message.statement}
+
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}
+Expiration Time: ${message.expirationTime}
+Not Before: ${message.notBefore}
+Request ID: ${message.requestId}
+Resources:
+- ${message.resources![0]}
+- ${message.resources![1]}
+- ${message.resources![2]}`);
+  });
+
+  describe('statement', () => {
+    it('should add a new line before and after the statement', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', faker.lorem.sentence())
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+
+${message.statement}
+
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+
+    it('should not add an empty statement', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', '')
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+  });
+
+  describe('expirationTime', () => {
+    it('should add the expirationTime if present', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', faker.date.recent().toISOString())
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}
+Expiration Time: ${message.expirationTime}`);
+    });
+
+    it('should not add an empty expirationTime', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', '')
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+  });
+
+  describe('notBefore', () => {
+    it('should add the notBefore time if present', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', faker.date.recent().toISOString())
+        .with('requestId', undefined)
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}
+Not Before: ${message.notBefore}`);
+    });
+
+    it('should not add an empty notBefore', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', '')
+        .with('requestId', undefined)
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+  });
+
+  describe('requestId', () => {
+    it('should add the requestId if present', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', faker.string.uuid())
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}
+Request ID: ${message.requestId}`);
+    });
+
+    it('should not add an empty requestId', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', '')
+        .with('resources', undefined)
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+  });
+
+  describe('resources', () => {
+    it('should add each resource on a new line if present', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', [
+          faker.internet.url(),
+          faker.internet.url(),
+          faker.internet.url(),
+        ])
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}
+Resources:
+- ${message.resources![0]}
+- ${message.resources![1]}
+- ${message.resources![2]}`);
+    });
+
+    it('should not add empty resources', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', [])
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+
+    it('should filter empty resources', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', [''])
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}`);
+    });
+
+    it('should filter empty resources', () => {
+      const message = siweMessageBuilder()
+        .with('scheme', undefined)
+        .with('statement', undefined)
+        .with('expirationTime', undefined)
+        .with('notBefore', undefined)
+        .with('requestId', undefined)
+        .with('resources', [faker.internet.url(), '', faker.internet.url()])
+        .build();
+
+      const result = toSignableSiweMessage(message);
+
+      expect(result)
+        .toBe(`${message.domain} wants you to sign in with your Ethereum account:
+${message.address}
+URI: ${message.uri}
+Version: ${message.version}
+Chain ID: ${message.chainId}
+Nonce: ${message.nonce}
+Issued At: ${message.issuedAt}
+Resources:
+- ${message.resources![0]}
+- ${message.resources![2]}`);
+    });
+  });
+});

--- a/src/datasources/auth-api/utils/to-signable-siwe-message.ts
+++ b/src/datasources/auth-api/utils/to-signable-siwe-message.ts
@@ -1,0 +1,53 @@
+import { SiweMessage } from '@/domain/auth/entities/siwe-message.entity';
+
+/**
+ * The following adheres to the EIP-4361 (SiWe) standard
+ * {@link https://eips.ethereum.org/EIPS/eip-4361}
+ */
+export function toSignableSiweMessage(message: SiweMessage): string {
+  const lines = [];
+
+  const origin = message.scheme
+    ? `${message.scheme}://${message.domain}`
+    : message.domain;
+
+  lines.push(
+    `${origin} wants you to sign in with your Ethereum account:`,
+    message.address,
+  );
+
+  if (message.statement) {
+    // Ensure new line above and below statement
+    lines.push('', message.statement, '');
+  }
+
+  lines.push(
+    `URI: ${message.uri}`,
+    `Version: ${message.version}`,
+    `Chain ID: ${message.chainId}`,
+    `Nonce: ${message.nonce}`,
+    `Issued At: ${message.issuedAt}`,
+  );
+
+  if (message.expirationTime) {
+    lines.push(`Expiration Time: ${message.expirationTime}`);
+  }
+
+  if (message.notBefore) {
+    lines.push(`Not Before: ${message.notBefore}`);
+  }
+
+  if (message.requestId) {
+    lines.push(`Request ID: ${message.requestId}`);
+  }
+
+  if (Array.isArray(message.resources) && message.resources.length > 0) {
+    const resources = message.resources.filter(Boolean);
+
+    if (resources.length > 0) {
+      lines.push('Resources:', ...resources.map((resource) => `- ${resource}`));
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/domain/auth/entities/__tests__/siwe-message.builder.ts
+++ b/src/domain/auth/entities/__tests__/siwe-message.builder.ts
@@ -1,0 +1,26 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { SiweMessage } from '@/domain/auth/entities/siwe-message.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+export function siweMessageBuilder(): IBuilder<SiweMessage> {
+  return new Builder<SiweMessage>()
+    .with('scheme', faker.internet.protocol())
+    .with('domain', faker.internet.domainName())
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('statement', faker.lorem.sentence())
+    .with('uri', faker.internet.url({ appendSlash: false }))
+    .with('version', '1')
+    .with('chainId', faker.number.int({ min: 1 }))
+    .with('nonce', faker.string.alphanumeric({ length: 8 }))
+    .with('issuedAt', faker.date.recent().toISOString())
+    .with('expirationTime', faker.date.future().toISOString())
+    .with('notBefore', faker.date.past().toISOString())
+    .with('requestId', faker.string.uuid())
+    .with(
+      'resources',
+      Array.from({ length: faker.number.int({ min: 1, max: 5 }) }, () =>
+        faker.internet.url({ appendSlash: false }),
+      ),
+    );
+}

--- a/src/domain/auth/entities/siwe-message.entity.ts
+++ b/src/domain/auth/entities/siwe-message.entity.ts
@@ -1,0 +1,16 @@
+// TODO: Infer from forthcoming Zod schema
+export type SiweMessage = {
+  scheme: 'http' | 'https' | undefined;
+  domain: string;
+  address: `0x${string}`;
+  statement: string | undefined;
+  uri: string;
+  version: '1';
+  chainId: number;
+  nonce: string;
+  issuedAt: string;
+  expirationTime: string | undefined;
+  notBefore: string | undefined;
+  requestId: string | undefined;
+  resources: Array<string> | undefined;
+};

--- a/src/domain/interfaces/auth-api.interface.ts
+++ b/src/domain/interfaces/auth-api.interface.ts
@@ -1,0 +1,13 @@
+import { SiweMessage } from '@/domain/auth/entities/siwe-message.entity';
+
+export const IAuthApi = Symbol('IAuthApi');
+
+export interface IAuthApi {
+  generateNonce(): string;
+
+  verifyMessage(args: {
+    address: `0x${string}`;
+    message: SiweMessage;
+    signature: `0x${string}`;
+  }): Promise<boolean>;
+}


### PR DESCRIPTION
## Summary

This adds the `AuthApiModule` datasource as part of a test implementation for SiWe authentication, breaking down https://github.com/safe-global/safe-client-gateway/pull/1321 for review.

It assumes the [EIP-4361 (SiWe) standard](https://eips.ethereum.org/EIPS/eip-4361) for authentication. Relative type names are therefore explicit.

Note: a proprietary implementation was chosen for SiWe message parsing as it reduces the necessity for the `siwe-parser` package. Said package is also reliant on `ethers`, which we do not use in the project.

## Changes

- Add `AuthApiModule`/`SiweApiService`, adhering to `IAuthApi`:
  - `generateNonce` returns an alphanumic nonce of at least 8 characters.
  -  `verifyMessage` accepts and validates a signed SiWe-standard message
- `toSignableSiwMessage` converts an object-based SiWe message to a standard-adherent string that would've been signed.
- Appropriate test coverage for the above.