### PR TITLE
Decrease prefix length of imitation recipient check

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -201,7 +201,8 @@ export default (): ReturnType<typeof configuration> => ({
   },
   mappings: {
     imitationTransactions: {
-      vanityAddressChars: faker.number.int(),
+      prefixLength: faker.number.int(),
+      suffixLength: faker.number.int(),
     },
     history: {
       maxNestedTransfers: faker.number.int({ min: 1, max: 5 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -223,7 +223,8 @@ export default () => ({
   },
   mappings: {
     imitationTransactions: {
-      vanityAddressChars: parseInt(process.env.VANITY_ADDRESS_CHARS ?? `${4}`),
+      prefixLength: parseInt(process.env.IMITATION_PREFIX_LENGTH ?? `${3}`),
+      suffixLength: parseInt(process.env.VANITY_ADDRESS_CHARS ?? `${4}`),
     },
     history: {
       maxNestedTransfers: parseInt(

--- a/src/routes/transactions/helpers/imitation-transactions.helper.ts
+++ b/src/routes/transactions/helpers/imitation-transactions.helper.ts
@@ -8,13 +8,17 @@ import { isErc20Transfer } from '@/routes/transactions/entities/transfers/erc20-
 import { Inject } from '@nestjs/common';
 
 export class ImitationTransactionsHelper {
-  private readonly vanityAddressChars: number;
+  private readonly prefixLength: number;
+  private readonly suffixLength: number;
 
   constructor(
     @Inject(IConfigurationService) configurationService: IConfigurationService,
   ) {
-    this.vanityAddressChars = configurationService.getOrThrow(
-      'mappings.imitationTransactions.vanityAddressChars',
+    this.prefixLength = configurationService.getOrThrow(
+      'mappings.imitationTransactions.prefixLength',
+    );
+    this.suffixLength = configurationService.getOrThrow(
+      'mappings.imitationTransactions.suffixLength',
     );
   }
 
@@ -98,10 +102,9 @@ export class ImitationTransactionsHelper {
 
     const isSamePrefix =
       // Ignore `0x` prefix
-      a1.slice(2, 2 + this.vanityAddressChars) ===
-      a2.slice(2, 2 + this.vanityAddressChars);
+      a1.slice(2, 2 + this.prefixLength) === a2.slice(2, 2 + this.prefixLength);
     const isSameSuffix =
-      a1.slice(-this.vanityAddressChars) === a2.slice(-this.vanityAddressChars);
+      a1.slice(-this.suffixLength) === a2.slice(-this.suffixLength);
     return isSamePrefix && isSameSuffix;
   }
 }

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -67,7 +67,8 @@ describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
-  const vanityAddressChars = 4;
+  const prefixLength = 2;
+  const suffixLength = 4;
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -77,7 +78,8 @@ describe('Transactions History Controller (Unit)', () => {
       mappings: {
         ...configuration().mappings,
         imitationTransactions: {
-          vanityAddressChars,
+          prefixLength,
+          suffixLength,
         },
         features: {
           imitationFiltering: true,

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -67,7 +67,7 @@ describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
-  const prefixLength = 2;
+  const prefixLength = 3;
   const suffixLength = 4;
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary

We oversaw the prefix comparison length when making adjustments in https://github.com/safe-global/safe-client-gateway/pull/1524#discussion_r1598031861. This reduces the character length of prefix comparison from 4 to 3 characters as this is most common length seen of imitation vanity addresses.

## Changes

- Split prefix and suffix char. length.
- Reduce prefix length to 3.