### PR TITLE
Remove relay feature flag

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -56,7 +56,6 @@ export class AppModule implements NestModule {
       auth: isAuthFeatureEnabled,
       email: isEmailFeatureEnabled,
       locking: isLockingFeatureEnabled,
-      relay: isRelayFeatureEnabled,
       confirmationView: isConfirmationViewEnabled,
     } = configFactory()['features'];
 
@@ -87,7 +86,7 @@ export class AppModule implements NestModule {
         MessagesModule,
         NotificationsModule,
         OwnersModule,
-        ...(isRelayFeatureEnabled ? [RelayControllerModule] : []),
+        RelayControllerModule,
         RootModule,
         SafeAppsModule,
         SafesModule,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -184,7 +184,6 @@ export default (): ReturnType<typeof configuration> => ({
     email: false,
     zerionBalancesChainIds: ['137'],
     locking: true,
-    relay: true,
     swapsDecoding: true,
     historyDebugLogs: false,
     auth: false,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -191,7 +191,6 @@ export default () => ({
     zerionBalancesChainIds:
       process.env.FF_ZERION_BALANCES_CHAIN_IDS?.split(',') ?? [],
     locking: process.env.FF_LOCKING?.toLowerCase() === 'true',
-    relay: process.env.FF_RELAY?.toLowerCase() === 'true',
     swapsDecoding: process.env.FF_SWAPS_DECODING?.toLowerCase() === 'true',
     historyDebugLogs:
       process.env.FF_HISTORY_DEBUG_LOGS?.toLowerCase() === 'true',

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -88,10 +88,6 @@ describe('Relay controller', () => {
     const defaultConfiguration = configuration();
     const testConfiguration = (): typeof defaultConfiguration => ({
       ...defaultConfiguration,
-      features: {
-        ...defaultConfiguration.features,
-        relay: true,
-      },
       relay: {
         ...defaultConfiguration.relay,
         limit: 5,

--- a/src/routes/relay/relay.legacy.controller.spec.ts
+++ b/src/routes/relay/relay.legacy.controller.spec.ts
@@ -20,17 +20,8 @@ describe('Relay controller', () => {
   beforeEach(async () => {
     jest.resetAllMocks();
 
-    const defaultConfiguration = configuration();
-    const testConfiguration = (): typeof defaultConfiguration => ({
-      ...defaultConfiguration,
-      features: {
-        ...defaultConfiguration.features,
-        relay: true,
-      },
-    });
-
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(testConfiguration)],
+      imports: [AppModule.register(configuration)],
     })
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)


### PR DESCRIPTION
## Summary

Now that relaying is live and in use, there is no need for a feature flag. This removes the `features.relay` configuration and associated logic.

## Changes

- Remove `features.relay` from configuration
- Remove conditional module loading
- Remove opt-in from (legacy) test