### PR TITLE
Remove `trusted` condition for filtering imitation transfers

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -141,7 +141,9 @@ export class TransactionsHistoryMapper {
       .filter(<T>(x: T): x is NonNullable<T> => x != null)
       .flat();
 
-    if (!this.isImitationFilteringEnabled || !args.onlyTrusted) {
+    // TODO: Make conditional according to args.onlyTrusted if clients fetch
+    // trusted regardless of token lists
+    if (!this.isImitationFilteringEnabled) {
       return transactionItems;
     }
 


### PR DESCRIPTION
## Summary

This removes the conditional filtering of imitation transactions based on the `trusted` param. This is done for testing on staging as the clients conditionally fetch `trusted` and it is not possible to see the filtering otherwise.

## Changes

- Remove conditional filtering based on `trusted` param