### PR TITLE
Mark POST /v1/chains/:chainId/delegates as deprecated

### DIFF
--- a/src/routes/delegates/delegates.controller.ts
+++ b/src/routes/delegates/delegates.controller.ts
@@ -81,6 +81,7 @@ export class DelegatesController {
     });
   }
 
+  @ApiOperation({ deprecated: true })
   @HttpCode(200)
   @Post('chains/:chainId/delegates')
   async postDelegate(


### PR DESCRIPTION
## Changes
- Marks `POST /v1/chains/:chainId/delegates` as deprecated
