### PR TITLE
Map historical transactions before grouping them

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -1,9 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { groupBy } from 'lodash';
-import { CreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
-import { EthereumTransaction } from '@/domain/safe/entities/ethereum-transaction.entity';
-import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
-import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import {
   isCreationTransaction,
@@ -20,16 +16,6 @@ import { ModuleTransactionMapper } from '@/routes/transactions/mappers/module-tr
 import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-
-class TransactionDomainGroup {
-  timestamp!: number;
-  transactions!: (
-    | MultisigTransaction
-    | ModuleTransaction
-    | EthereumTransaction
-    | CreationTransaction
-  )[];
-}
 
 @Injectable()
 export class TransactionsHistoryMapper {
@@ -58,71 +44,62 @@ export class TransactionsHistoryMapper {
     if (transactionsDomain.length == 0) {
       return [];
     }
-    const previousTransaction = this.getPreviousItem(
-      offset,
-      transactionsDomain,
-    );
-    let prevPageTimestamp = 0;
-    if (previousTransaction !== null) {
-      prevPageTimestamp = this.getDayFromTransactionDate(
-        previousTransaction,
-        timezoneOffset,
-      ).getTime();
+    const previousTransaction = await (async (): Promise<
+      TransactionItem | undefined
+    > => {
+      const prevDomainTransaction = this.getPreviousItem(
+        offset,
+        transactionsDomain,
+      );
+      if (!prevDomainTransaction) {
+        return;
+      }
+      // We map in order to filter last list item against it
+      const mappedPreviousTransaction = await this.mapTransaction(
+        prevDomainTransaction,
+        chainId,
+        safe,
+        onlyTrusted,
+      );
       // Remove first transaction that was requested to get previous day timestamp
       transactionsDomain = transactionsDomain.slice(1);
-    }
 
-    const transactionsDomainGroups = this.groupByDay(
-      transactionsDomain,
-      timezoneOffset,
-    );
+      return Array.isArray(mappedPreviousTransaction)
+        ? // All transfers should have same execution date but the last is "true" previous
+          mappedPreviousTransaction.at(-1)
+        : mappedPreviousTransaction;
+    })();
 
-    const transactionList = await Promise.all(
-      transactionsDomainGroups.map(async (transactionGroup) => {
-        const items: (TransactionItem | DateLabel)[] = [];
-        const groupTransactions = (
-          await this.mapGroupTransactions(
-            transactionGroup,
-            chainId,
-            safe,
-            onlyTrusted,
-          )
-        )
-          .filter(<T>(x: T | undefined): x is T => x != null)
-          .flat();
+    const transactions = await (async (): Promise<Array<TransactionItem>> => {
+      const mappedTransactions = await Promise.all(
+        transactionsDomain.map((transaction) => {
+          return this.mapTransaction(transaction, chainId, safe, onlyTrusted);
+        }),
+      );
+      return mappedTransactions
+        .filter(<T>(x: T): x is NonNullable<T> => x != null)
+        .flat();
+    })();
+
+    // The groups respect timezone offset – this was done for grouping only.
+    const transactionsByDay = this.groupByDay(transactions, timezoneOffset);
+    return transactionsByDay.reduce<Array<TransactionItem | DateLabel>>(
+      (transactionList, transactionsOnDay) => {
+        // The actual value of the group should be in the UTC timezone instead
+        // A group should always have at least one transaction.
+        const { timestamp } = transactionsOnDay[0].transaction;
 
         // If the current group is a follow-up from the previous page,
         // or the group is empty, the date label shouldn't be added.
-        const isFollowUp = transactionGroup.timestamp == prevPageTimestamp;
-        if (!isFollowUp && groupTransactions.length) {
-          items.push(new DateLabel(transactionGroup.timestamp));
+        const isFollowUp =
+          timestamp == previousTransaction?.transaction.timestamp;
+        if (!isFollowUp && transactionsOnDay.length > 0 && timestamp) {
+          transactionList.push(new DateLabel(timestamp));
         }
-        items.push(...groupTransactions);
-        return items;
-      }),
+        return transactionList.concat(transactionsOnDay);
+      },
+      [],
     );
-
-    return transactionList.flat();
-  }
-
-  private getTransactionTimestamp(transaction: TransactionDomain): Date {
-    let timestamp: Date | null;
-    if (isMultisigTransaction(transaction)) {
-      const executionDate = transaction.executionDate;
-      timestamp = executionDate ?? transaction.submissionDate;
-    } else if (isEthereumTransaction(transaction)) {
-      timestamp = transaction.executionDate;
-    } else if (isModuleTransaction(transaction)) {
-      timestamp = transaction.executionDate;
-    } else if (isCreationTransaction(transaction)) {
-      timestamp = transaction.created;
-    } else {
-      throw Error('Unknown transaction type');
-    }
-    if (timestamp == null) {
-      throw Error('ExecutionDate cannot be null');
-    }
-    return timestamp;
   }
 
   private getPreviousItem(
@@ -134,34 +111,16 @@ export class TransactionsHistoryMapper {
     return transactions[0];
   }
 
-  private getDayFromTransactionDate(
-    transaction: TransactionDomain,
-    timezoneOffset: number,
-  ): Date {
-    const timestamp = this.getTransactionTimestamp(transaction);
-    return this.getDayStartForDate(timestamp, timezoneOffset);
-  }
-
   private groupByDay(
-    transactions: TransactionDomain[],
+    transactions: TransactionItem[],
     timezoneOffset: number,
-  ): TransactionDomainGroup[] {
-    return Object.entries(
-      groupBy(transactions, (transaction) => {
-        return this.getDayFromTransactionDate(
-          transaction,
-          timezoneOffset,
-        ).getTime();
-      }),
-    ).map(([, transactions]): TransactionDomainGroup => {
-      // The groups respect the timezone offset – this was done for grouping only.
-      // The actual value of the group should be in the UTC timezone instead
-      // A group should always have at least one transaction.
-      return {
-        timestamp: this.getTransactionTimestamp(transactions[0]).getTime(),
-        transactions: transactions,
-      };
+  ): TransactionItem[][] {
+    const grouped = groupBy(transactions, ({ transaction }) => {
+      // timestamp will always be defined for historical transactions
+      const date = new Date(transaction.timestamp ?? 0);
+      return this.getDayStartForDate(date, timezoneOffset).getTime();
     });
+    return Object.values(grouped);
   }
 
   /**
@@ -198,52 +157,40 @@ export class TransactionsHistoryMapper {
     );
   }
 
-  private mapGroupTransactions(
-    transactionGroup: TransactionDomainGroup,
+  private async mapTransaction(
+    transaction: TransactionDomain,
     chainId: string,
     safe: Safe,
     onlyTrusted: boolean,
-  ): Promise<(TransactionItem | TransactionItem[] | undefined)[]> {
-    return Promise.all(
-      transactionGroup.transactions.map(async (transaction) => {
-        if (isMultisigTransaction(transaction)) {
-          return new TransactionItem(
-            await this.multisigTransactionMapper.mapTransaction(
-              chainId,
-              transaction,
-              safe,
-            ),
-          );
-        } else if (isModuleTransaction(transaction)) {
-          return new TransactionItem(
-            await this.moduleTransactionMapper.mapTransaction(
-              chainId,
-              transaction,
-            ),
-          );
-        } else if (isEthereumTransaction(transaction)) {
-          const transfers = transaction.transfers;
-          if (transfers != null) {
-            return await this.mapTransfers(
-              transfers,
-              chainId,
-              safe,
-              onlyTrusted,
-            );
-          }
-        } else if (isCreationTransaction(transaction)) {
-          return new TransactionItem(
-            await this.creationTransactionMapper.mapTransaction(
-              chainId,
-              transaction,
-              safe,
-            ),
-          );
-        } else {
-          // This should never happen as Zod would not allow an unknown transaction to get to this stage
-          throw Error('Unrecognized transaction type');
-        }
-      }),
-    );
+  ): Promise<TransactionItem | TransactionItem[] | undefined> {
+    if (isMultisigTransaction(transaction)) {
+      return new TransactionItem(
+        await this.multisigTransactionMapper.mapTransaction(
+          chainId,
+          transaction,
+          safe,
+        ),
+      );
+    } else if (isModuleTransaction(transaction)) {
+      return new TransactionItem(
+        await this.moduleTransactionMapper.mapTransaction(chainId, transaction),
+      );
+    } else if (isEthereumTransaction(transaction)) {
+      const transfers = transaction.transfers;
+      if (transfers != null) {
+        return await this.mapTransfers(transfers, chainId, safe, onlyTrusted);
+      }
+    } else if (isCreationTransaction(transaction)) {
+      return new TransactionItem(
+        await this.creationTransactionMapper.mapTransaction(
+          chainId,
+          transaction,
+          safe,
+        ),
+      );
+    } else {
+      // This should never happen as Zod would not allow an unknown transaction to get to this stage
+      throw Error('Unrecognized transaction type');
+    }
   }
 }

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -251,10 +251,12 @@ describe('Transactions History Controller (Unit)', () => {
         .with('executionDate', new Date('2022-12-25T00:00:00Z'))
         .build(),
     );
-    const nativeTokenTransfer = nativeTokenTransferBuilder().build();
+    const nativeTokenTransfer = nativeTokenTransferBuilder()
+      .with('executionDate', new Date('2022-12-31T00:00:00Z'))
+      .build();
     const incomingTransaction = ethereumTransactionToJson(
       ethereumTransactionBuilder()
-        .with('executionDate', new Date('2022-12-31T00:00:00Z'))
+        .with('executionDate', nativeTokenTransfer.executionDate)
         .with('transfers', [
           nativeTokenTransferToJson(nativeTokenTransfer) as Transfer,
         ])
@@ -996,12 +998,14 @@ describe('Transactions History Controller (Unit)', () => {
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
                   .with('value', faker.string.numeric({ exclude: ['0'] }))
+                  .with('executionDate', date)
                   .build(),
               ) as Transfer,
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', trustedToken.address)
                   .with('value', faker.string.numeric({ exclude: ['0'] }))
+                  .with('executionDate', date)
                   .build(),
               ) as Transfer,
             ])
@@ -1015,12 +1019,14 @@ describe('Transactions History Controller (Unit)', () => {
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
                   .with('value', faker.string.numeric({ exclude: ['0'] }))
+                  .with('executionDate', oneDayAfter)
                   .build(),
               ) as Transfer,
               erc20TransferToJson(
                 erc20TransferBuilder()
                   .with('tokenAddress', untrustedToken.address)
                   .with('value', faker.string.numeric({ exclude: ['0'] }))
+                  .with('executionDate', oneDayAfter)
                   .build(),
               ) as Transfer,
             ])
@@ -1034,6 +1040,7 @@ describe('Transactions History Controller (Unit)', () => {
                 erc20TransferBuilder()
                   .with('tokenAddress', trustedToken.address)
                   .with('value', faker.string.numeric({ exclude: ['0'] }))
+                  .with('executionDate', twoDaysAfter)
                   .build(),
               ) as Transfer,
             ])


### PR DESCRIPTION
## Summary

This simplifies the mapping of historical transactions in preparation for tackling address poisoning, breaking down #1428.

We currently group domain transactions "as is". This means that we have [duplicate logic](https://github.com/safe-global/safe-client-gateway/commit/991c552823c8f2fe3f460064ec97787266900e59#diff-bfd101886211fde88eb856ba9dbd3e719b1b6a389cf1c603840e6b3e6cf84be0L108-L126) for extracting the timestamp of domain transactions (of varying types) that is otherwise done in their respective mappers, e.g. [for multisig transactions](https://github.com/safe-global/safe-client-gateway/blob/address-poisoning-demo/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts#L45).

This maps domain transactions before grouping them, as well as simplifying the grouping logic. (This will allow for simpler filtering of address poisoning attempts as all transactions will be the same type.)

## Changes

- Change `mapGroupTransactions` to only map singular transaction (`mapTransaction`)
- Map previous transaction (for date label calculation) if it exists
- Map domain transactions before grouping them
- Simplify grouping logic
- Update tests accordingly (the mock data has always been wrong)