### PR TITLE
Include not listed Safe Apps on transaction mappings

### DIFF
--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -165,17 +165,17 @@ describe('ConfigApi', () => {
     expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
-  it('should return the safe apps retrieved by chainId, clientUrl and ignoreVisibility', async () => {
+  it('should return the safe apps retrieved by chainId, clientUrl and onlyListed', async () => {
     const chainId = faker.string.numeric();
     const clientUrl = faker.internet.url({ appendSlash: false });
-    const ignoreVisibility = faker.datatype.boolean();
+    const onlyListed = faker.datatype.boolean();
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
     mockDataSource.get.mockResolvedValue(data);
 
     const actual = await service.getSafeApps({
       chainId,
       clientUrl,
-      ignoreVisibility,
+      onlyListed,
     });
 
     expect(actual).toBe(data);
@@ -185,7 +185,7 @@ describe('ConfigApi', () => {
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: {
-        params: { chainId, clientUrl, ignoreVisibility, url: undefined },
+        params: { chainId, clientUrl, onlyListed, url: undefined },
       },
       expireTimeSeconds: expirationTimeInSeconds,
     });

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -165,6 +165,33 @@ describe('ConfigApi', () => {
     expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
   });
 
+  it('should return the safe apps retrieved by chainId, clientUrl and ignoreVisibility', async () => {
+    const chainId = faker.string.numeric();
+    const clientUrl = faker.internet.url({ appendSlash: false });
+    const ignoreVisibility = faker.datatype.boolean();
+    const data = [safeAppBuilder().build(), safeAppBuilder().build()];
+    mockDataSource.get.mockResolvedValue(data);
+
+    const actual = await service.getSafeApps({
+      chainId,
+      clientUrl,
+      ignoreVisibility,
+    });
+
+    expect(actual).toBe(data);
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
+      cacheDir: new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
+      url: `${baseUri}/api/v1/safe-apps/`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: {
+        params: { chainId, clientUrl, ignoreVisibility, url: undefined },
+      },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
+  });
+
   it('should forward error', async () => {
     const expected = new DataSourceError('some unexpected error');
     mockHttpErrorFactory.from.mockReturnValue(expected);

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -85,7 +85,7 @@ export class ConfigApi implements IConfigApi {
   async getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
-    ignoreVisibility?: boolean;
+    onlyListed?: boolean;
     url?: string;
   }): Promise<SafeApp[]> {
     try {
@@ -93,7 +93,7 @@ export class ConfigApi implements IConfigApi {
       const params = {
         chainId: args.chainId,
         clientUrl: args.clientUrl,
-        ignoreVisibility: args.ignoreVisibility,
+        onlyListed: args.onlyListed,
         url: args.url,
       };
       const cacheDir = CacheRouter.getSafeAppsCacheDir(args);

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -85,6 +85,7 @@ export class ConfigApi implements IConfigApi {
   async getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
+    ignoreVisibility?: boolean;
     url?: string;
   }): Promise<SafeApp[]> {
     try {
@@ -92,6 +93,7 @@ export class ConfigApi implements IConfigApi {
       const params = {
         chainId: args.chainId,
         clientUrl: args.clientUrl,
+        ignoreVisibility: args.ignoreVisibility,
         url: args.url,
       };
       const cacheDir = CacheRouter.getSafeAppsCacheDir(args);

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -14,7 +14,7 @@ export interface IConfigApi {
   getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
-    ignoreVisibility?: boolean;
+    onlyListed?: boolean;
     url?: string;
   }): Promise<SafeApp[]>;
 

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -14,6 +14,7 @@ export interface IConfigApi {
   getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
+    ignoreVisibility?: boolean;
     url?: string;
   }): Promise<SafeApp[]>;
 

--- a/src/domain/safe-apps/safe-apps.repository.interface.ts
+++ b/src/domain/safe-apps/safe-apps.repository.interface.ts
@@ -12,6 +12,7 @@ export interface ISafeAppsRepository {
   getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
+    ignoreVisibility?: boolean;
     url?: string;
   }): Promise<SafeApp[]>;
 

--- a/src/domain/safe-apps/safe-apps.repository.interface.ts
+++ b/src/domain/safe-apps/safe-apps.repository.interface.ts
@@ -12,7 +12,7 @@ export interface ISafeAppsRepository {
   getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
-    ignoreVisibility?: boolean;
+    onlyListed?: boolean;
     url?: string;
   }): Promise<SafeApp[]>;
 

--- a/src/domain/safe-apps/safe-apps.repository.ts
+++ b/src/domain/safe-apps/safe-apps.repository.ts
@@ -14,6 +14,7 @@ export class SafeAppsRepository implements ISafeAppsRepository {
   async getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
+    ignoreVisibility?: boolean;
     url?: string;
   }): Promise<SafeApp[]> {
     const safeApps = await this.configApi.getSafeApps(args);

--- a/src/domain/safe-apps/safe-apps.repository.ts
+++ b/src/domain/safe-apps/safe-apps.repository.ts
@@ -14,7 +14,7 @@ export class SafeAppsRepository implements ISafeAppsRepository {
   async getSafeApps(args: {
     chainId?: string;
     clientUrl?: string;
-    ignoreVisibility?: boolean;
+    onlyListed?: boolean;
     url?: string;
   }): Promise<SafeApp[]> {
     const safeApps = await this.configApi.getSafeApps(args);

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -18,7 +18,10 @@ export class SafeAppsService {
     clientUrl?: string;
     url?: string;
   }): Promise<SafeApp[]> {
-    const result = await this.safeAppsRepository.getSafeApps(args);
+    const result = await this.safeAppsRepository.getSafeApps({
+      ...args,
+      ignoreVisibility: false,
+    });
 
     return result.map(
       (safeApp) =>

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -20,7 +20,7 @@ export class SafeAppsService {
   }): Promise<SafeApp[]> {
     const result = await this.safeAppsRepository.getSafeApps({
       ...args,
-      ignoreVisibility: false,
+      onlyListed: true,
     });
 
     return result.map(

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -75,7 +75,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
       chainId,
-      ignoreVisibility: true,
+      onlyListed: false,
       url: transactionOrigin.url,
     });
   });
@@ -105,7 +105,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
       chainId,
-      ignoreVisibility: true,
+      onlyListed: false,
       url: transactionOrigin.url,
     });
   });
@@ -148,7 +148,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
       chainId,
-      ignoreVisibility: true,
+      onlyListed: false,
       url: transactionOrigin.url,
     });
   });

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -37,6 +37,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
 
     expect(actual).toBeNull();
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(0);
   });
 
   it('should get a null SafeAppInfo for a transaction with no url into origin', async () => {
@@ -53,17 +54,30 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
 
     expect(actual).toBeNull();
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(0);
   });
 
   it('should return null if no SafeApp is found and origin is not null', async () => {
     const chainId = faker.string.numeric();
     const safeApps: Array<SafeApp> = [];
-    const transaction = multisigTransactionBuilder().build();
+    const transactionOrigin = {
+      url: faker.internet.url({ appendSlash: false }),
+      name: faker.word.words(),
+    };
+    const transaction = multisigTransactionBuilder()
+      .with('origin', JSON.stringify(transactionOrigin))
+      .build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
 
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
 
     expect(actual).toBeNull();
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
+      chainId,
+      ignoreVisibility: true,
+      url: transactionOrigin.url,
+    });
   });
 
   it('should get SafeAppInfo for a transaction with origin', async () => {
@@ -71,7 +85,13 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const safeApp = safeAppBuilder().build();
     const anotherSafeApp = safeAppBuilder().build();
     const safeApps = [safeApp, anotherSafeApp];
-    const transaction = multisigTransactionBuilder().build();
+    const transactionOrigin = {
+      url: faker.internet.url({ appendSlash: false }),
+      name: faker.word.words(),
+    };
+    const transaction = multisigTransactionBuilder()
+      .with('origin', JSON.stringify(transactionOrigin))
+      .build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
     const expected = new SafeAppInfo(
       safeApp.name,
@@ -82,6 +102,12 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
 
     expect(actual).toEqual(expected);
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
+      chainId,
+      ignoreVisibility: true,
+      url: transactionOrigin.url,
+    });
   });
 
   it('should return null origin on invalid JSON', async () => {
@@ -93,6 +119,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
 
     expect(actual).toBeNull();
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(0);
   });
 
   it('should replace IPFS origin urls', async () => {
@@ -101,7 +128,13 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const safeApp = safeAppBuilder().with('url', originUrl).build();
     const safeApps = [safeApp];
     const expectedUrl = 'https://cloudflare-ipfs.com/test';
-    const transaction = multisigTransactionBuilder().build();
+    const transactionOrigin = {
+      url: faker.internet.url({ appendSlash: false }),
+      name: faker.word.words(),
+    };
+    const transaction = multisigTransactionBuilder()
+      .with('origin', JSON.stringify(transactionOrigin))
+      .build();
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
     const expected = new SafeAppInfo(
       safeApp.name,
@@ -112,5 +145,11 @@ describe('SafeAppInfo mapper (Unit)', () => {
     const actual = await mapper.mapSafeAppInfo(chainId, transaction);
 
     expect(actual).toEqual(expected);
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
+    expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
+      chainId,
+      ignoreVisibility: true,
+      url: transactionOrigin.url,
+    });
   });
 });

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -26,6 +26,7 @@ export class SafeAppInfoMapper {
 
     const [safeApp] = await this.safeAppsRepository.getSafeApps({
       chainId,
+      ignoreVisibility: true,
       url: originUrl,
     });
     if (!safeApp) {

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -26,7 +26,7 @@ export class SafeAppInfoMapper {
 
     const [safeApp] = await this.safeAppsRepository.getSafeApps({
       chainId,
-      ignoreVisibility: true,
+      onlyListed: false,
       url: originUrl,
     });
     if (!safeApp) {


### PR DESCRIPTION
## Summary
Depends on https://github.com/safe-global/safe-config-service/pull/1111

This PR integrates the `onlyListed` Config Service query param when calling `GET /safe-apps/` endpoint. 

## Changes
- Adds `onlyListed` query parameter.
- Sets it to `false` on transaction mapping.
- Sets it to `true` when retrieving Safe Apps directly from the CGW API.
