### PR TITLE
Increase max overview amount

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -209,7 +209,7 @@ export default () => ({
       ),
     },
     safe: {
-      maxOverviews: parseInt(process.env.MAX_SAFE_OVERVIEWS ?? `${7}`),
+      maxOverviews: parseInt(process.env.MAX_SAFE_OVERVIEWS ?? `${10}`),
     },
   },
   redis: {


### PR DESCRIPTION
## Summary

This increases the max number of Safes returned by the overview endpoint (`/v1/safes`) from 7 to 10. Although this can be achieved by an env. var., this is the desired value by the interface and as this is still being tested, it has been adjusted directly.
