### PR TITLE
Allow Swap App restriction

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -235,5 +235,7 @@ export default (): ReturnType<typeof configuration> => ({
       11155111: faker.internet.url(),
     },
     explorerBaseUri: faker.internet.url(),
+    restrictApps: false,
+    allowedApps: [],
   },
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -268,6 +268,8 @@ export default () => ({
     restrictApps: process.env.SWAPS_RESTRICT_APPS?.toLowerCase() === 'true',
     // The comma-separated collection of allowed CoW Swap Apps.
     // In order for this collection to take effect, restrictApps should be set to true
+    // The app names should match the "App Code" of the metadata provided to CoW Swap.
+    // See https://explorer.cow.fi/appdata?tab=encode
     allowedApps: process.env.SWAPS_ALLOWED_APPS?.split(',') || [],
   },
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -263,5 +263,11 @@ export default () => ({
     },
     explorerBaseUri:
       process.env.SWAPS_EXPLORER_URI || 'https://explorer.cow.fi/',
+    // If set to true, it will restrict the Swap Feature to be used only
+    // with Apps contained in allowedApps
+    restrictApps: process.env.SWAPS_RESTRICT_APPS?.toLowerCase() === 'true',
+    // The comma-separated collection of allowed CoW Swap Apps.
+    // In order for this collection to take effect, restrictApps should be set to true
+    allowedApps: process.env.SWAPS_ALLOWED_APPS?.split(',') || [],
   },
 });

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -1,4 +1,4 @@
-import { Injectable, Module } from '@nestjs/common';
+import { Inject, Injectable, Module } from '@nestjs/common';
 import { SetPreSignatureDecoder } from '@/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper';
 import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
@@ -6,12 +6,19 @@ import {
   SwapOrderHelper,
   SwapOrderHelperModule,
 } from '@/routes/transactions/helpers/swap-order.helper';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 
 @Injectable()
 export class SwapOrderMapper {
+  private readonly restrictApps =
+    this.configurationService.getOrThrow('swaps.restrictApps');
+
   constructor(
     private readonly setPreSignatureDecoder: SetPreSignatureDecoder,
     private readonly swapOrderHelper: SwapOrderHelper,
+    @Inject('SWAP_ALLOWED_APPS') private readonly allowedApps: Set<string>,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
   ) {}
 
   async mapSwapOrder(
@@ -28,6 +35,13 @@ export class SwapOrderMapper {
       chainId,
       orderUid,
     });
+
+    if (
+      this.restrictApps &&
+      !this.allowedApps.has(order.fullAppData['appCode'])
+    ) {
+      throw new Error(`Unsupported App: ${order.fullAppData['appCode']}`);
+    }
 
     return new SwapOrderTransactionInfo({
       uid: order.uid,
@@ -62,9 +76,25 @@ export class SwapOrderMapper {
   }
 }
 
+function allowedAppsFactory(
+  configurationService: IConfigurationService,
+): Set<string> {
+  const allowedApps =
+    configurationService.getOrThrow<string[]>('swaps.allowedApps');
+  return new Set(allowedApps);
+}
+
 @Module({
   imports: [SwapOrderHelperModule],
-  providers: [SwapOrderMapper, SetPreSignatureDecoder],
+  providers: [
+    SwapOrderMapper,
+    SetPreSignatureDecoder,
+    {
+      provide: 'SWAP_ALLOWED_APPS',
+      useFactory: allowedAppsFactory,
+      inject: [IConfigurationService],
+    },
+  ],
   exports: [SwapOrderMapper],
 })
 export class SwapOrderMapperModule {}


### PR DESCRIPTION
## Summary

Adds the ability to restrict the decoding functionality to specific Swap applications. Swap applications can be identified with Metadata that is added to each order by the respective apps. The property which contains this metadata is `fullAppData` – https://explorer.cow.fi/appdata?tab=encode

## Changes

- Two configuration properties were added:
  * `SWAPS_RESTRICT_APPS` – this configuration controls if the App restriction should be enabled or disabled.
  * `SWAPS_ALLOWED_APPS` – this configuration contains the comma separated collection of Swap apps which are allowed to be decoded. This configuration only has an effect if `SWAPS_RESTRICT_APPS` is set to `true`.