### PR TITLE
Fix `no-useless-escape` instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
-      'no-useless-escape': 'off',
       '@typescript-eslint/await-thenable': 'off',
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-misused-promises': 'off',

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -29,7 +29,7 @@ function configureSwagger(app: INestApplication): void {
   SwaggerModule.setup('api', app, document, {
     customfavIcon: '/favicon.png',
     customSiteTitle: 'Safe Client Gateway',
-    customCss: `.topbar-wrapper img { content:url(\'logo.svg\'); }`,
+    customCss: `.topbar-wrapper img { content:url('logo.svg'); }`,
   });
 }
 

--- a/src/domain/account/entities/account.entity.ts
+++ b/src/domain/account/entities/account.entity.ts
@@ -22,7 +22,7 @@ export interface VerificationCode {
 export class EmailAddress {
   // https://www.ietf.org/rfc/rfc5322.txt
   private static EMAIL_REGEX: RegExp =
-    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
   constructor(readonly value: string) {
     if (!EmailAddress.EMAIL_REGEX.test(value)) {

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -43,10 +43,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
   it('should get a null SafeAppInfo for a transaction with no url into origin', async () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder()
-      .with(
-        'origin',
-        `{ \"${faker.word.sample()}\": \"${faker.word.sample()}\" }`,
-      )
+      .with('origin', `{ "${faker.word.sample()}": "${faker.word.sample()}" }`)
       .build();
     const safeApps = [safeAppBuilder().build(), safeAppBuilder().build()];
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);


### PR DESCRIPTION
## Summary

When updating to ESLint 9, some rules had to be ignored as their recommendations changed. Of which, was the [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) rule.

This removes unnecessary escape characters present in the project.

## Changes

- Enable `no-useless-escape` ESLint rule
- Remove unnecessary escape characters from:
  - `app.provider.ts`
  - `domain/account/entities/account.entity.ts`
  - `routes/transactions/mappers/common/safe-app-info.mapper.spec.ts`