### PR TITLE
Add origin field to HTTP requests logger

### DIFF
--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -23,8 +23,7 @@ export function formatRouteLogMessage(
   origin: string | null;
 } {
   const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
-  const safe_app_user_agent =
-    request.header(HEADER_SAFE_APP_USER_AGENT) ?? null;
+  const safeAppUserAgent = request.header(HEADER_SAFE_APP_USER_AGENT) ?? null;
   const chainId = request.params['chainId'] ?? null;
   const origin = request.header(HEADER_ORIGIN) ?? null;
 
@@ -35,10 +34,10 @@ export function formatRouteLogMessage(
     response_time_ms: performance.now() - startTimeMs,
     route: request.route.path,
     path: request.url,
-    safe_app_user_agent: safe_app_user_agent,
+    safe_app_user_agent: safeAppUserAgent,
     status_code: statusCode,
     detail: detail ?? null,
-    origin: origin,
+    origin,
   };
 }
 

--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -3,6 +3,7 @@ import { get } from 'lodash';
 
 const HEADER_IP_ADDRESS = 'X-Real-IP';
 const HEADER_SAFE_APP_USER_AGENT = 'Safe-App-User-Agent';
+const HEADER_ORIGIN = 'Origin';
 
 export function formatRouteLogMessage(
   statusCode: number,
@@ -19,11 +20,13 @@ export function formatRouteLogMessage(
   safe_app_user_agent: string | null;
   status_code: number;
   detail: string | null;
+  origin: string | null;
 } {
   const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
   const safe_app_user_agent =
     request.header(HEADER_SAFE_APP_USER_AGENT) ?? null;
   const chainId = request.params['chainId'] ?? null;
+  const origin = request.header(HEADER_ORIGIN) ?? null;
 
   return {
     chain_id: chainId,
@@ -35,6 +38,7 @@ export function formatRouteLogMessage(
     safe_app_user_agent: safe_app_user_agent,
     status_code: statusCode,
     detail: detail ?? null,
+    origin: origin,
   };
 }
 

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -88,6 +88,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/server-error',
       safe_app_user_agent: null,
       status_code: 500,
+      origin: null,
     });
     expect(mockLoggingService.info).not.toHaveBeenCalled();
     expect(mockLoggingService.debug).not.toHaveBeenCalled();
@@ -115,6 +116,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/server-data-source-error',
       safe_app_user_agent: null,
       status_code: 501,
+      origin: null,
     });
     expect(mockLoggingService.info).not.toHaveBeenCalled();
     expect(mockLoggingService.debug).not.toHaveBeenCalled();
@@ -135,6 +137,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/client-error',
       safe_app_user_agent: null,
       status_code: 405,
+      origin: null,
     });
     expect(mockLoggingService.error).not.toHaveBeenCalled();
     expect(mockLoggingService.debug).not.toHaveBeenCalled();
@@ -155,6 +158,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/success',
       safe_app_user_agent: null,
       status_code: 200,
+      origin: null,
     });
     expect(mockLoggingService.error).not.toHaveBeenCalled();
     expect(mockLoggingService.debug).not.toHaveBeenCalled();
@@ -178,6 +182,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/success/:chainId',
       safe_app_user_agent: null,
       status_code: 200,
+      origin: null,
     });
     expect(mockLoggingService.error).not.toHaveBeenCalled();
     expect(mockLoggingService.debug).not.toHaveBeenCalled();
@@ -200,6 +205,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/server-error-non-http',
       safe_app_user_agent: null,
       status_code: 500,
+      origin: null,
     });
     expect(mockLoggingService.info).not.toHaveBeenCalled();
     expect(mockLoggingService.debug).not.toHaveBeenCalled();
@@ -224,6 +230,7 @@ describe('RouteLoggerInterceptor tests', () => {
       route: '/test/success',
       safe_app_user_agent: safeAppUserAgentHeader,
       status_code: 200,
+      origin: null,
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds an `origin` field to all the logs generated by HTTP requests (`RouteLoggerInterceptor`).

## Changes
- Adds an `origin` field to `RouteLoggerInterceptor`.