### PR TITLE
Put delegates v2 endpoints behind a feature flag

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -57,6 +57,7 @@ export class AppModule implements NestModule {
       auth: isAuthFeatureEnabled,
       email: isEmailFeatureEnabled,
       confirmationView: isConfirmationViewEnabled,
+      delegatesV2: isDelegatesV2Enabled,
     } = configFactory()['features'];
 
     return {
@@ -73,7 +74,7 @@ export class AppModule implements NestModule {
         DataDecodedModule,
         // TODO: delete/rename DelegatesModule when clients migration to v2 is completed.
         DelegatesModule,
-        DelegatesV2Module,
+        ...(isDelegatesV2Enabled ? [DelegatesV2Module] : []),
         ...(isEmailFeatureEnabled
           ? [
               AlertsControllerModule,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -188,6 +188,7 @@ export default (): ReturnType<typeof configuration> => ({
     auth: false,
     confirmationView: false,
     eventsQueue: false,
+    delegatesV2: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -197,6 +197,7 @@ export default () => ({
     confirmationView:
       process.env.FF_CONFIRMATION_VIEW?.toLowerCase() === 'true',
     eventsQueue: process.env.FF_EVENTS_QUEUE?.toLowerCase() === 'true',
+    delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/delegates/v2/delegates.v2.controller.spec.ts
+++ b/src/routes/delegates/v2/delegates.v2.controller.spec.ts
@@ -36,9 +36,18 @@ describe('Delegates controller', () => {
 
   beforeEach(async () => {
     jest.resetAllMocks();
+    const baseConfig = configuration();
+
+    const testConfiguration: typeof configuration = () => ({
+      ...baseConfig,
+      features: {
+        ...baseConfig.features,
+        delegatesV2: true,
+      },
+    });
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(testConfiguration)],
     })
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)


### PR DESCRIPTION
## Summary
This PR puts the `DelegatesV2Module` behind the `FF_DELEGATES_V2` feature flag.

## Changes
- Conditionally adds `DelegatesV2Module` to the bootstrap dependencies.
