### PR TITLE
Add `toJson` helpers for locking controller tests

### DIFF
--- a/src/domain/locking/entities/__tests__/campaign.builder.ts
+++ b/src/domain/locking/entities/__tests__/campaign.builder.ts
@@ -18,3 +18,12 @@ export function campaignBuilder(): IBuilder<Campaign> {
       ),
     );
 }
+
+export function toJson(campaign: Campaign): unknown {
+  return {
+    ...campaign,
+    startDate: campaign.startDate.toISOString(),
+    endDate: campaign.endDate.toISOString(),
+    lastUpdated: campaign.lastUpdated.toISOString(),
+  };
+}

--- a/src/domain/locking/entities/__tests__/locking-event.builder.ts
+++ b/src/domain/locking/entities/__tests__/locking-event.builder.ts
@@ -45,3 +45,12 @@ export function withdrawEventItemBuilder(): IBuilder<WithdrawEventItem> {
     .with('unlockIndex', faker.string.numeric())
     .with('logIndex', faker.string.numeric());
 }
+
+export function toJson(
+  event: LockEventItem | UnlockEventItem | WithdrawEventItem,
+): unknown {
+  return {
+    ...event,
+    executionDate: event.executionDate.toISOString(),
+  };
+}

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -22,6 +22,7 @@ import {
   lockEventItemBuilder,
   unlockEventItemBuilder,
   withdrawEventItemBuilder,
+  toJson as lockingEventToJson,
 } from '@/domain/locking/entities/__tests__/locking-event.builder';
 import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
@@ -31,7 +32,10 @@ import { rankBuilder } from '@/domain/locking/entities/__tests__/rank.builder';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
-import { campaignBuilder } from '@/domain/locking/entities/__tests__/campaign.builder';
+import {
+  campaignBuilder,
+  toJson as campaignToJson,
+} from '@/domain/locking/entities/__tests__/campaign.builder';
 import { Campaign } from '@/domain/locking/entities/campaign.entity';
 
 describe('Locking (Unit)', () => {
@@ -84,12 +88,7 @@ describe('Locking (Unit)', () => {
       await request(app.getHttpServer())
         .get(`/v1/locking/campaigns/${campaign.campaignId}`)
         .expect(200)
-        .expect({
-          ...campaign,
-          startDate: campaign.startDate.toISOString(),
-          endDate: campaign.endDate.toISOString(),
-          lastUpdated: campaign.lastUpdated.toISOString(),
-        });
+        .expect(campaignToJson(campaign) as Campaign);
     });
 
     it('should get the list of campaigns', async () => {
@@ -115,12 +114,7 @@ describe('Locking (Unit)', () => {
           count: 1,
           next: null,
           previous: null,
-          results: campaignsPage.results.map((campaign) => ({
-            ...campaign,
-            startDate: campaign.startDate.toISOString(),
-            endDate: campaign.endDate.toISOString(),
-            lastUpdated: campaign.lastUpdated.toISOString(),
-          })),
+          results: campaignsPage.results.map(campaignToJson),
         });
     });
 
@@ -177,12 +171,7 @@ describe('Locking (Unit)', () => {
           count: 1,
           next: null,
           previous: null,
-          results: campaignsPage.results.map((campaign) => ({
-            ...campaign,
-            startDate: campaign.startDate.toISOString(),
-            endDate: campaign.endDate.toISOString(),
-            lastUpdated: campaign.lastUpdated.toISOString(),
-          })),
+          results: campaignsPage.results.map(campaignToJson),
         });
 
       expect(networkService.get).toHaveBeenCalledWith({
@@ -476,10 +465,7 @@ describe('Locking (Unit)', () => {
           count: lockingHistoryPage.count,
           next: null,
           previous: null,
-          results: lockingHistoryPage.results.map((result) => ({
-            ...result,
-            executionDate: result.executionDate.toISOString(),
-          })),
+          results: lockingHistoryPage.results.map(lockingEventToJson),
         });
 
       expect(networkService.get).toHaveBeenCalledWith({
@@ -527,10 +513,7 @@ describe('Locking (Unit)', () => {
           count: lockingHistoryPage.count,
           next: null,
           previous: null,
-          results: lockingHistoryPage.results.map((result) => ({
-            ...result,
-            executionDate: result.executionDate.toISOString(),
-          })),
+          results: lockingHistoryPage.results.map(lockingEventToJson),
         });
 
       expect(networkService.get).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

Our locking controller tests often need to convert `Date` objects to ISO strings. In other areas of the project, we have `toJson` wrappers that automatically do this for given data structures. This adds the equivalent for locking events and campaigns.

## Changes

- Add `Campaign`-specific `toJson` helper
- Add `LockEventItem | UnlockEventItem | WithdrawEventItem`-specific `toJson` helper
- Use the above in their respective tests