### PR TITLE
Map `TransactionInfo` according to `Transfer['type']`

### DIFF
--- a/src/domain/safe/entities/transfer.entity.ts
+++ b/src/domain/safe/entities/transfer.entity.ts
@@ -14,51 +14,8 @@ export const TransferSchema = z.discriminatedUnion('type', [
 
 export const TransferPageSchema = buildPageSchema(TransferSchema);
 
-const hasTokenAddress = (
-  transfer: Transfer,
-): transfer is Transfer & {
-  tokenAddress: (ERC20Transfer | ERC721Transfer)['tokenAddress'];
-} => {
-  return 'tokenAddress' in transfer && transfer.tokenAddress != null;
-};
-
-const hasValue = (
-  transfer: Transfer,
-): transfer is Transfer & {
-  value: (ERC20Transfer | NativeTokenTransfer)['value'];
-} => {
-  return 'value' in transfer && transfer.value != null;
-};
-
-const hasTokenId = (
-  transfer: Transfer,
-): transfer is Transfer & {
-  tokenId: ERC721Transfer['tokenId'];
-} => {
-  return 'tokenId' in transfer && transfer.tokenId != null;
-};
-
 export type ERC20Transfer = z.infer<typeof Erc20TransferSchema>;
-
-// TODO: Just check `type` is `"ERC20_TRANSFER"`
-export function isERC20Transfer(transfer: Transfer): transfer is ERC20Transfer {
-  return hasTokenAddress(transfer) && hasValue(transfer);
-}
 
 export type ERC721Transfer = z.infer<typeof Erc721TransferSchema>;
 
-// TODO: Just check `type` is `"ERC721_TRANSFER"`
-export function isERC721Transfer(
-  transfer: Transfer,
-): transfer is ERC721Transfer {
-  return hasTokenAddress(transfer) && hasTokenId(transfer);
-}
-
 export type NativeTokenTransfer = z.infer<typeof NativeTokenTransferSchema>;
-
-// TODO: Just check `type` is `"ETHER_TRANSFER"`
-export function isNativeTokenTransfer(
-  transfer: Transfer,
-): transfer is NativeTokenTransfer {
-  return !hasTokenAddress(transfer) && hasValue(transfer);
-}

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -1,11 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Safe } from '@/domain/safe/entities/safe.entity';
-import {
-  isERC20Transfer,
-  isERC721Transfer,
-  isNativeTokenTransfer,
-  Transfer as DomainTransfer,
-} from '@/domain/safe/entities/transfer.entity';
+import { Transfer as DomainTransfer } from '@/domain/safe/entities/transfer.entity';
 import { Token } from '@/domain/tokens/entities/token.entity';
 import { TokenRepository } from '@/domain/tokens/token.repository';
 import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
@@ -56,7 +51,7 @@ export class TransferInfoMapper {
     chainId: string,
     domainTransfer: DomainTransfer,
   ): Promise<Transfer> {
-    if (isERC20Transfer(domainTransfer)) {
+    if (domainTransfer.type === 'ERC20_TRANSFER') {
       const { tokenAddress, value } = domainTransfer;
       const token: Token | null = await this.getToken(
         chainId,
@@ -71,7 +66,7 @@ export class TransferInfoMapper {
         token?.decimals,
         token?.trusted,
       );
-    } else if (isERC721Transfer(domainTransfer)) {
+    } else if (domainTransfer.type === 'ERC721_TRANSFER') {
       const { tokenAddress, tokenId } = domainTransfer;
       const token = await this.getToken(chainId, tokenAddress).catch(
         () => null,
@@ -84,7 +79,7 @@ export class TransferInfoMapper {
         token?.logoUri,
         token?.trusted,
       );
-    } else if (isNativeTokenTransfer(domainTransfer)) {
+    } else if (domainTransfer.type === 'ETHER_TRANSFER') {
       return new NativeCoinTransfer(domainTransfer.value);
     } else {
       throw Error('Unknown transfer type');


### PR DESCRIPTION
## Summary

We were mapping the types of `Transfer`s based on properties in the entity. However, a `type` decriminator exists. Migrating to this was marked as a TODO and this adjusts the code to instead use that.

## Changes

- Remove and migrate from using `isERC20Transfer` to instead check for `type === ERC20_TRANSFER`
- Remove and migrate from using `isERC721Transfer` to instead check for `type === ERC721_TRANSFER`
- Remove and migrate from using `isNativeTokenTransfer` to instead check for `type === ETHER_TRANSFER`