### PR TITLE
Add const assertions to order.builder

### DIFF
--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -28,16 +28,24 @@ export function orderBuilder(): IBuilder<Order> {
       }),
     )
     .with('feeAmount', faker.number.bigInt({ min: 1 }))
-    .with('kind', faker.helpers.arrayElement(['buy', 'sell']))
+    .with('kind', faker.helpers.arrayElement(['buy', 'sell'] as const))
     .with('partiallyFillable', faker.datatype.boolean())
     .with(
       'sellTokenBalance',
-      faker.helpers.arrayElement(['erc20', 'internal', 'external']),
+      faker.helpers.arrayElement(['erc20', 'internal', 'external'] as const),
     )
-    .with('buyTokenBalance', faker.helpers.arrayElement(['erc20', 'internal']))
+    .with(
+      'buyTokenBalance',
+      faker.helpers.arrayElement(['erc20', 'internal'] as const),
+    )
     .with(
       'signingScheme',
-      faker.helpers.arrayElement(['eip712', 'ethsign', 'presign', 'eip1271']),
+      faker.helpers.arrayElement([
+        'eip712',
+        'ethsign',
+        'presign',
+        'eip1271',
+      ] as const),
     )
     .with('signature', faker.string.hexadecimal() as `0x${string}`)
     .with(
@@ -96,7 +104,7 @@ export function orderBuilder(): IBuilder<Order> {
               'QuoteNotFound',
               'ValidToTooFarInFuture',
               'PreValidationError',
-            ]),
+            ] as const),
           }
         : null,
     )


### PR DESCRIPTION
## Summary

In order to further narrow down the types used with Faker to create an `Order`, `const` assertions were added to the array elements used.

## Changes

- Adds `const` assertions to `kind`, `sellTokenBalance`, `buyTokenBalance`, `signingScheme` and `placementError`.
