### PR TITLE
Add queues routes layer

### DIFF
--- a/src/__tests__/amqp-client.factory.ts
+++ b/src/__tests__/amqp-client.factory.ts
@@ -1,0 +1,23 @@
+import amqp, { ChannelWrapper } from 'amqp-connection-manager';
+import { Channel } from 'amqplib';
+
+export async function amqpClientFactory(): Promise<{
+  channel: ChannelWrapper;
+  queueName: string;
+}> {
+  const { AMQP_URL, AMQP_EXCHANGE_NAME, AMQP_EXCHANGE_MODE, AMQP_QUEUE } =
+    process.env;
+  const connection = amqp.connect(AMQP_URL);
+  const channel = connection.createChannel({
+    json: true,
+    setup: async (ch: Channel) => {
+      await ch.assertExchange(AMQP_EXCHANGE_NAME!, AMQP_EXCHANGE_MODE!, {
+        durable: true,
+      });
+      await ch.assertQueue(AMQP_QUEUE!, { durable: true });
+      await ch.bindQueue(AMQP_QUEUE!, AMQP_EXCHANGE_NAME!, '');
+    },
+  });
+
+  return { channel, queueName: AMQP_QUEUE! };
+}

--- a/src/__tests__/util/retry.ts
+++ b/src/__tests__/util/retry.ts
@@ -1,0 +1,33 @@
+/**
+ * Stops execution for {@link milliseconds} milliseconds.
+ */
+export async function milliseconds(milliseconds: number): Promise<void> {
+  await new Promise((_) => setTimeout(_, milliseconds));
+}
+
+/**
+ * Executes the function {@link fn}, retrying if it throws an error.
+ * Uses a linear strategy by retrying each {@link delayMs} milliseconds.
+ * If {@link maxAttempts} is reached, it throws the error returned by {@link fn} last execution.
+ */
+export async function retry(
+  fn: () => void,
+  maxAttempts: number = 40,
+  delayMs: number = 100,
+): Promise<void> {
+  let attempt = 0;
+  const execute = async (): Promise<void> => {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= maxAttempts) {
+        throw error;
+      }
+    }
+
+    await milliseconds(delayMs);
+    attempt++;
+    return execute();
+  };
+  return execute();
+}

--- a/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -1,0 +1,502 @@
+import { amqpClientFactory } from '@/__tests__/amqp-client.factory';
+import { redisClientFactory } from '@/__tests__/redis-client.factory';
+import { retry } from '@/__tests__/util/retry';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { AppModule } from '@/app.module';
+import configuration from '@/config/entities/configuration';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ChannelWrapper } from 'amqp-connection-manager';
+import { RedisClientType } from 'redis';
+import { getAddress } from 'viem';
+
+describe('Events queue processing e2e tests', () => {
+  let app: INestApplication;
+  let redisClient: RedisClientType;
+  let channel: ChannelWrapper;
+  let queueName: string;
+  const cacheKeyPrefix = crypto.randomUUID();
+  const chainId = '1'; // Mainnet
+
+  beforeAll(async () => {
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        eventsQueue: true,
+      },
+    });
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule.register(testConfiguration)],
+    })
+      .overrideProvider(CacheKeyPrefix)
+      .useValue(cacheKeyPrefix)
+      .compile();
+
+    app = await new TestAppProvider().provide(moduleRef);
+    await app.init();
+    redisClient = await redisClientFactory();
+    const amqpClient = await amqpClientFactory();
+    channel = amqpClient.channel;
+    queueName = amqpClient.queueName;
+  });
+
+  afterAll(async () => {
+    await redisClient.quit();
+    await channel.close();
+    await app.close();
+  });
+
+  it.only.each([
+    {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    // {
+    //   type: 'OUTGOING_ETHER',
+    //   txHash: faker.string.hexadecimal({ length: 32 }),
+    //   value: faker.string.numeric(),
+    // },
+    // {
+    //   type: 'INCOMING_ETHER',
+    //   txHash: faker.string.hexadecimal({ length: 32 }),
+    //   value: faker.string.numeric(),
+    // },
+    // {
+    //   type: 'OUTGOING_TOKEN',
+    //   tokenAddress: faker.finance.ethereumAddress(),
+    //   txHash: faker.string.hexadecimal({ length: 32 }),
+    // },
+  ])('$type clears balances', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_safe_balances_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'PENDING_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'NEW_CONFIRMATION',
+      owner: faker.finance.ethereumAddress(),
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'DELETED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears multisig transactions', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_multisig_transactions_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'PENDING_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'NEW_CONFIRMATION',
+      owner: faker.finance.ethereumAddress(),
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'DELETED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears multisig transaction', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_multisig_transaction_${payload.safeTxHash}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'MODULE_TRANSACTION',
+      module: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears safe info', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_safe_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'OUTGOING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears safe collectibles', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_safe_collectibles_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'OUTGOING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears safe collectible transfers', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_transfers_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'INCOMING_ETHER',
+      txHash: faker.string.hexadecimal({ length: 32 }),
+      value: faker.string.numeric(),
+    },
+  ])('$type clears incoming transfers', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_incoming_transfers_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'MODULE_TRANSACTION',
+      module: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears module transactions', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_module_transactions_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'MODULE_TRANSACTION',
+      module: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.string.hexadecimal({ length: 32 }),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'OUTGOING_ETHER',
+      txHash: faker.string.hexadecimal({ length: 32 }),
+      value: faker.string.numeric(),
+    },
+    {
+      type: 'INCOMING_ETHER',
+      txHash: faker.string.hexadecimal({ length: 32 }),
+      value: faker.string.numeric(),
+    },
+    {
+      type: 'OUTGOING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears all transactions', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_all_transactions_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'MESSAGE_CREATED',
+      messageHash: faker.string.hexadecimal({ length: 32 }),
+    },
+    {
+      type: 'MESSAGE_CONFIRMATION',
+      messageHash: faker.string.hexadecimal({ length: 32 }),
+    },
+  ])('$type clears messages', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const cacheDir = new CacheDir(
+      `${chainId}_messages_${getAddress(safeAddress)}`,
+      faker.string.alpha(),
+    );
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { address: safeAddress, chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'CHAIN_UPDATE',
+    },
+  ])('$type clears chain', async (payload) => {
+    const chainId = faker.string.numeric();
+    const cacheDir = new CacheDir(`${chainId}_chain`, '');
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+
+  it.each([
+    {
+      type: 'SAFE_APPS_UPDATE',
+    },
+  ])('$type clears safe apps', async (payload) => {
+    const cacheDir = new CacheDir(`${chainId}_safe_apps`, '');
+    await redisClient.hSet(
+      `${cacheKeyPrefix}-${cacheDir.key}`,
+      cacheDir.field,
+      faker.string.alpha(),
+    );
+    const data = { chainId, ...payload };
+
+    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+
+    await retry(async () => {
+      const cacheContent = await redisClient.hGet(
+        `${cacheKeyPrefix}-${cacheDir.key}`,
+        cacheDir.field,
+      );
+      expect(cacheContent).toBeNull();
+    });
+  });
+});

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -22,6 +22,8 @@ import {
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { getAddress } from 'viem';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication;
@@ -31,11 +33,9 @@ describe('Post Hook Events (Unit)', () => {
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let configurationService: IConfigurationService;
 
-  beforeEach(async () => {
-    jest.resetAllMocks();
-
+  async function initApp(config: typeof configuration): Promise<void> {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(config)],
     })
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)
@@ -45,6 +45,8 @@ describe('Post Hook Events (Unit)', () => {
       .useModule(TestLoggingModule)
       .overrideModule(NetworkModule)
       .useModule(TestNetworkModule)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
     app = moduleFixture.createNestApplication();
 
@@ -55,10 +57,47 @@ describe('Post Hook Events (Unit)', () => {
     networkService = moduleFixture.get(NetworkService);
 
     await app.init();
+  }
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    await initApp(configuration);
   });
 
   afterAll(async () => {
     await app.close();
+  });
+
+  it('should return 410 if the eventsQueue FF is active and the hook is not CHAIN_UPDATE or SAFE_APPS_UPDATE', async () => {
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        eventsQueue: true,
+      },
+    });
+
+    await initApp(testConfiguration);
+
+    const payload = {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    };
+    const safeAddress = faker.finance.ethereumAddress();
+    const chainId = faker.string.numeric();
+    const data = {
+      address: safeAddress,
+      chainId: chainId,
+      ...payload,
+    };
+
+    await request(app.getHttpServer())
+      .post(`/hooks/events`)
+      .set('Authorization', `Basic ${authToken}`)
+      .send(data)
+      .expect(410);
   });
 
   it('should throw an error if authorization is not sent in the request headers', async () => {
@@ -832,4 +871,80 @@ describe('Post Hook Events (Unit)', () => {
 
     await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
+
+  it.each([
+    {
+      type: 'CHAIN_UPDATE',
+    },
+  ])(
+    '$type clears chains even if the eventsQueue FF is active ',
+    async (payload) => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): typeof defaultConfiguration => ({
+        ...defaultConfiguration,
+        features: {
+          ...defaultConfiguration.features,
+          eventsQueue: true,
+        },
+      });
+      await initApp(testConfiguration);
+      const chainId = faker.string.numeric();
+      const cacheDir = new CacheDir(`chains`, '');
+      await fakeCacheService.set(
+        cacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      const data = {
+        chainId: chainId,
+        ...payload,
+      };
+
+      await request(app.getHttpServer())
+        .post(`/hooks/events`)
+        .set('Authorization', `Basic ${authToken}`)
+        .send(data)
+        .expect(202);
+
+      await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
+    },
+  );
+
+  it.each([
+    {
+      type: 'SAFE_APPS_UPDATE',
+    },
+  ])(
+    '$type clears safe apps even if the eventsQueue FF is active',
+    async (payload) => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): typeof defaultConfiguration => ({
+        ...defaultConfiguration,
+        features: {
+          ...defaultConfiguration.features,
+          eventsQueue: true,
+        },
+      });
+      await initApp(testConfiguration);
+      const chainId = faker.string.numeric();
+      const cacheDir = new CacheDir(`${chainId}_safe_apps`, '');
+      await fakeCacheService.set(
+        cacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      const data = {
+        chainId: chainId,
+        ...payload,
+      };
+
+      await request(app.getHttpServer())
+        .post(`/hooks/events`)
+        .set('Authorization', `Basic ${authToken}`)
+        .send(data)
+        .expect(202);
+
+      await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
+    },
+  );
 });

--- a/src/routes/cache-hooks/cache-hooks.module.ts
+++ b/src/routes/cache-hooks/cache-hooks.module.ts
@@ -8,6 +8,7 @@ import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interf
 import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
 import { MessagesRepositoryModule } from '@/domain/messages/messages.repository.interface';
 import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repository.interface';
+import { QueuesRepositoryModule } from '@/domain/queues/queues-repository.interface';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repositor
     MessagesRepositoryModule,
     SafeAppsRepositoryModule,
     SafeRepositoryModule,
+    QueuesRepositoryModule,
   ],
   providers: [JsonSchemaService, CacheHooksService],
   controllers: [CacheHooksController],

--- a/src/routes/cache-hooks/errors/event-protocol-changed.error.ts
+++ b/src/routes/cache-hooks/errors/event-protocol-changed.error.ts
@@ -1,0 +1,7 @@
+import { GoneException } from '@nestjs/common';
+
+export class EventProtocolChangedError extends GoneException {
+  constructor() {
+    super('Protocol has been changed for this kind of event.');
+  }
+}

--- a/src/routes/cache-hooks/filters/event-protocol-changed.filter.ts
+++ b/src/routes/cache-hooks/filters/event-protocol-changed.filter.ts
@@ -1,0 +1,21 @@
+import { EventProtocolChangedError } from '@/routes/cache-hooks/errors/event-protocol-changed.error';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(EventProtocolChangedError)
+export class EventProtocolChangedFilter implements ExceptionFilter {
+  catch(_: EventProtocolChangedError, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.GONE).json({
+      message: 'Unsupported protocol for this kind of event',
+      statusCode: HttpStatus.GONE,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Depends on #1412 
Depends on #1418 

This implements the _routes_ layer part of the events consumption feature. The full implementation of the feature was drafted in (https://github.com/safe-global/safe-client-gateway/pull/1382)

## Changes
- Modifies `CacheHooksService` to subscribe its `onEvent` function to the events queue on module startup.
- Modifies `CacheHooksController` to accept `POST /hooks/events` only if the queue consumption is disabled.
- Adds `CacheHooksController` unit tests.
- Adds end-to-end tests for testing the feature, with some AMQP test utilities (`amqpClientFactory`, `retry` functions).
