### PR TITLE
Make TransactionApiModule non-global

### DIFF
--- a/src/datasources/transaction-api/transaction-api.module.ts
+++ b/src/datasources/transaction-api/transaction-api.module.ts
@@ -1,11 +1,10 @@
-import { Global, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data.source.module';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { TransactionApiManager } from '@/datasources/transaction-api/transaction-api.manager';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 
-@Global()
 @Module({
   imports: [CacheFirstDataSourceModule, ConfigApiModule],
   providers: [


### PR DESCRIPTION
Depends on #1365

- The `TransactionApiModule` was made Global to facilitate overriding this module in the tests (with a fake one).
- Since NestJS now provides the ability to override modules based on the respective token, we should require the respective dependants to declare the need for it (increasing encapsulation).
