### PR TITLE
Add logging of headers to auth nonce route

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -43,6 +43,7 @@ export class AuthController {
     nonce: string;
   }> {
     // TODO: Remove after debugging
+    this.loggingService.info(req.originalUrl);
     this.loggingService.info(req.headers);
     return this.authService.getNonce();
   }

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Post, HttpCode, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  HttpCode,
+  Res,
+  Inject,
+  Req,
+} from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { AuthService } from '@/routes/auth/auth.service';
@@ -6,8 +15,9 @@ import {
   VerifyAuthMessageDto,
   VerifyAuthMessageDtoSchema,
 } from '@/routes/auth/entities/verify-auth-message.dto.entity';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { getMillisecondsUntil } from '@/domain/common/utils/time';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 /**
  * The AuthController is responsible for handling authentication:
@@ -23,12 +33,17 @@ import { getMillisecondsUntil } from '@/domain/common/utils/time';
 export class AuthController {
   static readonly ACCESS_TOKEN_COOKIE_NAME = 'access_token';
 
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
 
   @Get('nonce')
-  async getNonce(): Promise<{
+  async getNonce(@Req() req: Request): Promise<{
     nonce: string;
   }> {
+    // TODO: Remove after debugging
+    this.loggingService.info(req.headers);
     return this.authService.getNonce();
   }
 


### PR DESCRIPTION
## Summary

We are unsure what `Origin` is being received by the Gateway. This adds temporary logging of the `originalUrl` and `headers` to the `/v1/auth/nonce` route in order to determine the value.

## Changes

- Add `info` logging of `Request['headers' | 'originalUrl']` to `/v1/auth/nonce` route