### PR TITLE
Remove unnecessary events message parsing

### DIFF
--- a/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -86,7 +86,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -129,7 +129,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -172,7 +172,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -207,7 +207,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -247,7 +247,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -287,7 +287,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -322,7 +322,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -352,7 +352,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -407,7 +407,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -440,7 +440,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { address: safeAddress, chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -465,7 +465,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(
@@ -489,7 +489,7 @@ describe('Events queue processing e2e tests', () => {
     );
     const data = { chainId, ...payload };
 
-    await channel.sendToQueue(queueName, Buffer.from(JSON.stringify(data)));
+    await channel.sendToQueue(queueName, data);
 
     await retry(async () => {
       const cacheContent = await redisClient.hGet(

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -47,9 +47,7 @@ export class CacheHooksService implements OnModuleInit {
       async (msg: ConsumeMessage) => {
         try {
           const content = JSON.parse(msg.content.toString());
-          const event: Event = WebHookSchema.parse(
-            JSON.parse(Buffer.from(content.data).toString()),
-          );
+          const event: Event = WebHookSchema.parse(content);
           await this.onEvent(event);
         } catch (err) {
           this.loggingService.error(err);


### PR DESCRIPTION
## Summary
This PR aims to fix an unnecessary double message parsing on `src/routes/cache-hooks/cache-hooks.service.ts`. This led to errors as a wrong assumption was taken: it is not needed to parse messages as a `Buffer` since `amqp-connection-manager`'s `ChannelWrapper` class does it automatically.

## Changes
- Remove unnecessary `Buffer`-wrappings in end-to-end tests.
- Remove unnecessary `JSON.parse(Buffer.from(...))` call in `CacheHooksService`.
