### PR TITLE
Enable Email Feature for Subscription Controller tests

### DIFF
--- a/src/routes/subscriptions/subscription.controller.spec.ts
+++ b/src/routes/subscriptions/subscription.controller.spec.ts
@@ -27,8 +27,17 @@ describe('Subscription Controller tests', () => {
     jest.resetAllMocks();
     jest.useFakeTimers();
 
+    const defaultTestConfiguration = configuration();
+    const testConfiguration: typeof configuration = () => ({
+      ...defaultTestConfiguration,
+      features: {
+        ...defaultTestConfiguration.features,
+        email: true,
+      },
+    });
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration), EmailControllerModule],
+      imports: [AppModule.register(testConfiguration), EmailControllerModule],
     })
       .overrideModule(EmailApiModule)
       .useModule(TestEmailApiModule)


### PR DESCRIPTION
The Subscription Controller tests were dependent on the value of the test configuration object, which means that if `features.email` was set to `false`, these tests would fail as the routes would not be installed.

By setting the value of `features.email` in the test setup, we isolate the test execution from the state of the test configuration object.
