### PR TITLE
Include E2E tests requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker compose up -d db-test
 yarn run test
 
 # e2e tests
-yarn run test:e2e
+docker-compose up -d redis rabbitmq && yarn run test:e2e
 
 # test coverage
 yarn run test:cov


### PR DESCRIPTION
## Changes
- Adds `redis` and `rabbitmq` running containers as a requirement to execute end-to-end tests.
