### PR TITLE
Change AddressInfo.name empty string values to explicit nulls

### DIFF
--- a/src/routes/common/entities/address-info.entity.ts
+++ b/src/routes/common/entities/address-info.entity.ts
@@ -14,7 +14,8 @@ export class AddressInfo {
     logoUri: string | null = null,
   ) {
     this.value = value;
-    this.name = name;
+    // Return null if name is an empty string
+    this.name = name?.length === 0 ? null : name;
     this.logoUri = logoUri;
   }
 }


### PR DESCRIPTION
## Summary
This PR reverts the change introduced in this PR: https://github.com/safe-global/safe-client-gateway/pull/1430/files#diff-68b98fcedd4c2f740a8007f5abd015a53faf61751fe684d9a3db56629774d793L13-L19

The clients' expected behavior when a token name is not present is to return `null` instead of an empty string.

## Changes
- Changes the behavior of `AddressInfo` in order to explicitly return `null` instead of an empty string for `AddressInfo.name`.
