### PR TITLE
Omit erroneous overview elements

### DIFF
--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -1219,7 +1219,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect(({ body }) =>
@@ -1418,7 +1418,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect(({ body }) =>
@@ -1639,7 +1639,7 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&wallet_address=${walletAddress}`,
         )
         .expect(200)
         .expect(({ body }) =>

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -1036,7 +1036,7 @@ describe('Safes Controller Overview (Unit)', () => {
   });
 
   describe('Validation', () => {
-    it('omits erroroneous Safes on chains returning an error from the Config Service', async () => {
+    it('omits erroneous Safes on chains returning an error from the Config Service', async () => {
       const chain1 = chainBuilder().with('chainId', '1').build();
       const chain2 = chainBuilder().with('chainId', '10').build();
       const safeInfo1 = safeBuilder().build();
@@ -1263,7 +1263,7 @@ describe('Safes Controller Overview (Unit)', () => {
         );
     });
 
-    it('omits erroroneous Safes from the Transaction Service', async () => {
+    it('omits erroneous Safes from the Transaction Service', async () => {
       const chain1 = chainBuilder().with('chainId', '1').build();
       const chain2 = chainBuilder().with('chainId', '10').build();
       const safeInfo1 = safeBuilder().build();
@@ -1462,7 +1462,7 @@ describe('Safes Controller Overview (Unit)', () => {
         );
     });
 
-    it('omits erroroneous Safes validation of the Transaction Service return Promise.rejects', async () => {
+    it('omits erroneous Safes validation of the Transaction Service return Promise.rejects', async () => {
       const chain1 = chainBuilder().with('chainId', '1').build();
       const chain2 = chainBuilder().with('chainId', '10').build();
       const safeInfo1 = safeBuilder().build();

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -1036,104 +1036,178 @@ describe('Safes Controller Overview (Unit)', () => {
   });
 
   describe('Validation', () => {
-    it('forwards error responses from the Config Service', async () => {
-      const chain = chainBuilder().with('chainId', '10').build();
-      const safeInfo = safeBuilder().build();
-      const currency = faker.finance.currencyCode();
+    it('omits erroroneous Safes on chains returning an error from the Config Service', async () => {
+      const chain1 = chainBuilder().with('chainId', '1').build();
+      const chain2 = chainBuilder().with('chainId', '10').build();
+      const safeInfo1 = safeBuilder().build();
+      const safeInfo2 = safeBuilder().build();
+      const safeInfo3 = safeBuilder().build();
 
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            const error = new NetworkResponseError(
-              new URL(`${safeConfigUrl}/api/v1/chains/${chain.chainId}`),
-              {
-                status: 404,
-              } as Response,
-            );
-            return Promise.reject(error);
-          }
-          default: {
-            return Promise.reject(`No matching rule for url: ${url}`);
-          }
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(
-          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
-        )
-        .expect(404);
-    });
-
-    it('forwards error responses from the Transaction Service', async () => {
-      const chain = chainBuilder().with('chainId', '10').build();
-      const safeInfo = safeBuilder().build();
-      const currency = faker.finance.currencyCode();
-
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            const error = new NetworkResponseError(
-              new URL(
-                `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
-              ),
-              {
-                status: 500,
-              } as Response,
-            );
-            return Promise.reject(error);
-          }
-          default: {
-            return Promise.reject(`No matching rule for url: ${url}`);
-          }
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(
-          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
-        )
-        .expect(500);
-    });
-
-    it('throw a 500 if validation of the Transaction Service return Promise.rejects', async () => {
-      const chain = chainBuilder().with('chainId', '10').build();
-      const safeInfo = safeBuilder().build();
-      const tokenAddress = faker.finance.ethereumAddress();
-      const secondTokenAddress = faker.finance.ethereumAddress();
-      const transactionApiBalancesResponse = [
+      const tokenAddress1 = faker.finance.ethereumAddress();
+      const tokenAddress2 = faker.finance.ethereumAddress();
+      const secondTokenAddress1 = faker.finance.ethereumAddress();
+      const secondTokenAddress2 = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse1 = [
         balanceBuilder()
           .with('tokenAddress', null)
           .with('balance', '3000000000000000000')
           .with('token', null)
           .build(),
         balanceBuilder()
-          .with('tokenAddress', getAddress(tokenAddress))
+          .with('tokenAddress', getAddress(tokenAddress1))
           .with('balance', '4000000000000000000')
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
         balanceBuilder()
-          .with('tokenAddress', getAddress(secondTokenAddress))
+          .with('tokenAddress', getAddress(secondTokenAddress1))
           .with('balance', '3000000000000000000')
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
+      const transactionApiBalancesResponse2 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress2))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress1))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse3 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress1))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress2))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId1 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
+        );
+      const nativeCoinId2 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
+        );
+      const chainName1 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
+        );
+      const chainName2 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
+        );
       const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
+        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress1]: { [currency.toLowerCase()]: 10 },
+        [secondTokenAddress2]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const queuedTransactions1 = pageBuilder().build();
+      const queuedTransactions2 = pageBuilder().build();
+      const queuedTransactions3 = pageBuilder().build();
 
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
+          case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
+            const error = new NetworkResponseError(
+              new URL(`${safeConfigUrl}/api/v1/chains/${chain1.chainId}`),
+              {
+                status: 404,
+              } as Response,
+            );
+            return Promise.reject(error);
           }
-          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            return Promise.resolve({ data: 'invalid', status: 200 });
+          case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
+            return Promise.resolve({ data: chain2, status: 200 });
           }
-          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
+            return Promise.resolve({ data: safeInfo1, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
+            return Promise.resolve({ data: safeInfo2, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
+            return Promise.resolve({ data: safeInfo3, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: transactionApiBalancesResponse1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse3,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions3,
               status: 200,
             });
           }
@@ -1145,10 +1219,468 @@ describe('Safes Controller Overview (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}`,
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
         )
-        .expect(500)
-        .expect({ statusCode: 500, message: 'Internal server error' });
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            // safeInfo1 is omitted
+            {
+              address: {
+                value: safeInfo2.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo2.threshold,
+              owners: safeInfo2.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '4910.25',
+              queued: queuedTransactions2.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo3.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo3.threshold,
+              owners: safeInfo3.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions3.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+          ]),
+        );
+    });
+
+    it('omits erroroneous Safes from the Transaction Service', async () => {
+      const chain1 = chainBuilder().with('chainId', '1').build();
+      const chain2 = chainBuilder().with('chainId', '10').build();
+      const safeInfo1 = safeBuilder().build();
+      const safeInfo2 = safeBuilder().build();
+      const safeInfo3 = safeBuilder().build();
+
+      const tokenAddress1 = faker.finance.ethereumAddress();
+      const tokenAddress2 = faker.finance.ethereumAddress();
+      const secondTokenAddress1 = faker.finance.ethereumAddress();
+      const secondTokenAddress2 = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse2 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress2))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress1))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse3 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress1))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress2))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId1 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
+        );
+      const nativeCoinId2 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
+        );
+      const chainName1 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
+        );
+      const chainName2 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
+        );
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
+        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress1]: { [currency.toLowerCase()]: 10 },
+        [secondTokenAddress2]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const queuedTransactions2 = pageBuilder().build();
+      const queuedTransactions3 = pageBuilder().build();
+
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
+            return Promise.resolve({ data: chain1, status: 200 });
+          }
+          case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
+            return Promise.resolve({ data: chain2, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
+            const error = new NetworkResponseError(
+              new URL(
+                `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`,
+              ),
+              {
+                status: 500,
+              } as Response,
+            );
+            return Promise.reject(error);
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
+            return Promise.resolve({ data: safeInfo2, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
+            return Promise.resolve({ data: safeInfo3, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse3,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions3,
+              status: 200,
+            });
+          }
+          default: {
+            return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            // safeInfo1 is omitted
+            {
+              address: {
+                value: safeInfo2.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo2.threshold,
+              owners: safeInfo2.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '4910.25',
+              queued: queuedTransactions2.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo3.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo3.threshold,
+              owners: safeInfo3.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions3.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+          ]),
+        );
+    });
+
+    it('omits erroroneous Safes validation of the Transaction Service return Promise.rejects', async () => {
+      const chain1 = chainBuilder().with('chainId', '1').build();
+      const chain2 = chainBuilder().with('chainId', '10').build();
+      const safeInfo1 = safeBuilder().build();
+      const safeInfo2 = safeBuilder().build();
+      const safeInfo3 = safeBuilder().build();
+
+      const tokenAddress1 = faker.finance.ethereumAddress();
+      const tokenAddress2 = faker.finance.ethereumAddress();
+      const secondTokenAddress1 = faker.finance.ethereumAddress();
+      const secondTokenAddress2 = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse1 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress1))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress1))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse2 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress2))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress1))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const transactionApiBalancesResponse3 = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress1))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress2))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId1 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
+        );
+      const nativeCoinId2 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
+        );
+      const chainName1 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
+        );
+      const chainName2 = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
+        );
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
+        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress1]: { [currency.toLowerCase()]: 10 },
+        [secondTokenAddress2]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = faker.finance.ethereumAddress();
+      const queuedTransactions1 = pageBuilder().build();
+      const queuedTransactions2 = pageBuilder().build();
+      const queuedTransactions3 = pageBuilder().build();
+
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
+            return Promise.resolve({ data: chain1, status: 200 });
+          }
+          case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
+            return Promise.resolve({ data: chain2, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
+            return Promise.resolve({ data: 'invalid', status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
+            return Promise.resolve({ data: safeInfo2, status: 200 });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
+            return Promise.resolve({ data: safeInfo3, status: 200 });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse3,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions1,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions2,
+              status: 200,
+            });
+          }
+          case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions3,
+              status: 200,
+            });
+          }
+          default: {
+            return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain1.chainId}:${safeInfo1.address},${chain2.chainId}:${safeInfo2.address},${chain2.chainId}:${safeInfo3.address}&walletAddress=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            // safeInfo1 is omitted
+            {
+              address: {
+                value: safeInfo2.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo2.threshold,
+              owners: safeInfo2.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '4910.25',
+              queued: queuedTransactions2.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+            {
+              address: {
+                value: safeInfo3.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain2.chainId,
+              threshold: safeInfo3.threshold,
+              owners: safeInfo3.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: queuedTransactions3.count,
+              awaitingConfirmation: expect.any(Number),
+            },
+          ]),
+        );
     });
 
     it('should return a 0-balance when an error is thrown by the provider', async () => {

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -24,6 +24,8 @@ import { IBalancesRepository } from '@/domain/balances/balances.repository.inter
 import { getNumberString } from '@/domain/common/utils/utils';
 import { SafeOverview } from '@/routes/safes/entities/safe-overview.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
 
 @Injectable()
 export class SafesService {
@@ -40,6 +42,7 @@ export class SafesService {
     @Inject(IBalancesRepository)
     private readonly balancesRepository: IBalancesRepository,
     @Inject(IConfigurationService) configurationService: IConfigurationService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
     this.maxOverviews = configurationService.getOrThrow(
       'mappings.safe.maxOverviews',
@@ -134,7 +137,7 @@ export class SafesService {
   }): Promise<Array<SafeOverview>> {
     const limitedSafes = args.addresses.slice(0, this.maxOverviews);
 
-    return Promise.all(
+    const settledOverviews = await Promise.allSettled(
       limitedSafes.map(async ({ chainId, address }) => {
         const [safe, balances] = await Promise.all([
           this.safeRepository.getSafe({
@@ -176,6 +179,20 @@ export class SafesService {
         );
       }),
     );
+
+    const safeOverviews: Array<SafeOverview> = [];
+
+    for (const safeOverview of settledOverviews) {
+      if (safeOverview.status === 'rejected') {
+        this.loggingService.error(
+          `Error while getting Safe overview: ${asError(safeOverview.reason)} `,
+        );
+      } else if (safeOverview.status === 'fulfilled') {
+        safeOverviews.push(safeOverview.value);
+      }
+    }
+
+    return safeOverviews;
   }
 
   public async getNonces(args: {

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -184,7 +184,7 @@ export class SafesService {
 
     for (const safeOverview of settledOverviews) {
       if (safeOverview.status === 'rejected') {
-        this.loggingService.error(
+        this.loggingService.warn(
           `Error while getting Safe overview: ${asError(safeOverview.reason)} `,
         );
       } else if (safeOverview.status === 'fulfilled') {


### PR DESCRIPTION
## Summary

This filters the return array of the Safe overview endpoint (`/v1/safes`), removing any elements that threw. This prevents one thrown retrieval of a `SafeOverview` from blocking others.

## Changes

- Change request from `Promise.all` to `Promise.allSettled`
- Filter out `'rejected'` elements, logging if existent