### PR TITLE
Fix SwapOrderMapper dependency injection

### DIFF
--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -1,7 +1,6 @@
-import { Inject, Injectable, Module } from '@nestjs/common';
+import { Injectable, Module } from '@nestjs/common';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
-import { IConfigurationService } from '@/config/configuration.service.interface';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import {
   SwapOrderHelper,
@@ -12,7 +11,6 @@ import {
 export class SwapOrderMapper {
   constructor(
     private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
-    @Inject(IConfigurationService)
     private readonly swapOrderHelper: SwapOrderHelper,
   ) {}
 


### PR DESCRIPTION
## Summary

The `SwapOrderHelper` was being injected incorrectly by requesting a `IConfigurationService` from the graph.

This was caused by the following refactor: https://github.com/safe-global/safe-client-gateway/commit/8f93ef19e54e1849eff9d25cbdb4aeb10916c01b#diff-17d1bb74f1a0f749598b5ccb73caac05e9a27c3dc59f0475e26fe527f621577aR16

## Changes

- Removes `@Inject(IConfigurationService)` as it doesn't apply to `SwapOrderHelper`