### PR TITLE
Get prices provider configuration from Safe Config Service

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -250,6 +250,67 @@ describe('CoingeckoAPI', () => {
     );
   });
 
+  // TODO: remove this after the prices provider data is migrated to the Config Service
+  it('should return and cache one token price (using the fallback configuration)', async () => {
+    fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
+    const chain = chainBuilder().with('pricesProviderChainName', null).build();
+    const chainName = faker.string.sample();
+    const tokenAddress = faker.finance.ethereumAddress();
+    const fiatCode = faker.finance.currencyCode();
+    const lowerCaseFiatCode = fiatCode.toLowerCase();
+    const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const coingeckoPrice: AssetPrice = {
+      [tokenAddress]: { [lowerCaseFiatCode]: price },
+    };
+    mockCacheService.get.mockResolvedValue(undefined);
+    mockNetworkService.get.mockResolvedValue({
+      data: coingeckoPrice,
+      status: 200,
+    });
+    fakeConfigurationService.set(
+      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
+      chainName,
+    );
+    const service = new CoingeckoApi(
+      fakeConfigurationService,
+      mockCacheFirstDataSource,
+      mockNetworkService,
+      mockCacheService,
+      mockLoggingService,
+    );
+
+    const assetPrice = await service.getTokenPrices({
+      chain,
+      tokenAddresses: [tokenAddress],
+      fiatCode,
+    });
+
+    const expectedCacheDir = new CacheDir(
+      `${chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
+      '',
+    );
+    expect(assetPrice).toEqual([
+      { [tokenAddress]: { [lowerCaseFiatCode]: price } },
+    ]);
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      networkRequest: {
+        params: {
+          contract_addresses: tokenAddress,
+          vs_currencies: lowerCaseFiatCode,
+        },
+      },
+    });
+    expect(mockCacheService.get).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.get).toHaveBeenCalledWith(expectedCacheDir);
+    expect(mockCacheService.set).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.set).toHaveBeenCalledWith(
+      expectedCacheDir,
+      JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
+      pricesTtlSeconds,
+    );
+  });
+
   it('should return and cache multiple token prices', async () => {
     const chain = chainBuilder().build();
     const fiatCode = faker.finance.currencyCode();
@@ -700,6 +761,46 @@ describe('CoingeckoAPI', () => {
       networkRequest: {
         params: {
           ids: chain.pricesProviderNativeCoin,
+          vs_currencies: lowerCaseFiatCode,
+        },
+      },
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      expireTimeSeconds: nativeCoinPricesTtlSeconds,
+    });
+  });
+
+  // TODO: remove this after the prices provider data is migrated to the Config Service
+  it('should return the native coin price (using the fallback configuration)', async () => {
+    const chain = chainBuilder().with('pricesProviderNativeCoin', null).build();
+    const nativeCoinId = faker.string.sample();
+    const fiatCode = faker.finance.currencyCode();
+    const lowerCaseFiatCode = fiatCode.toLowerCase();
+    const expectedAssetPrice: AssetPrice = { gnosis: { eur: 98.86 } };
+    mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
+    fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
+    fakeConfigurationService.set(
+      `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
+      nativeCoinId,
+    );
+    const service = new CoingeckoApi(
+      fakeConfigurationService,
+      mockCacheFirstDataSource,
+      mockNetworkService,
+      mockCacheService,
+      mockLoggingService,
+    );
+
+    await service.getNativeCoinPrice({ chain, fiatCode });
+
+    expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
+      cacheDir: new CacheDir(
+        `${nativeCoinId}_native_coin_price_${lowerCaseFiatCode}`,
+        '',
+      ),
+      url: `${coingeckoBaseUri}/simple/price`,
+      networkRequest: {
+        params: {
+          ids: nativeCoinId,
           vs_currencies: lowerCaseFiatCode,
         },
       },

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -147,7 +147,6 @@ describe('CoingeckoAPI', () => {
 
   it('should return and cache one token price (using an API key)', async () => {
     const chain = chainBuilder().build();
-    const chainName = faker.string.sample();
     const tokenAddress = faker.finance.ethereumAddress();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
@@ -160,26 +159,22 @@ describe('CoingeckoAPI', () => {
       data: coingeckoPrice,
       status: 200,
     });
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-      chainName,
-    );
 
     const assetPrice = await service.getTokenPrices({
-      chainId: chain.chainId,
+      chain,
       tokenAddresses: [tokenAddress],
       fiatCode,
     });
 
     const expectedCacheDir = new CacheDir(
-      `${chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
+      `${chain.pricesProviderChainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
       '',
     );
     expect(assetPrice).toEqual([
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -203,7 +198,6 @@ describe('CoingeckoAPI', () => {
   it('should return and cache one token price (with no API key)', async () => {
     fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
     const chain = chainBuilder().build();
-    const chainName = faker.string.sample();
     const tokenAddress = faker.finance.ethereumAddress();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
@@ -216,10 +210,6 @@ describe('CoingeckoAPI', () => {
       data: coingeckoPrice,
       status: 200,
     });
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-      chainName,
-    );
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
@@ -229,20 +219,20 @@ describe('CoingeckoAPI', () => {
     );
 
     const assetPrice = await service.getTokenPrices({
-      chainId: chain.chainId,
+      chain,
       tokenAddresses: [tokenAddress],
       fiatCode,
     });
 
     const expectedCacheDir = new CacheDir(
-      `${chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
+      `${chain.pricesProviderChainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
       '',
     );
     expect(assetPrice).toEqual([
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
       networkRequest: {
         params: {
           contract_addresses: tokenAddress,
@@ -261,7 +251,6 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should return and cache multiple token prices', async () => {
-    const chainName = faker.string.sample();
     const chain = chainBuilder().build();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
@@ -276,10 +265,6 @@ describe('CoingeckoAPI', () => {
       [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
       [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
     };
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-      chainName,
-    );
     mockCacheService.get.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
       data: coingeckoPrice,
@@ -287,7 +272,7 @@ describe('CoingeckoAPI', () => {
     });
 
     const assetPrice = await service.getTokenPrices({
-      chainId: chain.chainId,
+      chain,
       tokenAddresses: [
         firstTokenAddress,
         secondTokenAddress,
@@ -302,7 +287,7 @@ describe('CoingeckoAPI', () => {
       { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -320,26 +305,26 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledTimes(3);
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -349,7 +334,7 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -359,7 +344,7 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -371,7 +356,6 @@ describe('CoingeckoAPI', () => {
 
   it('should return and cache with low TTL one high-refresh-rate token price', async () => {
     const chain = chainBuilder().build();
-    const chainName = faker.string.sample();
     const highRefreshRateTokenAddress = faker.finance.ethereumAddress();
     const anotherTokenAddress = faker.finance.ethereumAddress();
     const fiatCode = faker.finance.currencyCode();
@@ -387,10 +371,6 @@ describe('CoingeckoAPI', () => {
       data: coingeckoPrice,
       status: 200,
     });
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-      chainName,
-    );
     fakeConfigurationService.set(
       `balances.providers.safe.prices.highRefreshRateTokens`,
       [
@@ -408,7 +388,7 @@ describe('CoingeckoAPI', () => {
     );
 
     const assetPrice = await service.getTokenPrices({
-      chainId: chain.chainId,
+      chain,
       tokenAddresses: [highRefreshRateTokenAddress, anotherTokenAddress],
       fiatCode,
     });
@@ -418,7 +398,7 @@ describe('CoingeckoAPI', () => {
       { [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -437,13 +417,13 @@ describe('CoingeckoAPI', () => {
     // high-refresh-rate token price is cached with highRefreshRateTokensTtlSeconds
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -454,13 +434,13 @@ describe('CoingeckoAPI', () => {
     // another token price is cached with pricesCacheTtlSeconds
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -471,7 +451,6 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should cache new token prices only', async () => {
-    const chainName = faker.string.sample();
     const chain = chainBuilder().build();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
@@ -496,13 +475,9 @@ describe('CoingeckoAPI', () => {
       data: coingeckoPrice,
       status: 200,
     });
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-      chainName,
-    );
 
     const assetPrices = await service.getTokenPrices({
-      chainId: chain.chainId,
+      chain,
       tokenAddresses: [
         firstTokenAddress,
         secondTokenAddress,
@@ -522,7 +497,7 @@ describe('CoingeckoAPI', () => {
       ),
     );
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -536,19 +511,19 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
@@ -556,7 +531,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       1,
       new CacheDir(
-        `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -567,7 +542,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       2,
       new CacheDir(
-        `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -578,7 +553,6 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should cache not found token prices with an extended TTL', async () => {
-    const chainName = faker.string.sample();
     const chain = chainBuilder().build();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
@@ -603,13 +577,9 @@ describe('CoingeckoAPI', () => {
       data: coingeckoPrice,
       status: 200,
     });
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-      chainName,
-    );
 
     const assetPrices = await service.getTokenPrices({
-      chainId: chain.chainId,
+      chain,
       tokenAddresses: [
         firstTokenAddress,
         secondTokenAddress,
@@ -629,7 +599,7 @@ describe('CoingeckoAPI', () => {
       ),
     );
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -643,19 +613,19 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
@@ -676,25 +646,17 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should return the native coin price (using an API key)', async () => {
-    const nativeCoinId = faker.string.sample();
     const chain = chainBuilder().build();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const expectedAssetPrice: AssetPrice = { gnosis: { eur: 98.86 } };
     mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-      nativeCoinId,
-    );
 
-    await service.getNativeCoinPrice({
-      chainId: chain.chainId,
-      fiatCode,
-    });
+    await service.getNativeCoinPrice({ chain, fiatCode });
 
     expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
-        `${nativeCoinId}_native_coin_price_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderNativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
         '',
       ),
       url: `${coingeckoBaseUri}/simple/price`,
@@ -703,7 +665,7 @@ describe('CoingeckoAPI', () => {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
         params: {
-          ids: nativeCoinId,
+          ids: chain.pricesProviderNativeCoin,
           vs_currencies: lowerCaseFiatCode,
         },
       },
@@ -713,17 +675,12 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should return the native coin price (with no API key)', async () => {
-    const nativeCoinId = faker.string.sample();
     const chain = chainBuilder().build();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const expectedAssetPrice: AssetPrice = { gnosis: { eur: 98.86 } };
     mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
     fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
-    fakeConfigurationService.set(
-      `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-      nativeCoinId,
-    );
     const service = new CoingeckoApi(
       fakeConfigurationService,
       mockCacheFirstDataSource,
@@ -732,17 +689,17 @@ describe('CoingeckoAPI', () => {
       mockLoggingService,
     );
 
-    await service.getNativeCoinPrice({ chainId: chain.chainId, fiatCode });
+    await service.getNativeCoinPrice({ chain, fiatCode });
 
     expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
-        `${nativeCoinId}_native_coin_price_${lowerCaseFiatCode}`,
+        `${chain.pricesProviderNativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
         '',
       ),
       url: `${coingeckoBaseUri}/simple/price`,
       networkRequest: {
         params: {
-          ids: nativeCoinId,
+          ids: chain.pricesProviderNativeCoin,
           vs_currencies: lowerCaseFiatCode,
         },
       },

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -9,6 +9,7 @@ import { INetworkService } from '@/datasources/network/network.service.interface
 import { sortBy } from 'lodash';
 import { ILoggingService } from '@/logging/logging.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { pricesProviderBuilder } from '@/domain/chains/entities/__tests__/prices-provider.builder';
 
 const mockCacheFirstDataSource = jest.mocked({
   get: jest.fn(),
@@ -167,14 +168,14 @@ describe('CoingeckoAPI', () => {
     });
 
     const expectedCacheDir = new CacheDir(
-      `${chain.pricesProviderChainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
+      `${chain.pricesProvider.chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
       '',
     );
     expect(assetPrice).toEqual([
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -225,14 +226,14 @@ describe('CoingeckoAPI', () => {
     });
 
     const expectedCacheDir = new CacheDir(
-      `${chain.pricesProviderChainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
+      `${chain.pricesProvider.chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
       '',
     );
     expect(assetPrice).toEqual([
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         params: {
           contract_addresses: tokenAddress,
@@ -253,7 +254,12 @@ describe('CoingeckoAPI', () => {
   // TODO: remove this after the prices provider data is migrated to the Config Service
   it('should return and cache one token price (using the fallback configuration)', async () => {
     fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
-    const chain = chainBuilder().with('pricesProviderChainName', null).build();
+    const chain = chainBuilder()
+      .with(
+        'pricesProvider',
+        pricesProviderBuilder().with('chainName', null).build(),
+      )
+      .build();
     const chainName = faker.string.sample();
     const tokenAddress = faker.finance.ethereumAddress();
     const fiatCode = faker.finance.currencyCode();
@@ -348,7 +354,7 @@ describe('CoingeckoAPI', () => {
       { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -366,26 +372,26 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledTimes(3);
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -395,7 +401,7 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -405,7 +411,7 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -459,7 +465,7 @@ describe('CoingeckoAPI', () => {
       { [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -478,13 +484,13 @@ describe('CoingeckoAPI', () => {
     // high-refresh-rate token price is cached with highRefreshRateTokensTtlSeconds
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -495,13 +501,13 @@ describe('CoingeckoAPI', () => {
     // another token price is cached with pricesCacheTtlSeconds
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -558,7 +564,7 @@ describe('CoingeckoAPI', () => {
       ),
     );
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -572,19 +578,19 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
@@ -592,7 +598,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       1,
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -603,7 +609,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       2,
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
       JSON.stringify({
@@ -660,7 +666,7 @@ describe('CoingeckoAPI', () => {
       ),
     );
     expect(mockNetworkService.get).toHaveBeenCalledWith({
-      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProviderChainName}`,
+      url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
           'x-cg-pro-api-key': coingeckoApiKey,
@@ -674,19 +680,19 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
-        `${chain.pricesProviderChainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
@@ -717,7 +723,7 @@ describe('CoingeckoAPI', () => {
 
     expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
-        `${chain.pricesProviderNativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.nativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
         '',
       ),
       url: `${coingeckoBaseUri}/simple/price`,
@@ -726,7 +732,7 @@ describe('CoingeckoAPI', () => {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: lowerCaseFiatCode,
         },
       },
@@ -754,13 +760,13 @@ describe('CoingeckoAPI', () => {
 
     expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
-        `${chain.pricesProviderNativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
+        `${chain.pricesProvider.nativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
         '',
       ),
       url: `${coingeckoBaseUri}/simple/price`,
       networkRequest: {
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: lowerCaseFiatCode,
         },
       },
@@ -771,7 +777,12 @@ describe('CoingeckoAPI', () => {
 
   // TODO: remove this after the prices provider data is migrated to the Config Service
   it('should return the native coin price (using the fallback configuration)', async () => {
-    const chain = chainBuilder().with('pricesProviderNativeCoin', null).build();
+    const chain = chainBuilder()
+      .with(
+        'pricesProvider',
+        pricesProviderBuilder().with('nativeCoin', null).build(),
+      )
+      .build();
     const nativeCoinId = faker.string.sample();
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -114,8 +114,9 @@ export class CoingeckoApi implements IPricesApi {
   }): Promise<number | null> {
     try {
       const lowerCaseFiatCode = args.fiatCode.toLowerCase();
+      // TODO: remove configurationService fallback when fully migrated.
       const nativeCoinId =
-        args.chain.pricesProviderNativeCoin ??
+        args.chain.pricesProvider.nativeCoin ??
         this.configurationService.getOrThrow<string>(
           `balances.providers.safe.prices.chains.${args.chain.chainId}.nativeCoin`,
         );
@@ -171,8 +172,9 @@ export class CoingeckoApi implements IPricesApi {
       const lowerCaseTokenAddresses = args.tokenAddresses.map((address) =>
         address.toLowerCase(),
       );
+      // TODO: remove configurationService fallback when fully migrated.
       const chainName =
-        args.chain.pricesProviderChainName ??
+        args.chain.pricesProvider.chainName ??
         this.configurationService.getOrThrow<string>(
           `balances.providers.safe.prices.chains.${args.chain.chainId}.chainName`,
         );

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -17,6 +17,7 @@ import { difference, get } from 'lodash';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { asError } from '@/logging/utils';
+import { Chain } from '@/domain/chains/entities/chain.entity';
 
 @Injectable()
 export class CoingeckoApi implements IPricesApi {
@@ -99,15 +100,26 @@ export class CoingeckoApi implements IPricesApi {
       );
   }
 
+  /**
+   * Gets prices for a chain's native coin, trying to get it from cache first.
+   * If it's not found in the cache, it tries to retrieve it from the Coingecko API.
+   *
+   * @param args.chain Chain entity containing the chain-specific configuration
+   * @param args.fiatCode
+   * @returns number representing the native coin price, or null if not found.
+   */
   async getNativeCoinPrice(args: {
-    chainId: string;
+    chain: Chain;
     fiatCode: string;
   }): Promise<number | null> {
     try {
       const lowerCaseFiatCode = args.fiatCode.toLowerCase();
-      const nativeCoinId = this.configurationService.getOrThrow<string>(
-        `balances.providers.safe.prices.chains.${args.chainId}.nativeCoin`,
-      );
+      const nativeCoinId = args.chain.pricesProviderNativeCoin;
+      if (!nativeCoinId) {
+        throw new Error(
+          `pricesProviderNativeCoin not configured for chain ${args.chain.chainId}`,
+        );
+      }
       const cacheDir = CacheRouter.getNativeCoinPriceCacheDir({
         nativeCoinId,
         fiatCode: lowerCaseFiatCode,
@@ -145,13 +157,13 @@ export class CoingeckoApi implements IPricesApi {
    * Gets prices for a set of token addresses, trying to get them from cache first.
    * For those not found in the cache, it tries to retrieve them from the Coingecko API.
    *
-   * @param args.chainName Coingecko's name for the chain (see configuration)
+   * @param args.chain Chain entity containing the chain-specific configuration
    * @param args.tokenAddresses Array of token addresses which prices are being retrieved
    * @param args.fiatCode
    * @returns Array of {@link AssetPrice}
    */
   async getTokenPrices(args: {
-    chainId: string;
+    chain: Chain;
     tokenAddresses: string[];
     fiatCode: string;
   }): Promise<AssetPrice[]> {
@@ -160,9 +172,12 @@ export class CoingeckoApi implements IPricesApi {
       const lowerCaseTokenAddresses = args.tokenAddresses.map((address) =>
         address.toLowerCase(),
       );
-      const chainName = this.configurationService.getOrThrow<string>(
-        `balances.providers.safe.prices.chains.${args.chainId}.chainName`,
-      );
+      const chainName = args.chain.pricesProviderChainName;
+      if (!chainName) {
+        throw new Error(
+          `pricesProviderChainName not configured for chain ${args.chain.chainId}`,
+        );
+      }
       const pricesFromCache = await this._getTokenPricesFromCache({
         chainName,
         tokenAddresses: lowerCaseTokenAddresses,

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -114,12 +114,11 @@ export class CoingeckoApi implements IPricesApi {
   }): Promise<number | null> {
     try {
       const lowerCaseFiatCode = args.fiatCode.toLowerCase();
-      const nativeCoinId = args.chain.pricesProviderNativeCoin;
-      if (!nativeCoinId) {
-        throw new Error(
-          `pricesProviderNativeCoin not configured for chain ${args.chain.chainId}`,
+      const nativeCoinId =
+        args.chain.pricesProviderNativeCoin ??
+        this.configurationService.getOrThrow<string>(
+          `balances.providers.safe.prices.chains.${args.chain.chainId}.nativeCoin`,
         );
-      }
       const cacheDir = CacheRouter.getNativeCoinPriceCacheDir({
         nativeCoinId,
         fiatCode: lowerCaseFiatCode,
@@ -172,12 +171,11 @@ export class CoingeckoApi implements IPricesApi {
       const lowerCaseTokenAddresses = args.tokenAddresses.map((address) =>
         address.toLowerCase(),
       );
-      const chainName = args.chain.pricesProviderChainName;
-      if (!chainName) {
-        throw new Error(
-          `pricesProviderChainName not configured for chain ${args.chain.chainId}`,
+      const chainName =
+        args.chain.pricesProviderChainName ??
+        this.configurationService.getOrThrow<string>(
+          `balances.providers.safe.prices.chains.${args.chain.chainId}.chainName`,
         );
-      }
       const pricesFromCache = await this._getTokenPricesFromCache({
         chainName,
         tokenAddresses: lowerCaseTokenAddresses,

--- a/src/datasources/balances-api/prices-api.interface.ts
+++ b/src/datasources/balances-api/prices-api.interface.ts
@@ -1,15 +1,16 @@
 import { AssetPrice } from '@/datasources/balances-api/entities/asset-price.entity';
+import { Chain } from '@/domain/chains/entities/chain.entity';
 
 export const IPricesApi = Symbol('IPricesApi');
 
 export interface IPricesApi {
   getNativeCoinPrice(args: {
-    chainId: string;
+    chain: Chain;
     fiatCode: string;
   }): Promise<number | null>;
 
   getTokenPrices(args: {
-    chainId: string;
+    chain: Chain;
     tokenAddresses: string[];
     fiatCode: string;
   }): Promise<AssetPrice[]>;

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -2,6 +2,7 @@ import { Balance } from '@/domain/balances/entities/balance.entity';
 import { Module } from '@nestjs/common';
 import { BalancesRepository } from '@/domain/balances/balances.repository';
 import { BalancesApiModule } from '@/datasources/balances-api/balances-api.module';
+import { Chain } from '@/domain/chains/entities/chain.entity';
 
 export const IBalancesRepository = Symbol('IBalancesRepository');
 
@@ -11,7 +12,7 @@ export interface IBalancesRepository {
    * on {@link chainId}
    */
   getBalances(args: {
-    chainId: string;
+    chain: Chain;
     safeAddress: string;
     fiatCode: string;
     trusted?: boolean;

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -3,6 +3,7 @@ import { IBalancesRepository } from '@/domain/balances/balances.repository.inter
 import { Balance } from '@/domain/balances/entities/balance.entity';
 import { BalanceSchema } from '@/domain/balances/entities/balance.entity';
 import { IBalancesApiManager } from '@/domain/interfaces/balances-api.manager.interface';
+import { Chain } from '@/domain/chains/entities/chain.entity';
 
 @Injectable()
 export class BalancesRepository implements IBalancesRepository {
@@ -12,13 +13,15 @@ export class BalancesRepository implements IBalancesRepository {
   ) {}
 
   async getBalances(args: {
-    chainId: string;
+    chain: Chain;
     safeAddress: string;
     fiatCode: string;
     trusted?: boolean;
     excludeSpam?: boolean;
   }): Promise<Balance[]> {
-    const api = await this.balancesApiManager.getBalancesApi(args.chainId);
+    const api = await this.balancesApiManager.getBalancesApi(
+      args.chain.chainId,
+    );
     const balances = await api.getBalances(args);
     return balances.map((balance) => BalanceSchema.parse(balance));
   }

--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -37,5 +37,7 @@ export function chainBuilder(): IBuilder<Chain> {
     )
     .with('disabledWallets', [faker.word.sample(), faker.word.sample()])
     .with('features', [faker.word.sample(), faker.word.sample()])
-    .with('recommendedMasterCopyVersion', faker.system.semver());
+    .with('recommendedMasterCopyVersion', faker.system.semver())
+    .with('pricesProviderChainName', faker.company.name())
+    .with('pricesProviderNativeCoin', faker.finance.currencyName());
 }

--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -8,6 +8,7 @@ import { nativeCurrencyBuilder } from '@/domain/chains/entities/__tests__/native
 import { rpcUriBuilder } from '@/domain/chains/entities/__tests__/rpc-uri.builder';
 import { themeBuilder } from '@/domain/chains/entities/__tests__/theme.builder';
 import { Chain } from '@/domain/chains/entities/chain.entity';
+import { pricesProviderBuilder } from '@/domain/chains/entities/__tests__/prices-provider.builder';
 
 export function chainBuilder(): IBuilder<Chain> {
   return new Builder<Chain>()
@@ -23,6 +24,7 @@ export function chainBuilder(): IBuilder<Chain> {
     .with('publicRpcUri', rpcUriBuilder().build())
     .with('blockExplorerUriTemplate', blockExplorerUriTemplateBuilder().build())
     .with('nativeCurrency', nativeCurrencyBuilder().build())
+    .with('pricesProvider', pricesProviderBuilder().build())
     .with('transactionService', faker.internet.url({ appendSlash: false }))
     .with('vpcTransactionService', faker.internet.url({ appendSlash: false }))
     .with('theme', themeBuilder().build())
@@ -37,7 +39,5 @@ export function chainBuilder(): IBuilder<Chain> {
     )
     .with('disabledWallets', [faker.word.sample(), faker.word.sample()])
     .with('features', [faker.word.sample(), faker.word.sample()])
-    .with('recommendedMasterCopyVersion', faker.system.semver())
-    .with('pricesProviderChainName', faker.company.name())
-    .with('pricesProviderNativeCoin', faker.finance.currencyName());
+    .with('recommendedMasterCopyVersion', faker.system.semver());
 }

--- a/src/domain/chains/entities/__tests__/prices-provider.builder.ts
+++ b/src/domain/chains/entities/__tests__/prices-provider.builder.ts
@@ -1,0 +1,9 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { PricesProvider } from '@/domain/chains/entities/prices-provider.entity';
+import { faker } from '@faker-js/faker';
+
+export function pricesProviderBuilder(): IBuilder<PricesProvider> {
+  return new Builder<PricesProvider>()
+    .with('chainName', faker.company.name())
+    .with('nativeCoin', faker.finance.currencyName());
+}

--- a/src/domain/chains/entities/prices-provider.entity.ts
+++ b/src/domain/chains/entities/prices-provider.entity.ts
@@ -1,0 +1,4 @@
+import { PricesProviderSchema } from '@/domain/chains/entities/schemas/chain.schema';
+import { z } from 'zod';
+
+export type PricesProvider = z.infer<typeof PricesProviderSchema>;

--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -311,17 +311,19 @@ describe('Chain schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it.each([['chainLogoUri' as const], ['ensRegistryAddress' as const]])(
-      'should allow undefined %s and default to null',
-      (field) => {
-        const chain = chainBuilder().build();
-        delete chain[field];
+    it.each([
+      ['chainLogoUri' as const],
+      ['ensRegistryAddress' as const],
+      ['pricesProviderChainName' as const],
+      ['pricesProviderNativeCoin' as const],
+    ])('should allow undefined %s and default to null', (field) => {
+      const chain = chainBuilder().build();
+      delete chain[field];
 
-        const result = ChainSchema.safeParse(chain);
+      const result = ChainSchema.safeParse(chain);
 
-        expect(result.success && result.data[field]).toBe(null);
-      },
-    );
+      expect(result.success && result.data[field]).toBe(null);
+    });
 
     it.each([
       ['chainId' as const],

--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -3,6 +3,7 @@ import { gasPriceFixedEIP1559Builder } from '@/domain/chains/entities/__tests__/
 import { gasPriceFixedBuilder } from '@/domain/chains/entities/__tests__/gas-price-fixed.builder';
 import { gasPriceOracleBuilder } from '@/domain/chains/entities/__tests__/gas-price-oracle.builder';
 import { nativeCurrencyBuilder } from '@/domain/chains/entities/__tests__/native.currency.builder';
+import { pricesProviderBuilder } from '@/domain/chains/entities/__tests__/prices-provider.builder';
 import { rpcUriBuilder } from '@/domain/chains/entities/__tests__/rpc-uri.builder';
 import { themeBuilder } from '@/domain/chains/entities/__tests__/theme.builder';
 import {
@@ -12,6 +13,7 @@ import {
   GasPriceOracleSchema,
   GasPriceSchema,
   NativeCurrencySchema,
+  PricesProviderSchema,
   RpcUriSchema,
   ThemeSchema,
 } from '@/domain/chains/entities/schemas/chain.schema';
@@ -302,6 +304,56 @@ describe('Chain schemas', () => {
     });
   });
 
+  describe('PricesProviderSchema', () => {
+    it('should validate a valid prices provider', () => {
+      const pricesProvider = pricesProviderBuilder().build();
+
+      const result = PricesProviderSchema.safeParse(pricesProvider);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not validate an invalid prices provider chainName', () => {
+      const pricesProvider = {
+        chainName: 1,
+      };
+
+      const result = PricesProviderSchema.safeParse(pricesProvider);
+
+      expect(!result.success && result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'invalid_type',
+            expected: 'string',
+            received: 'number',
+            path: ['chainName'],
+            message: 'Expected string, received number',
+          },
+        ]),
+      );
+    });
+
+    it('should not validate an invalid prices provider nativeCoin', () => {
+      const pricesProvider = {
+        nativeCoin: 1,
+      };
+
+      const result = PricesProviderSchema.safeParse(pricesProvider);
+
+      expect(!result.success && result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'invalid_type',
+            expected: 'string',
+            received: 'number',
+            path: ['nativeCoin'],
+            message: 'Expected string, received number',
+          },
+        ]),
+      );
+    });
+  });
+
   describe('ChainSchema', () => {
     it('should validate a valid chain', () => {
       const chain = chainBuilder().build();
@@ -311,19 +363,17 @@ describe('Chain schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it.each([
-      ['chainLogoUri' as const],
-      ['ensRegistryAddress' as const],
-      ['pricesProviderChainName' as const],
-      ['pricesProviderNativeCoin' as const],
-    ])('should allow undefined %s and default to null', (field) => {
-      const chain = chainBuilder().build();
-      delete chain[field];
+    it.each([['chainLogoUri' as const], ['ensRegistryAddress' as const]])(
+      'should allow undefined %s and default to null',
+      (field) => {
+        const chain = chainBuilder().build();
+        delete chain[field];
 
-      const result = ChainSchema.safeParse(chain);
+        const result = ChainSchema.safeParse(chain);
 
-      expect(result.success && result.data[field]).toBe(null);
-    });
+        expect(result.success && result.data[field]).toBe(null);
+      },
+    );
 
     it.each([
       ['chainId' as const],

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -54,6 +54,11 @@ export const GasPriceSchema = z.array(
   ]),
 );
 
+export const PricesProviderSchema = z.object({
+  chainName: z.string().nullish().default(null),
+  nativeCoin: z.string().nullish().default(null),
+});
+
 export const ChainSchema = z.object({
   chainId: z.string(),
   chainName: z.string(),
@@ -67,6 +72,7 @@ export const ChainSchema = z.object({
   publicRpcUri: RpcUriSchema,
   blockExplorerUriTemplate: BlockExplorerUriTemplateSchema,
   nativeCurrency: NativeCurrencySchema,
+  pricesProvider: PricesProviderSchema,
   transactionService: z.string().url(),
   vpcTransactionService: z.string().url(),
   theme: ThemeSchema,
@@ -76,8 +82,6 @@ export const ChainSchema = z.object({
   features: z.array(z.string()),
   // TODO: Extract and use RelayDtoSchema['version'] when fully migrated to zod
   recommendedMasterCopyVersion: z.string(),
-  pricesProviderChainName: z.string().nullish().default(null),
-  pricesProviderNativeCoin: z.string().nullish().default(null),
 });
 
 export const ChainPageSchema = buildPageSchema(ChainSchema);

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -76,6 +76,8 @@ export const ChainSchema = z.object({
   features: z.array(z.string()),
   // TODO: Extract and use RelayDtoSchema['version'] when fully migrated to zod
   recommendedMasterCopyVersion: z.string(),
+  pricesProviderChainName: z.string().nullish().default(null),
+  pricesProviderNativeCoin: z.string().nullish().default(null),
 });
 
 export const ChainPageSchema = buildPageSchema(ChainSchema);

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -1,4 +1,5 @@
 import { Balance } from '@/domain/balances/entities/balance.entity';
+import { Chain } from '@/domain/chains/entities/chain.entity';
 import { Collectible } from '@/domain/collectibles/entities/collectible.entity';
 import { Page } from '@/domain/entities/page.entity';
 
@@ -6,7 +7,7 @@ export interface IBalancesApi {
   getBalances(args: {
     safeAddress: string;
     fiatCode: string;
-    chainId?: string;
+    chain?: Chain;
     trusted?: boolean;
     excludeSpam?: boolean;
   }): Promise<Balance[]>;

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -227,10 +227,13 @@ describe('Balances Controller (Unit)', () => {
 
         expect(networkService.get.mock.calls.length).toBe(2);
         expect(networkService.get.mock.calls[0][0].url).toBe(
+          `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+        );
+        expect(networkService.get.mock.calls[1][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`,
         );
         expect(
-          networkService.get.mock.calls[0][0].networkRequest,
+          networkService.get.mock.calls[1][0].networkRequest,
         ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
@@ -239,9 +242,6 @@ describe('Balances Controller (Unit)', () => {
             sort: 'value',
           },
         });
-        expect(networkService.get.mock.calls[1][0].url).toBe(
-          `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
-        );
       });
 
       it('returns large numbers as is (not in scientific notation)', async () => {
@@ -376,10 +376,13 @@ describe('Balances Controller (Unit)', () => {
 
         expect(networkService.get.mock.calls.length).toBe(2);
         expect(networkService.get.mock.calls[0][0].url).toBe(
+          `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+        );
+        expect(networkService.get.mock.calls[1][0].url).toBe(
           `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`,
         );
         expect(
-          networkService.get.mock.calls[0][0].networkRequest,
+          networkService.get.mock.calls[1][0].networkRequest,
         ).toStrictEqual({
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
@@ -388,9 +391,6 @@ describe('Balances Controller (Unit)', () => {
             sort: 'value',
           },
         });
-        expect(networkService.get.mock.calls[1][0].url).toBe(
-          `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
-        );
       });
     });
 

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -94,7 +94,7 @@ describe('Balances Controller (Unit)', () => {
         .getOrThrow('balances.providers.safe.prices.apiKey');
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProviderNativeCoin!]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -116,7 +116,7 @@ describe('Balances Controller (Unit)', () => {
               data: nativeCoinPriceProviderResponse,
               status: 200,
             });
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -195,7 +195,7 @@ describe('Balances Controller (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
@@ -213,7 +213,7 @@ describe('Balances Controller (Unit)', () => {
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
@@ -245,7 +245,7 @@ describe('Balances Controller (Unit)', () => {
               data: transactionApiBalancesResponse,
               status: 200,
             });
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -282,7 +282,7 @@ describe('Balances Controller (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProviderNativeCoin!]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -356,7 +356,7 @@ describe('Balances Controller (Unit)', () => {
               data: transactionApiBalancesResponse,
               status: 200,
             });
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -405,7 +405,7 @@ describe('Balances Controller (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
     });
 
@@ -456,7 +456,7 @@ describe('Balances Controller (Unit)', () => {
                 data: transactionApiBalancesResponse,
                 status: 200,
               });
-            case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
+            case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
               return Promise.reject();
             default:
               return Promise.reject(new Error(`Could not match ${url}`));
@@ -515,7 +515,7 @@ describe('Balances Controller (Unit)', () => {
                 data: transactionApiBalancesResponse,
                 status: 200,
               });
-            case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
+            case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
               return Promise.resolve({
                 data: tokenPriceProviderResponse,
                 status: 200,

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -89,22 +89,14 @@ describe('Balances Controller (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-        );
       const apiKey = app
         .get(IConfigurationService)
         .getOrThrow('balances.providers.safe.prices.apiKey');
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [chain.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
@@ -124,7 +116,7 @@ describe('Balances Controller (Unit)', () => {
               data: nativeCoinPriceProviderResponse,
               status: 200,
             });
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`:
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -203,7 +195,7 @@ describe('Balances Controller (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
       );
       expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
@@ -220,7 +212,10 @@ describe('Balances Controller (Unit)', () => {
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
-        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+        params: {
+          ids: chain.pricesProviderNativeCoin,
+          vs_currencies: currency.toLowerCase(),
+        },
       });
     });
 
@@ -237,11 +232,6 @@ describe('Balances Controller (Unit)', () => {
       ];
       const excludeSpam = true;
       const trusted = true;
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
@@ -255,7 +245,7 @@ describe('Balances Controller (Unit)', () => {
               data: transactionApiBalancesResponse,
               status: 200,
             });
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`:
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -291,13 +281,10 @@ describe('Balances Controller (Unit)', () => {
           .build(),
       ];
       const currency = faker.finance.currencyCode();
-      const nativeCoinId = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-        );
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [chain.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
@@ -356,11 +343,6 @@ describe('Balances Controller (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
@@ -374,7 +356,7 @@ describe('Balances Controller (Unit)', () => {
               data: transactionApiBalancesResponse,
               status: 200,
             });
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`:
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -423,7 +405,7 @@ describe('Balances Controller (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
       );
     });
 
@@ -465,11 +447,6 @@ describe('Balances Controller (Unit)', () => {
             .with('token', balanceTokenBuilder().with('decimals', 17).build())
             .build(),
         ];
-        const chainName = app
-          .get(IConfigurationService)
-          .getOrThrow(
-            `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-          );
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -479,7 +456,7 @@ describe('Balances Controller (Unit)', () => {
                 data: transactionApiBalancesResponse,
                 status: 200,
               });
-            case `${pricesProviderUrl}/simple/token_price/${chainName}`:
+            case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
               return Promise.reject();
             default:
               return Promise.reject(new Error(`Could not match ${url}`));
@@ -528,11 +505,6 @@ describe('Balances Controller (Unit)', () => {
             .with('token', balanceTokenBuilder().with('decimals', 17).build())
             .build(),
         ];
-        const chainName = app
-          .get(IConfigurationService)
-          .getOrThrow(
-            `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-          );
         const tokenPriceProviderResponse = 'notAnObject';
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
@@ -543,7 +515,7 @@ describe('Balances Controller (Unit)', () => {
                 data: transactionApiBalancesResponse,
                 status: 200,
               });
-            case `${pricesProviderUrl}/simple/token_price/${chainName}`:
+            case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`:
               return Promise.resolve({
                 data: tokenPriceProviderResponse,
                 status: 200,

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -27,10 +27,13 @@ export class BalancesService {
     excludeSpam: boolean;
   }): Promise<Balances> {
     const { chainId } = args;
-    const domainBalances = await this.balancesRepository.getBalances(args);
-    const { nativeCurrency } = await this.chainsRepository.getChain(chainId);
+    const chain = await this.chainsRepository.getChain(chainId);
+    const domainBalances = await this.balancesRepository.getBalances({
+      ...args,
+      chain,
+    });
     const balances: Balance[] = domainBalances.map((balance) =>
-      this._mapBalance(balance, nativeCurrency),
+      this._mapBalance(balance, chain.nativeCurrency),
     );
     const fiatTotal = balances
       .filter((b) => b.fiatBalance !== null)

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -111,7 +111,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProviderNativeCoin!]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -157,7 +157,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -217,7 +217,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
@@ -235,7 +235,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
@@ -268,7 +268,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProviderNativeCoin!]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -326,7 +326,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -386,7 +386,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
@@ -404,7 +404,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
@@ -477,10 +477,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProviderNativeCoin!]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProviderNativeCoin!]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -536,13 +536,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -700,10 +700,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProviderNativeCoin!]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProviderNativeCoin!]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -759,13 +759,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -881,7 +881,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProviderNativeCoin!]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -918,7 +918,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -977,7 +977,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
@@ -995,7 +995,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
@@ -1028,7 +1028,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProviderNativeCoin!]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1066,7 +1066,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1125,7 +1125,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: true, exclude_spam: false },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
@@ -1143,7 +1143,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
-          ids: chain.pricesProviderNativeCoin,
+          ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
@@ -1218,10 +1218,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProviderNativeCoin!]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProviderNativeCoin!]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1283,13 +1283,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1412,10 +1412,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProviderNativeCoin!]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProviderNativeCoin!]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1472,13 +1472,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1612,10 +1612,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProviderNativeCoin!]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProviderNativeCoin!]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1671,13 +1671,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -109,19 +109,11 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-        );
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [chain.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
@@ -165,7 +157,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -210,27 +202,24 @@ describe('Safes Controller Overview (Unit)', () => {
           ]),
         );
 
-      expect(networkService.get.mock.calls.length).toBe(7);
+      expect(networkService.get.mock.calls.length).toBe(6);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
-      );
-      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -240,14 +229,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
-        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+        params: {
+          ids: chain.pricesProviderNativeCoin,
+          vs_currencies: currency.toLowerCase(),
+        },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
@@ -274,19 +266,11 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-        );
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [chain.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
@@ -342,7 +326,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -387,27 +371,24 @@ describe('Safes Controller Overview (Unit)', () => {
           ]),
         );
 
-      expect(networkService.get.mock.calls.length).toBe(7);
+      expect(networkService.get.mock.calls.length).toBe(6);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
-      );
-      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -417,14 +398,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
-        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+        params: {
+          ids: chain.pricesProviderNativeCoin,
+          vs_currencies: currency.toLowerCase(),
+        },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
@@ -491,30 +475,14 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
-        );
-      const nativeCoinId2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
-        );
-      const chainName1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
-        );
-      const chainName2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
-        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+        [chain1.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
+        [chain2.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
@@ -568,13 +536,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -730,30 +698,14 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
-        );
-      const nativeCoinId2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
-        );
-      const chainName1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
-        );
-      const chainName2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
-        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+        [chain1.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
+        [chain2.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
@@ -807,13 +759,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -927,19 +879,11 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-        );
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [chain.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
@@ -974,7 +918,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1018,27 +962,24 @@ describe('Safes Controller Overview (Unit)', () => {
           },
         ]);
 
-      expect(networkService.get.mock.calls.length).toBe(7);
+      expect(networkService.get.mock.calls.length).toBe(6);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
-      );
-      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -1048,19 +989,22 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
-        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+        params: {
+          ids: chain.pricesProviderNativeCoin,
+          vs_currencies: currency.toLowerCase(),
+        },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
 
-    it('forwards trusted and exlude spam queries', async () => {
+    it('forwards trusted and exclude spam queries', async () => {
       const chain = chainBuilder().with('chainId', '10').build();
       const safeInfo = safeBuilder().build();
       const tokenAddress = faker.finance.ethereumAddress();
@@ -1082,19 +1026,11 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.nativeCoin`,
-        );
-      const chainName = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [chain.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
@@ -1130,7 +1066,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1173,28 +1109,25 @@ describe('Safes Controller Overview (Unit)', () => {
           },
         ]);
 
-      expect(networkService.get.mock.calls.length).toBe(7);
+      expect(networkService.get.mock.calls.length).toBe(6);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
-      );
-      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         // Forwarded params
         params: { trusted: true, exclude_spam: false },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
-        `${pricesProviderUrl}/simple/token_price/${chainName}`,
+      expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProviderChainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -1204,14 +1137,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
-        params: { ids: nativeCoinId, vs_currencies: currency.toLowerCase() },
+        params: {
+          ids: chain.pricesProviderNativeCoin,
+          vs_currencies: currency.toLowerCase(),
+        },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
@@ -1280,30 +1216,14 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
-        );
-      const nativeCoinId2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
-        );
-      const chainName1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
-        );
-      const chainName2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
-        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+        [chain1.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
+        [chain2.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
@@ -1363,13 +1283,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1490,30 +1410,14 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
-        );
-      const nativeCoinId2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
-        );
-      const chainName1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
-        );
-      const chainName2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
-        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+        [chain1.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
+        [chain2.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
@@ -1568,13 +1472,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
@@ -1706,30 +1610,14 @@ describe('Safes Controller Overview (Unit)', () => {
           .with('token', balanceTokenBuilder().with('decimals', 17).build())
           .build(),
       ];
-      const nativeCoinId1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.nativeCoin`,
-        );
-      const nativeCoinId2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.nativeCoin`,
-        );
-      const chainName1 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain1.chainId}.chainName`,
-        );
-      const chainName2 = app
-        .get(IConfigurationService)
-        .getOrThrow(
-          `balances.providers.safe.prices.chains.${chain2.chainId}.chainName`,
-        );
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId1]: { [currency.toLowerCase()]: 1536.75 },
-        [nativeCoinId2]: { [currency.toLowerCase()]: 1536.75 },
+        [chain1.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
+        [chain2.pricesProviderNativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
       };
       const tokenPriceProviderResponse = {
         [tokenAddress1]: { [currency.toLowerCase()]: 12.5 },
@@ -1783,13 +1671,13 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName1}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
-          case `${pricesProviderUrl}/simple/token_price/${chainName2}`: {
+          case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProviderChainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -138,13 +138,14 @@ export class SafesService {
 
     const settledOverviews = await Promise.allSettled(
       limitedSafes.map(async ({ chainId, address }) => {
+        const chain = await this.chainsRepository.getChain(chainId);
         const [safe, balances] = await Promise.all([
           this.safeRepository.getSafe({
             chainId,
             address,
           }),
           this.balancesRepository.getBalances({
-            chainId,
+            chain,
             safeAddress: address,
             trusted: args.trusted,
             fiatCode: args.currency,


### PR DESCRIPTION
## Summary
This PR changes the source for the Prices Provider (currently CoinGecko) configuration from the CGW hardcoded (`configuration.ts`) one, by the `Chain` entity coming from the Safe Config Service.

In this first iteration, the hardcoded configuration (`configuration.ts`) is kept as a fallback. If the Prices Provider configuration data is not present in the Config Service response, then the fallback data is used.

For more context see the Config Service PR: https://github.com/safe-global/safe-config-service/pull/1124

## Changes
- Changes the primary source for both `nativeCoinId` and `chainName` properties in `CoingeckoApi` to the `Chain` entity passed.
- Changes several interfaces accordingly to pass the whole `Chain` entity (holding the needed configuration) instead of passing the `chainId` property only.
- Adds the prices provider configuration fields to the `Chain` entity/schema.
- Modifies the affected test classes.
