### PR TITLE
Make ConfigApiModule non-global

### DIFF
--- a/src/datasources/balances-api/balances-api.module.ts
+++ b/src/datasources/balances-api/balances-api.module.ts
@@ -9,9 +9,10 @@ import {
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { CoingeckoApi } from '@/datasources/balances-api/coingecko-api.service';
 import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
+import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 
 @Module({
-  imports: [CacheFirstDataSourceModule],
+  imports: [CacheFirstDataSourceModule, ConfigApiModule],
   providers: [
     HttpErrorFactory,
     { provide: IBalancesApiManager, useClass: BalancesApiManager },

--- a/src/datasources/config-api/config-api.module.ts
+++ b/src/datasources/config-api/config-api.module.ts
@@ -1,10 +1,9 @@
-import { Global, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { ConfigApi } from '@/datasources/config-api/config-api.service';
 import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data.source.module';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 
-@Global()
 @Module({
   imports: [CacheFirstDataSourceModule],
   providers: [HttpErrorFactory, { provide: IConfigApi, useClass: ConfigApi }],

--- a/src/datasources/transaction-api/transaction-api.module.ts
+++ b/src/datasources/transaction-api/transaction-api.module.ts
@@ -3,10 +3,11 @@ import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { TransactionApiManager } from '@/datasources/transaction-api/transaction-api.manager';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 
 @Global()
 @Module({
-  imports: [CacheFirstDataSourceModule],
+  imports: [CacheFirstDataSourceModule, ConfigApiModule],
   providers: [
     HttpErrorFactory,
     { provide: ITransactionApiManager, useClass: TransactionApiManager },


### PR DESCRIPTION
- The `ConfigApiModule` was made Global to facilitate overriding this module in the tests (with a fake one).
- Since NestJS now provides the ability to override modules based on the respective token, we should require the respective dependants to declare the need for it (increasing encapsulation).