### PR TITLE
Perform lower case comparison for native currency

### DIFF
--- a/src/routes/transactions/helpers/swap-order.helper.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.ts
@@ -169,7 +169,12 @@ export class SwapOrderHelper {
     chainId: string;
     address: `0x${string}`;
   }): Promise<Token> {
-    if (args.address === SwapOrderHelper.NATIVE_CURRENCY_ADDRESS) {
+    // We perform lower case comparison because the provided address (3rd party service)
+    // might not be checksummed.
+    if (
+      args.address.toLowerCase() ===
+      SwapOrderHelper.NATIVE_CURRENCY_ADDRESS.toLowerCase()
+    ) {
       const { nativeCurrency } = await this.chainsRepository.getChain(
         args.chainId,
       );


### PR DESCRIPTION
- Ignores the checksummed state of the provided addresses – one address is provided by a 3rd party, and we should be able to correctly perform this comparison regardless of the representation of the respective address.