### PR TITLE
Fix @typescript-eslint/no-redundant-type-constituents instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
-      '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -212,7 +212,7 @@ export interface ITransactionApi {
 
   postMessage(args: {
     safeAddress: string;
-    message: string | unknown;
+    message: unknown;
     safeAppId: number | null;
     signature: string;
   }): Promise<Message>;

--- a/src/logging/__tests__/test.logging.module.ts
+++ b/src/logging/__tests__/test.logging.module.ts
@@ -12,22 +12,22 @@ class TestLoggingService implements ILoggingService {
     this.isSilent = configurationService.getOrThrow<boolean>('log.silent');
   }
 
-  debug(message: string | unknown): void {
+  debug(message: unknown): void {
     if (this.isSilent) return;
     console.debug(message);
   }
 
-  error(message: string | unknown): void {
+  error(message: unknown): void {
     if (this.isSilent) return;
     console.error(message);
   }
 
-  info(message: string | unknown): void {
+  info(message: unknown): void {
     if (this.isSilent) return;
     console.info(message);
   }
 
-  warn(message: string | unknown): void {
+  warn(message: unknown): void {
     if (this.isSilent) return;
     console.warn(message);
   }

--- a/src/logging/logging.interface.ts
+++ b/src/logging/logging.interface.ts
@@ -1,11 +1,11 @@
 export const LoggingService = Symbol('ILoggingService');
 
 export interface ILoggingService {
-  info(message: string | unknown): void;
+  info(message: unknown): void;
 
-  debug(message: string | unknown): void;
+  debug(message: unknown): void;
 
-  error(message: string | unknown): void;
+  error(message: unknown): void;
 
-  warn(message: string | unknown): void;
+  warn(message: unknown): void;
 }

--- a/src/logging/logging.service.ts
+++ b/src/logging/logging.service.ts
@@ -25,23 +25,23 @@ export class RequestScopedLoggingService implements ILoggingService {
     this.buildNumber = configurationService.get('about.buildNumber');
   }
 
-  info(message: string | unknown): void {
+  info(message: unknown): void {
     this.logger.log('info', this.formatMessage(message));
   }
 
-  error(message: string | unknown): void {
+  error(message: unknown): void {
     this.logger.log('error', this.formatMessage(message));
   }
 
-  warn(message: string | unknown): void {
+  warn(message: unknown): void {
     this.logger.log('warn', this.formatMessage(message));
   }
 
-  debug(message: string | unknown): void {
+  debug(message: unknown): void {
     this.logger.log('debug', this.formatMessage(message));
   }
 
-  private formatMessage(message: string | unknown): {
+  private formatMessage(message: unknown): {
     message: unknown;
     build_number: string | undefined;
     request_id: string;


### PR DESCRIPTION
## Summary

While upgrading to ESLint 9, certain rules were temporarily ignored due to changes in their recommendations. One such rule was the [`@typescript-eslint/no-redundant-type-constituents`](https://typescript-eslint.io/rules/no-redundant-type-constituents) rule.

This PR addresses instances where redundant type constituents were used, specifically `string | unknown` which is effectively the same as `unknown`.

## Changes

- Enable `@typescript-eslint/no-redundant-type-constituents` ESLint rule
- Replace `string | unknown` with `unknown`.