### PR TITLE
Fix @typescript-eslint/no-unnecessary-type-assertion instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
-      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',

--- a/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
+++ b/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
@@ -44,15 +44,15 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
 
     const data = encodeAbiParameters(
       parseAbiParameters(TransactionAddedEventBuilder.NON_INDEXED_PARAMS),
-      [args.to!, args.value!, args.data!, args.operation!],
+      [args.to, args.value, args.data, args.operation],
     );
 
     const topics = encodeEventTopics({
       abi,
       eventName: 'TransactionAdded',
       args: {
-        queueNonce: args.queueNonce!,
-        txHash: args.txHash!,
+        queueNonce: args.queueNonce,
+        txHash: args.txHash,
       },
     }) as TransactionAddedEvent['topics'];
 

--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -35,7 +35,7 @@ import {
   getSafeL2SingletonDeployment,
   getSafeSingletonDeployment,
 } from '@safe-global/safe-deployments';
-import { Hex, getAddress } from 'viem';
+import { getAddress } from 'viem';
 import configuration from '@/config/entities/configuration';
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 
@@ -97,7 +97,7 @@ describe('LimitAddressesMapper', () => {
             const safeAddress = getAddress(safe.address);
             const data = execTransactionEncoder()
               .with('value', faker.number.bigInt())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -116,7 +116,7 @@ describe('LimitAddressesMapper', () => {
             const safeAddress = getAddress(safe.address);
             const data = execTransactionEncoder()
               .with('data', erc20TransferEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -135,7 +135,7 @@ describe('LimitAddressesMapper', () => {
             const safeAddress = getAddress(safe.address);
             const data = execTransactionEncoder()
               .with('data', erc20TransferFromEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -154,7 +154,7 @@ describe('LimitAddressesMapper', () => {
             const safeAddress = getAddress(safe.address);
             const data = execTransactionEncoder()
               .with('data', erc20ApproveEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -174,7 +174,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', '0x')
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -194,7 +194,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', addOwnerWithThresholdEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -214,7 +214,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', changeThresholdEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -234,7 +234,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', enableModuleEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -254,7 +254,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', disableModuleEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -274,7 +274,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', removeOwnerEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -294,7 +294,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', setFallbackHandlerEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -314,7 +314,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', setGuardEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -334,7 +334,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', swapOwnerEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -353,7 +353,7 @@ describe('LimitAddressesMapper', () => {
             const safeAddress = getAddress(safe.address);
             const data = execTransactionEncoder()
               .with('data', execTransactionEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -373,7 +373,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('value', faker.number.bigInt())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockRejectedValue(true);
 
@@ -398,7 +398,7 @@ describe('LimitAddressesMapper', () => {
                 'data',
                 erc20TransferEncoder().with('to', safeAddress).encode(),
               )
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -425,7 +425,7 @@ describe('LimitAddressesMapper', () => {
                   .with('recipient', safeAddress)
                   .encode(),
               )
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -453,7 +453,7 @@ describe('LimitAddressesMapper', () => {
                   .with('recipient', recipient)
                   .encode(),
               )
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -476,7 +476,7 @@ describe('LimitAddressesMapper', () => {
             const data = execTransactionEncoder()
               .with('to', safeAddress)
               .with('data', erc20ApproveEncoder().encode())
-              .encode() as Hex;
+              .encode();
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -498,7 +498,7 @@ describe('LimitAddressesMapper', () => {
             const safeAddress = getAddress(safe.address);
             const data = execTransactionEncoder()
               .with('to', safeAddress)
-              .encode() as Hex;
+              .encode();
             // Unofficial mastercopy
             mockSafeRepository.getSafe.mockRejectedValue(
               new Error('Not official mastercopy'),
@@ -523,7 +523,7 @@ describe('LimitAddressesMapper', () => {
         const version = '0.0.1';
         const safe = safeBuilder().build();
         const safeAddress = getAddress(safe.address);
-        const data = execTransactionEncoder().encode() as Hex;
+        const data = execTransactionEncoder().encode();
         // Official mastercopy
         mockSafeRepository.getSafe.mockResolvedValue(safe);
 

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -630,7 +630,7 @@ describe('Alerts (Unit)', () => {
             .with('data', multiSend.encode())
             .with(
               'to',
-              getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress!),
+              getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress),
             )
             .encode();
 
@@ -1171,7 +1171,7 @@ describe('Alerts (Unit)', () => {
           .with('data', multiSend.encode())
           .with(
             'to',
-            getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress!),
+            getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress),
           )
           .encode();
 
@@ -1286,7 +1286,7 @@ describe('Alerts (Unit)', () => {
           .with('data', multiSend.encode())
           .with(
             'to',
-            getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress!),
+            getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress),
           )
           .encode();
 

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -20,7 +20,7 @@ import { INestApplication } from '@nestjs/common';
 import { faker } from '@faker-js/faker';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
-import { Hex, getAddress } from 'viem';
+import { getAddress } from 'viem';
 import {
   addOwnerWithThresholdEncoder,
   changeThresholdEncoder,
@@ -137,7 +137,7 @@ describe('Relay controller', () => {
                 const safeAddress = getAddress(safe.address);
                 const data = execTransactionEncoder()
                   .with('value', faker.number.bigInt())
-                  .encode() as Hex;
+                  .encode();
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
@@ -177,7 +177,7 @@ describe('Relay controller', () => {
                 const safe = safeBuilder().build();
                 const safeAddress = getAddress(safe.address);
                 const gasLimit = faker.string.numeric({ exclude: '0' });
-                const data = execTransactionEncoder().encode() as Hex;
+                const data = execTransactionEncoder().encode();
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
@@ -262,7 +262,7 @@ describe('Relay controller', () => {
                   const safe = safeBuilder().build();
                   const data = execTransactionEncoder()
                     .with('data', execTransactionData)
-                    .encode() as Hex;
+                    .encode();
                   const taskId = faker.string.uuid();
                   networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
@@ -312,7 +312,7 @@ describe('Relay controller', () => {
                 const data = execTransactionEncoder()
                   .with('to', safeAddress)
                   .with('data', execTransactionEncoder().encode())
-                  .encode() as Hex;
+                  .encode();
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
@@ -747,7 +747,7 @@ describe('Relay controller', () => {
                 const data = execTransactionEncoder()
                   .with('to', safeAddress)
                   .with('value', faker.number.bigInt())
-                  .encode() as Hex;
+                  .encode();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -785,7 +785,7 @@ describe('Relay controller', () => {
                     'data',
                     erc20TransferEncoder().with('to', safeAddress).encode(),
                   )
-                  .encode() as Hex;
+                  .encode();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -825,7 +825,7 @@ describe('Relay controller', () => {
                       .with('recipient', safeAddress)
                       .encode(),
                   )
-                  .encode() as Hex;
+                  .encode();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -866,7 +866,7 @@ describe('Relay controller', () => {
                       .with('recipient', recipient)
                       .encode(),
                   )
-                  .encode() as Hex;
+                  .encode();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -902,7 +902,7 @@ describe('Relay controller', () => {
                 const data = execTransactionEncoder()
                   .with('to', safeAddress)
                   .with('data', erc20ApproveEncoder().encode())
-                  .encode() as Hex;
+                  .encode();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -936,7 +936,7 @@ describe('Relay controller', () => {
                 const safeAddress = faker.finance.ethereumAddress();
                 const data = execTransactionEncoder()
                   .with('value', faker.number.bigInt())
-                  .encode() as Hex;
+                  .encode();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -1245,7 +1245,7 @@ describe('Relay controller', () => {
           const safeAddress = getAddress(safe.address);
           const data = execTransactionEncoder()
             .with('value', faker.number.bigInt())
-            .encode() as Hex;
+            .encode();
           const gasLimit = 'invalid';
 
           await request(app.getHttpServer())
@@ -1310,7 +1310,7 @@ describe('Relay controller', () => {
               const safeAddress = getAddress(safe.address);
               const data = execTransactionEncoder()
                 .with('value', faker.number.bigInt())
-                .encode() as Hex;
+                .encode();
               const taskId = faker.string.uuid();
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
@@ -1495,7 +1495,7 @@ describe('Relay controller', () => {
           const checksummedSafeAddress = getAddress(safe.address);
           const data = execTransactionEncoder()
             .with('value', faker.number.bigInt())
-            .encode() as Hex;
+            .encode();
           const taskId = faker.string.uuid();
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1554,7 +1554,7 @@ describe('Relay controller', () => {
           const safeAddress = getAddress(safe.address);
           const data = execTransactionEncoder()
             .with('value', faker.number.bigInt())
-            .encode() as Hex;
+            .encode();
           const taskId = faker.string.uuid();
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1600,7 +1600,7 @@ describe('Relay controller', () => {
           const safeAddress = getAddress(safe.address);
           const data = execTransactionEncoder()
             .with('value', faker.number.bigInt())
-            .encode() as Hex;
+            .encode();
           const taskId = faker.string.uuid();
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1653,7 +1653,7 @@ describe('Relay controller', () => {
         const version = '1.3.0';
         const chain = chainBuilder().with('chainId', chainId).build();
         const safe = safeBuilder().build();
-        const data = execTransactionEncoder().encode() as Hex;
+        const data = execTransactionEncoder().encode();
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -1702,7 +1702,7 @@ describe('Relay controller', () => {
         const safeAddress = getAddress(safe.address);
         const data = execTransactionEncoder()
           .with('value', faker.number.bigInt())
-          .encode() as Hex;
+          .encode();
         const taskId = faker.string.uuid();
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {

--- a/src/routes/transactions/helpers/swap-order.helper.spec.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.spec.ts
@@ -165,7 +165,7 @@ describe('Swap Order Helper tests', () => {
     await expect(
       target.getOrder({
         chainId,
-        orderUid: orderUid as `0x${string}`,
+        orderUid: orderUid,
       }),
     ).rejects.toThrow(error);
 

--- a/src/routes/transactions/helpers/swap-order.helper.spec.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.spec.ts
@@ -162,12 +162,7 @@ describe('Swap Order Helper tests', () => {
     const error = new Error('Order not found');
     swapsRepositoryMock.getOrder.mockRejectedValue(error);
 
-    await expect(
-      target.getOrder({
-        chainId,
-        orderUid: orderUid,
-      }),
-    ).rejects.toThrow(error);
+    await expect(target.getOrder({ chainId, orderUid })).rejects.toThrow(error);
 
     expect(swapsRepositoryMock.getOrder).toHaveBeenCalledTimes(1);
     expect(swapsRepositoryMock.getOrder).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

In the process of updating to ESLint 9, some rules were temporarily ignored due to changes in their recommendations. One of these rules was the [`@typescript-eslint/no-unnecessary-type-assertion`](https://typescript-eslint.io/rules/no-unnecessary-type-assertion) rule.

This PR re-enables the `@typescript-eslint/no-unnecessary-type-assertion` rule and addresses instances where redundant type constituents were used.

## Changes

- Enable `@typescript-eslint/no-unnecessary-type-assertion` ESLint rule in `eslint.config.mjs`