### PR TITLE
Add high refresh rate token prices feature

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,12 @@
 # The cache TTL for a missing token price.
 # (default is 259200 [72 hours])
 # NOT_FOUND_PRICE_TTL_SECONDS=
+# Token addresses whose prices should be refresed more often (with HIGH_REFRESH_RATE_TOKENS_TTL_SECONDS TTL).
+# (default is [])
+# HIGH_REFRESH_RATE_TOKENS=
+# The cache TTL for high-refresh-rate token addresses.
+# (default is 30)
+# HIGH_REFRESH_RATE_TOKENS_TTL_SECONDS=
 
 # Balances Provider - Zerion API
 # Chain ids configured to use this provider. (comma-separated numbers)

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -91,6 +91,8 @@ export default (): ReturnType<typeof configuration> => ({
               chainName: faker.string.sample(),
             },
           },
+          highRefreshRateTokens: [],
+          highRefreshRateTokensTtlSeconds: faker.number.int(),
         },
       },
       zerion: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -47,6 +47,11 @@ export default () => ({
             84531: { nativeCoin: 'ethereum', chainName: 'base' },
             84532: { nativeCoin: 'ethereum', chainName: 'base' },
           },
+          highRefreshRateTokens:
+            process.env.HIGH_REFRESH_RATE_TOKENS?.split(',') ?? [],
+          highRefreshRateTokensTtlSeconds: parseInt(
+            process.env.HIGH_REFRESH_RATE_TOKENS_TTL_SECONDS ?? `${30}`,
+          ),
         },
       },
       zerion: {

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -377,7 +377,6 @@ describe('CoingeckoAPI', () => {
       [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price },
       [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice },
     };
-    // TODO: document
     mockCacheService.get.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
       data: coingeckoPrice,
@@ -391,7 +390,7 @@ describe('CoingeckoAPI', () => {
       `balances.providers.safe.prices.highRefreshRateTokens`,
       [
         faker.finance.ethereumAddress(),
-        highRefreshRateTokenAddress,
+        highRefreshRateTokenAddress.toUpperCase(), // to check this configuration is case insensitive
         faker.finance.ethereumAddress(),
       ],
     );

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -34,6 +34,7 @@ describe('CoingeckoAPI', () => {
   const coingeckoBaseUri = faker.internet.url({ appendSlash: false });
   const coingeckoApiKey = faker.string.sample();
   const pricesCacheTtlSeconds = faker.number.int();
+  const highRefreshRateTokensTtlSeconds = faker.number.int();
   const notFoundPriceTtlSeconds = faker.number.int();
   const defaultExpirationTimeInSeconds = faker.number.int();
   const notFoundExpirationTimeInSeconds = faker.number.int();
@@ -50,8 +51,16 @@ describe('CoingeckoAPI', () => {
       coingeckoApiKey,
     );
     fakeConfigurationService.set(
+      `balances.providers.safe.prices.highRefreshRateTokens`,
+      [],
+    );
+    fakeConfigurationService.set(
       'balances.providers.safe.prices.pricesTtlSeconds',
       pricesCacheTtlSeconds,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.safe.prices.highRefreshRateTokensTtlSeconds',
+      highRefreshRateTokensTtlSeconds,
     );
     fakeConfigurationService.set(
       'balances.providers.safe.prices.notFoundPriceTtlSeconds',
@@ -350,6 +359,108 @@ describe('CoingeckoAPI', () => {
       ),
       JSON.stringify({
         [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
+      }),
+      pricesCacheTtlSeconds,
+    );
+  });
+
+  it('should return and cache with low TTL one high-refresh-rate token price', async () => {
+    const chain = chainBuilder().build();
+    const chainName = faker.string.sample();
+    const highRefreshRateTokenAddress = faker.finance.ethereumAddress();
+    const anotherTokenAddress = faker.finance.ethereumAddress();
+    const fiatCode = faker.finance.currencyCode();
+    const lowerCaseFiatCode = fiatCode.toLowerCase();
+    const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const anotherPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const coingeckoPrice: AssetPrice = {
+      [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price },
+      [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice },
+    };
+    // TODO: document
+    mockCacheService.get.mockResolvedValue(undefined);
+    mockNetworkService.get.mockResolvedValue({
+      data: coingeckoPrice,
+      status: 200,
+    });
+    fakeConfigurationService.set(
+      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
+      chainName,
+    );
+    fakeConfigurationService.set(
+      `balances.providers.safe.prices.highRefreshRateTokens`,
+      [
+        faker.finance.ethereumAddress(),
+        highRefreshRateTokenAddress,
+        faker.finance.ethereumAddress(),
+      ],
+    );
+    const service = new CoingeckoApi(
+      fakeConfigurationService,
+      mockCacheFirstDataSource,
+      mockNetworkService,
+      mockCacheService,
+      mockLoggingService,
+    );
+
+    const assetPrice = await service.getTokenPrices({
+      chainId: chain.chainId,
+      tokenAddresses: [highRefreshRateTokenAddress, anotherTokenAddress],
+      fiatCode,
+    });
+
+    expect(assetPrice).toEqual([
+      { [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price } },
+      { [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice } },
+    ]);
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
+        headers: {
+          'x-cg-pro-api-key': coingeckoApiKey,
+        },
+        params: {
+          contract_addresses: [
+            highRefreshRateTokenAddress,
+            anotherTokenAddress,
+          ].join(','),
+          vs_currencies: lowerCaseFiatCode,
+        },
+      },
+    });
+    expect(mockCacheService.get).toHaveBeenCalledTimes(2);
+    expect(mockCacheService.set).toHaveBeenCalledTimes(2);
+    // high-refresh-rate token price is cached with highRefreshRateTokensTtlSeconds
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
+        '',
+      ),
+      JSON.stringify({
+        [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price },
+      }),
+      highRefreshRateTokensTtlSeconds,
+    );
+    // another token price is cached with pricesCacheTtlSeconds
+    expect(mockCacheService.get).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
+        '',
+      ),
+    );
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      new CacheDir(
+        `${chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
+        '',
+      ),
+      JSON.stringify({
+        [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice },
       }),
       pricesCacheTtlSeconds,
     );

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -272,22 +272,19 @@ export class CoingeckoApi implements IPricesApi {
    * Gets the cache TTL for storing the price value.
    * If the token address is included in {@link highRefreshRateTokens} (defaults to []),
    * then {@link highRefreshRateTokensTtlSeconds} is used (defaults to 30 seconds).
-   * If the price cannot ve retrieved {@link _getRandomNotFoundTokenPriceTtl} is called.
+   * If the price cannot ve retrieved (or it's zero) {@link _getRandomNotFoundTokenPriceTtl} is called.
    * Else {@link pricesTtlSeconds} is used (defaults to 300 seconds).
    */
   private _getTtl(
     price: number | null | undefined,
     tokenAddress: string,
-  ): number | undefined {
-    const isHighRefreshRateToken =
-      this.highRefreshRateTokens.includes(tokenAddress);
-
-    if (price == null) {
-      return this._getRandomNotFoundTokenPriceTtl();
+  ): number {
+    if (this.highRefreshRateTokens.includes(tokenAddress)) {
+      return this.highRefreshRateTokensTtlSeconds;
     }
 
-    return isHighRefreshRateToken
-      ? this.highRefreshRateTokensTtlSeconds
+    return !price
+      ? this._getRandomNotFoundTokenPriceTtl()
       : this.pricesTtlSeconds;
   }
 


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-client-gateway/issues/1420

## Summary
The CGW caches token prices for some amount of time. All token prices are currently stored in the cache with the same TTL (except for the not-found tokens, which have longer TTLs).

This PR adds the concept of high-refresh-rate token prices. The main goal is to add the ability to set token addresses via configuration, which prices would be retrieved in a different frequency (i.e.: stored in cache with a lower TTL).

## Changes
- Adds `HIGH_REFRESH_RATE_TOKENS` and `HIGH_REFRESH_RATE_TOKENS_TTL_SECONDS`, which manage the list of token addresses affected, and the desired TTL for these token prices.
- Adds the private function `_getTtl` to `CoingeckoApi`, in order to compute the proper TTL for each token address.
- Adds related tests.
