### PR TITLE
Add ISwapsRepository interface

### DIFF
--- a/src/domain/swaps/swaps.module.ts
+++ b/src/domain/swaps/swaps.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
-import { SwapsRepository } from '@/domain/swaps/swaps.repository';
+import {
+  ISwapsRepository,
+  SwapsRepository,
+} from '@/domain/swaps/swaps.repository';
 import { SwapsApiModule } from '@/datasources/swaps-api/swaps-api.module';
 
 @Module({
   imports: [SwapsApiModule],
-  providers: [SwapsRepository],
-  exports: [SwapsRepository],
+  providers: [{ provide: ISwapsRepository, useClass: SwapsRepository }],
+  exports: [ISwapsRepository],
 })
 export class SwapsModule {}

--- a/src/domain/swaps/swaps.repository.e2e-spec.ts
+++ b/src/domain/swaps/swaps.repository.e2e-spec.ts
@@ -7,7 +7,7 @@ import { ValidationModule } from '@/validation/validation.module';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '@/config/configuration.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import { SwapsRepository } from '@/domain/swaps/swaps.repository';
+import { ISwapsRepository } from '@/domain/swaps/swaps.repository';
 import { Order } from '@/domain/swaps/entities/order.entity';
 import configuration from '@/config/entities/configuration';
 
@@ -104,7 +104,7 @@ const orderIds = {
 };
 describe('CowSwap E2E tests', () => {
   let app: INestApplication;
-  let repository: SwapsRepository;
+  let repository: ISwapsRepository;
 
   beforeAll(async () => {
     const cacheKeyPrefix = crypto.randomUUID();
@@ -124,7 +124,7 @@ describe('CowSwap E2E tests', () => {
       .compile();
 
     app = moduleRef.createNestApplication();
-    repository = app.get(SwapsRepository);
+    repository = app.get(ISwapsRepository);
     await app.init();
   });
 

--- a/src/domain/swaps/swaps.repository.ts
+++ b/src/domain/swaps/swaps.repository.ts
@@ -2,8 +2,14 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ISwapsApiFactory } from '@/domain/interfaces/swaps-api.factory';
 import { Order, OrderSchema } from '@/domain/swaps/entities/order.entity';
 
+export const ISwapsRepository = Symbol('ISwapsRepository');
+
+export interface ISwapsRepository {
+  getOrder(chainId: string, orderUid: `0x${string}`): Promise<Order>;
+}
+
 @Injectable()
-export class SwapsRepository {
+export class SwapsRepository implements ISwapsRepository {
   constructor(
     @Inject(ISwapsApiFactory)
     private readonly swapsApiFactory: ISwapsApiFactory,

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -8,7 +8,7 @@ import {
   ITokenRepository,
   TokenRepositoryModule,
 } from '@/domain/tokens/token.repository.interface';
-import { SwapsRepository } from '@/domain/swaps/swaps.repository';
+import { ISwapsRepository } from '@/domain/swaps/swaps.repository';
 import { SwapsModule } from '@/domain/swaps/swaps.module';
 import { Order } from '@/domain/swaps/entities/order.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -19,7 +19,8 @@ export class SwapOrderMapper {
     this.configurationService.getOrThrow('swaps.explorerBaseUri');
 
   constructor(
-    private readonly swapsRepository: SwapsRepository,
+    @Inject(ISwapsRepository)
+    private readonly swapsRepository: ISwapsRepository,
     private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
     @Inject(ITokenRepository)
     private readonly tokenRepository: ITokenRepository,


### PR DESCRIPTION
## Summary

The `SwapsRepository` didn't implement any interface. In order to be more aligned with the rest of the repositories, one was added – `ISwapsRepository`.

`SwapsRepository` is now not directly available in the graph. Its instance is then provided via the symbol `ISwapsRepository`.

## Changes

- Adds a `ISwapsRepository` which `SwapsRepository` implements.
