### PR TITLE
Fix `no-case-declarations` instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
-      'no-case-declarations': 'off',
       'no-useless-escape': 'off',
       '@typescript-eslint/await-thenable': 'off',
       '@typescript-eslint/no-base-to-string': 'off',

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -109,7 +109,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain, status: 200 });
-        case getModuleTransactionUrl:
+        case getModuleTransactionUrl: {
           const error = new NetworkResponseError(
             new URL(getModuleTransactionUrl),
             {
@@ -117,6 +117,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             } as Response,
           );
           return Promise.reject(error);
+        }
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -153,7 +154,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
           return Promise.resolve({ data: chain, status: 200 });
         case getSafeUrl:
           return Promise.resolve({ data: safe, status: 200 });
-        case getModuleTransactionUrl:
+        case getModuleTransactionUrl: {
           const error = new NetworkResponseError(
             new URL(getModuleTransactionUrl),
             {
@@ -161,6 +162,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             } as Response,
           );
           return Promise.reject(error);
+        }
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }


### PR DESCRIPTION
## Summary

When updating to ESLint 9, some rules had to be ignored as their recommendations changed. Of which, was the `no-case-declarations` rule.

This addresses the instances where lexical declarations occur inside `case` clauses.