### PR TITLE
Move relay count CRUD to datasource

### DIFF
--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -2,7 +2,7 @@ import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.
 import { GelatoApi } from '@/datasources/relay-api/gelato-api.service';
 import { faker } from '@faker-js/faker';
 import { INetworkService } from '@/datasources/network/network.service.interface';
-import { Hex } from 'viem';
+import { Hex, getAddress } from 'viem';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
@@ -170,7 +170,7 @@ describe('GelatoApi', () => {
   describe('getRelayCount', () => {
     it('should return the count', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
       const count = faker.number.int({ min: 1 });
       await fakeCacheService.set(
         new CacheDir(`${chainId}_relay_${address}`, ''),
@@ -188,7 +188,7 @@ describe('GelatoApi', () => {
 
     it('should return 0 if the count is not cached', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
 
       const result = await target.getRelayCount({
         chainId,
@@ -202,7 +202,7 @@ describe('GelatoApi', () => {
   describe('setRelayCount', () => {
     it('should cache the count', async () => {
       const chainId = faker.string.numeric();
-      const address = faker.finance.ethereumAddress() as Hex;
+      const address = getAddress(faker.finance.ethereumAddress());
       const count = faker.number.int({ min: 1 });
 
       await target.setRelayCount({

--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -6,6 +6,8 @@ import { Hex } from 'viem';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
 const mockNetworkService = jest.mocked({
   post: jest.fn(),
@@ -14,7 +16,9 @@ const mockNetworkService = jest.mocked({
 describe('GelatoApi', () => {
   let target: GelatoApi;
   let fakeConfigurationService: FakeConfigurationService;
+  let fakeCacheService: FakeCacheService;
   let baseUri: string;
+  let ttlSeconds: number;
   let httpErrorFactory: HttpErrorFactory;
 
   beforeEach(async () => {
@@ -22,18 +26,23 @@ describe('GelatoApi', () => {
 
     httpErrorFactory = new HttpErrorFactory();
     fakeConfigurationService = new FakeConfigurationService();
+    fakeCacheService = new FakeCacheService();
     baseUri = faker.internet.url({ appendSlash: false });
+    ttlSeconds = faker.number.int();
     fakeConfigurationService.set('relay.baseUri', baseUri);
+    fakeConfigurationService.set('relay.ttlSeconds', ttlSeconds);
 
     target = new GelatoApi(
       mockNetworkService,
       fakeConfigurationService,
       httpErrorFactory,
+      fakeCacheService,
     );
   });
 
   it('should error if baseUri is not defined', () => {
     const fakeConfigurationService = new FakeConfigurationService();
+    const fakeCacheService = new FakeCacheService();
     const httpErrorFactory = new HttpErrorFactory();
 
     expect(
@@ -42,6 +51,7 @@ describe('GelatoApi', () => {
           mockNetworkService,
           fakeConfigurationService,
           httpErrorFactory,
+          fakeCacheService,
         ),
     ).toThrow();
   });
@@ -154,6 +164,57 @@ describe('GelatoApi', () => {
           gasLimit: null,
         }),
       ).rejects.toThrow(new DataSourceError('Unexpected error', status));
+    });
+  });
+
+  describe('getRelayCount', () => {
+    it('should return the count', async () => {
+      const chainId = faker.string.numeric();
+      const address = faker.finance.ethereumAddress() as Hex;
+      const count = faker.number.int({ min: 1 });
+      await fakeCacheService.set(
+        new CacheDir(`${chainId}_relay_${address}`, ''),
+        count.toString(),
+        ttlSeconds,
+      );
+
+      const result = await target.getRelayCount({
+        chainId,
+        address,
+      });
+
+      expect(result).toBe(count);
+    });
+
+    it('should return 0 if the count is not cached', async () => {
+      const chainId = faker.string.numeric();
+      const address = faker.finance.ethereumAddress() as Hex;
+
+      const result = await target.getRelayCount({
+        chainId,
+        address,
+      });
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('setRelayCount', () => {
+    it('should cache the count', async () => {
+      const chainId = faker.string.numeric();
+      const address = faker.finance.ethereumAddress() as Hex;
+      const count = faker.number.int({ min: 1 });
+
+      await target.setRelayCount({
+        chainId,
+        address,
+        count,
+      });
+
+      const result = await fakeCacheService.get(
+        new CacheDir(`${chainId}_relay_${address}`, ''),
+      );
+      expect(result).toBe(count.toString());
     });
   });
 });

--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -11,6 +11,8 @@ import {
   CacheService,
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class GelatoApi implements IRelayApi {
@@ -76,7 +78,7 @@ export class GelatoApi implements IRelayApi {
     chainId: string;
     address: string;
   }): Promise<number> {
-    const cacheDir = CacheRouter.getRelayCacheDir(args);
+    const cacheDir = this.getRelayCacheKey(args);
     const count = await this.cacheService.get(cacheDir);
     return count ? parseInt(count) : 0;
   }
@@ -86,11 +88,22 @@ export class GelatoApi implements IRelayApi {
     address: string;
     count: number;
   }): Promise<void> {
-    const cacheDir = CacheRouter.getRelayCacheDir(args);
+    const cacheDir = this.getRelayCacheKey(args);
     await this.cacheService.set(
       cacheDir,
       args.count.toString(),
       this.ttlSeconds,
     );
+  }
+
+  private getRelayCacheKey(args: {
+    chainId: string;
+    address: string;
+  }): CacheDir {
+    return CacheRouter.getRelayCacheDir({
+      chainId: args.chainId,
+      // Ensure address is checksummed to always have a consistent cache key
+      address: getAddress(args.address),
+    });
   }
 }

--- a/src/domain/interfaces/relay-api.interface.ts
+++ b/src/domain/interfaces/relay-api.interface.ts
@@ -7,4 +7,12 @@ export interface IRelayApi {
     data: string;
     gasLimit: bigint | null;
   }): Promise<{ taskId: string }>;
+
+  getRelayCount(args: { chainId: string; address: string }): Promise<number>;
+
+  setRelayCount(args: {
+    chainId: string;
+    address: string;
+    count: number;
+  }): Promise<void>;
 }

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -4,19 +4,11 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { IRelayApi } from '@/domain/interfaces/relay-api.interface';
 import { LimitAddressesMapper } from '@/domain/relay/limit-addresses.mapper';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { CacheRouter } from '@/datasources/cache/cache.router';
-import {
-  CacheService,
-  ICacheService,
-} from '@/datasources/cache/cache.service.interface';
-import { getAddress } from 'viem';
-import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
 @Injectable()
 export class RelayRepository {
   // Number of relay requests per ttl
   private readonly limit: number;
-  private readonly ttlSeconds: number;
 
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
@@ -24,10 +16,8 @@ export class RelayRepository {
     private readonly limitAddressesMapper: LimitAddressesMapper,
     @Inject(IRelayApi)
     private readonly relayApi: IRelayApi,
-    @Inject(CacheService) private readonly cacheService: ICacheService,
   ) {
     this.limit = configurationService.getOrThrow('relay.limit');
-    this.ttlSeconds = configurationService.getOrThrow('relay.ttlSeconds');
   }
 
   async relay(args: {
@@ -76,9 +66,7 @@ export class RelayRepository {
     chainId: string;
     address: string;
   }): Promise<number> {
-    const cacheDir = this.getRelayCacheKey(args);
-    const currentCount = await this.cacheService.get(cacheDir);
-    return currentCount ? parseInt(currentCount) : 0;
+    return this.relayApi.getRelayCount(args);
   }
 
   private async canRelay(args: {
@@ -95,22 +83,10 @@ export class RelayRepository {
   }): Promise<void> {
     const currentCount = await this.getRelayCount(args);
     const incremented = currentCount + 1;
-    const cacheDir = this.getRelayCacheKey(args);
-    return this.cacheService.set(
-      cacheDir,
-      incremented.toString(),
-      this.ttlSeconds,
-    );
-  }
-
-  private getRelayCacheKey(args: {
-    chainId: string;
-    address: string;
-  }): CacheDir {
-    return CacheRouter.getRelayCacheDir({
+    return this.relayApi.setRelayCount({
       chainId: args.chainId,
-      // Ensure address is checksummed to always have a consistent cache key
-      address: getAddress(args.address),
+      address: args.address,
+      count: incremented,
     });
   }
 }

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -1677,64 +1677,6 @@ describe('Relay controller', () => {
           );
         });
 
-        it('should handle both checksummed and non-checksummed addresses', async () => {
-          const chain = chainBuilder().with('chainId', chainId).build();
-          const safe = safeBuilder().build();
-          const nonChecksummedAddress = safe.address.toLowerCase();
-          const checksummedSafeAddress = getAddress(safe.address);
-          const data = execTransactionEncoder()
-            .with('value', faker.number.bigInt())
-            .encode() as Hex;
-          const taskId = faker.string.uuid();
-          networkService.get.mockImplementation(({ url }) => {
-            switch (url) {
-              case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
-              case `${chain.transactionService}/api/v1/safes/${nonChecksummedAddress}`:
-              case `${chain.transactionService}/api/v1/safes/${checksummedSafeAddress}`:
-                // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
-              default:
-                return Promise.reject(`No matching rule for url: ${url}`);
-            }
-          });
-          networkService.post.mockImplementation(({ url }) => {
-            switch (url) {
-              case `${relayUrl}/relays/v2/sponsored-call`:
-                return Promise.resolve({ data: { taskId }, status: 200 });
-              default:
-                return Promise.reject(`No matching rule for url: ${url}`);
-            }
-          });
-
-          for (const address of [
-            nonChecksummedAddress,
-            checksummedSafeAddress,
-          ]) {
-            await request(app.getHttpServer())
-              .post(`/v1/chains/${chain.chainId}/relay`)
-              .send({
-                to: address,
-                data,
-              });
-          }
-
-          await request(app.getHttpServer())
-            .get(`/v1/chains/${chain.chainId}/relay/${nonChecksummedAddress}`)
-            .expect(({ body }) => {
-              expect(body).toMatchObject({
-                remaining: 3,
-              });
-            });
-          await request(app.getHttpServer())
-            .get(`/v1/chains/${chain.chainId}/relay/${checksummedSafeAddress}`)
-            .expect(({ body }) => {
-              expect(body).toMatchObject({
-                remaining: 3,
-              });
-            });
-        });
-
         it('should not rate limit the same address on different chains', async () => {
           const differentChainId = faker.string.numeric({ exclude: chainId });
           const chain = chainBuilder().with('chainId', chainId).build();


### PR DESCRIPTION
## Summary

This moves the relay count get/set methods to the `IRelayApi` datasource in accordance with the separation of layers throughout the project.

## Changes

- Add `IRelayApi['getRelayCount' | 'setRelayCount']`
- Use above methods in `RelayRepository
- Update tests accordingly