### PR TITLE
Make `Chain['pricesProvider']` optional

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -168,6 +168,7 @@ describe('CoingeckoAPI', () => {
     });
 
     const expectedCacheDir = new CacheDir(
+      // @ts-expect-error - TODO: remove after migration
       `${chain.pricesProvider.chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
       '',
     );
@@ -175,6 +176,7 @@ describe('CoingeckoAPI', () => {
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
+      // @ts-expect-error - TODO: remove after migration
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
@@ -226,6 +228,7 @@ describe('CoingeckoAPI', () => {
     });
 
     const expectedCacheDir = new CacheDir(
+      // @ts-expect-error - TODO: remove after migration
       `${chain.pricesProvider.chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}`,
       '',
     );
@@ -233,6 +236,7 @@ describe('CoingeckoAPI', () => {
       { [tokenAddress]: { [lowerCaseFiatCode]: price } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
+      // @ts-expect-error - TODO: remove after migration
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         params: {
@@ -354,6 +358,7 @@ describe('CoingeckoAPI', () => {
       { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
+      // @ts-expect-error - TODO: remove after migration
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
@@ -372,18 +377,21 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -391,6 +399,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenCalledTimes(3);
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -401,6 +410,7 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -411,6 +421,7 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -465,6 +476,7 @@ describe('CoingeckoAPI', () => {
       { [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice } },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
+      // @ts-expect-error - TODO: remove after migration
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
@@ -484,12 +496,14 @@ describe('CoingeckoAPI', () => {
     // high-refresh-rate token price is cached with highRefreshRateTokensTtlSeconds
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${highRefreshRateTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -501,12 +515,14 @@ describe('CoingeckoAPI', () => {
     // another token price is cached with pricesCacheTtlSeconds
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.set).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${anotherTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -564,6 +580,7 @@ describe('CoingeckoAPI', () => {
       ),
     );
     expect(mockNetworkService.get).toHaveBeenCalledWith({
+      // @ts-expect-error - TODO: remove after migration
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
@@ -578,18 +595,21 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -598,6 +618,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       1,
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -609,6 +630,7 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.set).toHaveBeenNthCalledWith(
       2,
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -666,6 +688,7 @@ describe('CoingeckoAPI', () => {
       ),
     );
     expect(mockNetworkService.get).toHaveBeenCalledWith({
+      // @ts-expect-error - TODO: remove after migration
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
       networkRequest: {
         headers: {
@@ -680,18 +703,21 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.get).toHaveBeenCalledTimes(3);
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
     );
     expect(mockCacheService.get).toHaveBeenCalledWith(
       new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.chainName}_token_price_${thirdTokenAddress}_${lowerCaseFiatCode}`,
         '',
       ),
@@ -723,6 +749,7 @@ describe('CoingeckoAPI', () => {
 
     expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.nativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
         '',
       ),
@@ -732,6 +759,7 @@ describe('CoingeckoAPI', () => {
           'x-cg-pro-api-key': coingeckoApiKey,
         },
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: lowerCaseFiatCode,
         },
@@ -760,12 +788,14 @@ describe('CoingeckoAPI', () => {
 
     expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
       cacheDir: new CacheDir(
+        // @ts-expect-error - TODO: remove after migration
         `${chain.pricesProvider.nativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
         '',
       ),
       url: `${coingeckoBaseUri}/simple/price`,
       networkRequest: {
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: lowerCaseFiatCode,
         },

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -116,7 +116,7 @@ export class CoingeckoApi implements IPricesApi {
       const lowerCaseFiatCode = args.fiatCode.toLowerCase();
       // TODO: remove configurationService fallback when fully migrated.
       const nativeCoinId =
-        args.chain.pricesProvider.nativeCoin ??
+        args.chain.pricesProvider?.nativeCoin ??
         this.configurationService.getOrThrow<string>(
           `balances.providers.safe.prices.chains.${args.chain.chainId}.nativeCoin`,
         );
@@ -174,7 +174,7 @@ export class CoingeckoApi implements IPricesApi {
       );
       // TODO: remove configurationService fallback when fully migrated.
       const chainName =
-        args.chain.pricesProvider.chainName ??
+        args.chain.pricesProvider?.chainName ??
         this.configurationService.getOrThrow<string>(
           `balances.providers.safe.prices.chains.${args.chain.chainId}.chainName`,
         );

--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -363,6 +363,15 @@ describe('Chain schemas', () => {
       expect(result.success).toBe(true);
     });
 
+    // TODO: remove when fully migrated.
+    it('should allow optional pricesProvider', () => {
+      const chain = chainBuilder().with('pricesProvider', undefined).build();
+
+      const result = ChainSchema.safeParse(chain);
+
+      expect(result.success).toBe(true);
+    });
+
     it.each([['chainLogoUri' as const], ['ensRegistryAddress' as const]])(
       'should allow undefined %s and default to null',
       (field) => {

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -72,7 +72,8 @@ export const ChainSchema = z.object({
   publicRpcUri: RpcUriSchema,
   blockExplorerUriTemplate: BlockExplorerUriTemplateSchema,
   nativeCurrency: NativeCurrencySchema,
-  pricesProvider: PricesProviderSchema,
+  // TODO: remove optionality when fully migrated.
+  pricesProvider: PricesProviderSchema.optional(),
   transactionService: z.string().url(),
   vpcTransactionService: z.string().url(),
   theme: ThemeSchema,

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -94,6 +94,7 @@ describe('Balances Controller (Unit)', () => {
         .getOrThrow('balances.providers.safe.prices.apiKey');
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -116,6 +117,7 @@ describe('Balances Controller (Unit)', () => {
               data: nativeCoinPriceProviderResponse,
               status: 200,
             });
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -195,6 +197,7 @@ describe('Balances Controller (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
@@ -213,6 +216,7 @@ describe('Balances Controller (Unit)', () => {
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
@@ -245,6 +249,7 @@ describe('Balances Controller (Unit)', () => {
               data: transactionApiBalancesResponse,
               status: 200,
             });
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -282,6 +287,7 @@ describe('Balances Controller (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -356,6 +362,7 @@ describe('Balances Controller (Unit)', () => {
               data: transactionApiBalancesResponse,
               status: 200,
             });
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -405,6 +412,7 @@ describe('Balances Controller (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[2][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
     });
@@ -456,6 +464,7 @@ describe('Balances Controller (Unit)', () => {
                 data: transactionApiBalancesResponse,
                 status: 200,
               });
+            // @ts-expect-error - TODO: remove after migration
             case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
               return Promise.reject();
             default:
@@ -515,6 +524,7 @@ describe('Balances Controller (Unit)', () => {
                 data: transactionApiBalancesResponse,
                 status: 200,
               });
+            // @ts-expect-error - TODO: remove after migration
             case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
               return Promise.resolve({
                 data: tokenPriceProviderResponse,

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -111,6 +111,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -157,6 +158,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -217,6 +219,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
@@ -235,6 +238,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
@@ -268,6 +272,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -326,6 +331,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -386,6 +392,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
@@ -404,6 +411,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
@@ -477,9 +485,11 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
+        // @ts-expect-error - TODO: remove after migration
         [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -536,12 +546,14 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -700,9 +712,11 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
+        // @ts-expect-error - TODO: remove after migration
         [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -759,12 +773,14 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -881,6 +897,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -918,6 +935,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -977,6 +995,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: false, exclude_spam: true },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
@@ -995,6 +1014,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
@@ -1028,6 +1048,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -1066,6 +1087,7 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -1125,6 +1147,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: { trusted: true, exclude_spam: false },
       });
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
       expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
@@ -1143,6 +1166,7 @@ describe('Safes Controller Overview (Unit)', () => {
       expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
+          // @ts-expect-error - TODO: remove after migration
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
@@ -1218,9 +1242,11 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
+        // @ts-expect-error - TODO: remove after migration
         [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -1283,12 +1309,14 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -1412,9 +1440,11 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
+        // @ts-expect-error - TODO: remove after migration
         [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -1472,12 +1502,14 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
@@ -1612,9 +1644,11 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
         [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
+        // @ts-expect-error - TODO: remove after migration
         [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
@@ -1671,12 +1705,14 @@ describe('Safes Controller Overview (Unit)', () => {
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,
               status: 200,
             });
           }
+          // @ts-expect-error - TODO: remove after migration
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
               data: tokenPriceProviderResponse,


### PR DESCRIPTION
## Summary

We currently haven't fully migrated to fetching prices provider configuration from the Config Service and we have a local configuration fallback. This does not, however, take into account validation of the fetched data.

When running the project locally against the production Config Service, the schema was throwing and preventing retrieval of chain data because of this.

This makes the `Chain['pricesProvider']` of the `ChainSchema` optional, as well as adds a temporary test and relative TODO comments.

## Changes

- Make `ChainSchema['pricesProvider']` `optional` and add test coverage
- Add relevant optional chaining to `CoingeckoApi`