### PR TITLE
Add SwapOrderHelper

### DIFF
--- a/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
@@ -8,49 +8,27 @@ import {
   ApiPropertyOptional,
 } from '@nestjs/swagger';
 import { OrderClass, OrderStatus } from '@/domain/swaps/entities/order.entity';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 
-export class TokenInfo {
-  @ApiProperty({ description: 'The token address' })
-  address: `0x${string}`;
-
-  @ApiProperty({ description: 'The token decimals' })
-  decimals: number;
-
-  @ApiPropertyOptional({
-    type: String,
-    nullable: true,
-    description: 'The logo URI for the token',
-  })
-  logoUri: string | null;
-
-  @ApiProperty({ description: 'The token name' })
-  name: string;
-
-  @ApiProperty({ description: 'The token symbol' })
-  symbol: string;
-
-  @ApiProperty({ description: 'The token trusted status' })
-  trusted: boolean;
-
-  constructor(args: {
-    address: `0x${string}`;
-    decimals: number;
-    logoUri: string | null;
-    name: string;
-    symbol: string;
-    trusted: boolean;
-  }) {
-    this.address = args.address;
-    this.decimals = args.decimals;
-    this.logoUri = args.logoUri;
-    this.name = args.name;
-    this.symbol = args.symbol;
-    this.trusted = args.trusted;
-  }
+export interface OrderInfo {
+  uid: string;
+  status: OrderStatus;
+  kind: 'buy' | 'sell';
+  class: OrderClass;
+  validUntil: number;
+  sellAmount: string;
+  buyAmount: string;
+  executedSellAmount: string;
+  executedBuyAmount: string;
+  explorerUrl: URL;
+  executedSurplusFee: string | null;
 }
 
 @ApiExtraModels(TokenInfo)
-export class SwapOrderTransactionInfo extends TransactionInfo {
+export class SwapOrderTransactionInfo
+  extends TransactionInfo
+  implements OrderInfo
+{
   @ApiProperty({ enum: [TransactionInfoType.SwapOrder] })
   override type = TransactionInfoType.SwapOrder;
 

--- a/src/routes/transactions/entities/swaps/token-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/token-info.entity.ts
@@ -1,0 +1,41 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TokenInfo {
+  @ApiProperty({ description: 'The token address' })
+  address: `0x${string}`;
+
+  @ApiProperty({ description: 'The token decimals' })
+  decimals: number;
+
+  @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description: 'The logo URI for the token',
+  })
+  logoUri: string | null;
+
+  @ApiProperty({ description: 'The token name' })
+  name: string;
+
+  @ApiProperty({ description: 'The token symbol' })
+  symbol: string;
+
+  @ApiProperty({ description: 'The token trusted status' })
+  trusted: boolean;
+
+  constructor(args: {
+    address: `0x${string}`;
+    decimals: number;
+    logoUri: string | null;
+    name: string;
+    symbol: string;
+    trusted: boolean;
+  }) {
+    this.address = args.address;
+    this.decimals = args.decimals;
+    this.logoUri = args.logoUri;
+    this.name = args.name;
+    this.symbol = args.symbol;
+    this.trusted = args.trusted;
+  }
+}

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -13,7 +13,7 @@ import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity
 import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
 import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
-import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swap-order-info.entity';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
 
 @ApiExtraModels(
   CreationTransactionInfo,

--- a/src/routes/transactions/helpers/swap-order.helper.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.ts
@@ -1,0 +1,132 @@
+import { Inject, Injectable, Module } from '@nestjs/common';
+import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
+import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
+import {
+  ITokenRepository,
+  TokenRepositoryModule,
+} from '@/domain/tokens/token.repository.interface';
+import {
+  ISwapsRepository,
+  SwapsRepository,
+} from '@/domain/swaps/swaps.repository';
+import { Token } from '@/domain/tokens/entities/token.entity';
+import { Order } from '@/domain/swaps/entities/order.entity';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
+
+@Injectable()
+export class SwapOrderHelper {
+  private readonly swapsExplorerBaseUri: string =
+    this.configurationService.getOrThrow('swaps.explorerBaseUri');
+
+  constructor(
+    private readonly multiSendDecoder: MultiSendDecoder,
+    private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
+    @Inject(ITokenRepository)
+    private readonly tokenRepository: ITokenRepository,
+    @Inject(ISwapsRepository) private readonly swapsRepository: SwapsRepository,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {}
+
+  /**
+   * Finds the swap order in the transaction data.
+   * The swap order can be in the transaction data directly or in the data of a Multisend transaction.
+   *
+   * @param data - The transaction data
+   * @private
+   * @returns The swap order if found, otherwise null
+   */
+  public findSwapOrder(data: `0x${string}`): `0x${string}` | null {
+    // The swap order can be in the transaction data directly
+    if (this.isSwapOrder({ data })) {
+      return data;
+    }
+    // or in the data of a multisend transaction
+    if (this.multiSendDecoder.helpers.isMultiSend(data)) {
+      const transactions = this.multiSendDecoder.mapMultiSendTransactions(data);
+      // TODO If we can build a sorted hash map of the transactions, we can avoid iterating all of them
+      //  as we know the pattern of a Swap Order.
+      for (const transaction of transactions) {
+        if (this.isSwapOrder(transaction)) {
+          return transaction.data;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Retrieves detailed information about a specific order and its associated tokens
+   *
+   * @param {Object} args - The arguments required to fetch the order.
+   * @param {string} args.chainId - The network chain ID.
+   * @param {string} args.orderUid - The unique identifier of the order, prefixed with '0x'.
+   * @returns {Promise} A promise that resolves to an object containing the order and token details.
+   *
+   * The returned object includes:
+   * - `order`: An object representing the order.
+   * - `sellToken`: The Token object with a mandatory `decimals` property
+   * - `buyToken`: Similar to `sellToken`, for the token being purchased in the order.
+   *
+   * @throws {Error} Throws an error if the order `kind` is 'unknown'.
+   * @throws {Error} Throws an error if either the sellToken or buyToken object has null decimals.
+   */
+  async getOrder(args: { chainId: string; orderUid: `0x${string}` }): Promise<{
+    order: Omit<Order, 'kind'> & { kind: Exclude<Order['kind'], 'unknown'> };
+    sellToken: Token & { decimals: number };
+    buyToken: Token & { decimals: number };
+  }> {
+    const order = await this.swapsRepository.getOrder(
+      args.chainId,
+      args.orderUid,
+    );
+
+    if (order.kind === 'unknown') throw new Error('Unknown order kind');
+
+    const [buyToken, sellToken] = await Promise.all([
+      this.tokenRepository.getToken({
+        chainId: args.chainId,
+        address: order.buyToken,
+      }),
+      this.tokenRepository.getToken({
+        chainId: args.chainId,
+        address: order.sellToken,
+      }),
+    ]);
+
+    if (buyToken.decimals === null || sellToken.decimals === null) {
+      throw new Error('Invalid token decimals');
+    }
+
+    return {
+      order: { ...order, kind: order.kind },
+      buyToken: { ...buyToken, decimals: buyToken.decimals },
+      sellToken: { ...sellToken, decimals: sellToken.decimals },
+    };
+  }
+
+  /**
+   * Returns the URL to the explorer page of an order.
+   *
+   * @param order - The order to get the explorer URL for.
+   * @private
+   */
+  getOrderExplorerUrl(order: Order): URL {
+    const url = new URL(this.swapsExplorerBaseUri);
+    url.pathname = `/orders/${order.uid}`;
+    return url;
+  }
+
+  private isSwapOrder(transaction: { data?: `0x${string}` }): boolean {
+    if (!transaction.data) return false;
+    return this.setPreSignatureDecoder.isSetPreSignature(transaction.data);
+  }
+}
+
+@Module({
+  imports: [SwapsRepositoryModule, TokenRepositoryModule],
+  providers: [SwapOrderHelper, MultiSendDecoder, SetPreSignatureDecoder],
+  exports: [SwapOrderHelper],
+})
+export class SwapOrderHelperModule {}

--- a/src/routes/transactions/helpers/swap-order.helper.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.ts
@@ -73,7 +73,7 @@ export class SwapOrderHelper {
    * @throws {Error} Throws an error if either the sellToken or buyToken object has null decimals.
    */
   async getOrder(args: { chainId: string; orderUid: `0x${string}` }): Promise<{
-    order: Omit<Order, 'kind'> & { kind: Exclude<Order['kind'], 'unknown'> };
+    order: Order & { kind: Exclude<Order['kind'], 'unknown'> };
     sellToken: Token & { decimals: number };
     buyToken: Token & { decimals: number };
   }> {

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -1,31 +1,19 @@
 import { Inject, Injectable, Module } from '@nestjs/common';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
-import {
-  SwapOrderTransactionInfo,
-  TokenInfo,
-} from '@/routes/transactions/entities/swap-order-info.entity';
-import {
-  ITokenRepository,
-  TokenRepositoryModule,
-} from '@/domain/tokens/token.repository.interface';
-import { ISwapsRepository } from '@/domain/swaps/swaps.repository';
-import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
-import { Order } from '@/domain/swaps/entities/order.entity';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
+import {
+  SwapOrderHelper,
+  SwapOrderHelperModule,
+} from '@/routes/transactions/helpers/swap-order.helper';
 
 @Injectable()
 export class SwapOrderMapper {
-  private readonly swapsExplorerBaseUri: string =
-    this.configurationService.getOrThrow('swaps.explorerBaseUri');
-
   constructor(
-    @Inject(ISwapsRepository)
-    private readonly swapsRepository: ISwapsRepository,
     private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
-    @Inject(ITokenRepository)
-    private readonly tokenRepository: ITokenRepository,
     @Inject(IConfigurationService)
-    private readonly configurationService: IConfigurationService,
+    private readonly swapOrderHelper: SwapOrderHelper,
   ) {}
 
   async mapSwapOrder(
@@ -38,25 +26,10 @@ export class SwapOrderMapper {
       throw new Error('Order UID not found in transaction data');
     }
 
-    const order = await this.swapsRepository.getOrder(chainId, orderUid);
-    if (order.kind === 'unknown') {
-      throw new Error('Unknown order kind');
-    }
-
-    const [buyToken, sellToken] = await Promise.all([
-      this.tokenRepository.getToken({
-        chainId,
-        address: order.buyToken,
-      }),
-      this.tokenRepository.getToken({
-        chainId,
-        address: order.sellToken,
-      }),
-    ]);
-
-    if (sellToken.decimals === null || buyToken.decimals === null) {
-      throw new Error('Invalid token decimals');
-    }
+    const { order, sellToken, buyToken } = await this.swapOrderHelper.getOrder({
+      chainId,
+      orderUid,
+    });
 
     return new SwapOrderTransactionInfo({
       uid: order.uid,
@@ -84,26 +57,14 @@ export class SwapOrderMapper {
         symbol: buyToken.symbol,
         trusted: buyToken.trusted,
       }),
-      explorerUrl: this._getOrderExplorerUrl(order),
+      explorerUrl: this.swapOrderHelper.getOrderExplorerUrl(order),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
     });
-  }
-
-  /**
-   * Returns the URL to the explorer page of an order.
-   *
-   * @param order - The order to get the explorer URL for.
-   * @private
-   */
-  private _getOrderExplorerUrl(order: Order): URL {
-    const url = new URL(this.swapsExplorerBaseUri);
-    url.pathname = `/orders/${order.uid}`;
-    return url;
   }
 }
 
 @Module({
-  imports: [SwapsRepositoryModule, TokenRepositoryModule],
+  imports: [SwapOrderHelperModule],
   providers: [SwapOrderMapper, SetPreSignatureDecoder],
   exports: [SwapOrderMapper],
 })

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -29,13 +29,13 @@ import { TransactionsController } from '@/routes/transactions/transactions.contr
 import { TransactionsService } from '@/routes/transactions/transactions.service';
 import { SwapOrderMapperModule } from '@/routes/transactions/mappers/common/swap-order.mapper';
 import { SetPreSignatureDecoderModule } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
-import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
 import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
 import { HumanDescriptionRepositoryModule } from '@/domain/human-description/human-description.repository.interface';
 import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repository.interface';
 import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interface';
+import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.helper';
 
 @Module({
   controllers: [TransactionsController],
@@ -48,6 +48,7 @@ import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interfac
     SafeAppsRepositoryModule,
     SetPreSignatureDecoderModule,
     SwapOrderMapperModule,
+    SwapOrderHelperModule,
     TokenRepositoryModule,
   ],
   providers: [
@@ -60,7 +61,6 @@ import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interfac
     ModuleTransactionDetailsMapper,
     ModuleTransactionMapper,
     ModuleTransactionStatusMapper,
-    MultiSendDecoder,
     MultisigTransactionDetailsMapper,
     MultisigTransactionExecutionDetailsMapper,
     MultisigTransactionExecutionInfoMapper,


### PR DESCRIPTION
## Summary

The functionality that was present in the `SwapOrderMapper` can be shared with other components (outside of the mapping module for a collection of transactions).

This functionality was then extracted to a `SwapOrderHelper` which contains the following functionality:
- `findSwapOrder` – no changes. Given a transaction, extract the Swap Order from it if available (supports MultiSend).
- `getOrder` – given an Order ID, attempts to retrieve its data alongside the buy and sell token information.
- `getOrderExplorerUrl` – no changes. Given an `Order` object, builds the Swap Order explorer URL.

This helper is available via the `SwapOrderHelperModule`.

## Changes

- Adds a `SwapOrderHelper`.
- Moves functionality from `SwapOrderMapper` and `MultisigTransactionInfoMapper` to the `SwapOrderHelper`.
- Extracts the `TokenInfo` schema in order to be used by other components.
