### PR TITLE
Add surplusLabel to Order

### DIFF
--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -105,6 +105,12 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
   })
   executionPriceLabel: string;
 
+  @ApiProperty({
+    description:
+      'The (averaged) surplus for this order in the format of "$surplusAmount $tokenSymbol"',
+  })
+  surplusLabel: string;
+
   constructor(args: {
     orderUid: string;
     orderKind: 'buy' | 'sell';
@@ -113,6 +119,7 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
     expiresTimestamp: number;
     feeLabel: string | null;
     executionPriceLabel: string;
+    surplusLabel: string;
     filledPercentage: string;
     explorerUrl: URL;
   }) {
@@ -120,6 +127,7 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
     this.status = 'fulfilled';
     this.feeLabel = args.feeLabel;
     this.executionPriceLabel = args.executionPriceLabel;
+    this.surplusLabel = args.surplusLabel;
   }
 }
 

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -87,6 +87,14 @@ describe('Swap Order Mapper tests', () => {
       asDecimal(order.executedSellAmount, sellToken.decimals!) /
       asDecimal(order.executedBuyAmount, buyToken.decimals!);
     const expectedExecutionPrice = `1 ${sellToken.symbol} = ${executionRatio} ${buyToken.symbol}`;
+    const expectedSurplus = Math.abs(
+      order.kind === 'buy'
+        ? asDecimal(order.sellAmount, sellToken.decimals!) -
+            asDecimal(order.executedSellAmount, sellToken.decimals!)
+        : asDecimal(order.buyAmount, buyToken.decimals!) -
+            asDecimal(order.executedBuyAmount, buyToken.decimals!),
+    );
+    const expectedSurplusLabel = `${expectedSurplus} ${order.kind === 'buy' ? sellToken.symbol : buyToken.symbol}`;
     expect(result).toBeInstanceOf(FulfilledSwapOrderTransactionInfo);
     expect(result).toEqual({
       type: 'SwapOrder',
@@ -108,6 +116,7 @@ describe('Swap Order Mapper tests', () => {
       explorerUrl: new URL(`${explorerBaseUrl}/orders/${order.uid}`),
       feeLabel: expectedFeeLabel,
       executionPriceLabel: expectedExecutionPrice,
+      surplusLabel: expectedSurplusLabel,
       humanDescription: null,
       richDecodedInfo: null,
     });

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -208,7 +208,7 @@ export class SwapOrderMapper {
         args.sellToken,
         args.buyToken,
       ),
-      surplusLabel: surplusLabel,
+      surplusLabel,
       filledPercentage: this._getFilledPercentage(args.order),
       explorerUrl: this._getOrderExplorerUrl(args.order),
     });

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -139,6 +139,13 @@ export class SwapOrderMapper {
     return `1 ${sellToken.token.symbol} = ${ratio} ${buyToken.token.symbol}`;
   }
 
+  private _getSurplusPriceLabel(tokenAmount: TokenAmount): string {
+    const surplus = Math.abs(
+      tokenAmount.getAmount() - tokenAmount.getExecutedAmount(),
+    ).toString();
+    return `${surplus} ${tokenAmount.token.symbol}`;
+  }
+
   /**
    * Returns the filled percentage of an order.
    * The percentage is calculated as the ratio of the executed amount to the total amount.
@@ -186,6 +193,10 @@ export class SwapOrderMapper {
       ? this._getFeeLabel(args.order.executedSurplusFee, args.sellToken.token)
       : null;
 
+    const surplusLabel = this._getSurplusPriceLabel(
+      args.order.kind === 'buy' ? args.sellToken : args.buyToken,
+    );
+
     return new FulfilledSwapOrderTransactionInfo({
       orderUid: args.order.uid,
       orderKind: args.order.kind,
@@ -197,6 +208,7 @@ export class SwapOrderMapper {
         args.sellToken,
         args.buyToken,
       ),
+      surplusLabel: surplusLabel,
       filledPercentage: this._getFilledPercentage(args.order),
       explorerUrl: this._getOrderExplorerUrl(args.order),
     });


### PR DESCRIPTION
- Adds the surplus property to a Fulfilled order.
- The surplus is computed with the absolute difference between the initial token amount and the executed amount of the order.