### PR TITLE
Add LockingApi.getCampaignById

### DIFF
--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -44,6 +44,45 @@ describe('LockingApi', () => {
     );
   });
 
+  describe('getCampaignById', () => {
+    it('should get a campaign by campaignId', async () => {
+      const campaign = campaignBuilder().build();
+
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: campaign,
+        status: 200,
+      });
+
+      const result = await service.getCampaignById(campaign.campaignId);
+
+      expect(result).toEqual(campaign);
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`,
+      });
+    });
+
+    it('should forward error', async () => {
+      const status = faker.internet.httpStatusCode({ types: ['serverError'] });
+      const campaign = campaignBuilder().build();
+      const error = new NetworkResponseError(
+        new URL(`${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`),
+        {
+          status,
+        } as Response,
+        {
+          message: 'Unexpected error',
+        },
+      );
+      mockNetworkService.get.mockRejectedValueOnce(error);
+
+      await expect(
+        service.getCampaignById(campaign.campaignId),
+      ).rejects.toThrow(new DataSourceError('Unexpected error', status));
+
+      expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getCampaigns', () => {
     it('should get campaigns', async () => {
       const campaignsPage = pageBuilder()

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -25,6 +25,16 @@ export class LockingApi implements ILockingApi {
       this.configurationService.getOrThrow<string>('locking.baseUri');
   }
 
+  async getCampaignById(campaignId: string): Promise<Campaign> {
+    try {
+      const url = `${this.baseUri}/api/v1/campaigns/${campaignId}`;
+      const { data } = await this.networkService.get<Campaign>({ url });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getCampaigns(args: {
     limit?: number;
     offset?: number;

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -6,6 +6,8 @@ import { Rank } from '@/domain/locking/entities/rank.entity';
 export const ILockingApi = Symbol('ILockingApi');
 
 export interface ILockingApi {
+  getCampaignById(campaignId: string): Promise<Campaign>;
+
   getCampaigns(args: {
     limit?: number;
     offset?: number;


### PR DESCRIPTION
Depends on https://github.com/safe-global/safe-client-gateway/pull/1543

## Changes
- Adds `ILockingApi.getCampaignById` along with its implementation.
