### PR TITLE
Only return awaiting confirmations count if it is required

### DIFF
--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -131,6 +131,7 @@ describe('Safes Controller Overview (Unit)', () => {
       const multisigTransactions = [
         multisigTransactionToJson(
           multisigTransactionBuilder()
+            .with('confirmationsRequired', 0)
             .with('confirmations', [
               // Signature provided
               confirmationBuilder().with('owner', walletAddress).build(),
@@ -250,6 +251,177 @@ describe('Safes Controller Overview (Unit)', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
+
+    it('should not return awaiting confirmations if no more confirmations are required', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const secondTokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const nativeCoinId = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
+        );
+      const chainName = app
+        .get(IConfigurationService)
+        .getOrThrow(
+          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
+        );
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = getAddress(faker.finance.ethereumAddress());
+      const multisigTransactions = [
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('confirmationsRequired', 0)
+            .with('confirmations', [
+              // Not wallet address
+              confirmationBuilder().with('owner', getAddress(faker.finance.ethereumAddress())).build(),
+            ])
+            .build(),
+        ),
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+          .with('confirmationsRequired', 0)
+          .with('confirmations', [
+            // Not wallet address
+            confirmationBuilder().with('owner', getAddress(faker.finance.ethereumAddress())).build(),
+          ]).build())
+      ];
+      const queuedTransactions = pageBuilder()
+        .with('results', multisigTransactions)
+        .with('count', multisigTransactions.length)
+        .build();
+
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: safeInfo, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions,
+              status: 200,
+            });
+          }
+          default: {
+            return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&wallet_address=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            {
+              address: {
+                value: safeInfo.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain.chainId,
+              threshold: safeInfo.threshold,
+              owners: safeInfo.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: 2,
+              awaitingConfirmation: 0,
+            },
+          ]),
+        );
+
+      expect(networkService.get.mock.calls.length).toBe(7);
+
+      expect(networkService.get.mock.calls[0][0].url).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[1][0].url).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[2][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
+      );
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+        params: { trusted: false, exclude_spam: true },
+      });
+      expect(networkService.get.mock.calls[4][0].url).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      );
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: {
+          vs_currencies: currency.toLowerCase(),
+          contract_addresses: [
+            tokenAddress.toLowerCase(),
+            secondTokenAddress.toLowerCase(),
+          ].join(','),
+        },
+      });
+      expect(networkService.get.mock.calls[5][0].url).toBe(
+        `${pricesProviderUrl}/simple/price`,
+      );
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+      });
+      expect(networkService.get.mock.calls[6][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+    })
 
     it('overview of multiple Safes across different chains is correctly serialised', async () => {
       const chain1 = chainBuilder().with('chainId', '1').build();

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -299,17 +299,23 @@ describe('Safes Controller Overview (Unit)', () => {
             .with('confirmationsRequired', 0)
             .with('confirmations', [
               // Not wallet address
-              confirmationBuilder().with('owner', getAddress(faker.finance.ethereumAddress())).build(),
+              confirmationBuilder()
+                .with('owner', getAddress(faker.finance.ethereumAddress()))
+                .build(),
             ])
             .build(),
         ),
         multisigTransactionToJson(
           multisigTransactionBuilder()
-          .with('confirmationsRequired', 0)
-          .with('confirmations', [
-            // Not wallet address
-            confirmationBuilder().with('owner', getAddress(faker.finance.ethereumAddress())).build(),
-          ]).build())
+            .with('confirmationsRequired', 0)
+            .with('confirmations', [
+              // Not wallet address
+              confirmationBuilder()
+                .with('owner', getAddress(faker.finance.ethereumAddress()))
+                .build(),
+            ])
+            .build(),
+        ),
       ];
       const queuedTransactions = pageBuilder()
         .with('results', multisigTransactions)
@@ -421,7 +427,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[6][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
-    })
+    });
 
     it('overview of multiple Safes across different chains is correctly serialised', async () => {
       const chain1 = chainBuilder().with('chainId', '1').build();

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -206,16 +206,19 @@ export class SafesService {
     transactions: Array<MultisigTransaction>;
     walletAddress: string;
   }): number {
-    return args.transactions.reduce((acc, { confirmationsRequired, confirmations }) => {
-      const isConfirmed = confirmationsRequired === 0
-      const isSignedByWallet = confirmations?.some((confirmation) => {
-        return confirmation.owner === args.walletAddress;
-      })
-      if (!isConfirmed && !isSignedByWallet) {
-        acc++
-      }
-      return acc;
-    }, 0);
+    return args.transactions.reduce(
+      (acc, { confirmationsRequired, confirmations }) => {
+        const isConfirmed = confirmationsRequired === 0;
+        const isSignedByWallet = confirmations?.some((confirmation) => {
+          return confirmation.owner === args.walletAddress;
+        });
+        if (!isConfirmed && !isSignedByWallet) {
+          acc++;
+        }
+        return acc;
+      },
+      0,
+    );
   }
 
   private toUnixTimestampInSecondsOrNull(date: Date | null): string | null {

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -209,10 +209,12 @@ export class SafesService {
     return args.transactions.reduce(
       (acc, { confirmationsRequired, confirmations }) => {
         const isConfirmed = confirmationsRequired === 0;
-        const isSignedByWallet = confirmations?.some((confirmation) => {
-          return confirmation.owner === args.walletAddress;
-        });
-        if (!isConfirmed && !isSignedByWallet) {
+        const isSignable =
+          !isConfirmed &&
+          !confirmations?.some((confirmation) => {
+            return confirmation.owner === args.walletAddress;
+          });
+        if (isSignable) {
           acc++;
         }
         return acc;

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -206,12 +206,16 @@ export class SafesService {
     transactions: Array<MultisigTransaction>;
     walletAddress: string;
   }): number {
-    return args.transactions.reduce((acc, { confirmations }) => {
-      const isConfirmed = !!confirmations?.some((confirmation) => {
+    return args.transactions.reduce((acc, { confirmationsRequired, confirmations }) => {
+      const isConfirmed = confirmationsRequired === 0
+      const isSignedByWallet = confirmations?.some((confirmation) => {
         return confirmation.owner === args.walletAddress;
-      });
-      return isConfirmed ? acc - 1 : acc;
-    }, args.transactions.length);
+      })
+      if (!isConfirmed && !isSignedByWallet) {
+        acc++
+      }
+      return acc;
+    }, 0);
   }
 
   private toUnixTimestampInSecondsOrNull(date: Date | null): string | null {


### PR DESCRIPTION
## Summary

`awaitingConfirmation` was previously being calculated according to whether `walletAddress` had submitted a confirmation, regardless of whether a sufficient confirmations exist. This meant that a fully confirmed transaction, when not signed by the given `walletAddress`, would still increase the awaiting confirmation count.

This now takes `confirmationsRequired` into account, only returning an awaiting count if it is `> 0`.

## Changes

- Take the `confirmationsRequired` into account when increasing the awaiting confirmation count
- Add test coverage