### PR TITLE
Migrate to `multisig-transactions` deletion endpoint

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -1487,7 +1487,7 @@ describe('TransactionApi', () => {
     it('should delete a transaction', async () => {
       const safeTxHash = faker.string.hexadecimal();
       const signature = faker.string.hexadecimal();
-      const deleteTransactionUrl = `${baseUrl}/api/v1/transactions/${safeTxHash}`;
+      const deleteTransactionUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}`;
       networkService.delete.mockResolvedValueOnce({
         status: 200,
         data: {},
@@ -1514,7 +1514,7 @@ describe('TransactionApi', () => {
     ])(`should forward a %s error`, async (_, error) => {
       const safeTxHash = faker.string.hexadecimal();
       const signature = faker.string.hexadecimal();
-      const deleteTransactionUrl = `${baseUrl}/api/v1/transactions/${safeTxHash}`;
+      const deleteTransactionUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}`;
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
       });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -619,7 +619,7 @@ export class TransactionApi implements ITransactionApi {
     signature: string;
   }): Promise<void> {
     try {
-      const url = `${this.baseUrl}/api/v1/transactions/${args.safeTxHash}`;
+      const url = `${this.baseUrl}/api/v1/multisig-transactions/${args.safeTxHash}`;
       await this.networkService.delete({
         url,
         data: {

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -111,7 +111,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     networkService.delete.mockImplementation(({ url }) => {
       if (
         url ===
-        `${chain.transactionService}/api/v1/transactions/${tx.safeTxHash}`
+        `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}`
       ) {
         return Promise.resolve({ data: {}, status: 204 });
       }
@@ -146,7 +146,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     networkService.delete.mockImplementation(({ url }) => {
       if (
         url ===
-        `${chain.transactionService}/api/v1/transactions/${tx.safeTxHash}`
+        `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}`
       ) {
         return Promise.resolve({ data: {}, status: 204 });
       }
@@ -195,7 +195,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     networkService.delete.mockImplementation(({ url }) => {
       if (
         url ===
-        `${chain.transactionService}/api/v1/transactions/${tx.safeTxHash}`
+        `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}`
       ) {
         return Promise.reject(
           new NetworkResponseError(


### PR DESCRIPTION
## Summary

The deprecated `/transactions/` endpoints of the Transaction Service are [to be removed](https://github.com/safe-global/safe-transaction-service/pull/2048).

As we are still using the relative `DELETE` endpoint, this migrates it to the `/multisig-transactions/` equivalent in preparation.

## Changes

- Change `TransactionApi['deleteTransaction']` to use `/api/v1/multisig-transactions/${safeTxHash}` of the Transaction Service.