### PR TITLE
Extract SetPreSignatureDecoder to its own module

### DIFF
--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
@@ -1,6 +1,6 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Module } from '@nestjs/common';
 import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
-import { toFunctionSelector, parseAbi } from 'viem';
+import { parseAbi, toFunctionSelector } from 'viem';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 
 export const abi = parseAbi([
@@ -43,3 +43,9 @@ export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
     }
   }
 }
+
+@Module({
+  providers: [SetPreSignatureDecoder],
+  exports: [SetPreSignatureDecoder],
+})
+export class SetPreSignatureDecoderModule {}

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -28,7 +28,7 @@ import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer
 import { TransactionsController } from '@/routes/transactions/transactions.controller';
 import { TransactionsService } from '@/routes/transactions/transactions.service';
 import { SwapOrderMapperModule } from '@/routes/transactions/mappers/common/swap-order.mapper';
-import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+import { SetPreSignatureDecoderModule } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
 import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
@@ -46,6 +46,7 @@ import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interfac
     HumanDescriptionRepositoryModule,
     SafeRepositoryModule,
     SafeAppsRepositoryModule,
+    SetPreSignatureDecoderModule,
     SwapOrderMapperModule,
     TokenRepositoryModule,
   ],
@@ -70,7 +71,6 @@ import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interfac
     QueuedItemsMapper,
     SafeAppInfoMapper,
     SettingsChangeMapper,
-    SetPreSignatureDecoder,
     TransactionDataMapper,
     TransactionPreviewMapper,
     TransactionsHistoryMapper,


### PR DESCRIPTION
## Summary

The `SetPreSignatureDecoder` can be seen as a utility class that can be used across multiple modules (e.g. can be used outside of the context of the transaction routes).

This is part of an effort to have more specialised modules (and smaller ones) which allows for a more modularised app.

## Changes

- Adds a new module – `SetPreSignatureDecoderModule`
- `SetPreSignatureDecoder` is now available via the new module.