### PR TITLE
Remove locking feature flag

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -55,7 +55,6 @@ export class AppModule implements NestModule {
     const {
       auth: isAuthFeatureEnabled,
       email: isEmailFeatureEnabled,
-      locking: isLockingFeatureEnabled,
       relay: isRelayFeatureEnabled,
       confirmationView: isConfirmationViewEnabled,
     } = configFactory()['features'];
@@ -83,7 +82,7 @@ export class AppModule implements NestModule {
           : []),
         EstimationsModule,
         HealthModule,
-        ...(isLockingFeatureEnabled ? [LockingModule] : []),
+        LockingModule,
         MessagesModule,
         NotificationsModule,
         OwnersModule,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -183,7 +183,6 @@ export default (): ReturnType<typeof configuration> => ({
     richFragments: true,
     email: false,
     zerionBalancesChainIds: ['137'],
-    locking: true,
     relay: true,
     swapsDecoding: true,
     historyDebugLogs: false,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -190,7 +190,6 @@ export default () => ({
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
     zerionBalancesChainIds:
       process.env.FF_ZERION_BALANCES_CHAIN_IDS?.split(',') ?? [],
-    locking: process.env.FF_LOCKING?.toLowerCase() === 'true',
     relay: process.env.FF_RELAY?.toLowerCase() === 'true',
     swapsDecoding: process.env.FF_SWAPS_DECODING?.toLowerCase() === 'true',
     historyDebugLogs:

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -38,17 +38,8 @@ describe('Locking (Unit)', () => {
   beforeEach(async () => {
     jest.resetAllMocks();
 
-    const defaultConfiguration = configuration();
-    const testConfiguration = (): typeof defaultConfiguration => ({
-      ...defaultConfiguration,
-      features: {
-        ...defaultConfiguration.features,
-        locking: true,
-      },
-    });
-
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(testConfiguration)],
+      imports: [AppModule.register(configuration)],
     })
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)


### PR DESCRIPTION
## Summary

Now that locking is live and in use, there is no need for a feature flag. This removes the `features.locking` configuration and associated logic.

## Changes

- Remove `features.locking` from configuration
- Remove conditional module loading
- Remove opt-in from test