### PR TITLE
Fix @typescript-eslint/no-misused-promises instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
-      '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -108,10 +108,9 @@ export class RedisCacheService
    */
   async onModuleDestroy(): Promise<void> {
     this.loggingService.info('Closing Redis connection');
-    const forceQuitTimeout = setTimeout(
-      this.forceQuit.bind(this),
-      this.quitTimeoutInSeconds * 1000,
-    );
+    const forceQuitTimeout = setTimeout(() => {
+      this.forceQuit.bind(this);
+    }, this.quitTimeoutInSeconds * 1000);
     await this.client.quit();
     clearTimeout(forceQuitTimeout);
     this.loggingService.info('Redis connection closed');


### PR DESCRIPTION
## Summary

When updating to ESLint 9, some rules had to be ignored as their recommendations changed. Of which, was the [`@typescript-eslint/no-misused-promises`](https://typescript-eslint.io/rules/no-misused-promises/) rule.

## Changes
- Enable `@typescript-eslint/no-misused-promises` ESLint rule
- Changes the `Promise` returns to sync functions returning `void` in:
  - `src/datasources/cache/redis.cache.service.ts`
  - `src/datasources/queues/queues-api.service.ts`