### PR TITLE
Filter out imitation transfers

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -185,6 +185,7 @@ export default (): ReturnType<typeof configuration> => ({
     zerionBalancesChainIds: ['137'],
     swapsDecoding: true,
     historyDebugLogs: false,
+    imitationFiltering: false,
     auth: false,
     confirmationView: false,
     eventsQueue: false,
@@ -199,6 +200,9 @@ export default (): ReturnType<typeof configuration> => ({
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
   mappings: {
+    imitationTransactions: {
+      vanityAddressChars: faker.number.int(),
+    },
     history: {
       maxNestedTransfers: faker.number.int({ min: 1, max: 5 }),
     },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -193,6 +193,8 @@ export default () => ({
     swapsDecoding: process.env.FF_SWAPS_DECODING?.toLowerCase() === 'true',
     historyDebugLogs:
       process.env.FF_HISTORY_DEBUG_LOGS?.toLowerCase() === 'true',
+    imitationFiltering:
+      process.env.FF_IMITATION_FILTERING?.toLowerCase() === 'true',
     auth: process.env.FF_AUTH?.toLowerCase() === 'true',
     confirmationView:
       process.env.FF_CONFIRMATION_VIEW?.toLowerCase() === 'true',
@@ -220,6 +222,9 @@ export default () => ({
     ownersTtlSeconds: parseInt(process.env.OWNERS_TTL_SECONDS ?? `${0}`),
   },
   mappings: {
+    imitationTransactions: {
+      vanityAddressChars: parseInt(process.env.VANITY_ADDRESS_CHARS ?? `${4}`),
+    },
     history: {
       maxNestedTransfers: parseInt(
         process.env.MAX_NESTED_TRANSFERS ?? `${100}`,

--- a/src/routes/transactions/helpers/imitation-transactions.helper.ts
+++ b/src/routes/transactions/helpers/imitation-transactions.helper.ts
@@ -1,0 +1,104 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { TransactionItem } from '@/routes/transactions/entities/transaction-item.entity';
+import {
+  isTransferTransactionInfo,
+  TransferDirection,
+} from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import { isErc20Transfer } from '@/routes/transactions/entities/transfers/erc20-transfer.entity';
+import { Inject } from '@nestjs/common';
+
+export class ImitationTransactionsHelper {
+  private readonly vanityAddressChars: number;
+
+  constructor(
+    @Inject(IConfigurationService) configurationService: IConfigurationService,
+  ) {
+    this.vanityAddressChars = configurationService.getOrThrow(
+      'mappings.imitationTransactions.vanityAddressChars',
+    );
+  }
+
+  /**
+   * Filters out outgoing ERC20 transfers that imitate their direct predecessor in
+   * value and vanity (but not the exact) address of the recipient.
+   *
+   * @param transactions - list of transactions to filter
+   * @param previousTransaction - transaction to compare last {@link transactions} against
+   *
+   * Note: this only handles singular imitation transfers. It does not handle multiple
+   * imitation transfers in a row, nor does it compare batched multiSend transactions
+   * as the "distance" between those batched and their imitation may not be immediate.
+   */
+  filterOutgoingErc20ImitationTransfers(
+    transactions: Array<TransactionItem>,
+    previousTransaction: TransactionItem | undefined,
+  ): Array<TransactionItem> {
+    // TODO: Instead of filtering, mark transactions so client can display them differently
+    return transactions.filter((item, i, arr) => {
+      // Executed by Safe - cannot be imitation
+      if (item.transaction.executionInfo) {
+        return item;
+      }
+
+      const prevItem = i === arr.length - 1 ? previousTransaction : arr[i + 1];
+
+      // No reference transaction to filter against
+      if (!prevItem) {
+        return item;
+      }
+
+      const txInfo = item.transaction.txInfo;
+      const prevTxInfo = prevItem.transaction.txInfo;
+
+      if (
+        // Only consider transfers...
+        !isTransferTransactionInfo(txInfo) ||
+        !isTransferTransactionInfo(prevTxInfo) ||
+        // ...of ERC20s...
+        !isErc20Transfer(txInfo.transferInfo) ||
+        !isErc20Transfer(prevTxInfo.transferInfo)
+      ) {
+        return item;
+      }
+
+      // ...that are outgoing
+      const isOutgoing = txInfo.direction === TransferDirection.Outgoing;
+      const isPrevOutgoing =
+        prevTxInfo.direction === TransferDirection.Outgoing;
+      if (!isOutgoing || !isPrevOutgoing) {
+        return item;
+      }
+
+      // Imitation transfers are of the same value...
+      const isSameValue =
+        txInfo.transferInfo.value === prevTxInfo.transferInfo.value;
+      if (!isSameValue) {
+        return item;
+      }
+
+      // ...from vanity (but not exact) recipient address
+      const isSameRecipient =
+        txInfo.recipient.value === prevTxInfo.recipient.value;
+      if (isSameRecipient) {
+        return item;
+      }
+      return !this.isVanityAddress(
+        txInfo.recipient.value,
+        prevTxInfo.recipient.value,
+      );
+    });
+  }
+
+  private isVanityAddress(address1: string, address2: string): boolean {
+    const a1 = address1.toLowerCase();
+    const a2 = address2.toLowerCase();
+
+    const isVanityPrefix =
+      // Ignore `0x` prefix
+      a1.slice(2, this.vanityAddressChars) ===
+      a2.slice(2, this.vanityAddressChars);
+    const isVanitySuffix =
+      a1.slice(-this.vanityAddressChars) === a2.slice(-this.vanityAddressChars);
+    return isVanityPrefix && isVanitySuffix;
+  }
+}

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -16,19 +16,26 @@ import { ModuleTransactionMapper } from '@/routes/transactions/mappers/module-tr
 import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { ImitationTransactionsHelper } from '@/routes/transactions/helpers/imitation-transactions.helper';
 
 @Injectable()
 export class TransactionsHistoryMapper {
+  private readonly isImitationFilteringEnabled: boolean;
   private readonly maxNestedTransfers: number;
 
   constructor(
-    @Inject(IConfigurationService) configurationService: IConfigurationService,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
     private readonly multisigTransactionMapper: MultisigTransactionMapper,
     private readonly moduleTransactionMapper: ModuleTransactionMapper,
     private readonly transferMapper: TransferMapper,
     private readonly creationTransactionMapper: CreationTransactionMapper,
+    private readonly imitationTransactionsHelper: ImitationTransactionsHelper,
   ) {
-    this.maxNestedTransfers = configurationService.getOrThrow(
+    this.isImitationFilteringEnabled = this.configurationService.getOrThrow(
+      'features.imitationFiltering',
+    );
+    this.maxNestedTransfers = this.configurationService.getOrThrow(
       'mappings.history.maxNestedTransfers',
     );
   }
@@ -53,17 +60,19 @@ export class TransactionsHistoryMapper {
       onlyTrusted,
     });
 
-    const mappedTransactions = await Promise.all(
-      transactionsDomain.map((transaction) => {
-        return this.mapTransaction(transaction, chainId, safe, onlyTrusted);
-      }),
-    );
-    const transactions = mappedTransactions
-      .filter(<T>(x: T): x is NonNullable<T> => x != null)
-      .flat();
+    const mappedTransactions = await this.getMappedTransactions({
+      transactionsDomain,
+      chainId,
+      safe,
+      previousTransaction,
+      onlyTrusted,
+    });
 
     // The groups respect timezone offset – this was done for grouping only.
-    const transactionsByDay = this.groupByDay(transactions, timezoneOffset);
+    const transactionsByDay = this.groupByDay(
+      mappedTransactions,
+      timezoneOffset,
+    );
     return transactionsByDay.reduce<Array<TransactionItem | DateLabel>>(
       (transactionList, transactionsOnDay) => {
         // The actual value of the group should be in the UTC timezone instead
@@ -109,6 +118,37 @@ export class TransactionsHistoryMapper {
       ? // All transfers should have same execution date but the last is "true" previous
         mappedPreviousTransaction.at(-1)
       : mappedPreviousTransaction;
+  }
+
+  private async getMappedTransactions(args: {
+    transactionsDomain: TransactionDomain[];
+    chainId: string;
+    safe: Safe;
+    previousTransaction: TransactionItem | undefined;
+    onlyTrusted: boolean;
+  }) {
+    const mappedTransactions = await Promise.all(
+      args.transactionsDomain.map((transaction) => {
+        return this.mapTransaction(
+          transaction,
+          args.chainId,
+          args.safe,
+          args.onlyTrusted,
+        );
+      }),
+    );
+    const transactionItems = mappedTransactions
+      .filter(<T>(x: T): x is NonNullable<T> => x != null)
+      .flat();
+
+    if (this.isImitationFilteringEnabled || !args.onlyTrusted) {
+      return transactionItems;
+    }
+
+    return this.imitationTransactionsHelper.filterOutgoingErc20ImitationTransfers(
+      transactionItems,
+      args.previousTransaction,
+    );
   }
 
   private groupByDay(

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -126,7 +126,7 @@ export class TransactionsHistoryMapper {
     safe: Safe;
     previousTransaction: TransactionItem | undefined;
     onlyTrusted: boolean;
-  }) {
+  }): Promise<TransactionItem[]> {
     const mappedTransactions = await Promise.all(
       args.transactionsDomain.map((transaction) => {
         return this.mapTransaction(

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -5,6 +5,7 @@ import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/dat
 import { Erc20TransferMapper } from '@/routes/transactions/mappers/common/erc20-transfer.mapper';
 import { Erc721TransferMapper } from '@/routes/transactions/mappers/common/erc721-transfer.mapper';
 import { HumanDescriptionMapper } from '@/routes/transactions/mappers/common/human-description.mapper';
+import { ImitationTransactionsHelper } from '@/routes/transactions/helpers/imitation-transactions.helper';
 import { NativeCoinTransferMapper } from '@/routes/transactions/mappers/common/native-coin-transfer.mapper';
 import { SafeAppInfoMapper } from '@/routes/transactions/mappers/common/safe-app-info.mapper';
 import { SettingsChangeMapper } from '@/routes/transactions/mappers/common/settings-change.mapper';
@@ -57,6 +58,7 @@ import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.
     DataDecodedParamHelper,
     Erc20TransferMapper,
     Erc721TransferMapper,
+    ImitationTransactionsHelper,
     TransferMapper,
     ModuleTransactionDetailsMapper,
     ModuleTransactionMapper,


### PR DESCRIPTION
## Summary

This adds `trusted` param-specific filtering of imitation transfers behind a feature flag. It removes outgoing, ERC-20 transfers that imitate the value and recipient in vanity of their neighbour, breaking down #1428.

It maps over the transaction history, keeping the transaction if the following conditions are met:

1. Was transaction executed by Safe?
2. Is there no previous transactions?
3. Is (previous transaction...
   - ..._not_ an ERC-20 transfer?
   - ...incoming?
   - ...of different value?
   - ...to same recipient?
   - ..._not_ a vanity address?

## Changes

- Add env. vars. for feature flag and number of chars. deemed vanity
- Add `ImitationTransactionsHelper`
   - `filterOutgoingErc20ImitationTransfers`
- Conditionally filter transfers if `trusted` param is `true` and feature enabled
- Add associated test coverage