### PR TITLE
Add support for `presignaturePending` orders

### DIFF
--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -39,8 +39,15 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
   @ApiProperty({ description: 'The order UID' })
   orderUid: string;
 
-  @ApiProperty({ enum: ['open', 'fulfilled', 'cancelled', 'expired'] })
-  status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
+  @ApiProperty({
+    enum: ['open', 'fulfilled', 'cancelled', 'expired', 'presignaturePending'],
+  })
+  status:
+    | 'open'
+    | 'fulfilled'
+    | 'cancelled'
+    | 'expired'
+    | 'presignaturePending';
 
   @ApiProperty({ enum: ['buy', 'sell'] })
   orderKind: 'buy' | 'sell';
@@ -65,7 +72,12 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
 
   protected constructor(args: {
     orderUid: string;
-    status: 'open' | 'fulfilled' | 'cancelled' | 'expired';
+    status:
+      | 'open'
+      | 'fulfilled'
+      | 'cancelled'
+      | 'expired'
+      | 'presignaturePending';
     orderKind: 'buy' | 'sell';
     sellToken: TokenInfo;
     buyToken: TokenInfo;
@@ -133,8 +145,10 @@ export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo 
 
 @ApiExtraModels(TokenInfo)
 export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
-  @ApiProperty({ enum: ['open', 'cancelled', 'expired'] })
-  override status: 'open' | 'cancelled' | 'expired';
+  @ApiProperty({
+    enum: ['open', 'cancelled', 'expired', 'presignaturePending'],
+  })
+  override status: 'open' | 'cancelled' | 'expired' | 'presignaturePending';
 
   @ApiProperty({
     description:
@@ -144,7 +158,7 @@ export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
 
   constructor(args: {
     orderUid: string;
-    status: 'open' | 'cancelled' | 'expired';
+    status: 'open' | 'cancelled' | 'expired' | 'presignaturePending';
     orderKind: 'buy' | 'sell';
     sellToken: TokenInfo;
     buyToken: TokenInfo;

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -122,7 +122,7 @@ describe('Swap Order Mapper tests', () => {
     });
   });
 
-  it.each(['open', 'cancelled', 'expired'])(
+  it.each(['open', 'cancelled', 'expired', 'presignaturePending'])(
     'should map %s swap orders successfully',
     async (orderStatus) => {
       const chainId = faker.string.numeric();
@@ -250,7 +250,7 @@ describe('Swap Order Mapper tests', () => {
     );
   });
 
-  it.each(['fulfilled', 'open', 'cancelled', 'expired'])(
+  it.each(['fulfilled', 'open', 'cancelled', 'expired', 'presignaturePending'])(
     'should throw if %s order kind is unknown',
     async (status) => {
       const chainId = faker.string.numeric();

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -113,6 +113,7 @@ export class SwapOrderMapper {
       case 'open':
       case 'cancelled':
       case 'expired':
+      case 'presignaturePending':
         return this._mapDefaultOrderStatus({
           buyToken: buyTokenAmount,
           sellToken: sellTokenAmount,
@@ -230,11 +231,7 @@ export class SwapOrderMapper {
     if (args.order.kind === 'unknown') {
       throw new Error('Unknown order kind');
     }
-    if (
-      args.order.status === 'fulfilled' ||
-      args.order.status === 'presignaturePending' ||
-      args.order.status === 'unknown'
-    )
+    if (args.order.status === 'fulfilled' || args.order.status === 'unknown')
       throw new Error(
         `${args.order.status} orders should not be mapped as default orders. Order UID = ${args.order.uid}`,
       );


### PR DESCRIPTION
- `presignaturePending` orders are now decoded.
- This is a new requirement as orders in this state were not previously supported.
