### PR TITLE
Log `Origin` on auth nonce route

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -43,8 +43,7 @@ export class AuthController {
     nonce: string;
   }> {
     // TODO: Remove after debugging
-    this.loggingService.info(req.originalUrl);
-    this.loggingService.info(req.headers);
+    this.loggingService.info(`/v1/auth/nonce, Origin: ${req.header('Origin')}`);
     return this.authService.getNonce();
   }
 


### PR DESCRIPTION
## Summary

As a continuation of #1520, we need to know the `Origin` of the request. This adds temporary logging of it.

## Changes

- Add logging of `Origin` to `/v1/auth/nonce` route