### PR TITLE
Use mock imitation transactions in tests

### DIFF
--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -1356,7 +1356,7 @@ describe('Transactions History Controller (Unit)', () => {
       });
   });
 
-  describe('Address poisoning', () => {
+  describe('Imitation transactions', () => {
     describe('Trusted tokens', () => {
       it('should flag outgoing ERC-20 transfers that imitate a direct predecessor', async () => {
         const chain = chainBuilder().build();

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -59,9 +59,12 @@ import {
 } from '@/domain/safe/entities/__tests__/erc721-transfer.builder';
 import { TransactionItem } from '@/routes/transactions/entities/transaction-item.entity';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
-import { getAddress } from 'viem';
+import { getAddress, zeroAddress } from 'viem';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
+import { EthereumTransaction } from '@/domain/safe/entities/ethereum-transaction.entity';
+import { erc20TransferEncoder } from '@/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
@@ -1354,157 +1357,114 @@ describe('Transactions History Controller (Unit)', () => {
   });
 
   describe('Address poisoning', () => {
-    // TODO: Add tests with a mixture of (non-)trusted tokens, as well add builder-based tests
     describe('Trusted tokens', () => {
       it('should flag outgoing ERC-20 transfers that imitate a direct predecessor', async () => {
-        // Example taken from arb1:0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4 - marked as trusted
         const chain = chainBuilder().build();
-        const safe = safeBuilder()
-          .with('address', '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4')
-          .with('owners', [
-            '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-          ])
-          .build();
+        const safe = safeBuilder().build();
 
-        const results = [
-          {
-            executionDate: '2024-03-20T09:42:58Z',
-            to: '0x0e74DE9501F54610169EDB5D6CC6b559d403D4B7',
-            data: '0x12514bba00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000cdb94376e0330b13f5becaece169602cbb14399c000000000000000000000000a52cd97c022e5373ee305010ff2263d29bb87a7000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009a6de84bf23ed9ba92bdb8027037975ef181b1c4000000000000000000000000345e400b58fbc0f9bc0eb176b6a125f35056ac300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fd737d98d9f6b566cc104fd40aecc449b8eaa5120000000000000000000000001b4b73713ada8a6f864b58d0dd6099ca54e59aa30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000878678326eac90000000000000000000000000000000000000000000000000000000000000001ed02f00000000000000000000000000000000000000000000000000000000000000000',
-            txHash:
-              '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-            blockNumber: 192295013,
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:42:58Z',
-                blockNumber: 192295013,
-                transactionHash:
-                  '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-                to: '0xFd737d98d9F6b566cc104Fd40aEcC449b8EaA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                transferId:
-                  'ef6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb44',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0xcDB94376E0330B13F5Becaece169602cbB14399c.png',
-                  trusted: true,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'ETHEREUM_TRANSACTION',
-            from: '0xA504C7e72AD25927EbFA6ea14aD5EA56fb0aB64a',
-          },
-          {
-            safe: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-            to: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-            value: '0',
-            data: '0xa9059cbb000000000000000000000000fd7e78798f312a29bb03133de9d26e151d3aa512000000000000000000000000000000000000000000000878678326eac9000000',
-            operation: 0,
-            gasToken: '0x0000000000000000000000000000000000000000',
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: '0',
-            refundReceiver: '0x0000000000000000000000000000000000000000',
-            nonce: 3,
-            executionDate: '2024-03-20T09:41:25Z',
-            submissionDate: '2024-03-20T09:38:11.447366Z',
-            modified: '2024-03-20T09:41:25Z',
-            blockNumber: 192294646,
-            transactionHash:
-              '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-            safeTxHash:
-              '0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
-            proposer: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            executor: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-            isExecuted: true,
-            isSuccessful: true,
-            ethGasPrice: '10946000',
-            maxFeePerGas: null,
-            maxPriorityFeePerGas: null,
-            gasUsed: 249105,
-            fee: '2726703330000',
-            origin: '{}',
-            dataDecoded: {
-              method: 'transfer',
-              parameters: [
-                {
-                  name: 'to',
-                  type: 'address',
-                  value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                },
-                {
-                  name: 'value',
-                  type: 'uint256',
-                  value: '40000000000000000000000',
-                },
-              ],
-            },
-            confirmationsRequired: 2,
-            confirmations: [
-              {
-                owner: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                submissionDate: '2024-03-20T09:38:11.479197Z',
-                transactionHash: null,
-                signature:
-                  '0x552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-                signatureType: 'EOA',
-              },
-              {
-                owner: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-                submissionDate: '2024-03-20T09:41:25Z',
-                transactionHash: null,
-                signature:
-                  '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001',
-                signatureType: 'APPROVED_HASH',
-              },
-            ],
-            trusted: true,
-            signatures:
-              '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:41:25Z',
-                blockNumber: 192294646,
-                transactionHash:
-                  '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-                to: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                transferId:
-                  'e7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f3718178133',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                  trusted: true,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'MULTISIG_TRANSACTION',
-          },
-        ];
+        const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
+        const multisigToken = tokenBuilder()
+          .with('trusted', true)
+          .with('type', TokenType.Erc20)
+          .build();
+        const multisigTransfer = {
+          ...erc20TransferBuilder()
+            .with('executionDate', multisigExecutionDate)
+            .with('from', safe.address)
+            .with('tokenAddress', multisigToken.address)
+            .build(),
+          tokenInfo: multisigToken,
+        };
+        const multisigTransaction = {
+          ...(multisigTransactionToJson(
+            multisigTransactionBuilder()
+              .with('executionDate', multisigExecutionDate)
+              .with('safe', safe.address)
+              .with('to', multisigToken.address)
+              .with('value', '0')
+              .with('data', '0x') // TODO: Use encoder
+              .with('operation', 0)
+              .with('gasToken', zeroAddress)
+              .with('safeTxGas', 0)
+              .with('baseGas', 0)
+              .with('gasPrice', '0')
+              .with('refundReceiver', zeroAddress)
+              .with('proposer', safe.owners[0])
+              .with('executor', safe.owners[0])
+              .with('isExecuted', true)
+              .with('isSuccessful', true)
+              .with('origin', null)
+              .with(
+                'dataDecoded',
+                dataDecodedBuilder()
+                  .with('method', 'transfer')
+                  .with('parameters', [
+                    dataDecodedParameterBuilder()
+                      .with('name', 'to')
+                      .with('type', 'address')
+                      .with('value', multisigTransfer.to)
+                      .build(),
+                    dataDecodedParameterBuilder()
+                      .with('name', 'value')
+                      .with('type', 'uint256')
+                      .with('value', multisigTransfer.value)
+                      .build(),
+                  ])
+                  .build(),
+              )
+              .with('confirmationsRequired', 1)
+              .with('confirmations', [
+                confirmationBuilder().with('owner', safe.owners[0]).build(),
+              ])
+              .with('trusted', true)
+              .build(),
+          ) as MultisigTransaction),
+          // TODO: Update type to include transfers - this could remove dataDecodedParamHelper.getFromParam/getToParam?
+          transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
+        } as MultisigTransaction;
+
+        // TODO: Value and recipient
+        const imitationAddress = getAddress(
+          multisigTransfer.to.slice(0, 5) +
+            faker.finance.ethereumAddress().slice(5, -4) +
+            multisigTransfer.to.slice(-4),
+        );
+        const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
+        const imitationErc20Transfer = erc20TransferEncoder()
+          .with('to', imitationAddress)
+          .with('value', BigInt(multisigTransfer.value));
+        const imitationToken = tokenBuilder()
+          .with('trusted', true)
+          .with('type', TokenType.Erc20)
+          .build();
+        const imitationTransfer = {
+          ...erc20TransferBuilder()
+            .with('from', safe.address)
+            .with('to', imitationAddress)
+            .with('tokenAddress', imitationToken.address)
+            .with('value', multisigTransfer.value)
+            .with('executionDate', imitationExecutionDate)
+            .build(),
+          // TODO: Update type to include tokenInfo
+          tokenInfo: imitationToken,
+        };
+        const imitationTransaction = ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with('executionDate', imitationTransfer.executionDate)
+            .with('data', imitationErc20Transfer.encode())
+            .with('transfers', [
+              erc20TransferToJson(imitationTransfer) as Transfer,
+            ])
+            .build(),
+        ) as EthereumTransaction;
+        const results = [imitationTransaction, multisigTransaction];
 
         const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+        // @ts-expect-error - Type does not contain transfers
         const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[0].transfers[0].tokenAddress}`;
+        // @ts-expect-error - Type does not contain transfers
         const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[1].transfers[0].tokenAddress}`;
         networkService.get.mockImplementation(({ url }) => {
           if (url === getChainUrl) {
@@ -1521,13 +1481,13 @@ describe('Transactions History Controller (Unit)', () => {
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: results[0].transfers[0].tokenInfo,
+              data: imitationToken,
               status: 200,
             });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: results[1].transfers[0].tokenInfo,
+              data: multisigToken,
               status: 200,
             });
           }
@@ -1549,7 +1509,8 @@ describe('Transactions History Controller (Unit)', () => {
                 conflictType: 'None',
                 transaction: {
                   executionInfo: null,
-                  id: 'transfer_0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4_ef6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb44',
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
                   safeAppInfo: null,
                   timestamp: 1710927778000,
                   txInfo: {
@@ -1558,26 +1519,24 @@ describe('Transactions History Controller (Unit)', () => {
                     recipient: {
                       logoUri: null,
                       name: null,
-                      value: '0xFd737d98d9F6b566cc104Fd40aEcC449b8EaA512',
+                      value: imitationAddress,
                     },
                     richDecodedInfo: null,
                     sender: {
                       logoUri: null,
                       name: null,
-                      value: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
+                      value: safe.address,
                     },
                     transferInfo: {
-                      decimals: 18,
+                      decimals: imitationToken.decimals,
                       imitation: true,
-                      logoUri:
-                        'https://safe-transaction-assets.safe.global/tokens/logos/0xcDB94376E0330B13F5Becaece169602cbB14399c.png',
-                      tokenAddress:
-                        '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                      tokenName: 'Arbitrum',
-                      tokenSymbol: 'ARB',
-                      trusted: true,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
                       type: 'ERC20',
-                      value: '40000000000000000000000',
+                      value: multisigTransfer.value,
                     },
                     type: 'Transfer',
                   },
@@ -1589,63 +1548,39 @@ describe('Transactions History Controller (Unit)', () => {
                 conflictType: 'None',
                 transaction: {
                   executionInfo: {
-                    confirmationsRequired: 2,
-                    confirmationsSubmitted: 2,
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
                     missingSigners: null,
-                    nonce: 3,
+                    nonce: multisigTransaction.nonce,
                     type: 'MULTISIG',
                   },
-                  id: 'multisig_0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4_0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
                   safeAppInfo: null,
                   timestamp: 1710927685000,
                   txInfo: {
                     direction: 'OUTGOING',
-                    humanDescription: 'Send 40000 ARB to 0xFd7e...A512',
+                    humanDescription: null,
                     recipient: {
                       logoUri: null,
                       name: null,
-                      value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
+                      value: multisigTransfer.to,
                     },
-                    richDecodedInfo: {
-                      fragments: [
-                        {
-                          type: 'text',
-                          value: 'Send',
-                        },
-                        {
-                          logoUri:
-                            'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                          symbol: 'ARB',
-                          type: 'tokenValue',
-                          value: '40000',
-                        },
-                        {
-                          type: 'text',
-                          value: 'to',
-                        },
-                        {
-                          type: 'address',
-                          value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                        },
-                      ],
-                    },
+                    richDecodedInfo: null,
                     sender: {
                       logoUri: null,
                       name: null,
-                      value: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
+                      value: safe.address,
                     },
                     transferInfo: {
-                      decimals: 18,
+                      decimals: multisigToken.decimals,
                       imitation: null,
-                      logoUri:
-                        'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                      tokenAddress:
-                        '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                      tokenName: 'Arbitrum',
-                      tokenSymbol: 'ARB',
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
                       trusted: null,
                       type: 'ERC20',
-                      value: '40000000000000000000000',
+                      value: multisigTransfer.value,
                     },
                     type: 'Transfer',
                   },
@@ -1658,154 +1593,112 @@ describe('Transactions History Controller (Unit)', () => {
       });
 
       it('should filter out outgoing ERC-20 transfers that imitate a direct predecessor', async () => {
-        // Example taken from arb1:0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4 - marked as trusted
         const chain = chainBuilder().build();
-        const safe = safeBuilder()
-          .with('address', '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4')
-          .with('owners', [
-            '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-          ])
-          .build();
+        const safe = safeBuilder().build();
 
-        const results = [
-          {
-            executionDate: '2024-03-20T09:42:58Z',
-            to: '0x0e74DE9501F54610169EDB5D6CC6b559d403D4B7',
-            data: '0x12514bba00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000cdb94376e0330b13f5becaece169602cbb14399c000000000000000000000000a52cd97c022e5373ee305010ff2263d29bb87a7000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009a6de84bf23ed9ba92bdb8027037975ef181b1c4000000000000000000000000345e400b58fbc0f9bc0eb176b6a125f35056ac300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fd737d98d9f6b566cc104fd40aecc449b8eaa5120000000000000000000000001b4b73713ada8a6f864b58d0dd6099ca54e59aa30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000878678326eac90000000000000000000000000000000000000000000000000000000000000001ed02f00000000000000000000000000000000000000000000000000000000000000000',
-            txHash:
-              '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-            blockNumber: 192295013,
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:42:58Z',
-                blockNumber: 192295013,
-                transactionHash:
-                  '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-                to: '0xFd737d98d9F6b566cc104Fd40aEcC449b8EaA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                transferId:
-                  'ef6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb44',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0xcDB94376E0330B13F5Becaece169602cbB14399c.png',
-                  trusted: true,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'ETHEREUM_TRANSACTION',
-            from: '0xA504C7e72AD25927EbFA6ea14aD5EA56fb0aB64a',
-          },
-          {
-            safe: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-            to: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-            value: '0',
-            data: '0xa9059cbb000000000000000000000000fd7e78798f312a29bb03133de9d26e151d3aa512000000000000000000000000000000000000000000000878678326eac9000000',
-            operation: 0,
-            gasToken: '0x0000000000000000000000000000000000000000',
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: '0',
-            refundReceiver: '0x0000000000000000000000000000000000000000',
-            nonce: 3,
-            executionDate: '2024-03-20T09:41:25Z',
-            submissionDate: '2024-03-20T09:38:11.447366Z',
-            modified: '2024-03-20T09:41:25Z',
-            blockNumber: 192294646,
-            transactionHash:
-              '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-            safeTxHash:
-              '0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
-            proposer: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            executor: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-            isExecuted: true,
-            isSuccessful: true,
-            ethGasPrice: '10946000',
-            maxFeePerGas: null,
-            maxPriorityFeePerGas: null,
-            gasUsed: 249105,
-            fee: '2726703330000',
-            origin: '{}',
-            dataDecoded: {
-              method: 'transfer',
-              parameters: [
-                {
-                  name: 'to',
-                  type: 'address',
-                  value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                },
-                {
-                  name: 'value',
-                  type: 'uint256',
-                  value: '40000000000000000000000',
-                },
-              ],
-            },
-            confirmationsRequired: 2,
-            confirmations: [
-              {
-                owner: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                submissionDate: '2024-03-20T09:38:11.479197Z',
-                transactionHash: null,
-                signature:
-                  '0x552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-                signatureType: 'EOA',
-              },
-              {
-                owner: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-                submissionDate: '2024-03-20T09:41:25Z',
-                transactionHash: null,
-                signature:
-                  '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001',
-                signatureType: 'APPROVED_HASH',
-              },
-            ],
-            trusted: true,
-            signatures:
-              '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:41:25Z',
-                blockNumber: 192294646,
-                transactionHash:
-                  '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-                to: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                transferId:
-                  'e7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f3718178133',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                  trusted: true,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'MULTISIG_TRANSACTION',
-          },
-        ];
+        const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
+        const multisigToken = tokenBuilder()
+          .with('trusted', true)
+          .with('type', TokenType.Erc20)
+          .build();
+        const multisigTransfer = {
+          ...erc20TransferBuilder()
+            .with('executionDate', multisigExecutionDate)
+            .with('from', safe.address)
+            .with('tokenAddress', multisigToken.address)
+            .build(),
+          tokenInfo: multisigToken,
+        };
+        const multisigTransaction = {
+          ...(multisigTransactionToJson(
+            multisigTransactionBuilder()
+              .with('executionDate', multisigExecutionDate)
+              .with('safe', safe.address)
+              .with('to', multisigToken.address)
+              .with('value', '0')
+              .with('data', '0x') // TODO: Use encoder
+              .with('operation', 0)
+              .with('gasToken', zeroAddress)
+              .with('safeTxGas', 0)
+              .with('baseGas', 0)
+              .with('gasPrice', '0')
+              .with('refundReceiver', zeroAddress)
+              .with('proposer', safe.owners[0])
+              .with('executor', safe.owners[0])
+              .with('isExecuted', true)
+              .with('isSuccessful', true)
+              .with('origin', null)
+              .with(
+                'dataDecoded',
+                dataDecodedBuilder()
+                  .with('method', 'transfer')
+                  .with('parameters', [
+                    dataDecodedParameterBuilder()
+                      .with('name', 'to')
+                      .with('type', 'address')
+                      .with('value', multisigTransfer.to)
+                      .build(),
+                    dataDecodedParameterBuilder()
+                      .with('name', 'value')
+                      .with('type', 'uint256')
+                      .with('value', multisigTransfer.value)
+                      .build(),
+                  ])
+                  .build(),
+              )
+              .with('confirmationsRequired', 1)
+              .with('confirmations', [
+                confirmationBuilder().with('owner', safe.owners[0]).build(),
+              ])
+              .with('trusted', true)
+              .build(),
+          ) as MultisigTransaction),
+          // TODO: Update type to include transfers - this could remove dataDecodedParamHelper.getFromParam/getToParam?
+          transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
+        } as MultisigTransaction;
+
+        // TODO: Value and recipient
+        const imitationAddress = getAddress(
+          multisigTransfer.to.slice(0, 5) +
+            faker.finance.ethereumAddress().slice(5, -4) +
+            multisigTransfer.to.slice(-4),
+        );
+        const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
+        const imitationErc20Transfer = erc20TransferEncoder()
+          .with('to', imitationAddress)
+          .with('value', BigInt(multisigTransfer.value));
+        const imitationToken = tokenBuilder()
+          .with('trusted', true)
+          .with('type', TokenType.Erc20)
+          .build();
+        const imitationTransfer = {
+          ...erc20TransferBuilder()
+            .with('from', safe.address)
+            .with('to', imitationAddress)
+            .with('tokenAddress', imitationToken.address)
+            .with('value', multisigTransfer.value)
+            .with('executionDate', imitationExecutionDate)
+            .build(),
+          // TODO: Update type to include tokenInfo
+          tokenInfo: imitationToken,
+        };
+        const imitationTransaction = ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with('executionDate', imitationTransfer.executionDate)
+            .with('data', imitationErc20Transfer.encode())
+            .with('transfers', [
+              erc20TransferToJson(imitationTransfer) as Transfer,
+            ])
+            .build(),
+        ) as EthereumTransaction;
+        const results = [imitationTransaction, multisigTransaction];
 
         const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+        // @ts-expect-error - Type does not contain transfers
         const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[0].transfers[0].tokenAddress}`;
+        // @ts-expect-error - Type does not contain transfers
         const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[1].transfers[0].tokenAddress}`;
         networkService.get.mockImplementation(({ url }) => {
           if (url === getChainUrl) {
@@ -1822,13 +1715,13 @@ describe('Transactions History Controller (Unit)', () => {
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: results[0].transfers[0].tokenInfo,
+              data: imitationToken,
               status: 200,
             });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: results[1].transfers[0].tokenInfo,
+              data: multisigToken,
               status: 200,
             });
           }
@@ -1850,63 +1743,39 @@ describe('Transactions History Controller (Unit)', () => {
                 conflictType: 'None',
                 transaction: {
                   executionInfo: {
-                    confirmationsRequired: 2,
-                    confirmationsSubmitted: 2,
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
                     missingSigners: null,
-                    nonce: 3,
+                    nonce: multisigTransaction.nonce,
                     type: 'MULTISIG',
                   },
-                  id: 'multisig_0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4_0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
                   safeAppInfo: null,
                   timestamp: 1710927685000,
                   txInfo: {
                     direction: 'OUTGOING',
-                    humanDescription: 'Send 40000 ARB to 0xFd7e...A512',
+                    humanDescription: null,
                     recipient: {
                       logoUri: null,
                       name: null,
-                      value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
+                      value: multisigTransfer.to,
                     },
-                    richDecodedInfo: {
-                      fragments: [
-                        {
-                          type: 'text',
-                          value: 'Send',
-                        },
-                        {
-                          logoUri:
-                            'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                          symbol: 'ARB',
-                          type: 'tokenValue',
-                          value: '40000',
-                        },
-                        {
-                          type: 'text',
-                          value: 'to',
-                        },
-                        {
-                          type: 'address',
-                          value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                        },
-                      ],
-                    },
+                    richDecodedInfo: null,
                     sender: {
                       logoUri: null,
                       name: null,
-                      value: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
+                      value: safe.address,
                     },
                     transferInfo: {
-                      decimals: 18,
+                      decimals: multisigToken.decimals,
                       imitation: null,
-                      logoUri:
-                        'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                      tokenAddress:
-                        '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                      tokenName: 'Arbitrum',
-                      tokenSymbol: 'ARB',
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
                       trusted: null,
                       type: 'ERC20',
-                      value: '40000000000000000000000',
+                      value: multisigTransfer.value,
                     },
                     type: 'Transfer',
                   },
@@ -1921,154 +1790,112 @@ describe('Transactions History Controller (Unit)', () => {
 
     describe('Non-trusted tokens', () => {
       it('should flag outgoing ERC-20 transfers that imitate a direct predecessor', async () => {
-        // Example taken from arb1:0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4
         const chain = chainBuilder().build();
-        const safe = safeBuilder()
-          .with('address', '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4')
-          .with('owners', [
-            '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-          ])
-          .build();
+        const safe = safeBuilder().build();
 
-        const results = [
-          {
-            executionDate: '2024-03-20T09:42:58Z',
-            to: '0x0e74DE9501F54610169EDB5D6CC6b559d403D4B7',
-            data: '0x12514bba00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000cdb94376e0330b13f5becaece169602cbb14399c000000000000000000000000a52cd97c022e5373ee305010ff2263d29bb87a7000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009a6de84bf23ed9ba92bdb8027037975ef181b1c4000000000000000000000000345e400b58fbc0f9bc0eb176b6a125f35056ac300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fd737d98d9f6b566cc104fd40aecc449b8eaa5120000000000000000000000001b4b73713ada8a6f864b58d0dd6099ca54e59aa30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000878678326eac90000000000000000000000000000000000000000000000000000000000000001ed02f00000000000000000000000000000000000000000000000000000000000000000',
-            txHash:
-              '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-            blockNumber: 192295013,
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:42:58Z',
-                blockNumber: 192295013,
-                transactionHash:
-                  '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-                to: '0xFd737d98d9F6b566cc104Fd40aEcC449b8EaA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                transferId:
-                  'ef6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb44',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0xcDB94376E0330B13F5Becaece169602cbB14399c.png',
-                  trusted: false,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'ETHEREUM_TRANSACTION',
-            from: '0xA504C7e72AD25927EbFA6ea14aD5EA56fb0aB64a',
-          },
-          {
-            safe: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-            to: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-            value: '0',
-            data: '0xa9059cbb000000000000000000000000fd7e78798f312a29bb03133de9d26e151d3aa512000000000000000000000000000000000000000000000878678326eac9000000',
-            operation: 0,
-            gasToken: '0x0000000000000000000000000000000000000000',
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: '0',
-            refundReceiver: '0x0000000000000000000000000000000000000000',
-            nonce: 3,
-            executionDate: '2024-03-20T09:41:25Z',
-            submissionDate: '2024-03-20T09:38:11.447366Z',
-            modified: '2024-03-20T09:41:25Z',
-            blockNumber: 192294646,
-            transactionHash:
-              '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-            safeTxHash:
-              '0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
-            proposer: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            executor: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-            isExecuted: true,
-            isSuccessful: true,
-            ethGasPrice: '10946000',
-            maxFeePerGas: null,
-            maxPriorityFeePerGas: null,
-            gasUsed: 249105,
-            fee: '2726703330000',
-            origin: '{}',
-            dataDecoded: {
-              method: 'transfer',
-              parameters: [
-                {
-                  name: 'to',
-                  type: 'address',
-                  value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                },
-                {
-                  name: 'value',
-                  type: 'uint256',
-                  value: '40000000000000000000000',
-                },
-              ],
-            },
-            confirmationsRequired: 2,
-            confirmations: [
-              {
-                owner: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                submissionDate: '2024-03-20T09:38:11.479197Z',
-                transactionHash: null,
-                signature:
-                  '0x552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-                signatureType: 'EOA',
-              },
-              {
-                owner: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-                submissionDate: '2024-03-20T09:41:25Z',
-                transactionHash: null,
-                signature:
-                  '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001',
-                signatureType: 'APPROVED_HASH',
-              },
-            ],
-            trusted: true,
-            signatures:
-              '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:41:25Z',
-                blockNumber: 192294646,
-                transactionHash:
-                  '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-                to: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                transferId:
-                  'e7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f3718178133',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                  trusted: false,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'MULTISIG_TRANSACTION',
-          },
-        ];
+        const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
+        const multisigToken = tokenBuilder()
+          .with('trusted', false)
+          .with('type', TokenType.Erc20)
+          .build();
+        const multisigTransfer = {
+          ...erc20TransferBuilder()
+            .with('executionDate', multisigExecutionDate)
+            .with('from', safe.address)
+            .with('tokenAddress', multisigToken.address)
+            .build(),
+          tokenInfo: multisigToken,
+        };
+        const multisigTransaction = {
+          ...(multisigTransactionToJson(
+            multisigTransactionBuilder()
+              .with('executionDate', multisigExecutionDate)
+              .with('safe', safe.address)
+              .with('to', multisigToken.address)
+              .with('value', '0')
+              .with('data', '0x') // TODO: Use encoder
+              .with('operation', 0)
+              .with('gasToken', zeroAddress)
+              .with('safeTxGas', 0)
+              .with('baseGas', 0)
+              .with('gasPrice', '0')
+              .with('refundReceiver', zeroAddress)
+              .with('proposer', safe.owners[0])
+              .with('executor', safe.owners[0])
+              .with('isExecuted', true)
+              .with('isSuccessful', true)
+              .with('origin', null)
+              .with(
+                'dataDecoded',
+                dataDecodedBuilder()
+                  .with('method', 'transfer')
+                  .with('parameters', [
+                    dataDecodedParameterBuilder()
+                      .with('name', 'to')
+                      .with('type', 'address')
+                      .with('value', multisigTransfer.to)
+                      .build(),
+                    dataDecodedParameterBuilder()
+                      .with('name', 'value')
+                      .with('type', 'uint256')
+                      .with('value', multisigTransfer.value)
+                      .build(),
+                  ])
+                  .build(),
+              )
+              .with('confirmationsRequired', 1)
+              .with('confirmations', [
+                confirmationBuilder().with('owner', safe.owners[0]).build(),
+              ])
+              .with('trusted', true)
+              .build(),
+          ) as MultisigTransaction),
+          // TODO: Update type to include transfers - this could remove dataDecodedParamHelper.getFromParam/getToParam?
+          transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
+        } as MultisigTransaction;
+
+        // TODO: Value and recipient
+        const imitationAddress = getAddress(
+          multisigTransfer.to.slice(0, 5) +
+            faker.finance.ethereumAddress().slice(5, -4) +
+            multisigTransfer.to.slice(-4),
+        );
+        const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
+        const imitationErc20Transfer = erc20TransferEncoder()
+          .with('to', imitationAddress)
+          .with('value', BigInt(multisigTransfer.value));
+        const imitationToken = tokenBuilder()
+          .with('trusted', false)
+          .with('type', TokenType.Erc20)
+          .build();
+        const imitationTransfer = {
+          ...erc20TransferBuilder()
+            .with('from', safe.address)
+            .with('to', imitationAddress)
+            .with('tokenAddress', imitationToken.address)
+            .with('value', multisigTransfer.value)
+            .with('executionDate', imitationExecutionDate)
+            .build(),
+          // TODO: Update type to include tokenInfo
+          tokenInfo: imitationToken,
+        };
+        const imitationTransaction = ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with('executionDate', imitationTransfer.executionDate)
+            .with('data', imitationErc20Transfer.encode())
+            .with('transfers', [
+              erc20TransferToJson(imitationTransfer) as Transfer,
+            ])
+            .build(),
+        ) as EthereumTransaction;
+        const results = [imitationTransaction, multisigTransaction];
 
         const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+        // @ts-expect-error - Type does not contain transfers
         const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[0].transfers[0].tokenAddress}`;
+        // @ts-expect-error - Type does not contain transfers
         const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[1].transfers[0].tokenAddress}`;
         networkService.get.mockImplementation(({ url }) => {
           if (url === getChainUrl) {
@@ -2085,13 +1912,13 @@ describe('Transactions History Controller (Unit)', () => {
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: results[0].transfers[0].tokenInfo,
+              data: imitationToken,
               status: 200,
             });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: results[1].transfers[0].tokenInfo,
+              data: multisigToken,
               status: 200,
             });
           }
@@ -2113,7 +1940,8 @@ describe('Transactions History Controller (Unit)', () => {
                 conflictType: 'None',
                 transaction: {
                   executionInfo: null,
-                  id: 'transfer_0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4_ef6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb44',
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
                   safeAppInfo: null,
                   timestamp: 1710927778000,
                   txInfo: {
@@ -2122,26 +1950,24 @@ describe('Transactions History Controller (Unit)', () => {
                     recipient: {
                       logoUri: null,
                       name: null,
-                      value: '0xFd737d98d9F6b566cc104Fd40aEcC449b8EaA512',
+                      value: imitationAddress,
                     },
                     richDecodedInfo: null,
                     sender: {
                       logoUri: null,
                       name: null,
-                      value: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
+                      value: safe.address,
                     },
                     transferInfo: {
-                      decimals: 18,
+                      decimals: imitationToken.decimals,
                       imitation: true,
-                      logoUri:
-                        'https://safe-transaction-assets.safe.global/tokens/logos/0xcDB94376E0330B13F5Becaece169602cbB14399c.png',
-                      tokenAddress:
-                        '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                      tokenName: 'Arbitrum',
-                      tokenSymbol: 'ARB',
-                      trusted: false,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
                       type: 'ERC20',
-                      value: '40000000000000000000000',
+                      value: multisigTransfer.value,
                     },
                     type: 'Transfer',
                   },
@@ -2153,63 +1979,39 @@ describe('Transactions History Controller (Unit)', () => {
                 conflictType: 'None',
                 transaction: {
                   executionInfo: {
-                    confirmationsRequired: 2,
-                    confirmationsSubmitted: 2,
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
                     missingSigners: null,
-                    nonce: 3,
+                    nonce: multisigTransaction.nonce,
                     type: 'MULTISIG',
                   },
-                  id: 'multisig_0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4_0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
                   safeAppInfo: null,
                   timestamp: 1710927685000,
                   txInfo: {
                     direction: 'OUTGOING',
-                    humanDescription: 'Send 40000 ARB to 0xFd7e...A512',
+                    humanDescription: null,
                     recipient: {
                       logoUri: null,
                       name: null,
-                      value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
+                      value: multisigTransfer.to,
                     },
-                    richDecodedInfo: {
-                      fragments: [
-                        {
-                          type: 'text',
-                          value: 'Send',
-                        },
-                        {
-                          logoUri:
-                            'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                          symbol: 'ARB',
-                          type: 'tokenValue',
-                          value: '40000',
-                        },
-                        {
-                          type: 'text',
-                          value: 'to',
-                        },
-                        {
-                          type: 'address',
-                          value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                        },
-                      ],
-                    },
+                    richDecodedInfo: null,
                     sender: {
                       logoUri: null,
                       name: null,
-                      value: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
+                      value: safe.address,
                     },
                     transferInfo: {
-                      decimals: 18,
+                      decimals: multisigToken.decimals,
                       imitation: null,
-                      logoUri:
-                        'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                      tokenAddress:
-                        '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                      tokenName: 'Arbitrum',
-                      tokenSymbol: 'ARB',
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
                       trusted: null,
                       type: 'ERC20',
-                      value: '40000000000000000000000',
+                      value: multisigTransfer.value,
                     },
                     type: 'Transfer',
                   },
@@ -2222,154 +2024,112 @@ describe('Transactions History Controller (Unit)', () => {
       });
 
       it('should filter out outgoing ERC-20 transfers that imitate a direct predecessor', async () => {
-        // Example taken from arb1:0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4
         const chain = chainBuilder().build();
-        const safe = safeBuilder()
-          .with('address', '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4')
-          .with('owners', [
-            '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-          ])
-          .build();
+        const safe = safeBuilder().build();
 
-        const results = [
-          {
-            executionDate: '2024-03-20T09:42:58Z',
-            to: '0x0e74DE9501F54610169EDB5D6CC6b559d403D4B7',
-            data: '0x12514bba00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000cdb94376e0330b13f5becaece169602cbb14399c000000000000000000000000a52cd97c022e5373ee305010ff2263d29bb87a7000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009a6de84bf23ed9ba92bdb8027037975ef181b1c4000000000000000000000000345e400b58fbc0f9bc0eb176b6a125f35056ac300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fd737d98d9f6b566cc104fd40aecc449b8eaa5120000000000000000000000001b4b73713ada8a6f864b58d0dd6099ca54e59aa30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000878678326eac90000000000000000000000000000000000000000000000000000000000000001ed02f00000000000000000000000000000000000000000000000000000000000000000',
-            txHash:
-              '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-            blockNumber: 192295013,
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:42:58Z',
-                blockNumber: 192295013,
-                transactionHash:
-                  '0xf6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb4',
-                to: '0xFd737d98d9F6b566cc104Fd40aEcC449b8EaA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                transferId:
-                  'ef6ab60f4e79f01e6f9615aa134725d5fe0d7222b47a441fff6233f9219593bb44',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0xcDB94376E0330B13F5Becaece169602cbB14399c',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0xcDB94376E0330B13F5Becaece169602cbB14399c.png',
-                  trusted: false,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'ETHEREUM_TRANSACTION',
-            from: '0xA504C7e72AD25927EbFA6ea14aD5EA56fb0aB64a',
-          },
-          {
-            safe: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-            to: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-            value: '0',
-            data: '0xa9059cbb000000000000000000000000fd7e78798f312a29bb03133de9d26e151d3aa512000000000000000000000000000000000000000000000878678326eac9000000',
-            operation: 0,
-            gasToken: '0x0000000000000000000000000000000000000000',
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: '0',
-            refundReceiver: '0x0000000000000000000000000000000000000000',
-            nonce: 3,
-            executionDate: '2024-03-20T09:41:25Z',
-            submissionDate: '2024-03-20T09:38:11.447366Z',
-            modified: '2024-03-20T09:41:25Z',
-            blockNumber: 192294646,
-            transactionHash:
-              '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-            safeTxHash:
-              '0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
-            proposer: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-            executor: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-            isExecuted: true,
-            isSuccessful: true,
-            ethGasPrice: '10946000',
-            maxFeePerGas: null,
-            maxPriorityFeePerGas: null,
-            gasUsed: 249105,
-            fee: '2726703330000',
-            origin: '{}',
-            dataDecoded: {
-              method: 'transfer',
-              parameters: [
-                {
-                  name: 'to',
-                  type: 'address',
-                  value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                },
-                {
-                  name: 'value',
-                  type: 'uint256',
-                  value: '40000000000000000000000',
-                },
-              ],
-            },
-            confirmationsRequired: 2,
-            confirmations: [
-              {
-                owner: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                submissionDate: '2024-03-20T09:38:11.479197Z',
-                transactionHash: null,
-                signature:
-                  '0x552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-                signatureType: 'EOA',
-              },
-              {
-                owner: '0xBE7d3f723d069a941228e44e222b37fBCe0731ce',
-                submissionDate: '2024-03-20T09:41:25Z',
-                transactionHash: null,
-                signature:
-                  '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001',
-                signatureType: 'APPROVED_HASH',
-              },
-            ],
-            trusted: true,
-            signatures:
-              '0x000000000000000000000000be7d3f723d069a941228e44e222b37fbce0731ce000000000000000000000000000000000000000000000000000000000000000001552b4bfaf92e7486785f6f922975e131f244152613486f2567112913a910047f14a5f5ce410d39192d0fbc7df1d9dc43e7c11b64510d44151dd2712be14665eb1c',
-            transfers: [
-              {
-                type: 'ERC20_TRANSFER',
-                executionDate: '2024-03-20T09:41:25Z',
-                blockNumber: 192294646,
-                transactionHash:
-                  '0x7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f371817813',
-                to: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                value: '40000000000000000000000',
-                tokenId: null,
-                tokenAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                transferId:
-                  'e7e60c76bb3b350dc552f3c261faf7dcdbfe141f7a740d9495efd49f3718178133',
-                tokenInfo: {
-                  type: 'ERC20',
-                  address: '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                  name: 'Arbitrum',
-                  symbol: 'ARB',
-                  decimals: 18,
-                  logoUri:
-                    'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                  trusted: false,
-                },
-                from: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
-              },
-            ],
-            txType: 'MULTISIG_TRANSACTION',
-          },
-        ];
+        const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
+        const multisigToken = tokenBuilder()
+          .with('trusted', false)
+          .with('type', TokenType.Erc20)
+          .build();
+        const multisigTransfer = {
+          ...erc20TransferBuilder()
+            .with('executionDate', multisigExecutionDate)
+            .with('from', safe.address)
+            .with('tokenAddress', multisigToken.address)
+            .build(),
+          tokenInfo: multisigToken,
+        };
+        const multisigTransaction = {
+          ...(multisigTransactionToJson(
+            multisigTransactionBuilder()
+              .with('executionDate', multisigExecutionDate)
+              .with('safe', safe.address)
+              .with('to', multisigToken.address)
+              .with('value', '0')
+              .with('data', '0x') // TODO: Use encoder
+              .with('operation', 0)
+              .with('gasToken', zeroAddress)
+              .with('safeTxGas', 0)
+              .with('baseGas', 0)
+              .with('gasPrice', '0')
+              .with('refundReceiver', zeroAddress)
+              .with('proposer', safe.owners[0])
+              .with('executor', safe.owners[0])
+              .with('isExecuted', true)
+              .with('isSuccessful', true)
+              .with('origin', null)
+              .with(
+                'dataDecoded',
+                dataDecodedBuilder()
+                  .with('method', 'transfer')
+                  .with('parameters', [
+                    dataDecodedParameterBuilder()
+                      .with('name', 'to')
+                      .with('type', 'address')
+                      .with('value', multisigTransfer.to)
+                      .build(),
+                    dataDecodedParameterBuilder()
+                      .with('name', 'value')
+                      .with('type', 'uint256')
+                      .with('value', multisigTransfer.value)
+                      .build(),
+                  ])
+                  .build(),
+              )
+              .with('confirmationsRequired', 1)
+              .with('confirmations', [
+                confirmationBuilder().with('owner', safe.owners[0]).build(),
+              ])
+              .with('trusted', true)
+              .build(),
+          ) as MultisigTransaction),
+          // TODO: Update type to include transfers - this could remove dataDecodedParamHelper.getFromParam/getToParam?
+          transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
+        } as MultisigTransaction;
+
+        // TODO: Value and recipient
+        const imitationAddress = getAddress(
+          multisigTransfer.to.slice(0, 5) +
+            faker.finance.ethereumAddress().slice(5, -4) +
+            multisigTransfer.to.slice(-4),
+        );
+        const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
+        const imitationErc20Transfer = erc20TransferEncoder()
+          .with('to', imitationAddress)
+          .with('value', BigInt(multisigTransfer.value));
+        const imitationToken = tokenBuilder()
+          .with('trusted', false)
+          .with('type', TokenType.Erc20)
+          .build();
+        const imitationTransfer = {
+          ...erc20TransferBuilder()
+            .with('from', safe.address)
+            .with('to', imitationAddress)
+            .with('tokenAddress', imitationToken.address)
+            .with('value', multisigTransfer.value)
+            .with('executionDate', imitationExecutionDate)
+            .build(),
+          // TODO: Update type to include tokenInfo
+          tokenInfo: imitationToken,
+        };
+        const imitationTransaction = ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with('executionDate', imitationTransfer.executionDate)
+            .with('data', imitationErc20Transfer.encode())
+            .with('transfers', [
+              erc20TransferToJson(imitationTransfer) as Transfer,
+            ])
+            .build(),
+        ) as EthereumTransaction;
+        const results = [imitationTransaction, multisigTransaction];
 
         const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+        // @ts-expect-error - Type does not contain transfers
         const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[0].transfers[0].tokenAddress}`;
+        // @ts-expect-error - Type does not contain transfers
         const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${results[1].transfers[0].tokenAddress}`;
         networkService.get.mockImplementation(({ url }) => {
           if (url === getChainUrl) {
@@ -2386,13 +2146,13 @@ describe('Transactions History Controller (Unit)', () => {
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: results[0].transfers[0].tokenInfo,
+              data: imitationToken,
               status: 200,
             });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: results[1].transfers[0].tokenInfo,
+              data: multisigToken,
               status: 200,
             });
           }
@@ -2414,63 +2174,39 @@ describe('Transactions History Controller (Unit)', () => {
                 conflictType: 'None',
                 transaction: {
                   executionInfo: {
-                    confirmationsRequired: 2,
-                    confirmationsSubmitted: 2,
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
                     missingSigners: null,
-                    nonce: 3,
+                    nonce: multisigTransaction.nonce,
                     type: 'MULTISIG',
                   },
-                  id: 'multisig_0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4_0xa0772fe5d26572fa777e0b4557da9a03d208086078215245ed26502f7a7bf683',
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
                   safeAppInfo: null,
                   timestamp: 1710927685000,
                   txInfo: {
                     direction: 'OUTGOING',
-                    humanDescription: 'Send 40000 ARB to 0xFd7e...A512',
+                    humanDescription: null,
                     recipient: {
                       logoUri: null,
                       name: null,
-                      value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
+                      value: multisigTransfer.to,
                     },
-                    richDecodedInfo: {
-                      fragments: [
-                        {
-                          type: 'text',
-                          value: 'Send',
-                        },
-                        {
-                          logoUri:
-                            'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                          symbol: 'ARB',
-                          type: 'tokenValue',
-                          value: '40000',
-                        },
-                        {
-                          type: 'text',
-                          value: 'to',
-                        },
-                        {
-                          type: 'address',
-                          value: '0xFd7e78798f312A29bb03133de9D26E151D3aA512',
-                        },
-                      ],
-                    },
+                    richDecodedInfo: null,
                     sender: {
                       logoUri: null,
                       name: null,
-                      value: '0x9a6dE84bF23ed9ba92BDB8027037975ef181b1c4',
+                      value: safe.address,
                     },
                     transferInfo: {
-                      decimals: 18,
+                      decimals: multisigToken.decimals,
                       imitation: null,
-                      logoUri:
-                        'https://safe-transaction-assets.safe.global/tokens/logos/0x912CE59144191C1204E64559FE8253a0e49E6548.png',
-                      tokenAddress:
-                        '0x912CE59144191C1204E64559FE8253a0e49E6548',
-                      tokenName: 'Arbitrum',
-                      tokenSymbol: 'ARB',
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
                       trusted: null,
                       type: 'ERC20',
-                      value: '40000000000000000000000',
+                      value: multisigTransfer.value,
                     },
                     type: 'Transfer',
                   },


### PR DESCRIPTION
## Summary

The mock data of the imitation transaction tests was taken from on-chain and was therefore not dynamic. This migrates to using builder-based mock data in order to increase the coverage of the tests.

## Changes

- Use dynamic mock data for imitation transaction tests.