### PR TITLE
Add campaigns routes

### DIFF
--- a/src/domain/locking/entities/__tests__/campaign.builder.ts
+++ b/src/domain/locking/entities/__tests__/campaign.builder.ts
@@ -1,4 +1,5 @@
 import { IBuilder, Builder } from '@/__tests__/builder';
+import { activityMetadataBuilder } from '@/domain/locking/entities/__tests__/activity-metadata.builder';
 import { Campaign } from '@/domain/locking/entities/campaign.entity';
 import { faker } from '@faker-js/faker';
 
@@ -9,5 +10,11 @@ export function campaignBuilder(): IBuilder<Campaign> {
     .with('description', faker.lorem.sentence())
     .with('periodStart', faker.date.recent())
     .with('periodEnd', faker.date.future())
-    .with('lastUpdated', faker.date.recent());
+    .with('lastUpdated', faker.date.recent())
+    .with(
+      'activities',
+      Array.from({ length: faker.number.int({ min: 0, max: 5 }) }, () =>
+        activityMetadataBuilder().build(),
+      ),
+    );
 }

--- a/src/domain/locking/entities/campaign.entity.ts
+++ b/src/domain/locking/entities/campaign.entity.ts
@@ -1,3 +1,4 @@
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { ActivityMetadataSchema } from '@/domain/locking/entities/activity-metadata.entity';
 import { z } from 'zod';
 
@@ -12,3 +13,5 @@ export const CampaignSchema = z.object({
   lastUpdated: z.coerce.date(),
   activities: z.array(ActivityMetadataSchema).nullish().default(null),
 });
+
+export const CampaignPageSchema = buildPageSchema(CampaignSchema);

--- a/src/domain/locking/locking.repository.interface.ts
+++ b/src/domain/locking/locking.repository.interface.ts
@@ -1,10 +1,18 @@
 import { Page } from '@/domain/entities/page.entity';
+import { Campaign } from '@/domain/locking/entities/campaign.entity';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
 
 export const ILockingRepository = Symbol('ILockingRepository');
 
 export interface ILockingRepository {
+  getCampaignById(campaignId: string): Promise<Campaign>;
+
+  getCampaigns(args: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Campaign>>;
+
   getRank(safeAddress: `0x${string}`): Promise<Rank>;
 
   getLeaderboard(args: {

--- a/src/domain/locking/locking.repository.ts
+++ b/src/domain/locking/locking.repository.ts
@@ -29,7 +29,7 @@ export class LockingRepository implements ILockingRepository {
     limit?: number | undefined;
     offset?: number | undefined;
   }): Promise<Page<Campaign>> {
-    const page = await this.getCampaigns(args);
+    const page = await this.lockingApi.getCampaigns(args);
     return CampaignPageSchema.parse(page);
   }
 

--- a/src/domain/locking/locking.repository.ts
+++ b/src/domain/locking/locking.repository.ts
@@ -1,5 +1,9 @@
 import { Page } from '@/domain/entities/page.entity';
 import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
+import {
+  Campaign,
+  CampaignPageSchema,
+} from '@/domain/locking/entities/campaign.entity';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
 import { LockingEventPageSchema } from '@/domain/locking/entities/schemas/locking-event.schema';
@@ -16,6 +20,18 @@ export class LockingRepository implements ILockingRepository {
     @Inject(ILockingApi)
     private readonly lockingApi: ILockingApi,
   ) {}
+
+  async getCampaignById(campaignId: string): Promise<Campaign> {
+    return this.lockingApi.getCampaignById(campaignId);
+  }
+
+  async getCampaigns(args: {
+    limit?: number | undefined;
+    offset?: number | undefined;
+  }): Promise<Page<Campaign>> {
+    const page = await this.getCampaigns(args);
+    return CampaignPageSchema.parse(page);
+  }
 
   async getRank(safeAddress: `0x${string}`): Promise<Rank> {
     const rank = await this.lockingApi.getRank(safeAddress);

--- a/src/routes/locking/entities/activity-metadata.entity.ts
+++ b/src/routes/locking/entities/activity-metadata.entity.ts
@@ -1,0 +1,13 @@
+import { ActivityMetadata as DomainActivityMetadata } from '@/domain/locking/entities/activity-metadata.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ActivityMetadata implements DomainActivityMetadata {
+  @ApiProperty()
+  campaignId!: string;
+  @ApiProperty()
+  name!: string;
+  @ApiProperty()
+  description!: string;
+  @ApiProperty()
+  maxPoints!: string;
+}

--- a/src/routes/locking/entities/campaign.entity.ts
+++ b/src/routes/locking/entities/campaign.entity.ts
@@ -1,0 +1,20 @@
+import { Campaign as DomainCampaign } from '@/domain/locking/entities/campaign.entity';
+import { ActivityMetadata } from '@/routes/locking/entities/activity-metadata.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Campaign implements DomainCampaign {
+  @ApiProperty()
+  campaignId!: string;
+  @ApiProperty()
+  name!: string;
+  @ApiProperty()
+  description!: string;
+  @ApiProperty({ type: String })
+  periodStart!: Date;
+  @ApiProperty({ type: String })
+  periodEnd!: Date;
+  @ApiProperty({ type: String })
+  lastUpdated!: Date;
+  @ApiProperty({ type: [ActivityMetadata] })
+  activities!: ActivityMetadata[] | null;
+}

--- a/src/routes/locking/entities/campaign.page.entity.ts
+++ b/src/routes/locking/entities/campaign.page.entity.ts
@@ -1,0 +1,8 @@
+import { Page } from '@/routes/common/entities/page.entity';
+import { Campaign } from '@/routes/locking/entities/campaign.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CampaignPage extends Page<Campaign> {
+  @ApiProperty({ type: [Campaign] })
+  results!: Array<Campaign>;
+}

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -120,7 +120,6 @@ describe('Locking (Unit)', () => {
             periodStart: campaign.periodStart.toISOString(),
             periodEnd: campaign.periodEnd.toISOString(),
             lastUpdated: campaign.lastUpdated.toISOString(),
-            activities: null,
           })),
         });
     });
@@ -183,7 +182,6 @@ describe('Locking (Unit)', () => {
             periodStart: campaign.periodStart.toISOString(),
             periodEnd: campaign.periodEnd.toISOString(),
             lastUpdated: campaign.lastUpdated.toISOString(),
-            activities: null,
           })),
         });
 

--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -9,6 +9,8 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { Controller, Get, Param } from '@nestjs/common';
 import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Campaign } from '@/routes/locking/entities/campaign.entity';
+import { CampaignPage } from '@/routes/locking/entities/campaign.page.entity';
 
 @ApiTags('locking')
 @Controller({
@@ -17,6 +19,28 @@ import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 })
 export class LockingController {
   constructor(private readonly lockingService: LockingService) {}
+
+  @ApiOkResponse({ type: Campaign })
+  @Get('/campaigns/:campaignId')
+  async getCampaignById(
+    @Param('campaignId') campaignId: string,
+  ): Promise<Campaign> {
+    return this.lockingService.getCampaignById(campaignId);
+  }
+
+  @ApiOkResponse({ type: CampaignPage })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+  })
+  @Get('/campaigns')
+  async getCampaigns(
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<CampaignPage> {
+    return this.lockingService.getCampaigns({ routeUrl, paginationData });
+  }
 
   @ApiOkResponse({ type: Rank })
   @Get('/leaderboard/rank/:safeAddress')

--- a/src/routes/locking/locking.service.ts
+++ b/src/routes/locking/locking.service.ts
@@ -1,4 +1,5 @@
 import { Page } from '@/domain/entities/page.entity';
+import { Campaign } from '@/domain/locking/entities/campaign.entity';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { Rank } from '@/domain/locking/entities/rank.entity';
 import { ILockingRepository } from '@/domain/locking/locking.repository.interface';
@@ -14,6 +15,32 @@ export class LockingService {
     @Inject(ILockingRepository)
     private readonly lockingRepository: ILockingRepository,
   ) {}
+
+  async getCampaignById(campaignId: string): Promise<Campaign> {
+    return this.lockingRepository.getCampaignById(campaignId);
+  }
+
+  async getCampaigns(args: {
+    routeUrl: URL;
+    paginationData: PaginationData;
+  }): Promise<Page<Campaign>> {
+    const result = await this.lockingRepository.getCampaigns(
+      args.paginationData,
+    );
+
+    const nextUrl = cursorUrlFromLimitAndOffset(args.routeUrl, result.next);
+    const previousUrl = cursorUrlFromLimitAndOffset(
+      args.routeUrl,
+      result.previous,
+    );
+
+    return {
+      count: result.count,
+      next: nextUrl?.toString() ?? null,
+      previous: previousUrl?.toString() ?? null,
+      results: result.results,
+    };
+  }
 
   async getRank(safeAddress: `0x${string}`): Promise<Rank> {
     return this.lockingRepository.getRank(safeAddress);


### PR DESCRIPTION
## Changes
- Adds the following endpoints to the service:
  - `GET /api/v1/locking/campaigns`
  - `GET /api/v1/locking/campaigns/:campaignId`
