### PR TITLE
Remove unnecessary address checksumming

### DIFF
--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -19,7 +19,6 @@ import {
 } from '@/routes/safes/entities/safe-info.entity';
 import { SafeNonces } from '@/routes/safes/entities/nonces.entity';
 import { Page } from '@/domain/entities/page.entity';
-import { isAddressEqual } from 'viem';
 import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
 import { getNumberString } from '@/domain/common/utils/utils';
 import { SafeOverview } from '@/routes/safes/entities/safe-overview.entity';
@@ -324,7 +323,7 @@ export class SafesService {
     // of the supported singletons we return UNKNOWN
     if (
       supportedSingletons.every(
-        (singleton) => !isAddressEqual(singleton.address, safe.masterCopy),
+        (singleton) => singleton.address !== safe.masterCopy,
       )
     )
       return MasterCopyVersionState.UNKNOWN;

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -19,7 +19,7 @@ import {
 } from '@/routes/safes/entities/safe-info.entity';
 import { SafeNonces } from '@/routes/safes/entities/nonces.entity';
 import { Page } from '@/domain/entities/page.entity';
-import { getAddress } from 'viem';
+import { isAddressEqual } from 'viem';
 import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
 import { getNumberString } from '@/domain/common/utils/utils';
 import { SafeOverview } from '@/routes/safes/entities/safe-overview.entity';
@@ -323,10 +323,9 @@ export class SafesService {
     // If the singleton of this safe is not part of the collection
     // of the supported singletons we return UNKNOWN
     if (
-      !supportedSingletons
-        .map((singleton) => singleton.address)
-        // TODO: Remove checksumming when Safe schema is in Zod
-        .includes(getAddress(safe.masterCopy))
+      supportedSingletons.every(
+        (singleton) => !isAddressEqual(singleton.address, safe.masterCopy),
+      )
     )
       return MasterCopyVersionState.UNKNOWN;
 


### PR DESCRIPTION
## Summary

This removes the unnecessary address checksumming when determining the `MasterCopyVersionState` of a Safe now that the relevant schemas are in place.