### PR TITLE
User `0x${string}` types throughout relay

### DIFF
--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -2,7 +2,7 @@ import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.
 import { GelatoApi } from '@/datasources/relay-api/gelato-api.service';
 import { faker } from '@faker-js/faker';
 import { INetworkService } from '@/datasources/network/network.service.interface';
-import { Hex } from 'viem';
+import { Hex, getAddress } from 'viem';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
@@ -49,7 +49,7 @@ describe('GelatoApi', () => {
   describe('relay', () => {
     it('should relay the payload', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
       const data = faker.string.hexadecimal() as Hex;
       const apiKey = faker.string.sample();
       const taskId = faker.string.uuid();
@@ -81,7 +81,7 @@ describe('GelatoApi', () => {
 
     it('should add a gas buffer if a gas limit is provided', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
       const data = faker.string.hexadecimal() as Hex;
       const gasLimit = faker.number.bigInt();
       const apiKey = faker.string.sample();
@@ -115,7 +115,7 @@ describe('GelatoApi', () => {
 
     it('should throw if there is no API key preset', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
       const data = faker.string.hexadecimal() as Hex;
 
       await expect(
@@ -130,7 +130,7 @@ describe('GelatoApi', () => {
 
     it('should forward error', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
       const data = faker.string.hexadecimal() as Hex;
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
       const apiKey = faker.string.sample();

--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -1022,7 +1022,7 @@ describe('LimitAddressesMapper', () => {
                 setupEncoder().with('owners', owners).encode(),
               )
               .encode();
-            const to = faker.finance.ethereumAddress();
+            const to = getAddress(faker.finance.ethereumAddress());
 
             await expect(
               target.getLimitAddresses({
@@ -1062,51 +1062,6 @@ describe('LimitAddressesMapper', () => {
         ).rejects.toThrow(
           'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
         );
-      });
-
-      it('should throw if the to address is not valid', async () => {
-        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
-        const to = '0x000000000000000000000000000000000INVALID';
-        const data = erc20TransferEncoder().encode();
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to,
-          }),
-        ).rejects.toThrow('Invalid to provided');
-      });
-
-      it('should throw if the to address is not hexadecimal', async () => {
-        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
-        const to = 'not hexadecimal';
-        const data = erc20TransferEncoder().encode();
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to,
-          }),
-        ).rejects.toThrow('Invalid to provided');
-      });
-
-      it('should throw if the calldata is not hexadecimal', async () => {
-        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
-        const to = faker.finance.ethereumAddress();
-        const data = 'not hexadecimal';
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to,
-          }),
-        ).rejects.toThrow('Invalid data provided');
       });
     });
   });

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -12,7 +12,6 @@ import {
   getProxyFactoryDeployment,
 } from '@safe-global/safe-deployments';
 import { SafeDecoder } from '@/domain/contracts/decoders/safe-decoder.helper';
-import { isAddressEqual } from 'viem';
 import { UnofficialMasterCopyError } from '@/domain/relay/errors/unofficial-master-copy.error';
 import { UnofficialMultiSendError } from '@/domain/relay/errors/unofficial-multisend.error';
 import { InvalidTransferError } from '@/domain/relay/errors/invalid-transfer.error';
@@ -186,7 +185,7 @@ export class LimitAddressesMapper {
 
     const [to] = erc20DecodedData.args;
     // to 'self' (the Safe) is not allowed
-    return !isAddressEqual(to, args.to);
+    return to !== args.to;
   }
 
   private isValidErc20TransferFrom(args: { to: Hex; data: Hex }): boolean {
@@ -201,9 +200,7 @@ export class LimitAddressesMapper {
 
     const [sender, recipient] = erc20DecodedData.args;
     // to 'self' (the Safe) or from sender to sender as recipient is not allowed
-    return (
-      !isAddressEqual(sender, recipient) && !isAddressEqual(recipient, args.to)
-    );
+    return sender !== recipient && recipient !== args.to;
   }
 
   private async isOfficialMastercopy(args: {

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -33,8 +33,8 @@ export class RelayRepository {
   async relay(args: {
     version: string;
     chainId: string;
-    to: string;
-    data: string;
+    to: `0x${string}`;
+    data: `0x${string}`;
     gasLimit: bigint | null;
   }): Promise<{ taskId: string }> {
     const relayAddresses =


### PR DESCRIPTION
## Summary

This increases the type strictness throughout the `LimitAddressesMapper` methods now that the relevant schemas are in place, as well as updates the associated tests.