### PR TITLE
Add `/views/transaction-confirmation` endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -45,6 +45,7 @@ import { LockingModule } from '@/routes/locking/locking.module';
 import { ZodErrorFilter } from '@/routes/common/filters/zod-error.filter';
 import { CacheControlInterceptor } from '@/routes/common/interceptors/cache-control.interceptor';
 import { AuthModule } from '@/routes/auth/auth.module';
+import { TransactionsViewControllerModule } from '@/routes/transactions/transactions-view.controller';
 
 @Module({})
 export class AppModule implements NestModule {
@@ -57,6 +58,7 @@ export class AppModule implements NestModule {
       email: isEmailFeatureEnabled,
       locking: isLockingFeatureEnabled,
       relay: isRelayFeatureEnabled,
+      confirmationView: isConfirmationViewEnabled,
     } = configFactory()['features'];
 
     return {
@@ -91,6 +93,9 @@ export class AppModule implements NestModule {
         SafeAppsModule,
         SafesModule,
         TransactionsModule,
+        ...(isConfirmationViewEnabled
+          ? [TransactionsViewControllerModule]
+          : []),
         // common
         CacheModule,
         // Module for storing and reading from the async local storage

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -171,6 +171,7 @@ export default (): ReturnType<typeof configuration> => ({
     swapsDecoding: true,
     historyDebugLogs: false,
     auth: false,
+    confirmationView: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -169,6 +169,8 @@ export default () => ({
     historyDebugLogs:
       process.env.FF_HISTORY_DEBUG_LOGS?.toLowerCase() === 'true',
     auth: process.env.FF_AUTH?.toLowerCase() === 'true',
+    confirmationView:
+      process.env.FF_CONFIRMATION_VIEW?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DataDecodedParameter } from '@/routes/data-decode/entities/data-decoded-parameter.entity';
+
+interface Baseline {
+  method: string;
+  parameters: DataDecodedParameter[] | null;
+}
+
+enum DecodedType {
+  Generic = 'GENERIC',
+}
+
+export class ConfirmationView implements Baseline {
+  @ApiProperty()
+  type = DecodedType.Generic;
+
+  @ApiProperty()
+  method: string;
+
+  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  parameters: DataDecodedParameter[] | null;
+
+  constructor(args: {
+    method: string;
+    parameters: DataDecodedParameter[] | null;
+  }) {
+    this.method = args.method;
+    this.parameters = args.parameters;
+  }
+}

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -36,7 +36,7 @@ export class TransactionsViewController {
   async getTransactionConfirmationView(
     @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))
-    safeAddress: string,
+    safeAddress: `0x${string}`,
     @Body(new ValidationPipe(TransactionDataDtoSchema))
     transactionDataDto: TransactionDataDto,
   ): Promise<ConfirmationView> {

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Module,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ConfirmationView } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import {
+  TransactionDataDto,
+  TransactionDataDtoSchema,
+} from '@/routes/common/entities/transaction-data.dto.entity';
+import { TransactionsViewService } from '@/routes/transactions/transactions-view.service';
+import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
+
+@ApiTags('transactions')
+@Controller({
+  path: '',
+  version: '1',
+})
+export class TransactionsViewController {
+  constructor(private readonly service: TransactionsViewService) {}
+
+  @HttpCode(200)
+  @ApiOkResponse({ type: ConfirmationView })
+  @Post('chains/:chainId/safes/:safeAddress/views/transaction-confirmation')
+  @ApiOperation({
+    summary: 'Confirm Transaction View',
+    description: 'This endpoint is experimental and may change.',
+  })
+  async getTransactionConfirmationView(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @Body(new ValidationPipe(TransactionDataDtoSchema))
+    transactionDataDto: TransactionDataDto,
+  ): Promise<ConfirmationView> {
+    return this.service.getTransactionConfirmationView({
+      chainId,
+      transactionDataDto,
+    });
+  }
+}
+
+@Module({
+  imports: [DataDecodedRepositoryModule],
+  providers: [TransactionsViewService],
+  controllers: [TransactionsViewController],
+})
+export class TransactionsViewControllerModule {}

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -15,6 +15,8 @@ import {
 } from '@/routes/common/entities/transaction-data.dto.entity';
 import { TransactionsViewService } from '@/routes/transactions/transactions-view.service';
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('transactions')
 @Controller({
@@ -32,8 +34,9 @@ export class TransactionsViewController {
     description: 'This endpoint is experimental and may change.',
   })
   async getTransactionConfirmationView(
-    @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: string,
     @Body(new ValidationPipe(TransactionDataDtoSchema))
     transactionDataDto: TransactionDataDto,
   ): Promise<ConfirmationView> {

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -1,0 +1,28 @@
+import { TransactionDataDto } from '@/routes/common/entities/transaction-data.dto.entity';
+import { ConfirmationView } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
+import { Inject, Injectable } from '@nestjs/common';
+import { IDataDecodedRepository } from '@/domain/data-decoder/data-decoded.repository.interface';
+
+@Injectable({})
+export class TransactionsViewService {
+  constructor(
+    @Inject(IDataDecodedRepository)
+    private readonly dataDecodedRepository: IDataDecodedRepository,
+  ) {}
+
+  async getTransactionConfirmationView(args: {
+    chainId: string;
+    transactionDataDto: TransactionDataDto;
+  }): Promise<ConfirmationView> {
+    const dataDecoded = await this.dataDecodedRepository.getDataDecoded({
+      chainId: args.chainId,
+      data: args.transactionDataDto.data,
+      to: args.transactionDataDto.to,
+    });
+
+    return new ConfirmationView({
+      method: dataDecoded.method,
+      parameters: dataDecoded.parameters,
+    });
+  }
+}


### PR DESCRIPTION
- Adds a `POST /v1/chains/:chainId/safes/:safeAddress/views/transaction-confirmation`
- The main goal of this endpoint is to return all the data required by the frontend apps to render the Transaction Confirmation Screen.
- Clients are expected to migrate to this endpoint from the `POST /v1/chains/:chainId/data-decoder` endpoint as this endpoint would be extended to provide more data to the Transaction Confirmation Screen.
- The Data Decoder endpoint would still be available as-is.
- This endpoint is currently experimental. To enable it, set `FF_CONFIRMATION_VIEW` to `true`.

### Future Work
Due to the experimental stage of the endpoint and its development cycle, tests will be added once we have a more stable to schema to test the endpoint against with.