### PR TITLE
Fix `no-unsafe-optional-chaining` instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,6 @@ export default tseslint.config(
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
       'no-case-declarations': 'off',
-      'no-unsafe-optional-chaining': 'off',
       'no-useless-escape': 'off',
       '@typescript-eslint/await-thenable': 'off',
       '@typescript-eslint/no-base-to-string': 'off',

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -152,7 +152,7 @@ export class TransactionDataMapper {
     for (const transaction of valueDecoded) {
       promises.push(this._getIfValid(chainId, transaction.to));
       if (transaction?.dataDecoded?.parameters) {
-        for (const param of transaction?.dataDecoded?.parameters) {
+        for (const param of transaction.dataDecoded.parameters) {
           if (param.type === ADDRESS_PARAMETER_TYPE) {
             promises.push(this._getIfValid(chainId, param.value));
           }


### PR DESCRIPTION
## Summary

When updating to ESLint 9, some rules had to be ignored. This addresses the error that flouts the `no-unsafe-optional-chaining` rule and reenables it.