### PR TITLE
Improve robustness of `RelayLegacyDtoSchema`

### DIFF
--- a/src/routes/relay/entities/schemas/__tests__/relay.legacy.dto.schema.spec.ts
+++ b/src/routes/relay/entities/schemas/__tests__/relay.legacy.dto.schema.spec.ts
@@ -52,7 +52,7 @@ describe('RelayLegacyDtoSchema', () => {
 
   it('should throw for a non-numeric chainId', () => {
     const relayLegacyDto = {
-      chainId: faker.string.alphanumeric(),
+      chainId: faker.string.alpha(),
       to: getAddress(faker.finance.ethereumAddress()),
       data: faker.string.hexadecimal(),
     };


### PR DESCRIPTION
## Summary

This changes the mock data of `chainId` in the `RelayLegacyDtoSchema` test to always be `alpha`, not `alphanumeric`, as the latter could return a numerical string.