### PR TITLE
Extract JWT configuration

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -170,13 +170,9 @@ export default (): ReturnType<typeof configuration> => ({
     relay: true,
     swapsDecoding: true,
     historyDebugLogs: false,
-    auth: true,
+    auth: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
-  jwt: {
-    issuer: faker.lorem.word(),
-    secret: faker.string.alphanumeric(),
-  },
   locking: {
     baseUri: faker.internet.url({ appendSlash: false }),
   },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -177,10 +177,6 @@ export default () => ({
       process.env.HTTP_CLIENT_REQUEST_TIMEOUT_MILLISECONDS ?? `${5_000}`,
     ),
   },
-  jwt: {
-    issuer: process.env.JWT_ISSUER,
-    secret: process.env.JWT_SECRET,
-  },
   locking: {
     baseUri:
       process.env.LOCKING_PROVIDER_API_BASE_URI ||

--- a/src/datasources/jwt/configuration/__tests__/jwt.configuration.ts
+++ b/src/datasources/jwt/configuration/__tests__/jwt.configuration.ts
@@ -1,7 +1,11 @@
 import { registerAs } from '@nestjs/config';
 import { faker } from '@faker-js/faker';
+import { JwtConfiguration } from '@/datasources/jwt/configuration/jwt.configuration';
 
-export default registerAs('jwt', () => ({
-  issuer: faker.lorem.word(),
-  secret: faker.string.alphanumeric(),
-}));
+export default registerAs(
+  'jwt',
+  (): JwtConfiguration => ({
+    issuer: faker.lorem.word(),
+    secret: faker.string.alphanumeric(),
+  }),
+);

--- a/src/datasources/jwt/configuration/__tests__/jwt.configuration.ts
+++ b/src/datasources/jwt/configuration/__tests__/jwt.configuration.ts
@@ -1,0 +1,7 @@
+import { registerAs } from '@nestjs/config';
+import { faker } from '@faker-js/faker';
+
+export default registerAs('jwt', () => ({
+  issuer: faker.lorem.word(),
+  secret: faker.string.alphanumeric(),
+}));

--- a/src/datasources/jwt/configuration/jwt.configuration.module.ts
+++ b/src/datasources/jwt/configuration/jwt.configuration.module.ts
@@ -1,0 +1,23 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces/config-factory.interface';
+import { ConfigModule } from '@nestjs/config';
+import { NestConfigurationService } from '@/config/nest.configuration.service';
+import jwtConfiguration from '@/datasources/jwt/configuration/jwt.configuration';
+
+@Module({})
+export class JwtConfigurationModule {
+  static register(configFactory: ConfigFactory): DynamicModule {
+    return {
+      module: JwtConfigurationModule,
+      imports: [ConfigModule.forFeature(configFactory)],
+      providers: [
+        { provide: IConfigurationService, useClass: NestConfigurationService },
+      ],
+      exports: [IConfigurationService],
+    };
+  }
+}
+
+export const JWT_CONFIGURATION_MODULE =
+  JwtConfigurationModule.register(jwtConfiguration);

--- a/src/datasources/jwt/configuration/jwt.configuration.ts
+++ b/src/datasources/jwt/configuration/jwt.configuration.ts
@@ -1,6 +1,14 @@
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('jwt', () => ({
-  issuer: process.env.JWT_ISSUER,
-  secret: process.env.JWT_SECRET,
-}));
+export interface JwtConfiguration {
+  issuer?: string;
+  secret?: string;
+}
+
+export default registerAs(
+  'jwt',
+  (): JwtConfiguration => ({
+    issuer: process.env.JWT_ISSUER,
+    secret: process.env.JWT_SECRET,
+  }),
+);

--- a/src/datasources/jwt/configuration/jwt.configuration.ts
+++ b/src/datasources/jwt/configuration/jwt.configuration.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('jwt', () => ({
+  issuer: process.env.JWT_ISSUER,
+  secret: process.env.JWT_SECRET,
+}));

--- a/src/datasources/jwt/jwt.module.ts
+++ b/src/datasources/jwt/jwt.module.ts
@@ -2,6 +2,7 @@ import * as jwt from 'jsonwebtoken';
 import { Module } from '@nestjs/common';
 import { JwtService } from '@/datasources/jwt/jwt.service';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { JWT_CONFIGURATION_MODULE } from '@/datasources/jwt/configuration/jwt.configuration.module';
 
 // Use inferred type
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -15,6 +16,7 @@ function jwtClientFactory() {
 export type JwtClient = ReturnType<typeof jwtClientFactory>;
 
 @Module({
+  imports: [JWT_CONFIGURATION_MODULE],
   providers: [
     {
       provide: 'JwtClient',

--- a/src/routes/auth/auth.controller.spec.ts
+++ b/src/routes/auth/auth.controller.spec.ts
@@ -21,6 +21,11 @@ import { toSignableSiweMessage } from '@/datasources/siwe-api/utils/to-signable-
 import { CacheService } from '@/datasources/cache/cache.service.interface';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import {
+  JWT_CONFIGURATION_MODULE,
+  JwtConfigurationModule,
+} from '@/datasources/jwt/configuration/jwt.configuration.module';
+import jwtConfiguration from '@/datasources/jwt/configuration/__tests__/jwt.configuration';
 
 describe('AuthController', () => {
   let app: INestApplication;
@@ -41,6 +46,8 @@ describe('AuthController', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule.register(testConfiguration)],
     })
+      .overrideModule(JWT_CONFIGURATION_MODULE)
+      .useModule(JwtConfigurationModule.register(jwtConfiguration))
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)
       .overrideModule(CacheModule)


### PR DESCRIPTION
- Extracts the JWT configuration out of the root configuration object into its own configuration object.
- This means that if validation is added to the respective properties, the variables won't be required to be set if the module is not enabled.
