### PR TITLE
Change AMQP prefetch configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -118,8 +118,7 @@
 # (default=fanout)
 #AMQP_EXCHANGE_MODE=
 # The message prefetch amount (max non-acknowledged messages being processed)
-# The default is 0, so no throttling.
-# (default=0)
+# (default=100)
 #AMQP_PREFETCH=
 
 # Authorization token to use privileged endpoints.

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -21,7 +21,7 @@ export default () => ({
     prefetch:
       process.env.AMQP_PREFETCH != null
         ? parseInt(process.env.AMQP_PREFETCH)
-        : 0,
+        : 100,
   },
   applicationPort: process.env.APPLICATION_PORT || '3000',
   auth: {


### PR DESCRIPTION
## Summary
The AMQP prefetch value was configured to `0` (therefore unlimited) assuming the explicit `ack` emitted by the consumers would automatically round-robin the delivery of the messages between them. 

But this does not consider the scenario where the service pods _cold-start_ and multiple messages are in the queue. In this scenario, we want to still round-robin between the pods, instead of letting one pod fill up with all the messages.

(Optional) Reference documentation: https://www.rabbitmq.com/docs/consumer-prefetch

Note: the value `100` was not chosen following any special logic, any non-zero value would serve the purpose of the PR. There are no strict rules regarding this value, it can be adjusted via service configuration if needed.

## Changes
- Changes the default value for `amqp.prefetch` configuration value from `0` to `100`.
