### PR TITLE
Fix `@typescript-eslint/await-thenable` instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
-      '@typescript-eslint/await-thenable': 'off',
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/no-redundant-type-constituents': 'off',

--- a/src/__tests__/util/retry.ts
+++ b/src/__tests__/util/retry.ts
@@ -11,7 +11,7 @@ export async function waitMilliseconds(milliseconds: number): Promise<void> {
  * If {@link maxAttempts} is reached, it throws the error returned by {@link fn} last execution.
  */
 export async function retry(
-  fn: () => void,
+  fn: () => Promise<void>,
   maxAttempts: number = 40,
   delayMs: number = 100,
 ): Promise<void> {

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -88,10 +88,10 @@ describe('CoingeckoAPI', () => {
     );
   });
 
-  it('should error if configuration is not defined', async () => {
+  it('should error if configuration is not defined', () => {
     const fakeConfigurationService = new FakeConfigurationService();
 
-    await expect(
+    expect(
       () =>
         new CoingeckoApi(
           fakeConfigurationService,

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -154,7 +154,7 @@ export class SafeBalancesApi implements IBalancesApi {
           );
           price = found?.[tokenAddress]?.[fiatCode.toLowerCase()] ?? null;
         }
-        const fiatBalance = await this._getFiatBalance(price, balance);
+        const fiatBalance = this._getFiatBalance(price, balance);
         return {
           ...balance,
           fiatBalance: fiatBalance ? getNumberString(fiatBalance) : null,

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -55,10 +55,10 @@ describe('ConfigApi', () => {
     );
   });
 
-  it('should error if configuration is not defined', async () => {
+  it('should error if configuration is not defined', () => {
     const fakeConfigurationService = new FakeConfigurationService();
 
-    await expect(
+    expect(
       () =>
         new ConfigApi(
           dataSource,

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -65,7 +65,7 @@ describe('RouteLoggerInterceptor tests', () => {
       controllers: [TestController],
     }).compile();
 
-    app = await moduleFixture.createNestApplication();
+    app = moduleFixture.createNestApplication();
     app.useGlobalInterceptors(new RouteLoggerInterceptor(mockLoggingService));
     await app.init();
   });


### PR DESCRIPTION
## Summary

When updating to ESLint 9, some rules had to be ignored as their recommendations changed. Of which, was the [`@typescript-eslint/await-thenable`](https://typescript-eslint.io/rules/await-thenable/) rule.

This removes instances of awaiting values that are not "thenable".

## Changes

- Enable `@typescript-eslint/await-thenable` ESLint rule
- Remove instances of awaiting values that are not "thenable" from:
  - `__tests__/util/retry.ts`
  - `datasources/balances-api/coingecko-api.service.spec.ts`
  - `datasources/balances-api/safe-balances-api.service.ts`
  - `datasources/config-api/config-api.service.spec.ts`
  - `routes/common/interceptors/route-logger.interceptor.spec.ts`