### PR TITLE
Compare submitted confirmations against those required

### DIFF
--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -208,7 +208,8 @@ export class SafesService {
   }): number {
     return args.transactions.reduce(
       (acc, { confirmationsRequired, confirmations }) => {
-        const isConfirmed = !!confirmations && confirmations.length >= confirmationsRequired;
+        const isConfirmed =
+          !!confirmations && confirmations.length >= confirmationsRequired;
         const isSignable =
           !isConfirmed &&
           !confirmations?.some((confirmation) => {

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -208,7 +208,7 @@ export class SafesService {
   }): number {
     return args.transactions.reduce(
       (acc, { confirmationsRequired, confirmations }) => {
-        const isConfirmed = confirmationsRequired === 0;
+        const isConfirmed = !!confirmations && confirmations.length >= confirmationsRequired;
         const isSignable =
           !isConfirmed &&
           !confirmations?.some((confirmation) => {


### PR DESCRIPTION
## Summary

The calculation of `awaitingConfirmations` of Safe overviews assumed that hte `confirmationsRequired` decreased with each confirmation submitted. However, it remains the same.

This changes the logic to compare the number of submitted confirmations against the number required.

Note: this has been tested working against live data.

## Changes

- Change confirmation flag to compare number of submitted confirmations against the number of those required