### PR TITLE
Add error messages for custom validation schemas

### DIFF
--- a/src/domain/auth/entities/__tests__/siwe-message.schema.spec.ts
+++ b/src/domain/auth/entities/__tests__/siwe-message.schema.spec.ts
@@ -118,7 +118,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid address',
+            message: 'Invalid checksummed address',
             path: ['address'],
           },
         ]),
@@ -136,7 +136,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid address',
+            message: 'Invalid checksummed address',
             path: ['address'],
           },
         ]),

--- a/src/domain/auth/entities/__tests__/siwe-message.schema.spec.ts
+++ b/src/domain/auth/entities/__tests__/siwe-message.schema.spec.ts
@@ -66,7 +66,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid RFC 3986 authority',
             path: ['domain'],
           },
         ]),
@@ -85,7 +85,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid RFC 3986 authority',
             path: ['domain'],
           },
         ]),
@@ -118,7 +118,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid address',
             path: ['address'],
           },
         ]),
@@ -136,7 +136,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid address',
             path: ['address'],
           },
         ]),
@@ -174,7 +174,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Must not include newlines',
             path: ['statement'],
           },
         ]),
@@ -567,7 +567,7 @@ describe('SiweMessageSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Must not include newlines',
             path: ['resources', 0],
           },
         ]),

--- a/src/domain/auth/entities/siwe-message.entity.ts
+++ b/src/domain/auth/entities/siwe-message.entity.ts
@@ -36,7 +36,7 @@ export const SiweMessageSchema = z.object({
     .string()
     // We cannot use AddressSchema here as the given address will have been referenced in the message signed
     .refine(isChecksummedAddress, {
-      message: 'Invalid address',
+      message: 'Invalid checksummed address',
     }),
   /**
    * OPTIONAL. A human-readable ASCII assertion that the user will sign which MUST NOT include '\n' (the byte 0x0a).

--- a/src/domain/locking/entities/schemas/__tests__/locking-event.schema.spec.ts
+++ b/src/domain/locking/entities/schemas/__tests__/locking-event.schema.spec.ts
@@ -67,7 +67,7 @@ describe('Locking event schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid hex string',
             path: ['transactionHash'],
           },
         ]),
@@ -102,7 +102,7 @@ describe('Locking event schemas', () => {
           new ZodError([
             {
               code: 'custom',
-              message: 'Invalid input',
+              message: 'Invalid numeric string',
               path: [field],
             },
           ]),
@@ -231,7 +231,7 @@ describe('Locking event schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid numeric string',
             path: [field],
           },
         ]),
@@ -366,7 +366,7 @@ describe('Locking event schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid numeric string',
             path: [field],
           },
         ]),

--- a/src/domain/locking/entities/schemas/__tests__/locking-event.schema.spec.ts
+++ b/src/domain/locking/entities/schemas/__tests__/locking-event.schema.spec.ts
@@ -67,7 +67,7 @@ describe('Locking event schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid hex string',
+            message: 'Invalid "0x" notated hex string',
             path: ['transactionHash'],
           },
         ]),
@@ -102,7 +102,7 @@ describe('Locking event schemas', () => {
           new ZodError([
             {
               code: 'custom',
-              message: 'Invalid numeric string',
+              message: 'Invalid base-10 numeric string',
               path: [field],
             },
           ]),
@@ -231,7 +231,7 @@ describe('Locking event schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid numeric string',
+            message: 'Invalid base-10 numeric string',
             path: [field],
           },
         ]),
@@ -366,7 +366,7 @@ describe('Locking event schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid numeric string',
+            message: 'Invalid base-10 numeric string',
             path: [field],
           },
         ]),

--- a/src/domain/messages/entities/schemas/__tests__/message.schema.spec.ts
+++ b/src/domain/messages/entities/schemas/__tests__/message.schema.spec.ts
@@ -63,7 +63,7 @@ describe('Message schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid hex string',
+            message: 'Invalid "0x" notated hex string',
             path: ['signature'],
           },
         ]),
@@ -144,7 +144,7 @@ describe('Message schemas', () => {
           new ZodError([
             {
               code: 'custom',
-              message: 'Invalid hex string',
+              message: 'Invalid "0x" notated hex string',
               path: [key],
             },
           ]),

--- a/src/domain/messages/entities/schemas/__tests__/message.schema.spec.ts
+++ b/src/domain/messages/entities/schemas/__tests__/message.schema.spec.ts
@@ -63,7 +63,7 @@ describe('Message schemas', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid hex string',
             path: ['signature'],
           },
         ]),
@@ -144,7 +144,7 @@ describe('Message schemas', () => {
           new ZodError([
             {
               code: 'custom',
-              message: 'Invalid input',
+              message: 'Invalid hex string',
               path: [key],
             },
           ]),

--- a/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
@@ -89,7 +89,7 @@ describe('CreationTransactionSchema', () => {
       expect(!result.success && result.error.issues).toEqual([
         {
           code: 'custom',
-          message: 'Invalid hex string',
+          message: 'Invalid "0x" notated hex string',
           path: [field],
         },
       ]);

--- a/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
@@ -57,8 +57,28 @@ describe('CreationTransactionSchema', () => {
     expect(result.success && result.data[field]).toBe(null);
   });
 
-  it.each(['creator' as const, 'setupData' as const])(
-    'should only allow hex %s',
+  it.each([
+    'creator' as const,
+    'factoryAddress' as const,
+    'masterCopy' as const,
+  ])('should not allow non-address %s', (field) => {
+    const creationTransaction = creationTransactionBuilder()
+      .with(field, 'not an address' as `0x${string}`)
+      .build();
+
+    const result = CreationTransactionSchema.safeParse(creationTransaction);
+
+    expect(!result.success && result.error.issues).toEqual([
+      {
+        code: 'custom',
+        message: 'Invalid address',
+        path: [field],
+      },
+    ]);
+  });
+
+  it.each(['transactionHash' as const, 'setupData' as const])(
+    'should not allow non-hex %s',
     (field) => {
       const creationTransaction = creationTransactionBuilder()
         .with(field, 'not a hex string' as `0x${string}`)
@@ -69,7 +89,7 @@ describe('CreationTransactionSchema', () => {
       expect(!result.success && result.error.issues).toEqual([
         {
           code: 'custom',
-          message: 'Invalid input',
+          message: 'Invalid hex string',
           path: [field],
         },
       ]);

--- a/src/domain/safe/entities/schemas/__tests__/module-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/module-transaction.schema.spec.ts
@@ -63,7 +63,7 @@ describe('ModuleTransaction schemas', () => {
           new ZodError([
             {
               code: 'custom',
-              message: 'Invalid hex string',
+              message: 'Invalid "0x" notated hex string',
               path: [key],
             },
           ]),

--- a/src/domain/safe/entities/schemas/__tests__/module-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/module-transaction.schema.spec.ts
@@ -63,7 +63,7 @@ describe('ModuleTransaction schemas', () => {
           new ZodError([
             {
               code: 'custom',
-              message: 'Invalid input',
+              message: 'Invalid hex string',
               path: [key],
             },
           ]),

--- a/src/routes/cache-hooks/entities/schemas/__tests__/deleted-multisig-transaction.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/deleted-multisig-transaction.schema.spec.ts
@@ -58,8 +58,8 @@ describe('DeletedMultisigTransactionEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/executed-transaction.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/executed-transaction.schema.spec.ts
@@ -55,8 +55,8 @@ describe('ExecutedTransactionEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/incoming-ether.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/incoming-ether.schema.spec.ts
@@ -45,8 +45,8 @@ describe('IncomingEtherEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/incoming-token.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/incoming-token.schema.spec.ts
@@ -47,8 +47,8 @@ describe('IncomingTokenEventSchema', () => {
         new ZodError([
           {
             code: 'custom',
+            message: 'Invalid address',
             path: [field],
-            message: 'Invalid input',
           },
         ]),
       );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/message-created.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/message-created.schema.spec.ts
@@ -45,8 +45,8 @@ describe('MessageCreatedEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/module-transaction.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/module-transaction.schema.spec.ts
@@ -53,8 +53,8 @@ describe('ModuleTransactionEventSchema', () => {
         new ZodError([
           {
             code: 'custom',
+            message: 'Invalid address',
             path: [field],
-            message: 'Invalid input',
           },
         ]),
       );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/new-confirmation.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/new-confirmation.schema.spec.ts
@@ -47,8 +47,8 @@ describe('NewConfirmationEventSchema', () => {
         new ZodError([
           {
             code: 'custom',
+            message: 'Invalid address',
             path: [field],
-            message: 'Invalid input',
           },
         ]),
       );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/new-message-confirmation.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/new-message-confirmation.schema.spec.ts
@@ -52,8 +52,8 @@ describe('NewMessageConfirmationEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/outgoing-ether.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/outgoing-ether.schema.spec.ts
@@ -45,8 +45,8 @@ describe('OutgoingEtherEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/outgoing-token.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/outgoing-token.schema.spec.ts
@@ -47,8 +47,8 @@ describe('OutgoingTokenEventSchema', () => {
         new ZodError([
           {
             code: 'custom',
+            message: 'Invalid address',
             path: [field],
-            message: 'Invalid input',
           },
         ]),
       );

--- a/src/routes/cache-hooks/entities/schemas/__tests__/pending-transaction.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/pending-transaction.schema.spec.ts
@@ -55,8 +55,8 @@ describe('PendingTransactionEventSchema', () => {
       new ZodError([
         {
           code: 'custom',
+          message: 'Invalid address',
           path: ['address'],
-          message: 'Invalid input',
         },
       ]),
     );

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -186,7 +186,7 @@ describe('Data decode e2e tests', () => {
         statusCode: 422,
         code: 'custom',
         path: ['to'],
-        message: 'Invalid input',
+        message: 'Invalid address',
       });
   });
 });

--- a/src/routes/data-decode/entities/schemas/__tests__/get-data-decoded.dto.schema.spec.ts
+++ b/src/routes/data-decode/entities/schemas/__tests__/get-data-decoded.dto.schema.spec.ts
@@ -47,7 +47,7 @@ describe('GetDataDecodedDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid hex string',
+          message: 'Invalid "0x" notated hex string',
           path: ['data'],
         },
       ]),

--- a/src/routes/data-decode/entities/schemas/__tests__/get-data-decoded.dto.schema.spec.ts
+++ b/src/routes/data-decode/entities/schemas/__tests__/get-data-decoded.dto.schema.spec.ts
@@ -47,7 +47,7 @@ describe('GetDataDecodedDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid input',
+          message: 'Invalid hex string',
           path: ['data'],
         },
       ]),

--- a/src/routes/delegates/entities/schemas/__tests__/delete-safe-delegate.dto.schema.spec.ts
+++ b/src/routes/delegates/entities/schemas/__tests__/delete-safe-delegate.dto.schema.spec.ts
@@ -45,7 +45,7 @@ describe('DeleteSafeDelegateDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid input',
+          message: 'Invalid hex string',
           path: ['signature'],
         },
       ]),

--- a/src/routes/delegates/entities/schemas/__tests__/delete-safe-delegate.dto.schema.spec.ts
+++ b/src/routes/delegates/entities/schemas/__tests__/delete-safe-delegate.dto.schema.spec.ts
@@ -45,7 +45,7 @@ describe('DeleteSafeDelegateDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid hex string',
+          message: 'Invalid "0x" notated hex string',
           path: ['signature'],
         },
       ]),

--- a/src/routes/delegates/entities/schemas/__tests__/get-delegate.dto.schema.spec.ts
+++ b/src/routes/delegates/entities/schemas/__tests__/get-delegate.dto.schema.spec.ts
@@ -47,7 +47,7 @@ describe('GetDelegateDtoSchema', () => {
   });
 
   it.each(['safe' as const, 'delegate' as const, 'delegator' as const])(
-    'should not validate non-hex %s',
+    'should not validate non-address %s',
     (property) => {
       const getDelegateDto = { [property]: faker.word.sample() };
 
@@ -57,8 +57,8 @@ describe('GetDelegateDtoSchema', () => {
         new ZodError([
           {
             code: 'custom',
+            message: 'Invalid address',
             path: [property],
-            message: 'Invalid input',
           },
         ]),
       );

--- a/src/routes/estimations/entities/schemas/__tests__/get-estimation.dto.schema.spec.ts
+++ b/src/routes/estimations/entities/schemas/__tests__/get-estimation.dto.schema.spec.ts
@@ -51,7 +51,7 @@ describe('GetEstimationDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid hex string',
+          message: 'Invalid "0x" notated hex string',
           path: ['data'],
         },
       ]),

--- a/src/routes/estimations/entities/schemas/__tests__/get-estimation.dto.schema.spec.ts
+++ b/src/routes/estimations/entities/schemas/__tests__/get-estimation.dto.schema.spec.ts
@@ -51,7 +51,7 @@ describe('GetEstimationDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid input',
+          message: 'Invalid hex string',
           path: ['data'],
         },
       ]),

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -99,8 +99,8 @@ describe('Locking (Unit)', () => {
         .expect({
           statusCode: 422,
           code: 'custom',
+          message: 'Invalid address',
           path: [],
-          message: 'Invalid input',
         });
     });
 
@@ -397,8 +397,8 @@ describe('Locking (Unit)', () => {
         .expect({
           statusCode: 422,
           code: 'custom',
+          message: 'Invalid address',
           path: [],
-          message: 'Invalid input',
         });
     });
 

--- a/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
@@ -28,7 +28,7 @@ describe('UpdateMessageSignatureDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid hex string',
+          message: 'Invalid "0x" notated hex string',
           path: ['signature'],
         },
       ]),

--- a/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
@@ -28,7 +28,7 @@ describe('UpdateMessageSignatureDtoSchema', () => {
       new ZodError([
         {
           code: 'custom',
-          message: 'Invalid input',
+          message: 'Invalid hex string',
           path: ['signature'],
         },
       ]),

--- a/src/routes/relay/entities/schemas/__tests__/relay.dto.schema.spec.ts
+++ b/src/routes/relay/entities/schemas/__tests__/relay.dto.schema.spec.ts
@@ -58,7 +58,7 @@ describe('RelayDtoSchema', () => {
     const result = RelayDtoSchema.safeParse(relayDto);
 
     expect(!result.success && result.error.issues).toStrictEqual([
-      { code: 'custom', message: 'Invalid input', path: ['to'] },
+      { code: 'custom', message: 'Invalid address', path: ['to'] },
     ]);
   });
 
@@ -72,7 +72,7 @@ describe('RelayDtoSchema', () => {
     const result = RelayDtoSchema.safeParse(relayDto);
 
     expect(!result.success && result.error.issues).toStrictEqual([
-      { code: 'custom', message: 'Invalid input', path: ['data'] },
+      { code: 'custom', message: 'Invalid hex string', path: ['data'] },
     ]);
   });
 
@@ -86,7 +86,7 @@ describe('RelayDtoSchema', () => {
     const result = RelayDtoSchema.safeParse(relayDto);
 
     expect(!result.success && result.error.issues).toStrictEqual([
-      { code: 'custom', message: 'Invalid input', path: ['version'] },
+      { code: 'custom', message: 'Invalid semver string', path: ['version'] },
     ]);
   });
 
@@ -101,7 +101,7 @@ describe('RelayDtoSchema', () => {
     const result = RelayDtoSchema.safeParse(relayDto);
 
     expect(!result.success && result.error.issues).toStrictEqual([
-      { code: 'custom', message: 'Invalid input', path: ['gasLimit'] },
+      { code: 'custom', message: 'Unable to parse value', path: ['gasLimit'] },
     ]);
   });
 });

--- a/src/routes/relay/entities/schemas/__tests__/relay.dto.schema.spec.ts
+++ b/src/routes/relay/entities/schemas/__tests__/relay.dto.schema.spec.ts
@@ -72,7 +72,11 @@ describe('RelayDtoSchema', () => {
     const result = RelayDtoSchema.safeParse(relayDto);
 
     expect(!result.success && result.error.issues).toStrictEqual([
-      { code: 'custom', message: 'Invalid hex string', path: ['data'] },
+      {
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: ['data'],
+      },
     ]);
   });
 

--- a/src/routes/relay/entities/schemas/__tests__/relay.legacy.dto.schema.spec.ts
+++ b/src/routes/relay/entities/schemas/__tests__/relay.legacy.dto.schema.spec.ts
@@ -62,7 +62,7 @@ describe('RelayLegacyDtoSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
-        message: 'Invalid input',
+        message: 'Invalid numeric string',
         path: ['chainId'],
       },
     ]);
@@ -80,7 +80,7 @@ describe('RelayLegacyDtoSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
-        message: 'Invalid input',
+        message: 'Invalid address',
         path: ['to'],
       },
     ]);
@@ -98,7 +98,7 @@ describe('RelayLegacyDtoSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
-        message: 'Invalid input',
+        message: 'Invalid hex string',
         path: ['data'],
       },
     ]);

--- a/src/routes/relay/entities/schemas/__tests__/relay.legacy.dto.schema.spec.ts
+++ b/src/routes/relay/entities/schemas/__tests__/relay.legacy.dto.schema.spec.ts
@@ -62,7 +62,7 @@ describe('RelayLegacyDtoSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
-        message: 'Invalid numeric string',
+        message: 'Invalid base-10 numeric string',
         path: ['chainId'],
       },
     ]);
@@ -98,7 +98,7 @@ describe('RelayLegacyDtoSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
-        message: 'Invalid hex string',
+        message: 'Invalid "0x" notated hex string',
         path: ['data'],
       },
     ]);

--- a/src/routes/relay/entities/schemas/relay.dto.schema.ts
+++ b/src/routes/relay/entities/schemas/relay.dto.schema.ts
@@ -11,7 +11,9 @@ export const RelayDtoSchema = z.object({
   data: HexSchema,
   version: z
     .string()
-    .refine((value) => semver.parse(value) !== null)
+    .refine((value) => semver.parse(value) !== null, {
+      message: 'Invalid semver string',
+    })
     .default(LEGACY_SUPPORTED_VERSION),
   gasLimit: z
     .string()
@@ -26,6 +28,7 @@ export const RelayDtoSchema = z.object({
       } catch (e) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
+          message: 'Unable to parse value',
         });
         return z.NEVER;
       }

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -1452,7 +1452,7 @@ describe('Relay controller', () => {
               statusCode: 422,
               code: 'custom',
               path: ['gasLimit'],
-              message: 'Invalid input',
+              message: 'Unable to parse value',
             });
         });
 

--- a/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
+++ b/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
@@ -85,7 +85,7 @@ describe('ProposeTransactionDtoSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid numeric string',
+            message: 'Invalid base-10 numeric string',
             path: [field],
           },
         ]),
@@ -118,7 +118,7 @@ describe('ProposeTransactionDtoSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid hex string',
+            message: 'Invalid "0x" notated hex string',
             path: [field],
           },
         ]),

--- a/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
+++ b/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
@@ -28,8 +28,8 @@ describe('ProposeTransactionDtoSchema', () => {
         new ZodError([
           {
             code: 'custom',
+            message: 'Invalid address',
             path: [field],
-            message: 'Invalid input',
           },
         ]),
       );
@@ -85,7 +85,7 @@ describe('ProposeTransactionDtoSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid numeric string',
             path: [field],
           },
         ]),
@@ -118,7 +118,7 @@ describe('ProposeTransactionDtoSchema', () => {
         new ZodError([
           {
             code: 'custom',
-            message: 'Invalid input',
+            message: 'Invalid hex string',
             path: [field],
           },
         ]),

--- a/src/validation/entities/schemas/address.schema.ts
+++ b/src/validation/entities/schemas/address.schema.ts
@@ -7,6 +7,7 @@ export const AddressSchema = z.string().transform((value, ctx) => {
   } catch (e) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      message: 'Invalid address',
     });
     return z.NEVER;
   }

--- a/src/validation/entities/schemas/hex.schema.ts
+++ b/src/validation/entities/schemas/hex.schema.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
 import { isHex } from 'viem';
 
-export const HexSchema = z.string().refine(isHex);
+export const HexSchema = z.string().refine(isHex, {
+  message: 'Invalid hex string',
+});

--- a/src/validation/entities/schemas/hex.schema.ts
+++ b/src/validation/entities/schemas/hex.schema.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { isHex } from 'viem';
 
 export const HexSchema = z.string().refine(isHex, {
-  message: 'Invalid hex string',
+  message: 'Invalid "0x" notated hex string',
 });

--- a/src/validation/entities/schemas/numeric-string.schema.ts
+++ b/src/validation/entities/schemas/numeric-string.schema.ts
@@ -4,4 +4,6 @@ function isNumeric(value: unknown): boolean {
   return typeof value === 'string' && !isNaN(Number(value));
 }
 
-export const NumericStringSchema = z.string().refine(isNumeric);
+export const NumericStringSchema = z.string().refine(isNumeric, {
+  message: 'Invalid numeric string',
+});

--- a/src/validation/entities/schemas/numeric-string.schema.ts
+++ b/src/validation/entities/schemas/numeric-string.schema.ts
@@ -5,5 +5,5 @@ function isNumeric(value: unknown): boolean {
 }
 
 export const NumericStringSchema = z.string().refine(isNumeric, {
-  message: 'Invalid numeric string',
+  message: 'Invalid base-10 numeric string',
 });


### PR DESCRIPTION
## Summary

This adds error messages for custom validation schemas.

## Changes

- Reused schemas now have the following error messages:
  - `NumericStringSchema` - 'Invalid base-10 numeric string'
  - `HexSchema` - 'Invalid "0x" notated hex string'
  - `AddressSchema` - 'Invalid address'
- A few isolated fields that have custom validation have had error messages added.
- The above changes have been propegated across test coverage. 