### PR TITLE
Validate overview `walletAddress` query

### DIFF
--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -12,6 +12,8 @@ import { SafesService } from '@/routes/safes/safes.service';
 import { SafeNonces } from '@/routes/safes/entities/nonces.entity';
 import { SafeOverview } from '@/routes/safes/entities/safe-overview.entity';
 import { Caip10AddressesPipe } from '@/routes/safes/pipes/caip-10-addresses.pipe';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('safes')
 @Controller({
@@ -48,8 +50,8 @@ export class SafesController {
     trusted: boolean,
     @Query('exclude_spam', new DefaultValuePipe(true), ParseBoolPipe)
     excludeSpam: boolean,
-    @Query('wallet_address')
-    walletAddress?: string,
+    @Query('wallet_address', new ValidationPipe(AddressSchema))
+    walletAddress?: `0x${string}`,
   ): Promise<Array<SafeOverview>> {
     return this.service.getSafeOverview({
       currency,

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -132,7 +132,7 @@ export class SafesService {
     addresses: Array<{ chainId: string; address: string }>;
     trusted: boolean;
     excludeSpam: boolean;
-    walletAddress?: string;
+    walletAddress?: `0x${string}`;
   }): Promise<Array<SafeOverview>> {
     const limitedSafes = args.addresses.slice(0, this.maxOverviews);
 
@@ -204,7 +204,7 @@ export class SafesService {
 
   private computeAwaitingConfirmation(args: {
     transactions: Array<MultisigTransaction>;
-    walletAddress: string;
+    walletAddress: `0x${string}`;
   }): number {
     return args.transactions.reduce((acc, { confirmations }) => {
       const isConfirmed = !!confirmations?.some((confirmation) => {


### PR DESCRIPTION
## Summary

This adds validation of the `walletAddress` query param on the overview endpoint as the endpoint is still in development.

## Changes

- Add `AddressSchema` validation pipe to `walletAddress` query