### PR TITLE
Forward the Order owner

### DIFF
--- a/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
@@ -108,6 +108,11 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
   })
   receiver: string | null;
 
+  @ApiProperty({
+    type: String,
+  })
+  owner: `0x${string}`;
+
   @ApiPropertyOptional({
     type: Object,
     nullable: true,
@@ -140,6 +145,7 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
     this.sellToken = args.sellToken;
     this.buyToken = args.buyToken;
     this.receiver = args.receiver;
+    this.owner = args.owner;
     this.fullAppData = args.fullAppData;
   }
 }

--- a/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/swap-order-info.entity.ts
@@ -23,6 +23,7 @@ export interface OrderInfo {
   explorerUrl: URL;
   executedSurplusFee: string | null;
   receiver: string | null;
+  owner: `0x${string}`;
   fullAppData: Record<string, unknown> | null;
 }
 
@@ -99,6 +100,11 @@ export class SwapOrderTransactionInfo
   })
   receiver: string | null;
 
+  @ApiProperty({
+    type: String,
+  })
+  owner: `0x${string}`;
+
   @ApiPropertyOptional({
     type: Object,
     nullable: true,
@@ -121,6 +127,7 @@ export class SwapOrderTransactionInfo
     explorerUrl: URL;
     executedSurplusFee: string | null;
     receiver: string | null;
+    owner: `0x${string}`;
     fullAppData: Record<string, unknown> | null;
   }) {
     super(TransactionInfoType.SwapOrder, null, null);
@@ -138,6 +145,7 @@ export class SwapOrderTransactionInfo
     this.explorerUrl = args.explorerUrl;
     this.executedSurplusFee = args.executedSurplusFee;
     this.receiver = args.receiver;
+    this.owner = args.owner;
     this.fullAppData = args.fullAppData;
   }
 }

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -58,6 +58,7 @@ export class SwapOrderMapper {
       explorerUrl: this.swapOrderHelper.getOrderExplorerUrl(order),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
       receiver: order.receiver,
+      owner: order.owner,
       fullAppData: order.fullAppData,
     });
   }

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -105,6 +105,7 @@ export class TransactionsViewService {
       }),
       executedSurplusFee: order.executedSurplusFee?.toString() ?? null,
       receiver: order.receiver,
+      owner: order.owner,
       fullAppData: order.fullAppData,
     });
   }


### PR DESCRIPTION
## Summary

A CoW Swap Order contains an `owner` property which represents the owner of that order.

## Changes

- Forwards the Order `owner` in the Confirmation View and Transaction decoding