### PR TITLE
Forward parsed fullAppData

### DIFF
--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -112,8 +112,5 @@ export function orderBuilder(): IBuilder<Order> {
       'executedSurplusFee',
       faker.datatype.boolean() ? faker.number.bigInt({ min: 1 }) : null,
     )
-    .with(
-      'fullAppData',
-      faker.datatype.boolean() ? faker.string.hexadecimal() : null,
-    );
+    .with('fullAppData', faker.datatype.boolean() ? JSON.stringify({}) : null);
 }

--- a/src/domain/swaps/entities/order.entity.spec.ts
+++ b/src/domain/swaps/entities/order.entity.spec.ts
@@ -123,4 +123,27 @@ describe('OrderSchema', () => {
       );
     });
   });
+
+  describe('fullAppData', () => {
+    it.each([
+      '[]',
+      '{}',
+      'null',
+      '{\n  "version": "0.1.0",\n  "appCode": "Yearn",\n  "metadata": {\n    "referrer": {\n      "version": "0.1.0",\n      "address": "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"\n    }\n  }\n}\n',
+    ])('is valid', (fullAppData) => {
+      const order = orderBuilder().with('fullAppData', fullAppData).build();
+
+      const result = OrderSchema.safeParse(order);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it.each(['a', 'a : b', '{', '['])('is not valid', (fullAppData) => {
+    const order = orderBuilder().with('fullAppData', fullAppData).build();
+
+    const result = OrderSchema.safeParse(order);
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/domain/swaps/entities/order.entity.spec.ts
+++ b/src/domain/swaps/entities/order.entity.spec.ts
@@ -130,20 +130,20 @@ describe('OrderSchema', () => {
       '{}',
       'null',
       '{\n  "version": "0.1.0",\n  "appCode": "Yearn",\n  "metadata": {\n    "referrer": {\n      "version": "0.1.0",\n      "address": "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"\n    }\n  }\n}\n',
-    ])('is valid', (fullAppData) => {
+    ])(' %s is valid', (fullAppData) => {
       const order = orderBuilder().with('fullAppData', fullAppData).build();
 
       const result = OrderSchema.safeParse(order);
 
       expect(result.success).toBe(true);
     });
-  });
 
-  it.each(['a', 'a : b', '{', '['])('is not valid', (fullAppData) => {
-    const order = orderBuilder().with('fullAppData', fullAppData).build();
+    it.each(['a', 'a : b', '{', '['])('%s is not valid', (fullAppData) => {
+      const order = orderBuilder().with('fullAppData', fullAppData).build();
 
-    const result = OrderSchema.safeParse(order);
+      const result = OrderSchema.safeParse(order);
 
-    expect(result.success).toBe(false);
+      expect(result.success).toBe(false);
+    });
   });
 });

--- a/src/domain/swaps/entities/order.entity.spec.ts
+++ b/src/domain/swaps/entities/order.entity.spec.ts
@@ -130,7 +130,7 @@ describe('OrderSchema', () => {
       '{}',
       'null',
       '{\n  "version": "0.1.0",\n  "appCode": "Yearn",\n  "metadata": {\n    "referrer": {\n      "version": "0.1.0",\n      "address": "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"\n    }\n  }\n}\n',
-    ])(' %s is valid', (fullAppData) => {
+    ])('%s is valid', (fullAppData) => {
       const order = orderBuilder().with('fullAppData', fullAppData).build();
 
       const result = OrderSchema.safeParse(order);

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -81,6 +81,8 @@ export const OrderSchema = z.object({
   executedSurplusFee: z.coerce.bigint().nullish().default(null),
   fullAppData: z
     .string()
+    .nullish()
+    .default(null)
     .transform((jsonString, ctx) => {
       try {
         if (!jsonString) return null;
@@ -92,7 +94,5 @@ export const OrderSchema = z.object({
         });
         return z.NEVER;
       }
-    })
-    .nullish()
-    .default(null),
+    }),
 });

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -79,5 +79,20 @@ export const OrderSchema = z.object({
     .nullish()
     .default(null),
   executedSurplusFee: z.coerce.bigint().nullish().default(null),
-  fullAppData: z.string().nullish().default(null),
+  fullAppData: z
+    .string()
+    .transform((jsonString, ctx) => {
+      try {
+        if (!jsonString) return null;
+        return JSON.parse(jsonString);
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Not a valid JSON payload',
+        });
+        return z.NEVER;
+      }
+    })
+    .nullish()
+    .default(null),
 });

--- a/src/domain/swaps/swaps.repository.e2e-spec.ts
+++ b/src/domain/swaps/swaps.repository.e2e-spec.ts
@@ -141,7 +141,10 @@ describe('CowSwap E2E tests', () => {
             orderId as `0x${string}`,
           );
 
-          expect(actual).toEqual(expectedObject);
+          expect(actual).toEqual({
+            ...expectedObject,
+            fullAppData: JSON.parse(expectedObject.fullAppData),
+          });
         });
       });
     });

--- a/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
@@ -101,6 +101,11 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
   })
   executedSurplusFee: string | null;
 
+  @ApiPropertyOptional({
+    type: Object,
+    nullable: true,
+    description: 'The App Data for this order',
+  })
   fullAppData: Record<string, unknown> | null;
 
   @ApiProperty({ description: 'The sell token of the order' })

--- a/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
@@ -101,6 +101,8 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
   })
   executedSurplusFee: string | null;
 
+  fullAppData: Record<string, unknown> | null;
+
   @ApiProperty({ description: 'The sell token of the order' })
   sellToken: TokenInfo;
 
@@ -125,5 +127,6 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
     this.executedSurplusFee = args.executedSurplusFee;
     this.sellToken = args.sellToken;
     this.buyToken = args.buyToken;
+    this.fullAppData = args.fullAppData;
   }
 }

--- a/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
@@ -91,6 +91,11 @@ export class SwapOrderTransactionInfo
   })
   executedSurplusFee: string | null;
 
+  @ApiPropertyOptional({
+    type: Object,
+    nullable: true,
+    description: 'The App Data for this order',
+  })
   fullAppData: Record<string, unknown> | null;
 
   constructor(args: {

--- a/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
@@ -22,6 +22,7 @@ export interface OrderInfo {
   executedBuyAmount: string;
   explorerUrl: URL;
   executedSurplusFee: string | null;
+  fullAppData: Record<string, unknown> | null;
 }
 
 @ApiExtraModels(TokenInfo)
@@ -90,6 +91,8 @@ export class SwapOrderTransactionInfo
   })
   executedSurplusFee: string | null;
 
+  fullAppData: Record<string, unknown> | null;
+
   constructor(args: {
     uid: string;
     orderStatus: OrderStatus;
@@ -104,6 +107,7 @@ export class SwapOrderTransactionInfo
     buyToken: TokenInfo;
     explorerUrl: URL;
     executedSurplusFee: string | null;
+    fullAppData: Record<string, unknown> | null;
   }) {
     super(TransactionInfoType.SwapOrder, null, null);
     this.uid = args.uid;
@@ -119,5 +123,6 @@ export class SwapOrderTransactionInfo
     this.buyToken = args.buyToken;
     this.explorerUrl = args.explorerUrl;
     this.executedSurplusFee = args.executedSurplusFee;
+    this.fullAppData = args.fullAppData;
   }
 }

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -57,6 +57,7 @@ export class SwapOrderMapper {
       }),
       explorerUrl: this.swapOrderHelper.getOrderExplorerUrl(order),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
+      fullAppData: order.fullAppData,
     });
   }
 }

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -104,6 +104,7 @@ export class TransactionsViewService {
         trusted: buyToken.trusted,
       }),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
+      fullAppData: order.fullAppData,
     });
   }
 }


### PR DESCRIPTION
## Summary

Adds the **parsed** App Data to the `OrderInfo` thus making it available in `CowSwapConfirmationView` and `SwapOrderTransactionInfo`.

This can be specially useful to the clients if access to other order properties is required (e.g. `slippageBips`)

## Changes

- Validates the JSON returned in `fullAppData`.
- Forwards the parsed `fullAppData` via `CowSwapConfirmationView` and `SwapOrderTransactionInfo`.
