### PR TITLE
Simplify `AddressInfo` entity types

### DIFF
--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -100,10 +100,7 @@ export class AddressInfoHelper {
       case 'CONTRACT':
         return this.contractsRepository
           .getContract({ chainId, contractAddress: address })
-          .then(
-            (c) =>
-              new AddressInfo(c.address, c.displayName, c.logoUri ?? undefined),
-          );
+          .then((c) => new AddressInfo(c.address, c.displayName, c.logoUri));
       case 'TOKEN':
         return this.tokenRepository
           .getToken({ chainId, address })

--- a/src/routes/common/entities/address-info.entity.ts
+++ b/src/routes/common/entities/address-info.entity.ts
@@ -10,13 +10,11 @@ export class AddressInfo {
 
   constructor(
     value: string,
-    name?: string,
-    // TODO: Change to `string | null` when possible to match schema types
-    // https://github.com/safe-global/safe-client-gateway/blob/c032b43720cef3d316cc80ba439c36fb1b6fb9ea/src/routes/common/address-info/address-info.helper.ts#L105
-    logoUri?: string,
+    name: string | null = null,
+    logoUri: string | null = null,
   ) {
     this.value = value;
-    this.name = name || null;
-    this.logoUri = logoUri || null;
+    this.name = name;
+    this.logoUri = logoUri;
   }
 }


### PR DESCRIPTION
## Summary

We marked a TODO in the code during schema migration. This tackles that TODO:

`Contract['logoUri']` did not match `AddressInfo['logoUri']`. Now that they match, it is possible to directly pass the `logoUri` between entities and, as such, simplify the `AddressInfo` type.

## Changes

- Change the `constructor` arguments of `AddressInfo` to match that of Swagger.
- Pass `Contract['logoUri']` directly to `AddressInfo` when retrieving a contract.