### PR TITLE
Forward the Order receiver

### DIFF
--- a/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
@@ -102,6 +102,13 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
   executedSurplusFee: string | null;
 
   @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description: 'The (optional) address to receive the proceeds of the trade',
+  })
+  receiver: string | null;
+
+  @ApiPropertyOptional({
     type: Object,
     nullable: true,
     description: 'The App Data for this order',
@@ -132,6 +139,7 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
     this.executedSurplusFee = args.executedSurplusFee;
     this.sellToken = args.sellToken;
     this.buyToken = args.buyToken;
+    this.receiver = args.receiver;
     this.fullAppData = args.fullAppData;
   }
 }

--- a/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
@@ -22,6 +22,7 @@ export interface OrderInfo {
   executedBuyAmount: string;
   explorerUrl: URL;
   executedSurplusFee: string | null;
+  receiver: string | null;
   fullAppData: Record<string, unknown> | null;
 }
 
@@ -92,6 +93,13 @@ export class SwapOrderTransactionInfo
   executedSurplusFee: string | null;
 
   @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description: 'The (optional) address to receive the proceeds of the trade',
+  })
+  receiver: string | null;
+
+  @ApiPropertyOptional({
     type: Object,
     nullable: true,
     description: 'The App Data for this order',
@@ -112,6 +120,7 @@ export class SwapOrderTransactionInfo
     buyToken: TokenInfo;
     explorerUrl: URL;
     executedSurplusFee: string | null;
+    receiver: string | null;
     fullAppData: Record<string, unknown> | null;
   }) {
     super(TransactionInfoType.SwapOrder, null, null);
@@ -128,6 +137,7 @@ export class SwapOrderTransactionInfo
     this.buyToken = args.buyToken;
     this.explorerUrl = args.explorerUrl;
     this.executedSurplusFee = args.executedSurplusFee;
+    this.receiver = args.receiver;
     this.fullAppData = args.fullAppData;
   }
 }

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -57,6 +57,7 @@ export class SwapOrderMapper {
       }),
       explorerUrl: this.swapOrderHelper.getOrderExplorerUrl(order),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
+      receiver: order.receiver,
       fullAppData: order.fullAppData,
     });
   }

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -104,6 +104,7 @@ export class TransactionsViewService {
         trusted: buyToken.trusted,
       }),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
+      receiver: order.receiver,
       fullAppData: order.fullAppData,
     });
   }


### PR DESCRIPTION
## Summary

A CoW Swap Order contains an optional `receiver` which represents the target address that should receive the proceeds from the trade. This field is required by the clients of this service API so it should be forwarded.

## Changes

- Forwards the Order `receiver` in the Confirmation View and Transaction decoding