### PR TITLE
Fix token used for fee label

### DIFF
--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -81,8 +81,8 @@ describe('Swap Order Mapper tests', () => {
       data: transaction.data as `0x${string}`,
     });
 
-    const fee = asDecimal(order.executedSurplusFee!, buyToken.decimals!);
-    const expectedFeeLabel = `${fee} ${buyToken.symbol}`;
+    const fee = asDecimal(order.executedSurplusFee!, sellToken.decimals!);
+    const expectedFeeLabel = `${fee} ${sellToken.symbol}`;
     const executionRatio =
       asDecimal(order.executedSellAmount, sellToken.decimals!) /
       asDecimal(order.executedBuyAmount, buyToken.decimals!);

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -183,7 +183,7 @@ export class SwapOrderMapper {
       throw new Error('Unknown order kind');
     }
     const feeLabel: string | null = args.order.executedSurplusFee
-      ? this._getFeeLabel(args.order.executedSurplusFee, args.buyToken.token)
+      ? this._getFeeLabel(args.order.executedSurplusFee, args.sellToken.token)
       : null;
 
     return new FulfilledSwapOrderTransactionInfo({


### PR DESCRIPTION
The sell token should be used for the fee label (instead of the buy token).