### PR TITLE
Add unique queue names per E2E test suite

### DIFF
--- a/src/__tests__/amqp-client.factory.ts
+++ b/src/__tests__/amqp-client.factory.ts
@@ -1,7 +1,7 @@
 import amqp, { ChannelWrapper } from 'amqp-connection-manager';
 import { Channel } from 'amqplib';
 
-export async function amqpClientFactory(): Promise<{
+export async function amqpClientFactory(queue?: string): Promise<{
   channel: ChannelWrapper;
   queueName: string;
 }> {
@@ -12,6 +12,7 @@ export async function amqpClientFactory(): Promise<{
     throw new Error('Invalid amqpClientFactory configuration');
   }
 
+  const queueName = queue ?? AMQP_QUEUE;
   const connection = amqp.connect(AMQP_URL);
   const channel = connection.createChannel({
     json: true,
@@ -19,10 +20,10 @@ export async function amqpClientFactory(): Promise<{
       await ch.assertExchange(AMQP_EXCHANGE_NAME, AMQP_EXCHANGE_MODE, {
         durable: true,
       });
-      await ch.assertQueue(AMQP_QUEUE, { durable: true });
-      await ch.bindQueue(AMQP_QUEUE, AMQP_EXCHANGE_NAME, '');
+      await ch.assertQueue(queueName, { durable: true });
+      await ch.bindQueue(queueName, AMQP_EXCHANGE_NAME, '');
     },
   });
 
-  return { channel, queueName: AMQP_QUEUE };
+  return { channel, queueName };
 }

--- a/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -19,12 +19,17 @@ describe('Events queue processing e2e tests', () => {
   let channel: ChannelWrapper;
   let queueName: string;
   const cacheKeyPrefix = crypto.randomUUID();
+  const queue = crypto.randomUUID();
   const chainId = '1'; // Mainnet
 
   beforeAll(async () => {
     const defaultConfiguration = configuration();
     const testConfiguration = (): typeof defaultConfiguration => ({
       ...defaultConfiguration,
+      amqp: {
+        ...defaultConfiguration.amqp,
+        queue,
+      },
       features: {
         ...defaultConfiguration.features,
         eventsQueue: true,
@@ -41,7 +46,7 @@ describe('Events queue processing e2e tests', () => {
     app = await new TestAppProvider().provide(moduleRef);
     await app.init();
     redisClient = await redisClientFactory();
-    const amqpClient = await amqpClientFactory();
+    const amqpClient = await amqpClientFactory(queue);
     channel = amqpClient.channel;
     queueName = amqpClient.queueName;
   });


### PR DESCRIPTION
## Summary
This PR addresses the interference issue between several running Node.js processes while executing Jest tests in parallel. 

Before this PR, a Jest test process could emit messages to a queue, and a different process could receive them. This was causing problems like a mismatch between the cache keys being cleared, as several test suites have isolated cache key namespaces.

To avoid this kind of side effects, this PR adds a `queue` parameter to the test RabbitMQ client, so each test suite has the possibility of using a different queue, and therefore avoiding side effects between processes.

## Changes
- Adds a `queue` parameter to `amqpClientFactory`, so the client class can choose using a custom queue name.
