### PR TITLE
Return non formatted Order data

### DIFF
--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -1,4 +1,4 @@
-import { Order } from '@/domain/swaps/entities/order.entity';
+import { Order, OrderStatus } from '@/domain/swaps/entities/order.entity';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
@@ -56,16 +56,7 @@ export function orderBuilder(): IBuilder<Order> {
     .with('executedBuyAmount', faker.number.bigInt({ min: 1 }))
     .with('executedFeeAmount', faker.number.bigInt({ min: 1 }))
     .with('invalidated', faker.datatype.boolean())
-    .with(
-      'status',
-      faker.helpers.arrayElement([
-        'presignaturePending',
-        'open',
-        'fulfilled',
-        'cancelled',
-        'expired',
-      ]),
-    )
+    .with('status', faker.helpers.arrayElement(Object.values(OrderStatus)))
     .with('fullFeeAmount', faker.number.bigInt({ min: 1 }))
     .with('isLiquidityOrder', faker.datatype.boolean())
     .with(

--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -1,4 +1,8 @@
-import { Order, OrderStatus } from '@/domain/swaps/entities/order.entity';
+import {
+  Order,
+  OrderClass,
+  OrderStatus,
+} from '@/domain/swaps/entities/order.entity';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
@@ -44,7 +48,14 @@ export function orderBuilder(): IBuilder<Order> {
     )
     .with('quoteId', faker.datatype.boolean() ? faker.number.int() : null)
     .with('creationDate', faker.date.recent())
-    .with('class', faker.helpers.arrayElement(['market', 'limit', 'liquidity']))
+    .with(
+      'class',
+      faker.helpers.arrayElement(
+        Object.values(OrderClass).filter(
+          (orderClass) => orderClass !== OrderClass.Unknown,
+        ),
+      ),
+    )
     .with('owner', getAddress(faker.finance.ethereumAddress()))
     .with('uid', faker.string.hexadecimal({ length: 112 }))
     .with(

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -13,6 +13,13 @@ export enum OrderStatus {
   Unknown = 'unknown',
 }
 
+export enum OrderClass {
+  Market = 'market',
+  Limit = 'limit',
+  Liquidity = 'liquidity',
+  Unknown = 'unknown',
+}
+
 export const OrderSchema = z.object({
   sellToken: AddressSchema,
   buyToken: AddressSchema,
@@ -35,7 +42,7 @@ export const OrderSchema = z.object({
   from: AddressSchema.nullish().default(null),
   quoteId: z.number().nullish().default(null),
   creationDate: z.coerce.date(),
-  class: z.enum(['market', 'limit', 'liquidity', 'unknown']).catch('unknown'),
+  class: z.nativeEnum(OrderClass).catch(OrderClass.Unknown),
   owner: AddressSchema,
   uid: z.string(),
   availableBalance: z.coerce.bigint().nullish().default(null),

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -4,6 +4,15 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 
 export type Order = z.infer<typeof OrderSchema>;
 
+export enum OrderStatus {
+  PreSignaturePending = 'presignaturePending',
+  Open = 'open',
+  Fulfilled = 'fulfilled',
+  Cancelled = 'cancelled',
+  Expired = 'expired',
+  Unknown = 'unknown',
+}
+
 export const OrderSchema = z.object({
   sellToken: AddressSchema,
   buyToken: AddressSchema,
@@ -35,16 +44,7 @@ export const OrderSchema = z.object({
   executedBuyAmount: z.coerce.bigint(),
   executedFeeAmount: z.coerce.bigint(),
   invalidated: z.boolean(),
-  status: z
-    .enum([
-      'presignaturePending',
-      'open',
-      'fulfilled',
-      'cancelled',
-      'expired',
-      'unknown',
-    ])
-    .catch('unknown'),
+  status: z.nativeEnum(OrderStatus).catch(OrderStatus.Unknown),
   fullFeeAmount: z.coerce.bigint(),
   isLiquidityOrder: z.boolean(),
   ethflowData: z

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -66,7 +66,7 @@ export class SwapOrderTransactionInfo extends TransactionInfo {
   kind: 'buy' | 'sell';
 
   @ApiProperty({ description: 'The timestamp when the order expires' })
-  validTo: number;
+  validUntil: number;
 
   @ApiProperty({
     description: 'The sell token raw amount (no decimals)',
@@ -111,7 +111,7 @@ export class SwapOrderTransactionInfo extends TransactionInfo {
     uid: string;
     status: OrderStatus;
     kind: 'buy' | 'sell';
-    validTo: number;
+    validUntil: number;
     sellAmount: string;
     buyAmount: string;
     executedSellAmount: string;
@@ -125,7 +125,7 @@ export class SwapOrderTransactionInfo extends TransactionInfo {
     this.uid = args.uid;
     this.status = args.status;
     this.kind = args.kind;
-    this.validTo = args.validTo;
+    this.validUntil = args.validUntil;
     this.sellAmount = args.sellAmount;
     this.buyAmount = args.buyAmount;
     this.executedSellAmount = args.executedSellAmount;

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -7,7 +7,7 @@ import {
   ApiProperty,
   ApiPropertyOptional,
 } from '@nestjs/swagger';
-import { OrderStatus } from '@/domain/swaps/entities/order.entity';
+import { OrderClass, OrderStatus } from '@/domain/swaps/entities/order.entity';
 
 export class TokenInfo {
   @ApiProperty({ description: 'The token address' })
@@ -65,6 +65,11 @@ export class SwapOrderTransactionInfo extends TransactionInfo {
   @ApiProperty({ enum: ['buy', 'sell'] })
   kind: 'buy' | 'sell';
 
+  @ApiProperty({
+    enum: OrderClass,
+  })
+  class: OrderClass;
+
   @ApiProperty({ description: 'The timestamp when the order expires' })
   validUntil: number;
 
@@ -111,6 +116,7 @@ export class SwapOrderTransactionInfo extends TransactionInfo {
     uid: string;
     status: OrderStatus;
     kind: 'buy' | 'sell';
+    class: OrderClass;
     validUntil: number;
     sellAmount: string;
     buyAmount: string;
@@ -125,6 +131,7 @@ export class SwapOrderTransactionInfo extends TransactionInfo {
     this.uid = args.uid;
     this.status = args.status;
     this.kind = args.kind;
+    this.class = args.class;
     this.validUntil = args.validUntil;
     this.sellAmount = args.sellAmount;
     this.buyAmount = args.buyAmount;

--- a/src/routes/transactions/entities/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swap-order-info.entity.ts
@@ -7,50 +7,86 @@ import {
   ApiProperty,
   ApiPropertyOptional,
 } from '@nestjs/swagger';
+import { OrderStatus } from '@/domain/swaps/entities/order.entity';
 
 export class TokenInfo {
+  @ApiProperty({ description: 'The token address' })
+  address: `0x${string}`;
+
+  @ApiProperty({ description: 'The token decimals' })
+  decimals: number;
+
   @ApiPropertyOptional({
     type: String,
     nullable: true,
-    description: 'The token logo',
+    description: 'The logo URI for the token',
   })
-  logo: string | null;
+  logoUri: string | null;
+
+  @ApiProperty({ description: 'The token name' })
+  name: string;
 
   @ApiProperty({ description: 'The token symbol' })
   symbol: string;
 
-  @ApiProperty({
-    description: 'The token amount in decimal format',
-  })
-  amount: string;
+  @ApiProperty({ description: 'The token trusted status' })
+  trusted: boolean;
 
-  constructor(args: { logo: string | null; symbol: string; amount: string }) {
-    this.logo = args.logo;
+  constructor(args: {
+    address: `0x${string}`;
+    decimals: number;
+    logoUri: string | null;
+    name: string;
+    symbol: string;
+    trusted: boolean;
+  }) {
+    this.address = args.address;
+    this.decimals = args.decimals;
+    this.logoUri = args.logoUri;
+    this.name = args.name;
     this.symbol = args.symbol;
-    this.amount = args.amount;
+    this.trusted = args.trusted;
   }
 }
 
 @ApiExtraModels(TokenInfo)
-export abstract class SwapOrderTransactionInfo extends TransactionInfo {
+export class SwapOrderTransactionInfo extends TransactionInfo {
   @ApiProperty({ enum: [TransactionInfoType.SwapOrder] })
-  override type: TransactionInfoType.SwapOrder;
+  override type = TransactionInfoType.SwapOrder;
 
   @ApiProperty({ description: 'The order UID' })
-  orderUid: string;
+  uid: string;
 
   @ApiProperty({
-    enum: ['open', 'fulfilled', 'cancelled', 'expired', 'presignaturePending'],
+    enum: OrderStatus,
   })
-  status:
-    | 'open'
-    | 'fulfilled'
-    | 'cancelled'
-    | 'expired'
-    | 'presignaturePending';
+  status: OrderStatus;
 
   @ApiProperty({ enum: ['buy', 'sell'] })
-  orderKind: 'buy' | 'sell';
+  kind: 'buy' | 'sell';
+
+  @ApiProperty({ description: 'The timestamp when the order expires' })
+  validTo: number;
+
+  @ApiProperty({
+    description: 'The sell token raw amount (no decimals)',
+  })
+  sellAmount: string;
+
+  @ApiProperty({
+    description: 'The buy token raw amount (no decimals)',
+  })
+  buyAmount: string;
+
+  @ApiProperty({
+    description: 'The executed sell token raw amount (no decimals)',
+  })
+  executedSellAmount: string;
+
+  @ApiProperty({
+    description: 'The executed buy token raw amount (no decimals)',
+  })
+  executedBuyAmount: string;
 
   @ApiProperty({ description: 'The sell token of the order' })
   sellToken: TokenInfo;
@@ -58,117 +94,45 @@ export abstract class SwapOrderTransactionInfo extends TransactionInfo {
   @ApiProperty({ description: 'The buy token of the order' })
   buyToken: TokenInfo;
 
-  @ApiProperty({ description: 'The timestamp when the order expires' })
-  expiresTimestamp: number;
-
   @ApiProperty({
-    description: 'The filled percentage of the order',
-    examples: ['0.00', '50.75', '100.00'],
+    type: String,
+    description: 'The URL to the explorer page of the order',
   })
-  filledPercentage: string;
-
-  @ApiProperty({ description: 'The URL to the explorer page of the order' })
   explorerUrl: URL;
-
-  protected constructor(args: {
-    orderUid: string;
-    status:
-      | 'open'
-      | 'fulfilled'
-      | 'cancelled'
-      | 'expired'
-      | 'presignaturePending';
-    orderKind: 'buy' | 'sell';
-    sellToken: TokenInfo;
-    buyToken: TokenInfo;
-    expiresTimestamp: number;
-    filledPercentage: string;
-    explorerUrl: URL;
-  }) {
-    super(TransactionInfoType.SwapOrder, null, null);
-    this.orderUid = args.orderUid;
-    this.type = TransactionInfoType.SwapOrder;
-    this.status = args.status;
-    this.orderKind = args.orderKind;
-    this.sellToken = args.sellToken;
-    this.buyToken = args.buyToken;
-    this.expiresTimestamp = args.expiresTimestamp;
-    this.filledPercentage = args.filledPercentage;
-    this.explorerUrl = args.explorerUrl;
-  }
-}
-
-@ApiExtraModels(TokenInfo)
-export class FulfilledSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
-  @ApiProperty({ enum: ['fulfilled'] })
-  override status: 'fulfilled';
 
   @ApiPropertyOptional({
     type: String,
     nullable: true,
-    description:
-      'The amount of fees paid for this order in the format of "$feeAmount $tokenSymbol"',
+    description: 'The amount of fees paid for this order.',
   })
-  feeLabel: string | null;
-
-  @ApiProperty({
-    description:
-      'The execution price label is in the format of "1 $sellTokenSymbol = $ratio $buyTokenSymbol"',
-  })
-  executionPriceLabel: string;
-
-  @ApiProperty({
-    description:
-      'The (averaged) surplus for this order in the format of "$surplusAmount $tokenSymbol"',
-  })
-  surplusLabel: string;
+  executedSurplusFee: string | null;
 
   constructor(args: {
-    orderUid: string;
-    orderKind: 'buy' | 'sell';
+    uid: string;
+    status: OrderStatus;
+    kind: 'buy' | 'sell';
+    validTo: number;
+    sellAmount: string;
+    buyAmount: string;
+    executedSellAmount: string;
+    executedBuyAmount: string;
     sellToken: TokenInfo;
     buyToken: TokenInfo;
-    expiresTimestamp: number;
-    feeLabel: string | null;
-    executionPriceLabel: string;
-    surplusLabel: string;
-    filledPercentage: string;
     explorerUrl: URL;
+    executedSurplusFee: string | null;
   }) {
-    super({ ...args, status: 'fulfilled' });
-    this.status = 'fulfilled';
-    this.feeLabel = args.feeLabel;
-    this.executionPriceLabel = args.executionPriceLabel;
-    this.surplusLabel = args.surplusLabel;
-  }
-}
-
-@ApiExtraModels(TokenInfo)
-export class DefaultSwapOrderTransactionInfo extends SwapOrderTransactionInfo {
-  @ApiProperty({
-    enum: ['open', 'cancelled', 'expired', 'presignaturePending'],
-  })
-  override status: 'open' | 'cancelled' | 'expired' | 'presignaturePending';
-
-  @ApiProperty({
-    description:
-      'The limit price label is in the format of "1 $sellTokenSymbol = $limitPriceLabel $buyTokenSymbol"',
-  })
-  limitPriceLabel: string;
-
-  constructor(args: {
-    orderUid: string;
-    status: 'open' | 'cancelled' | 'expired' | 'presignaturePending';
-    orderKind: 'buy' | 'sell';
-    sellToken: TokenInfo;
-    buyToken: TokenInfo;
-    expiresTimestamp: number;
-    limitPriceLabel: string;
-    filledPercentage: string;
-    explorerUrl: URL;
-  }) {
-    super(args);
+    super(TransactionInfoType.SwapOrder, null, null);
+    this.uid = args.uid;
     this.status = args.status;
-    this.limitPriceLabel = args.limitPriceLabel;
+    this.kind = args.kind;
+    this.validTo = args.validTo;
+    this.sellAmount = args.sellAmount;
+    this.buyAmount = args.buyAmount;
+    this.executedSellAmount = args.executedSellAmount;
+    this.executedBuyAmount = args.executedBuyAmount;
+    this.sellToken = args.sellToken;
+    this.buyToken = args.buyToken;
+    this.explorerUrl = args.explorerUrl;
+    this.executedSurplusFee = args.executedSurplusFee;
   }
 }

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -13,10 +13,7 @@ import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity
 import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
 import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
-import {
-  DefaultSwapOrderTransactionInfo,
-  FulfilledSwapOrderTransactionInfo,
-} from '@/routes/transactions/entities/swap-order-info.entity';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swap-order-info.entity';
 
 @ApiExtraModels(
   CreationTransactionInfo,
@@ -25,8 +22,7 @@ import {
   TransferTransactionInfo,
   ModuleExecutionInfo,
   MultisigExecutionInfo,
-  FulfilledSwapOrderTransactionInfo,
-  DefaultSwapOrderTransactionInfo,
+  SwapOrderTransactionInfo,
 )
 export class Transaction {
   @ApiProperty()
@@ -40,8 +36,7 @@ export class Transaction {
       { $ref: getSchemaPath(CreationTransactionInfo) },
       { $ref: getSchemaPath(CustomTransactionInfo) },
       { $ref: getSchemaPath(SettingsChangeTransaction) },
-      { $ref: getSchemaPath(DefaultSwapOrderTransactionInfo) },
-      { $ref: getSchemaPath(FulfilledSwapOrderTransactionInfo) },
+      { $ref: getSchemaPath(SwapOrderTransactionInfo) },
       { $ref: getSchemaPath(TransferTransactionInfo) },
     ],
   })

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -82,6 +82,7 @@ describe('Swap Order Mapper tests', () => {
         uid: order.uid,
         status: order.status,
         kind: order.kind,
+        class: order.class,
         validUntil: order.validTo,
         sellAmount: order.sellAmount.toString(),
         buyAmount: order.buyAmount.toString(),

--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -82,7 +82,7 @@ describe('Swap Order Mapper tests', () => {
         uid: order.uid,
         status: order.status,
         kind: order.kind,
-        validTo: order.validTo,
+        validUntil: order.validTo,
         sellAmount: order.sellAmount.toString(),
         buyAmount: order.buyAmount.toString(),
         executedSellAmount: order.executedSellAmount.toString(),

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -1,8 +1,6 @@
 import { Inject, Injectable, Module } from '@nestjs/common';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import {
-  DefaultSwapOrderTransactionInfo,
-  FulfilledSwapOrderTransactionInfo,
   SwapOrderTransactionInfo,
   TokenInfo,
 } from '@/routes/transactions/entities/swap-order-info.entity';
@@ -10,51 +8,10 @@ import {
   ITokenRepository,
   TokenRepositoryModule,
 } from '@/domain/tokens/token.repository.interface';
-import { Token } from '@/domain/tokens/entities/token.entity';
 import { SwapsRepository } from '@/domain/swaps/swaps.repository';
 import { SwapsModule } from '@/domain/swaps/swaps.module';
 import { Order } from '@/domain/swaps/entities/order.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-
-/**
- * Represents the amount of a token in a swap order.
- */
-class TokenAmount {
-  readonly token: Token & {
-    decimals: number;
-  };
-  private readonly amount: bigint;
-  private readonly executedAmount: bigint;
-
-  constructor(args: { token: Token; amount: bigint; executedAmount: bigint }) {
-    if (args.token.decimals === null)
-      throw new Error(`Token ${args.token.address} has no decimals set.`);
-
-    this.token = { ...args.token, decimals: args.token.decimals };
-    this.amount = args.amount;
-    this.executedAmount = args.executedAmount;
-  }
-
-  getAmount(): number {
-    return asDecimal(this.amount, this.token.decimals);
-  }
-
-  getExecutedAmount(): number {
-    return asDecimal(this.executedAmount, this.token.decimals);
-  }
-
-  toTokenInfo(): TokenInfo {
-    return new TokenInfo({
-      amount: this.getAmount().toString(),
-      symbol: this.token.symbol,
-      logo: this.token.logoUri,
-    });
-  }
-}
-
-function asDecimal(amount: number | bigint, decimals: number): number {
-  return Number(amount) / 10 ** decimals;
-}
 
 @Injectable()
 export class SwapOrderMapper {
@@ -81,6 +38,10 @@ export class SwapOrderMapper {
     }
 
     const order = await this.swapsRepository.getOrder(chainId, orderUid);
+    if (order.kind === 'unknown') {
+      throw new Error('Unknown order kind');
+    }
+
     const [buyToken, sellToken] = await Promise.all([
       this.tokenRepository.getToken({
         chainId,
@@ -92,82 +53,38 @@ export class SwapOrderMapper {
       }),
     ]);
 
-    const buyTokenAmount = new TokenAmount({
-      token: buyToken,
-      amount: order.buyAmount,
-      executedAmount: order.executedBuyAmount,
-    });
-    const sellTokenAmount = new TokenAmount({
-      token: sellToken,
-      amount: order.sellAmount,
-      executedAmount: order.executedSellAmount,
-    });
-
-    switch (order.status) {
-      case 'fulfilled':
-        return this._mapFulfilledOrderStatus({
-          buyToken: buyTokenAmount,
-          sellToken: sellTokenAmount,
-          order,
-        });
-      case 'open':
-      case 'cancelled':
-      case 'expired':
-      case 'presignaturePending':
-        return this._mapDefaultOrderStatus({
-          buyToken: buyTokenAmount,
-          sellToken: sellTokenAmount,
-          order,
-        });
-      default:
-        throw new Error(`Unknown order status: ${order.status}`);
-    }
-  }
-
-  private _getExecutionPriceLabel(
-    sellToken: TokenAmount,
-    buyToken: TokenAmount,
-  ): string {
-    const ratio = sellToken.getExecutedAmount() / buyToken.getExecutedAmount();
-    return `1 ${sellToken.token.symbol} = ${ratio} ${buyToken.token.symbol}`;
-  }
-
-  private _getLimitPriceLabel(
-    sellToken: TokenAmount,
-    buyToken: TokenAmount,
-  ): string {
-    const ratio = sellToken.getAmount() / buyToken.getAmount();
-    return `1 ${sellToken.token.symbol} = ${ratio} ${buyToken.token.symbol}`;
-  }
-
-  private _getSurplusPriceLabel(tokenAmount: TokenAmount): string {
-    const surplus = Math.abs(
-      tokenAmount.getAmount() - tokenAmount.getExecutedAmount(),
-    ).toString();
-    return `${surplus} ${tokenAmount.token.symbol}`;
-  }
-
-  /**
-   * Returns the filled percentage of an order.
-   * The percentage is calculated as the ratio of the executed amount to the total amount.
-   *
-   * @param order - The order to calculate the filled percentage for.
-   * @private
-   */
-  private _getFilledPercentage(order: Order): string {
-    let executed: number;
-    let total: number;
-    if (order.kind === 'buy') {
-      executed = Number(order.executedBuyAmount);
-      total = Number(order.buyAmount);
-    } else if (order.kind === 'sell') {
-      executed = Number(order.executedSellAmount);
-      total = Number(order.sellAmount);
-    } else {
-      throw new Error('Unknown order kind');
+    if (sellToken.decimals === null || buyToken.decimals === null) {
+      throw new Error('Invalid token decimals');
     }
 
-    return ((executed / total) * 100).toFixed(2).toString();
+    return new SwapOrderTransactionInfo({
+      uid: order.uid,
+      status: order.status,
+      kind: order.kind,
+      validTo: order.validTo,
+      sellAmount: order.sellAmount.toString(),
+      buyAmount: order.buyAmount.toString(),
+      executedSellAmount: order.executedSellAmount.toString(),
+      executedBuyAmount: order.executedBuyAmount.toString(),
+      sellToken: new TokenInfo({
+        address: sellToken.address,
+        decimals: sellToken.decimals,
+        logoUri: sellToken.logoUri,
+        name: sellToken.name,
+        symbol: sellToken.symbol,
+        trusted: sellToken.trusted,
+      }),
+      buyToken: new TokenInfo({
+        address: buyToken.address,
+        decimals: buyToken.decimals,
+        logoUri: buyToken.logoUri,
+        name: buyToken.name,
+        symbol: buyToken.symbol,
+        trusted: buyToken.trusted,
+      }),
+      explorerUrl: this._getOrderExplorerUrl(order),
+      executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
+    });
   }
 
   /**
@@ -180,72 +97,6 @@ export class SwapOrderMapper {
     const url = new URL(this.swapsExplorerBaseUri);
     url.pathname = `/orders/${order.uid}`;
     return url;
-  }
-
-  private _mapFulfilledOrderStatus(args: {
-    buyToken: TokenAmount;
-    sellToken: TokenAmount;
-    order: Order;
-  }): SwapOrderTransactionInfo {
-    if (args.order.kind === 'unknown') {
-      throw new Error('Unknown order kind');
-    }
-    const feeLabel: string | null = args.order.executedSurplusFee
-      ? this._getFeeLabel(args.order.executedSurplusFee, args.sellToken.token)
-      : null;
-
-    const surplusLabel = this._getSurplusPriceLabel(
-      args.order.kind === 'buy' ? args.sellToken : args.buyToken,
-    );
-
-    return new FulfilledSwapOrderTransactionInfo({
-      orderUid: args.order.uid,
-      orderKind: args.order.kind,
-      sellToken: args.sellToken.toTokenInfo(),
-      buyToken: args.buyToken.toTokenInfo(),
-      expiresTimestamp: args.order.validTo,
-      feeLabel: feeLabel,
-      executionPriceLabel: this._getExecutionPriceLabel(
-        args.sellToken,
-        args.buyToken,
-      ),
-      surplusLabel,
-      filledPercentage: this._getFilledPercentage(args.order),
-      explorerUrl: this._getOrderExplorerUrl(args.order),
-    });
-  }
-
-  private _getFeeLabel(
-    executedSurplusFee: bigint,
-    token: Token & { decimals: number },
-  ): string {
-    const surplus = asDecimal(executedSurplusFee, token.decimals);
-    return `${surplus} ${token.symbol}`;
-  }
-
-  private _mapDefaultOrderStatus(args: {
-    buyToken: TokenAmount;
-    sellToken: TokenAmount;
-    order: Order;
-  }): SwapOrderTransactionInfo {
-    if (args.order.kind === 'unknown') {
-      throw new Error('Unknown order kind');
-    }
-    if (args.order.status === 'fulfilled' || args.order.status === 'unknown')
-      throw new Error(
-        `${args.order.status} orders should not be mapped as default orders. Order UID = ${args.order.uid}`,
-      );
-    return new DefaultSwapOrderTransactionInfo({
-      orderUid: args.order.uid,
-      status: args.order.status,
-      orderKind: args.order.kind,
-      sellToken: args.sellToken.toTokenInfo(),
-      buyToken: args.buyToken.toTokenInfo(),
-      expiresTimestamp: args.order.validTo,
-      limitPriceLabel: this._getLimitPriceLabel(args.sellToken, args.buyToken),
-      filledPercentage: this._getFilledPercentage(args.order),
-      explorerUrl: this._getOrderExplorerUrl(args.order),
-    });
   }
 }
 

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -61,6 +61,7 @@ export class SwapOrderMapper {
       uid: order.uid,
       status: order.status,
       kind: order.kind,
+      class: order.class,
       validUntil: order.validTo,
       sellAmount: order.sellAmount.toString(),
       buyAmount: order.buyAmount.toString(),

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -61,7 +61,7 @@ export class SwapOrderMapper {
       uid: order.uid,
       status: order.status,
       kind: order.kind,
-      validTo: order.validTo,
+      validUntil: order.validTo,
       sellAmount: order.sellAmount.toString(),
       buyAmount: order.buyAmount.toString(),
       executedSellAmount: order.executedSellAmount.toString(),


### PR DESCRIPTION
## Summary

The service was previously following a render-ready approach when it came to Swap Orders (i.e.: pre-formatted labels that should be rendered as is).

While this approach is a valid one, the current setup that we have on the Wallet doesn't allow for this type of localisation to be driven by this web service.

Some examples include:
- Position of the currency symbol
- Use of comma vs period for thousands or decimals
- Difference in representation of negative amounts
- LTR vs RTL

Given that in the current state, the frontend clients are expected to have more information regarding the user localisation, this responsibility is then shifted from the CGW to the clients.

This has a couple implications on the API:

## Changes

- Removes the following labels (they now need to be computed on the client side):
  * feeLabel
  * executionPriceLabel
  * surplusLabel
  * filledPercentage
- Extends the `TokenInfo` with:
  * Token name
  * trusted status
- Token amounts are now returned without decimals (correct decimal formatting should be set by the clients).

```javascript
{
  "type": "SwapOrder",
  "uid": "string",
  "status": "presignaturePending | open | fulfilled | cancelled | expired | unknown",
  "kind": "buy | sell",
  "class": "market | limit | liquidity | unknown"
  "validUntil": "number",
  "sellAmount": "string",
  "buyAmount": "string",
  "executedSellAmount": "string",
  "executedBuyAmount": "string",
  "sellToken": "TokenInfo", // see below
  "buyToken": "TokenInfo",  // see below
  "explorerUrl": "URL",
  "executedSurplusFee": "string | null"
}

"TokenInfo": {
  "address": "0x{string}",
  "decimals": "number",
  "logoUri": "string | null",
  "name": "string",
  "symbol": "string",
  "trusted": "boolean"
}
```
