### PR TITLE
Update `AuthGuard` to only grant access to Safe owners

### DIFF
--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -30,9 +30,10 @@ export class AuthService {
       throw new UnauthorizedException();
     }
 
-    const { address, notBefore, expirationTime } = args.message;
+    const { chainId, address, notBefore, expirationTime } = args.message;
 
     const payload: JwtAccessTokenPayload = {
+      chain_id: chainId.toString(),
       signer_address: address,
     };
 

--- a/src/routes/auth/entities/jwt-access-token.payload.entity.ts
+++ b/src/routes/auth/entities/jwt-access-token.payload.entity.ts
@@ -1,8 +1,10 @@
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
 export type JwtAccessTokenPayload = z.infer<typeof JwtAccessTokenPayloadSchema>;
 
 export const JwtAccessTokenPayloadSchema = z.object({
+  chain_id: NumericStringSchema,
   signer_address: AddressSchema,
 });

--- a/src/routes/auth/entities/schemas/__tests__/jwt-access-token.payload.builder.ts
+++ b/src/routes/auth/entities/schemas/__tests__/jwt-access-token.payload.builder.ts
@@ -4,8 +4,7 @@ import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 
 export function jwtAccessTokenPayloadBuilder(): IBuilder<JwtAccessTokenPayload> {
-  return new Builder<JwtAccessTokenPayload>().with(
-    'signer_address',
-    getAddress(faker.finance.ethereumAddress()),
-  );
+  return new Builder<JwtAccessTokenPayload>()
+    .with('chain_id', faker.string.numeric({ exclude: ['0'] }))
+    .with('signer_address', getAddress(faker.finance.ethereumAddress()));
 }

--- a/src/routes/auth/entities/schemas/__tests__/jwt-access-token.payload.entity.spec.ts
+++ b/src/routes/auth/entities/schemas/__tests__/jwt-access-token.payload.entity.spec.ts
@@ -44,6 +44,23 @@ describe('JwtAccessTokenSchema', () => {
     ]);
   });
 
+  it('should not allow a non-numeric chain_id', () => {
+    const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+      .with('chain_id', faker.lorem.word())
+      .build();
+
+    const result = JwtAccessTokenPayloadSchema.safeParse(jwtAccessTokenPayload);
+
+    expect(result.success).toBe(false);
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid base-10 numeric string',
+        path: ['chain_id'],
+      },
+    ]);
+  });
+
   it('should not parse an invalid JwtAccessTokenSchema', () => {
     const jwtAccessTokenPayload = {
       unknown: 'payload',
@@ -53,6 +70,13 @@ describe('JwtAccessTokenSchema', () => {
 
     expect(result.success).toBe(false);
     expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['chain_id'],
+        received: 'undefined',
+      },
       {
         code: 'invalid_type',
         expected: 'string',

--- a/src/routes/auth/guards/auth.guard.spec.ts
+++ b/src/routes/auth/guards/auth.guard.spec.ts
@@ -1,5 +1,5 @@
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import { ConfigurationModule } from '@/config/configuration.module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
@@ -8,43 +8,81 @@ import { jwtAccessTokenPayloadBuilder } from '@/routes/auth/entities/schemas/__t
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { AuthGuard } from '@/routes/auth/guards/auth.guard';
 import { faker } from '@faker-js/faker';
-import { Get, INestApplication } from '@nestjs/common';
+import { Get, INestApplication, Module } from '@nestjs/common';
 import { Controller, UseGuards } from '@nestjs/common';
 import { TestingModule, Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { JwtRepositoryModule } from '@/domain/jwt/jwt.repository.interface';
 import { getSecondsUntil } from '@/domain/common/utils/time';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { AppModule } from '@/app.module';
+import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
 
 @Controller()
 class TestController {
-  @Get('valid')
+  @Get('valid/:safeAddress')
   @UseGuards(AuthGuard)
   async validRoute(): Promise<{ secret: string }> {
     return { secret: 'This is a secret message' };
   }
+
+  @Get('invalid')
+  @UseGuards(AuthGuard)
+  async invalidRoute(): Promise<{ secret: string }> {
+    return { secret: 'This is a different secret message' };
+  }
 }
+
+@Module({
+  imports: [JwtRepositoryModule, SafeRepositoryModule],
+  controllers: [TestController],
+})
+class TestModule {}
 
 describe('AuthGuard', () => {
   let app: INestApplication;
   let jwtService: IJwtService;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+  let safeConfigUrl: string | undefined;
 
   beforeEach(async () => {
     jest.useFakeTimers();
 
+    const testConfiguration: typeof configuration = () => ({
+      ...configuration(),
+      features: {
+        ...configuration().features,
+        auth: true,
+      },
+    });
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        TestLoggingModule,
-        ConfigurationModule.register(configuration),
-        CacheModule,
-        JwtRepositoryModule,
-      ],
-      controllers: [TestController],
+      imports: [AppModule.register(testConfiguration), TestModule],
     })
+      .overrideModule(AccountDataSourceModule)
+      .useModule(TestAccountDataSourceModule)
       .overrideModule(CacheModule)
       .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
       .compile();
 
+    const configurationService = moduleFixture.get(IConfigurationService);
     jwtService = moduleFixture.get<IJwtService>(IJwtService);
+    networkService = moduleFixture.get(NetworkService);
+    safeConfigUrl = configurationService.get('safeConfig.baseUri');
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
@@ -54,21 +92,44 @@ describe('AuthGuard', () => {
     await app.close();
   });
 
+  it('should not allow access if there is no Safe address', async () => {
+    const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
+    const accessToken = jwtService.sign(jwtAccessTokenPayload);
+
+    expect(() => jwtService.verify(accessToken)).not.toThrow();
+
+    await request(app.getHttpServer())
+      .get('/invalid')
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
   it('should not allow access if there is no token', async () => {
-    await request(app.getHttpServer()).get('/valid').expect(403).expect({
-      message: 'Forbidden resource',
-      error: 'Forbidden',
-      statusCode: 403,
-    });
+    const safeAddress = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .get(`/valid/${safeAddress}`)
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
   });
 
   it('should not allow access if verification of the token fails', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
     const accessToken = faker.string.alphanumeric();
 
     expect(() => jwtService.verify(accessToken)).toThrow('jwt malformed');
 
     await request(app.getHttpServer())
-      .get('/valid')
+      .get(`/valid/${safeAddress}`)
       .set('Cookie', [`access_token=${accessToken}`])
       .expect(403)
       .expect({
@@ -79,6 +140,7 @@ describe('AuthGuard', () => {
   });
 
   it('should not allow access if a token is not yet valid', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
     const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
     const notBefore = faker.date.future();
     const accessToken = jwtService.sign(jwtAccessTokenPayload, {
@@ -88,7 +150,7 @@ describe('AuthGuard', () => {
     expect(() => jwtService.verify(accessToken)).toThrow('jwt not active');
 
     await request(app.getHttpServer())
-      .get('/valid')
+      .get(`/valid/${safeAddress}`)
       .set('Cookie', [`access_token=${accessToken}`])
       .expect(403)
       .expect({
@@ -99,6 +161,7 @@ describe('AuthGuard', () => {
   });
 
   it('should not allow access if a token has expired', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
     const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
     const expiresIn = 0; // Now
     const accessToken = jwtService.sign(jwtAccessTokenPayload, {
@@ -109,7 +172,7 @@ describe('AuthGuard', () => {
     expect(() => jwtService.verify(accessToken)).toThrow('jwt expired');
 
     await request(app.getHttpServer())
-      .get('/valid')
+      .get(`/valid/${safeAddress}`)
       .set('Cookie', [`access_token=${accessToken}`])
       .expect(403)
       .expect({
@@ -120,6 +183,7 @@ describe('AuthGuard', () => {
   });
 
   it('should not allow access if a verified token is not that of a JwtAccessTokenPayload', async () => {
+    const safeAddress = faker.finance.ethereumAddress();
     const jwtAccessTokenPayload = {
       unknown: 'payload',
     };
@@ -128,7 +192,43 @@ describe('AuthGuard', () => {
     expect(() => jwtService.verify(accessToken)).not.toThrow();
 
     await request(app.getHttpServer())
-      .get('/valid')
+      .get(`/valid/${safeAddress}`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+
+    // No owner check as the token didn't pass validation
+    expect(networkService.get).not.toHaveBeenCalled();
+  });
+
+  it('should not allow access if a token is from a different chain', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+      .with('chain_id', faker.string.numeric({ exclude: chain.chainId }))
+      .with('signer_address', safe.owners[0])
+      .build();
+    const accessToken = jwtService.sign(jwtAccessTokenPayload);
+
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain, status: 200 });
+        case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+          return Promise.resolve({ data: safe, status: 200 });
+        default:
+          return Promise.reject(`No matching rule for url: ${url}`);
+      }
+    });
+
+    expect(() => jwtService.verify(accessToken)).not.toThrow();
+
+    await request(app.getHttpServer())
+      .get(`/valid/${safe.address}`)
       .set('Cookie', [`access_token=${accessToken}`])
       .expect(403)
       .expect({
@@ -138,54 +238,142 @@ describe('AuthGuard', () => {
       });
   });
 
-  describe('should allow access if the JwtAccessTokenSchema is valid', () => {
+  it('should not allow access if a the signer is not an owner', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+      .with('chain_id', chain.chainId)
+      .build();
+    const accessToken = jwtService.sign(jwtAccessTokenPayload);
+
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain, status: 200 });
+        case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+          return Promise.resolve({ data: safe, status: 200 });
+        default:
+          return Promise.reject(`No matching rule for url: ${url}`);
+      }
+    });
+
+    expect(() => jwtService.verify(accessToken)).not.toThrow();
+    expect(safe.owners.includes(jwtAccessTokenPayload.signer_address)).toBe(
+      false,
+    );
+
+    await request(app.getHttpServer())
+      .get(`/valid/${safe.address}`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(403)
+      .expect({
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+        statusCode: 403,
+      });
+  });
+
+  describe('should allow access if the JwtAccessTokenSchema is valid and from the current chain', () => {
     it('when notBefore nor expiresIn is specified', async () => {
-      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', safe.owners[0])
+        .build();
       const accessToken = jwtService.sign(jwtAccessTokenPayload);
+
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+            return Promise.resolve({ data: safe, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
 
       expect(() => jwtService.verify(accessToken)).not.toThrow();
 
       await request(app.getHttpServer())
-        .get('/valid')
+        .get(`/valid/${safe.address}`)
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect({ secret: 'This is a secret message' });
     });
 
     it('when notBefore is and expirationTime is not specified', async () => {
-      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', safe.owners[0])
+        .build();
       const notBefore = faker.date.past();
       const accessToken = jwtService.sign(jwtAccessTokenPayload, {
         notBefore: getSecondsUntil(notBefore),
       });
 
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+            return Promise.resolve({ data: safe, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
       expect(() => jwtService.verify(accessToken)).not.toThrow();
 
       await request(app.getHttpServer())
-        .get('/valid')
+        .get(`/valid/${safe.address}`)
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect({ secret: 'This is a secret message' });
     });
 
     it('when expiresIn is and notBefore is not specified', async () => {
-      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', safe.owners[0])
+        .build();
       const expiresIn = faker.date.future();
       const accessToken = jwtService.sign(jwtAccessTokenPayload, {
         expiresIn: getSecondsUntil(expiresIn),
       });
 
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+            return Promise.resolve({ data: safe, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
       expect(() => jwtService.verify(accessToken)).not.toThrow();
 
       await request(app.getHttpServer())
-        .get('/valid')
+        .get(`/valid/${safe.address}`)
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect({ secret: 'This is a secret message' });
     });
 
     it('when notBefore and expirationTime are specified', async () => {
-      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder().build();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const jwtAccessTokenPayload = jwtAccessTokenPayloadBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', safe.owners[0])
+        .build();
       const notBefore = faker.date.past();
       const expiresIn = faker.date.future();
       const accessToken = jwtService.sign(jwtAccessTokenPayload, {
@@ -193,10 +381,21 @@ describe('AuthGuard', () => {
         expiresIn: getSecondsUntil(expiresIn),
       });
 
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safe.address}`:
+            return Promise.resolve({ data: safe, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
       expect(() => jwtService.verify(accessToken)).not.toThrow();
 
       await request(app.getHttpServer())
-        .get('/valid')
+        .get(`/valid/${safe.address}`)
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect({ secret: 'This is a secret message' });

--- a/src/routes/auth/guards/auth.guard.ts
+++ b/src/routes/auth/guards/auth.guard.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { IJwtRepository } from '@/domain/jwt/jwt.repository.interface';
 import { AuthController } from '@/routes/auth/auth.controller';
+import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 
 /**
  * The AuthGuard should be used to protect routes that require authentication.
@@ -13,31 +14,39 @@ import { AuthController } from '@/routes/auth/auth.controller';
  * It checks for the presence of a valid JWT access token in the request and
  * verifies its validity before allowing access to the route.
  *
- * 1. Check for the presence of an access token in the request.
+ * 1. Check for the presence of an access token/Safe address in the request.
  * 2. Verify the token's validity.
- * 3. If valid, allow access.
+ * 3. If valid, check if the signer is an owner of the Safe.
+ * 4. If the signer is an owner, allow access.
  */
 
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(
     @Inject(IJwtRepository) private readonly jwtRepository: IJwtRepository,
+    @Inject(ISafeRepository) private readonly safeRepository: ISafeRepository,
   ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
 
+    const { safeAddress } = request.params;
     const accessToken =
       request.cookies[AuthController.ACCESS_TOKEN_COOKIE_NAME];
 
-    // No token in the request
-    if (!accessToken) {
+    if (!safeAddress || !accessToken) {
       return false;
     }
 
     try {
-      this.jwtRepository.verifyToken(accessToken);
-      return true;
+      const { chain_id, signer_address } =
+        this.jwtRepository.verifyToken(accessToken);
+
+      return await this.safeRepository.isOwner({
+        chainId: chain_id,
+        address: signer_address,
+        safeAddress,
+      });
     } catch {
       return false;
     }


### PR DESCRIPTION
⚠️ Depends on #1405

## Summary

This updates the `AuthGuard` to only authorise access owners of the requested Safe.

Providing a signer has authenticated themselves with SiWe, the session JWT token is now referenced against the owners of desired Safe and (if they are an owner) granted access.

Note: this does not remove the existing `OnlySafeOwnerGuard`. It will eventually replace all authentication guards used for email routes in a follow up PR.

## Changes

- Add validated `chain_id` claim to authentication JWT token payload.
- Modify `AuthGuard` to verify authenticated session is of a Safe owner.
- Add/update associated test coverage.