### PR TITLE
Improve SiWe nonce generation

### DIFF
--- a/src/datasources/auth-api/siwe-api.service.ts
+++ b/src/datasources/auth-api/siwe-api.service.ts
@@ -7,6 +7,8 @@ import { verifyMessage } from 'viem';
 
 @Injectable()
 export class SiweApi implements IAuthApi {
+  private readonly NONCE_LENGTH = 8;
+
   constructor(
     @Inject(LoggingService)
     private readonly loggingService: ILoggingService,
@@ -19,7 +21,13 @@ export class SiweApi implements IAuthApi {
    * @see https://eips.ethereum.org/EIPS/eip-4361#message-fields
    */
   generateNonce(): string {
-    return crypto.randomUUID().replace(/-/g, '');
+    // One byte is two hex chars
+    const length = this.NONCE_LENGTH / 2;
+    const randomValues = crypto.getRandomValues(new Uint8Array(length));
+
+    return Array.from(randomValues, (byte) => {
+      return byte.toString(16).padStart(2, '0');
+    }).join('');
   }
 
   async verifyMessage(args: {


### PR DESCRIPTION
## Summary

This improves the nonce generation for SiWe messages, favouring generation instead of modifying a UUID.

## Changes

- Leverage `crypto.getRandomValues` over `crypto.randomUUID`.