### PR TITLE
Configurable native coin prices TTL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,9 @@
 # The cache TTL for high-refresh-rate token addresses.
 # (default is 30)
 # HIGH_REFRESH_RATE_TOKENS_TTL_SECONDS=
+# The cache TTL for native coins.
+# (default is 100)
+# NATIVE_COINS_PRICES_TTL_SECONDS=
 
 # Balances Provider - Zerion API
 # Chain ids configured to use this provider. (comma-separated numbers)

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -20,6 +20,7 @@ export default (): ReturnType<typeof configuration> => ({
           baseUri: faker.internet.url({ appendSlash: false }),
           apiKey: faker.string.hexadecimal({ length: 32 }),
           pricesTtlSeconds: faker.number.int(),
+          nativeCoinPricesTtlSeconds: faker.number.int(),
           notFoundPriceTtlSeconds: faker.number.int(),
           chains: {
             1: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -25,6 +25,9 @@ export default () => ({
           pricesTtlSeconds: parseInt(
             process.env.PRICES_TTL_SECONDS ?? `${300}`,
           ),
+          nativeCoinPricesTtlSeconds: parseInt(
+            process.env.NATIVE_COINS_PRICES_TTL_SECONDS ?? `${100}`,
+          ),
           notFoundPriceTtlSeconds: parseInt(
             process.env.NOT_FOUND_PRICE_TTL_SECONDS ?? `${72 * 60 * 60}`,
           ),

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -33,7 +33,8 @@ describe('CoingeckoAPI', () => {
   let fakeConfigurationService: FakeConfigurationService;
   const coingeckoBaseUri = faker.internet.url({ appendSlash: false });
   const coingeckoApiKey = faker.string.sample();
-  const pricesCacheTtlSeconds = faker.number.int();
+  const pricesTtlSeconds = faker.number.int();
+  const nativeCoinPricesTtlSeconds = faker.number.int();
   const highRefreshRateTokensTtlSeconds = faker.number.int();
   const notFoundPriceTtlSeconds = faker.number.int();
   const defaultExpirationTimeInSeconds = faker.number.int();
@@ -56,7 +57,11 @@ describe('CoingeckoAPI', () => {
     );
     fakeConfigurationService.set(
       'balances.providers.safe.prices.pricesTtlSeconds',
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.safe.prices.nativeCoinPricesTtlSeconds',
+      nativeCoinPricesTtlSeconds,
     );
     fakeConfigurationService.set(
       'balances.providers.safe.prices.highRefreshRateTokensTtlSeconds',
@@ -191,7 +196,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenCalledWith(
       expectedCacheDir,
       JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
   });
 
@@ -251,7 +256,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenCalledWith(
       expectedCacheDir,
       JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
   });
 
@@ -340,7 +345,7 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({
         [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
       }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
@@ -350,7 +355,7 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({
         [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
       }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
@@ -360,7 +365,7 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({
         [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
       }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
   });
 
@@ -461,7 +466,7 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({
         [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice },
       }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
   });
 
@@ -557,7 +562,7 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({
         [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
       }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       2,
@@ -568,7 +573,7 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({
         [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
       }),
-      pricesCacheTtlSeconds,
+      pricesTtlSeconds,
     );
   });
 
@@ -703,7 +708,7 @@ describe('CoingeckoAPI', () => {
         },
       },
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
-      expireTimeSeconds: pricesCacheTtlSeconds,
+      expireTimeSeconds: nativeCoinPricesTtlSeconds,
     });
   });
 
@@ -742,7 +747,7 @@ describe('CoingeckoAPI', () => {
         },
       },
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
-      expireTimeSeconds: pricesCacheTtlSeconds,
+      expireTimeSeconds: nativeCoinPricesTtlSeconds,
     });
   });
 });

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -34,10 +34,17 @@ export class CoingeckoApi implements IPricesApi {
   static readonly NOT_FOUND_TTL_RANGE_SECONDS: number = 60 * 60 * 24;
   private readonly apiKey: string | undefined;
   private readonly baseUrl: string;
-  private readonly pricesTtlSeconds: number;
-  private readonly notFoundPriceTtlSeconds: number;
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
+  private readonly pricesTtlSeconds: number;
+  /**
+   * TTL in seconds for native coin prices.
+   */
+  private readonly nativeCoinPricesTtlSeconds: number;
+  /**
+   * TTL in seconds for a not found token price.
+   */
+  private readonly notFoundPriceTtlSeconds: number;
   /**
    * Token addresses that will be cached with a highRefreshRateTokensTtlSeconds TTL.
    */
@@ -68,6 +75,10 @@ export class CoingeckoApi implements IPricesApi {
     this.pricesTtlSeconds = this.configurationService.getOrThrow<number>(
       'balances.providers.safe.prices.pricesTtlSeconds',
     );
+    this.nativeCoinPricesTtlSeconds =
+      this.configurationService.getOrThrow<number>(
+        'balances.providers.safe.prices.nativeCoinPricesTtlSeconds',
+      );
     this.notFoundPriceTtlSeconds = this.configurationService.getOrThrow<number>(
       'balances.providers.safe.prices.notFoundPriceTtlSeconds',
     );
@@ -117,7 +128,7 @@ export class CoingeckoApi implements IPricesApi {
           }),
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
-        expireTimeSeconds: this.pricesTtlSeconds,
+        expireTimeSeconds: this.nativeCoinPricesTtlSeconds,
       });
       return result?.[nativeCoinId]?.[lowerCaseFiatCode];
     } catch (error) {


### PR DESCRIPTION
Closes #1421 

Depends on #1424 

## Summary
This PR makes native coins price TTL configurable.

## Changes
- Adds `NATIVE_COINS_PRICES_TTL_SECONDS` in order to make this value configurable.
