### PR TITLE
Rename wallet address param and mark it optional

### DIFF
--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -180,7 +180,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect(({ body }) =>
@@ -424,7 +424,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect(({ body }) =>
@@ -663,7 +663,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address},${chain2.chainId}:${safeInfo4.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address},${chain2.chainId}:${safeInfo4.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect(({ body }) =>
@@ -968,7 +968,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&walletAddress=${walletAddress}&trusted=${true}&exclude_spam=${false}`,
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&wallet_address=${walletAddress}&trusted=${true}&exclude_spam=${false}`,
         )
         .expect(200)
         .expect([
@@ -1223,7 +1223,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect([

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -1,4 +1,4 @@
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import {
   Controller,
   DefaultValuePipe,
@@ -38,6 +38,7 @@ export class SafesController {
     return this.service.getNonces({ chainId, safeAddress });
   }
 
+  @ApiQuery({ name: 'wallet_address', required: false })
   @Get('safes')
   async getSafeOverview(
     @Query('currency') currency: string,
@@ -47,7 +48,8 @@ export class SafesController {
     trusted: boolean,
     @Query('exclude_spam', new DefaultValuePipe(true), ParseBoolPipe)
     excludeSpam: boolean,
-    @Query('walletAddress') walletAddress?: string,
+    @Query('wallet_address')
+    walletAddress?: string,
   ): Promise<Array<SafeOverview>> {
     return this.service.getSafeOverview({
       currency,


### PR DESCRIPTION
## Summary

This updates the wallet address param of the `/v1/safes` endpoint, standardising it and marking it optional in Swagger.

## Changes

- Rename `walletAddress` to `wallet_address`.
- Implicitly mark it as an optional `ApiQuery` in Swagger:
![image](https://github.com/safe-global/safe-client-gateway/assets/20442784/78745659-bfad-48c6-b821-b750ad943264)