### PR TITLE
Remove `Origin` debug log

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -1,13 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Post,
-  HttpCode,
-  Res,
-  Inject,
-  Req,
-} from '@nestjs/common';
+import { Body, Controller, Get, Post, HttpCode, Res } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { AuthService } from '@/routes/auth/auth.service';
@@ -15,7 +6,7 @@ import {
   VerifyAuthMessageDto,
   VerifyAuthMessageDtoSchema,
 } from '@/routes/auth/entities/verify-auth-message.dto.entity';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { getMillisecondsUntil } from '@/domain/common/utils/time';
 
 /**
@@ -32,12 +23,10 @@ import { getMillisecondsUntil } from '@/domain/common/utils/time';
 export class AuthController {
   static readonly ACCESS_TOKEN_COOKIE_NAME = 'access_token';
 
-  constructor(
-    private readonly authService: AuthService,
-  ) {}
+  constructor(private readonly authService: AuthService) {}
 
   @Get('nonce')
-  async getNonce(@Req() req: Request): Promise<{
+  async getNonce(): Promise<{
     nonce: string;
   }> {
     return this.authService.getNonce();

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -17,7 +17,6 @@ import {
 } from '@/routes/auth/entities/verify-auth-message.dto.entity';
 import { Request, Response } from 'express';
 import { getMillisecondsUntil } from '@/domain/common/utils/time';
-import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 /**
  * The AuthController is responsible for handling authentication:
@@ -35,7 +34,6 @@ export class AuthController {
 
   constructor(
     private readonly authService: AuthService,
-    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   @Get('nonce')

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -42,8 +42,6 @@ export class AuthController {
   async getNonce(@Req() req: Request): Promise<{
     nonce: string;
   }> {
-    // TODO: Remove after debugging
-    this.loggingService.info(`/v1/auth/nonce, Origin: ${req.header('Origin')}`);
     return this.authService.getNonce();
   }
 


### PR DESCRIPTION
## Summary

This removes the debug logging that was added in #1520 and #1521 as the `Origin` receipt was confirmed.

## Changes

- Removes `Origin` log from `/v1/auth/nonce`