### PR TITLE
Extract schema validation logic

### DIFF
--- a/src/config/configuration.module.ts
+++ b/src/config/configuration.module.ts
@@ -2,8 +2,9 @@ import { DynamicModule, Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ConfigFactory } from '@nestjs/config/dist/interfaces/config-factory.interface';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { validate } from '@/config/configuration.validator';
 import { NestConfigurationService } from '@/config/nest.configuration.service';
+import { z } from 'zod';
+import configurationValidator from '@/config/configuration.validator';
 
 /**
  * A {@link Global} Module which provides local configuration support via {@link IConfigurationService}
@@ -20,7 +21,9 @@ export class ConfigurationModule {
       module: ConfigurationModule,
       imports: [
         ConfigModule.forRoot({
-          validate,
+          validate: (config: Record<string, unknown>) => {
+            return configurationValidator(config, RootConfigurationSchema);
+          },
           load: [configFactory],
         }),
       ],
@@ -31,3 +34,22 @@ export class ConfigurationModule {
     };
   }
 }
+
+export const RootConfigurationSchema = z.object({
+  AUTH_TOKEN: z.string(),
+  LOG_LEVEL: z
+    .enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'])
+    .optional(),
+  ALERTS_PROVIDER_SIGNING_KEY: z.string(),
+  ALERTS_PROVIDER_API_KEY: z.string(),
+  ALERTS_PROVIDER_ACCOUNT: z.string(),
+  ALERTS_PROVIDER_PROJECT: z.string(),
+  EMAIL_API_APPLICATION_CODE: z.string(),
+  EMAIL_API_FROM_EMAIL: z.string().email(),
+  EMAIL_API_KEY: z.string(),
+  EMAIL_TEMPLATE_RECOVERY_TX: z.string(),
+  EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: z.string(),
+  EMAIL_TEMPLATE_VERIFICATION_CODE: z.string(),
+  RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: z.string(),
+  RELAY_PROVIDER_API_KEY_SEPOLIA: z.string(),
+});

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -1,7 +1,8 @@
 import { faker } from '@faker-js/faker';
 import { fakeJson } from '@/__tests__/faker';
-import { validate } from '@/config/configuration.validator';
 import { omit } from 'lodash';
+import configurationValidator from '@/config/configuration.validator';
+import { RootConfigurationSchema } from '@/config/configuration.module';
 
 describe('Configuration validator', () => {
   const validConfiguration = {
@@ -24,13 +25,16 @@ describe('Configuration validator', () => {
   it('should bypass this validation on test environment', () => {
     process.env.NODE_ENV = 'test';
     const expected = JSON.parse(fakeJson());
-    const validated = validate(expected);
+    const validated = configurationValidator(expected, RootConfigurationSchema);
     expect(validated).toBe(expected);
   });
 
   it('should return the input configuration if validated in production environment', () => {
     process.env.NODE_ENV = 'production';
-    const validated = validate(validConfiguration);
+    const validated = configurationValidator(
+      validConfiguration,
+      RootConfigurationSchema,
+    );
     expect(validated).toBe(validConfiguration);
   });
 
@@ -52,32 +56,38 @@ describe('Configuration validator', () => {
     'should detect that $key is missing in the configuration in production environment',
     ({ key }) => {
       process.env.NODE_ENV = 'production';
-      expect(() => validate(omit(validConfiguration, key))).toThrow(
-        `Configuration is invalid: ${key} Required`,
-      );
+      expect(() =>
+        configurationValidator(
+          omit(validConfiguration, key),
+          RootConfigurationSchema,
+        ),
+      ).toThrow(`Configuration is invalid: ${key} Required`);
     },
   );
 
   it('should an invalid LOG_LEVEL configuration in production environment', () => {
     process.env.NODE_ENV = 'production';
     expect(() =>
-      validate({
-        ...JSON.parse(fakeJson()),
-        AUTH_TOKEN: faker.string.uuid(),
-        LOG_LEVEL: faker.word.words(),
-        ALERTS_PROVIDER_SIGNING_KEY: faker.string.uuid(),
-        ALERTS_PROVIDER_API_KEY: faker.string.uuid(),
-        ALERTS_PROVIDER_ACCOUNT: faker.string.alphanumeric(),
-        ALERTS_PROVIDER_PROJECT: faker.string.alphanumeric(),
-        EMAIL_API_APPLICATION_CODE: faker.string.alphanumeric(),
-        EMAIL_API_FROM_EMAIL: faker.internet.email(),
-        EMAIL_API_KEY: faker.string.uuid(),
-        EMAIL_TEMPLATE_RECOVERY_TX: faker.string.alphanumeric(),
-        EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
-        EMAIL_TEMPLATE_VERIFICATION_CODE: faker.string.alphanumeric(),
-        RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),
-        RELAY_PROVIDER_API_KEY_SEPOLIA: faker.string.uuid(),
-      }),
+      configurationValidator(
+        {
+          ...JSON.parse(fakeJson()),
+          AUTH_TOKEN: faker.string.uuid(),
+          LOG_LEVEL: faker.word.words(),
+          ALERTS_PROVIDER_SIGNING_KEY: faker.string.uuid(),
+          ALERTS_PROVIDER_API_KEY: faker.string.uuid(),
+          ALERTS_PROVIDER_ACCOUNT: faker.string.alphanumeric(),
+          ALERTS_PROVIDER_PROJECT: faker.string.alphanumeric(),
+          EMAIL_API_APPLICATION_CODE: faker.string.alphanumeric(),
+          EMAIL_API_FROM_EMAIL: faker.internet.email(),
+          EMAIL_API_KEY: faker.string.uuid(),
+          EMAIL_TEMPLATE_RECOVERY_TX: faker.string.alphanumeric(),
+          EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: faker.string.alphanumeric(),
+          EMAIL_TEMPLATE_VERIFICATION_CODE: faker.string.alphanumeric(),
+          RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),
+          RELAY_PROVIDER_API_KEY_SEPOLIA: faker.string.uuid(),
+        },
+        RootConfigurationSchema,
+      ),
     ).toThrow(
       /LOG_LEVEL Invalid enum value. Expected 'error' | 'warn' | 'info' | 'http' | 'verbose' | 'debug' | 'silly', received/,
     );

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -1,43 +1,32 @@
-import { z } from 'zod';
+import { ZodType } from 'zod';
 
-const ConfigurationSchema = z.object({
-  AUTH_TOKEN: z.string(),
-  LOG_LEVEL: z
-    .enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'])
-    .optional(),
-  ALERTS_PROVIDER_SIGNING_KEY: z.string(),
-  ALERTS_PROVIDER_API_KEY: z.string(),
-  ALERTS_PROVIDER_ACCOUNT: z.string(),
-  ALERTS_PROVIDER_PROJECT: z.string(),
-  EMAIL_API_APPLICATION_CODE: z.string(),
-  EMAIL_API_FROM_EMAIL: z.string().email(),
-  EMAIL_API_KEY: z.string(),
-  EMAIL_TEMPLATE_RECOVERY_TX: z.string(),
-  EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX: z.string(),
-  EMAIL_TEMPLATE_VERIFICATION_CODE: z.string(),
-  RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: z.string(),
-  RELAY_PROVIDER_API_KEY_SEPOLIA: z.string(),
-});
-
-export function validate(
+/**
+ * Validates the configuration against the provided schema
+ *
+ * @param configuration - The configuration to validate
+ * @param schema - The schema to validate the configuration against
+ */
+export default function (
   configuration: Record<string, unknown>,
+  schema: ZodType,
 ): Record<string, unknown> {
   if (process.env.NODE_ENV === 'test') {
     return configuration;
   }
 
-  const result = ConfigurationSchema.safeParse(configuration);
+  const result = schema.safeParse(configuration);
   if (result.success) {
     return configuration;
   }
 
-  const { fieldErrors } = result.error.flatten();
-
-  const errors = Object.entries(fieldErrors)
-    .reduce<Array<string>>((acc, [key, [error]]) => {
-      return [...acc, `${key} ${error}`];
-    }, [])
-    .join(', ');
+  const errors = Object.entries(result.error.flatten().fieldErrors)
+    .map(([field, errors]) => {
+      if (Array.isArray(errors)) {
+        return `${field} ${errors.join(', ')}`;
+      }
+      return `${field}: Unknown error format`;
+    })
+    .join('; ');
 
   throw Error(`Configuration is invalid: ${errors}`);
 }


### PR DESCRIPTION
- The `validate` function was rewritten to add the ability to provide the schema to validate against to the caller.
- Adds support for returning multiple errors for the same field.