### PR TITLE
Use Docker Registry cache backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   release:
     types: [released]
 
+env:
+  DOCKER_IMAGE_REGISTRY: safeglobal
+  DOCKER_IMAGE_NAME: safe-client-gateway-nest
+  DOCKER_BUILD_IMAGE_TAG: buildcache
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
@@ -124,27 +129,21 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/build-push-action@v5
-        env:
-          DOCKER_IMAGE_TAG: safeglobal/safe-client-gateway-nest:staging
         with:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
-          tags: ${{ env.DOCKER_IMAGE_TAG }}
-          # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
-          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
-          cache-to: type=inline
+          tags: ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:staging
+          # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   docker-publish-release:
     if: (github.event_name == 'release' && github.event.action == 'released')
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
-    env:
-      IMAGE_CACHE_SOURCE: staging
-      IMAGE_REGISTRY: safeglobal
-      IMAGE_NAME: safe-client-gateway-nest
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -166,10 +165,11 @@ jobs:
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
           tags: |
-            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_CACHE_SOURCE }}
-          cache-to: type=inline
+            ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:latest
+          # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   autodeploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

We were using the inline Docker cache for the Docker images produced by `docker-publish-staging` and `docker-publish-release`. The inline Docker cache bundles the cache metadata alongside the image (increasing its size) but it does not scale well with multi-stage builds (which we use).

Additionally, `inline` only supports `mode=min` – https://docs.docker.com/build/cache/backends/#cache-mode. This means that only the final layers which are exported (the last stage of the multi stage build) and therefore cached, resulting if fewer cache hits.

By using a `registry` cache backend (https://docs.docker.com/build/cache/backends/registry/), we can bundle the layers to be cached into a separate image, reducing the size of the staging/production images. A `registry` backend also supports `mode=max` which allows all the intermediary layers to be cached. This should improve the amount of cache hits that we get while building the staging and production images (thus reducing the time spent building each layer).

## Changes

- Change from `inline` to `registry` cache backend.
- Use `mode=max` to cache all intermediary layers.
- Use the external `buildcache` image as a cache reference for all the image layers (staging and production).
- Extract the `env` to the workflow root (to make it easier to share the configuration between jobs).
