### PR TITLE
Add onlyListed to CacheRouter.getSafeAppsCacheDir argument list

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -438,11 +438,12 @@ export class CacheRouter {
   static getSafeAppsCacheDir(args: {
     chainId?: string;
     clientUrl?: string;
+    onlyListed?: boolean;
     url?: string;
   }): CacheDir {
     return new CacheDir(
       `${args.chainId}_${CacheRouter.SAFE_APPS_KEY}`,
-      `${args.clientUrl}_${args.url}`,
+      `${args.clientUrl}_${args.onlyListed}_${args.url}`,
     );
   }
 

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -114,7 +114,10 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toHaveBeenCalledTimes(1);
     expect(mockDataSource.get).toHaveBeenCalledWith({
-      cacheDir: new CacheDir(`${chainId}_safe_apps`, 'undefined_undefined'),
+      cacheDir: new CacheDir(
+        `${chainId}_safe_apps`,
+        'undefined_undefined_undefined',
+      ),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: {
@@ -136,7 +139,10 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toHaveBeenCalledTimes(1);
     expect(mockDataSource.get).toHaveBeenCalledWith({
-      cacheDir: new CacheDir(`${chainId}_safe_apps`, `undefined_${url}`),
+      cacheDir: new CacheDir(
+        `${chainId}_safe_apps`,
+        `undefined_undefined_${url}`,
+      ),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: { params: { chainId, clientUrl: undefined, url } },
@@ -156,7 +162,10 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toHaveBeenCalledTimes(1);
     expect(mockDataSource.get).toHaveBeenCalledWith({
-      cacheDir: new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
+      cacheDir: new CacheDir(
+        `${chainId}_safe_apps`,
+        `${clientUrl}_undefined_undefined`,
+      ),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: { params: { chainId, clientUrl, url: undefined } },
@@ -181,7 +190,10 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toHaveBeenCalledTimes(1);
     expect(mockDataSource.get).toHaveBeenCalledWith({
-      cacheDir: new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
+      cacheDir: new CacheDir(
+        `${chainId}_safe_apps`,
+        `${clientUrl}_${onlyListed}_undefined`,
+      ),
       url: `${baseUri}/api/v1/safe-apps/`,
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
       networkRequest: {

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('Get Safe Apps e2e test', () => {
 
   it('GET /chains/<chainId>/safe-apps', async () => {
     const safeAppsCacheKey = `${cacheKeyPrefix}-${chainId}_safe_apps`;
-    const safeAppsCacheField = 'undefined_undefined';
+    const safeAppsCacheField = 'undefined_true_undefined';
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safe-apps`)
@@ -71,7 +71,7 @@ describe('Get Safe Apps e2e test', () => {
   it('GET /chains/<chainId>/safe-apps?url=${transactionBuilderUrl}', async () => {
     const safeAppsCacheKey = `${cacheKeyPrefix}-${chainId}_safe_apps`;
     const transactionBuilderUrl = 'https://safe-apps.dev.5afe.dev/tx-builder';
-    const safeAppsCacheField = `undefined_${transactionBuilderUrl}`;
+    const safeAppsCacheField = `undefined_true_${transactionBuilderUrl}`;
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safe-apps/?url=${transactionBuilderUrl}`)


### PR DESCRIPTION
## Changes
- Adds `onlyListed` parameter to the `CacheDir` field when storing Safe Apps list in the cache.
