### PR TITLE
Move `/locking` and `/campaign` routes under `/community`

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { ConfigurationModule } from '@/config/configuration.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { CacheHooksModule } from '@/routes/cache-hooks/cache-hooks.module';
 import { CollectiblesModule } from '@/routes/collectibles/collectibles.module';
+import { CommunityModule } from '@/routes/community/community.module';
 import { ContractsModule } from '@/routes/contracts/contracts.module';
 import { DataDecodedModule } from '@/routes/data-decode/data-decoded.module';
 import { DelegatesModule } from '@/routes/delegates/delegates.module';
@@ -70,6 +71,7 @@ export class AppModule implements NestModule {
         CacheHooksModule,
         ChainsModule,
         CollectiblesModule,
+        CommunityModule,
         ContractsModule,
         DataDecodedModule,
         // TODO: delete/rename DelegatesModule when clients migration to v2 is completed.

--- a/src/domain/locking/locking.domain.module.ts
+++ b/src/domain/locking/locking.domain.module.ts
@@ -8,4 +8,5 @@ import { LockingRepository } from '@/domain/locking/locking.repository';
   providers: [{ provide: ILockingRepository, useClass: LockingRepository }],
   exports: [ILockingRepository],
 })
+// TODO: Convert to CommunityDomainModule
 export class LockingDomainModule {}

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -1,0 +1,801 @@
+import * as request from 'supertest';
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { AppModule } from '@/app.module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import {
+  lockEventItemBuilder,
+  unlockEventItemBuilder,
+  withdrawEventItemBuilder,
+  toJson as lockingEventToJson,
+} from '@/domain/locking/entities/__tests__/locking-event.builder';
+import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
+import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
+import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
+import { getAddress } from 'viem';
+import { rankBuilder } from '@/domain/locking/entities/__tests__/rank.builder';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import {
+  campaignBuilder,
+  toJson as campaignToJson,
+} from '@/domain/locking/entities/__tests__/campaign.builder';
+import { Campaign } from '@/domain/locking/entities/campaign.entity';
+import { CampaignRank } from '@/domain/locking/entities/campaign-rank.entity';
+import { campaignRankBuilder } from '@/domain/locking/entities/__tests__/campaign-rank.builder';
+
+describe('Community (Unit)', () => {
+  let app: INestApplication;
+  let lockingBaseUri: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration)],
+    })
+      .overrideModule(AccountDataSourceModule)
+      .useModule(TestAccountDataSourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
+      .compile();
+
+    const configurationService = moduleFixture.get(IConfigurationService);
+    lockingBaseUri = configurationService.get('locking.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /community/campaigns', () => {
+    it('should get the list of campaigns', async () => {
+      const campaignsPage = pageBuilder<Campaign>()
+        .with('results', [campaignBuilder().build()])
+        .with('count', 1)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns`:
+            return Promise.resolve({ data: campaignsPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns`)
+        .expect(200)
+        .expect({
+          count: 1,
+          next: null,
+          previous: null,
+          results: campaignsPage.results.map(campaignToJson),
+        });
+    });
+
+    it('should validate the list of campaigns', async () => {
+      const invalidCampaigns = [{ invalid: 'campaign' }];
+      const campaignsPage = pageBuilder()
+        .with('results', invalidCampaigns)
+        .with('count', 1)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns`:
+            return Promise.resolve({ data: campaignsPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward the pagination parameters', async () => {
+      const limit = faker.number.int({ min: 1, max: 10 });
+      const offset = faker.number.int({ min: 1, max: 10 });
+      const campaignsPage = pageBuilder<Campaign>()
+        .with('results', [campaignBuilder().build()])
+        .with('count', 1)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns`:
+            return Promise.resolve({ data: campaignsPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/community/campaigns?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        )
+        .expect(200)
+        .expect({
+          count: 1,
+          next: null,
+          previous: null,
+          results: campaignsPage.results.map(campaignToJson),
+        });
+
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/campaigns`,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    it('should forward errors from the service', async () => {
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/api/v1/campaigns`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
+  describe('GET /community/campaigns/:campaignId', () => {
+    it('should get a campaign by ID', async () => {
+      const campaign = campaignBuilder().build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`:
+            return Promise.resolve({ data: campaign, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${campaign.campaignId}`)
+        .expect(200)
+        .expect(campaignToJson(campaign) as Campaign);
+    });
+
+    // TODO: Enable when validation is implemented
+    it.skip('should validate the response', async () => {
+      const invalidCampaign = {
+        campaignId: faker.string.uuid(),
+        invalid: 'campaign',
+      };
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${invalidCampaign.campaignId}`:
+            return Promise.resolve({ data: invalidCampaign, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${invalidCampaign.campaignId}`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const campaignId = faker.string.uuid();
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${campaignId}`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/api/v1/campaigns/${campaignId}`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${campaignId}`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
+  describe('GET /community/campaigns/:campaignId/leaderboard', () => {
+    it('should get the leaderboard by campaign ID', async () => {
+      const campaign = campaignBuilder().build();
+      const campaignRankPage = pageBuilder<CampaignRank>()
+        .with('results', [
+          campaignRankBuilder().build(),
+          campaignRankBuilder().build(),
+        ])
+        .with('count', 2)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+            return Promise.resolve({ data: campaignRankPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${campaign.campaignId}/leaderboard`)
+        .expect(200)
+        .expect({
+          count: 2,
+          next: null,
+          previous: null,
+          results: campaignRankPage.results,
+        });
+    });
+
+    it('should validate the response', async () => {
+      const campaign = campaignBuilder().build();
+      const invalidCampaignRanks = [{ invalid: 'campaignRank' }];
+      const campaignRankPage = pageBuilder()
+        .with('results', invalidCampaignRanks)
+        .with('count', invalidCampaignRanks.length)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+            return Promise.resolve({ data: campaignRankPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${campaign.campaignId}/leaderboard`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward the pagination parameters', async () => {
+      const limit = faker.number.int({ min: 1, max: 10 });
+      const offset = faker.number.int({ min: 1, max: 10 });
+      const campaign = campaignBuilder().build();
+      const campaignRankPage = pageBuilder<CampaignRank>()
+        .with('results', [
+          campaignRankBuilder().build(),
+          campaignRankBuilder().build(),
+        ])
+        .with('count', 2)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+            return Promise.resolve({ data: campaignRankPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/community/campaigns/${campaign.campaignId}/leaderboard?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        )
+        .expect(200)
+        .expect({
+          count: 2,
+          next: null,
+          previous: null,
+          results: campaignRankPage.results,
+        });
+
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    it('should forward errors from the service', async () => {
+      const campaign = campaignBuilder().build();
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(url),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${campaign.campaignId}/leaderboard`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
+  describe('GET /community/locking/leaderboard', () => {
+    it('should get the leaderboard', async () => {
+      const leaderboard = pageBuilder()
+        .with('results', [rankBuilder().build()])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.resolve({ data: leaderboard, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/leaderboard`)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            count: leaderboard.count,
+            next: expect.any(String),
+            previous: expect.any(String),
+            results: leaderboard.results,
+          });
+        });
+
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/leaderboard`,
+        networkRequest: {
+          params: {
+            limit: PaginationData.DEFAULT_LIMIT,
+            offset: PaginationData.DEFAULT_OFFSET,
+          },
+        },
+      });
+    });
+
+    it('should forward the pagination parameters', async () => {
+      const limit = faker.number.int({ min: 1, max: 10 });
+      const offset = faker.number.int({ min: 1, max: 10 });
+      const leaderboard = pageBuilder()
+        .with('results', [rankBuilder().build()])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.resolve({ data: leaderboard, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/community/locking/leaderboard?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        )
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            count: leaderboard.count,
+            next: expect.any(String),
+            previous: expect.any(String),
+            results: leaderboard.results,
+          });
+        });
+
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/leaderboard`,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    it('should validate the response', async () => {
+      const leaderboard = pageBuilder()
+        .with('results', [{ invalid: 'rank' }])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.resolve({ data: leaderboard, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/leaderboard`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/api/v1/leaderboard`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/leaderboard`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
+  describe('GET /community/locking/:safeAddress/rank', () => {
+    it('should get the rank', async () => {
+      const rank = rankBuilder().build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard/${rank.holder}`:
+            return Promise.resolve({ data: rank, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${rank.holder}/rank`)
+        .expect(200)
+        .expect(rank);
+    });
+
+    it('should validate the Safe address in URL', async () => {
+      const safeAddress = faker.string.alphanumeric();
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/rank`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'Invalid address',
+          path: [],
+        });
+    });
+
+    it('should validate the response', async () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const rank = { invalid: 'rank' };
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
+            return Promise.resolve({ data: rank, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/rank`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/rank`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
+  describe('GET /community/locking/:safeAddress/history', () => {
+    it('should get locking history', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const lockingHistory = [
+        lockEventItemBuilder().build(),
+        unlockEventItemBuilder().build(),
+        withdrawEventItemBuilder().build(),
+      ];
+      const lockingHistoryPage = pageBuilder<LockingEvent>()
+        .with('results', lockingHistory)
+        .with('count', lockingHistory.length)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          // Service will have checksummed address
+          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
+            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/history`)
+        .expect(200)
+        .expect({
+          count: lockingHistoryPage.count,
+          next: null,
+          previous: null,
+          results: lockingHistoryPage.results.map(lockingEventToJson),
+        });
+
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`,
+        networkRequest: {
+          params: {
+            limit: PaginationData.DEFAULT_LIMIT,
+            offset: PaginationData.DEFAULT_OFFSET,
+          },
+        },
+      });
+    });
+
+    it('should forward the pagination parameters', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const limit = faker.number.int({ min: 1, max: 10 });
+      const offset = faker.number.int({ min: 1, max: 10 });
+      const lockingHistory = [
+        lockEventItemBuilder().build(),
+        unlockEventItemBuilder().build(),
+        withdrawEventItemBuilder().build(),
+      ];
+      const lockingHistoryPage = pageBuilder<LockingEvent>()
+        .with('results', lockingHistory)
+        .with('count', lockingHistory.length)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          // Service will have checksummed address
+          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
+            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/community/locking/${safeAddress}/history?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        )
+        .expect(200)
+        .expect({
+          count: lockingHistoryPage.count,
+          next: null,
+          previous: null,
+          results: lockingHistoryPage.results.map(lockingEventToJson),
+        });
+
+      expect(networkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`,
+        networkRequest: {
+          params: {
+            limit,
+            offset,
+          },
+        },
+      });
+    });
+
+    it('should validate the Safe address in URL', async () => {
+      const safeAddress = faker.string.alphanumeric();
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/history`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'Invalid address',
+          path: [],
+        });
+    });
+
+    it('should validate the response', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const invalidLockingHistory = [{ invalid: 'value' }];
+      const lockingHistoryPage = pageBuilder()
+        .with('results', invalidLockingHistory)
+        .with('count', invalidLockingHistory.length)
+        .with('previous', null)
+        .with('next', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          // Service will have checksummed address
+          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
+            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/history`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(`${lockingBaseUri}/v1/locking/${safeAddress}/history`),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/locking/${safeAddress}/history`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+});

--- a/src/routes/community/community.controller.ts
+++ b/src/routes/community/community.controller.ts
@@ -1,0 +1,110 @@
+import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
+import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { CommunityService } from '@/routes/community/community.service';
+import { CampaignRankPage } from '@/routes/locking/entities/campaign-rank.page.entity';
+import { Campaign } from '@/routes/locking/entities/campaign.entity';
+import { CampaignPage } from '@/routes/locking/entities/campaign.page.entity';
+import { LockingEventPage } from '@/routes/locking/entities/locking-event.page.entity';
+import { Rank } from '@/routes/locking/entities/rank.entity';
+import { RankPage } from '@/routes/locking/entities/rank.page.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiTags, ApiOkResponse, ApiQuery } from '@nestjs/swagger';
+
+@ApiTags('community')
+@Controller({
+  path: 'community',
+  version: '1',
+})
+export class CommunityController {
+  constructor(private readonly communityService: CommunityService) {}
+
+  @ApiOkResponse({ type: CampaignPage })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+  })
+  @Get('/campaigns')
+  async getCampaigns(
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<CampaignPage> {
+    return this.communityService.getCampaigns({ routeUrl, paginationData });
+  }
+
+  @ApiOkResponse({ type: Campaign })
+  @Get('/campaigns/:campaignId')
+  async getCampaignById(
+    @Param('campaignId') campaignId: string,
+  ): Promise<Campaign> {
+    return this.communityService.getCampaignById(campaignId);
+  }
+
+  @ApiOkResponse({ type: CampaignRankPage })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+  })
+  @Get('/campaigns/:campaignId/leaderboard')
+  async getCampaignLeaderboard(
+    @Param('campaignId') campaignId: string,
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<CampaignRankPage> {
+    return this.communityService.getCampaignLeaderboard({
+      campaignId,
+      routeUrl,
+      paginationData,
+    });
+  }
+
+  @ApiOkResponse({ type: RankPage })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+  })
+  @Get('/locking/leaderboard')
+  async getLeaderboard(
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<RankPage> {
+    return this.communityService.getLockingLeaderboard({
+      routeUrl,
+      paginationData,
+    });
+  }
+
+  @ApiOkResponse({ type: Rank })
+  @Get('/locking/:safeAddress/rank')
+  async getRank(
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+  ): Promise<Rank> {
+    return this.communityService.getLockingRank(safeAddress);
+  }
+
+  @ApiOkResponse({ type: LockingEventPage })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+  })
+  @Get('/locking/:safeAddress/history')
+  async getLockingHistory(
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<LockingEventPage> {
+    return this.communityService.getLockingHistory({
+      safeAddress,
+      routeUrl,
+      paginationData,
+    });
+  }
+}

--- a/src/routes/community/community.module.ts
+++ b/src/routes/community/community.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { LockingDomainModule } from '@/domain/locking/locking.domain.module';
+import { CommunityService } from '@/routes/community/community.service';
+import { CommunityController } from '@/routes/community/community.controller';
+
+@Module({
+  imports: [LockingDomainModule],
+  providers: [CommunityService],
+  controllers: [CommunityController],
+})
+export class CommunityModule {}

--- a/src/routes/community/community.service.ts
+++ b/src/routes/community/community.service.ts
@@ -11,15 +11,11 @@ import {
 import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class LockingService {
+export class CommunityService {
   constructor(
     @Inject(ILockingRepository)
     private readonly lockingRepository: ILockingRepository,
   ) {}
-
-  async getCampaignById(campaignId: string): Promise<Campaign> {
-    return this.lockingRepository.getCampaignById(campaignId);
-  }
 
   async getCampaigns(args: {
     routeUrl: URL;
@@ -43,30 +39,8 @@ export class LockingService {
     };
   }
 
-  async getRank(safeAddress: `0x${string}`): Promise<Rank> {
-    return this.lockingRepository.getRank(safeAddress);
-  }
-
-  async getLeaderboard(args: {
-    routeUrl: URL;
-    paginationData: PaginationData;
-  }): Promise<Page<Rank>> {
-    const result = await this.lockingRepository.getLeaderboard(
-      args.paginationData,
-    );
-
-    const nextUrl = cursorUrlFromLimitAndOffset(args.routeUrl, result.next);
-    const previousUrl = cursorUrlFromLimitAndOffset(
-      args.routeUrl,
-      result.previous,
-    );
-
-    return {
-      count: result.count,
-      next: nextUrl?.toString() ?? null,
-      previous: previousUrl?.toString() ?? null,
-      results: result.results,
-    };
+  async getCampaignById(campaignId: string): Promise<Campaign> {
+    return this.lockingRepository.getCampaignById(campaignId);
   }
 
   async getCampaignLeaderboard(args: {
@@ -92,6 +66,32 @@ export class LockingService {
       previous: previousUrl?.toString() ?? null,
       results: result.results,
     };
+  }
+
+  async getLockingLeaderboard(args: {
+    routeUrl: URL;
+    paginationData: PaginationData;
+  }): Promise<Page<Rank>> {
+    const result = await this.lockingRepository.getLeaderboard(
+      args.paginationData,
+    );
+
+    const nextUrl = cursorUrlFromLimitAndOffset(args.routeUrl, result.next);
+    const previousUrl = cursorUrlFromLimitAndOffset(
+      args.routeUrl,
+      result.previous,
+    );
+
+    return {
+      count: result.count,
+      next: nextUrl?.toString() ?? null,
+      previous: previousUrl?.toString() ?? null,
+      results: result.results,
+    };
+  }
+
+  async getLockingRank(safeAddress: `0x${string}`): Promise<Rank> {
+    return this.lockingRepository.getRank(safeAddress);
   }
 
   async getLockingHistory(args: {

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -4,46 +4,20 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AppModule } from '@/app.module';
-import { IConfigurationService } from '@/config/configuration.service.interface';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { NetworkModule } from '@/datasources/network/network.module';
-import {
-  INetworkService,
-  NetworkService,
-} from '@/datasources/network/network.service.interface';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import configuration from '@/config/entities/__tests__/configuration';
-import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
-import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
-import {
-  lockEventItemBuilder,
-  unlockEventItemBuilder,
-  withdrawEventItemBuilder,
-  toJson as lockingEventToJson,
-} from '@/domain/locking/entities/__tests__/locking-event.builder';
-import { LockingEvent } from '@/domain/locking/entities/locking-event.entity';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
-import { getAddress } from 'viem';
-import { rankBuilder } from '@/domain/locking/entities/__tests__/rank.builder';
-import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
-import {
-  campaignBuilder,
-  toJson as campaignToJson,
-} from '@/domain/locking/entities/__tests__/campaign.builder';
-import { Campaign } from '@/domain/locking/entities/campaign.entity';
-import { CampaignRank } from '@/domain/locking/entities/campaign-rank.entity';
-import { campaignRankBuilder } from '@/domain/locking/entities/__tests__/campaign-rank.builder';
 
 describe('Locking (Unit)', () => {
   let app: INestApplication;
-  let lockingBaseUri: string;
-  let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -63,10 +37,6 @@ describe('Locking (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    lockingBaseUri = configurationService.get('locking.baseUri');
-    networkService = moduleFixture.get(NetworkService);
-
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
@@ -75,668 +45,70 @@ describe('Locking (Unit)', () => {
     await app.close();
   });
 
-  describe('GET campaign', () => {
-    it('should get the campaign', async () => {
-      const campaign = campaignBuilder().build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`:
-            return Promise.resolve({ data: campaign, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns/${campaign.campaignId}`)
-        .expect(200)
-        .expect(campaignToJson(campaign) as Campaign);
-    });
-
-    it('should get the list of campaigns', async () => {
-      const campaignsPage = pageBuilder<Campaign>()
-        .with('results', [campaignBuilder().build()])
-        .with('count', 1)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.resolve({ data: campaignsPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns`)
-        .expect(200)
-        .expect({
-          count: 1,
-          next: null,
-          previous: null,
-          results: campaignsPage.results.map(campaignToJson),
-        });
-    });
-
-    it('should validate the list of campaigns', async () => {
-      const invalidCampaigns = [{ invalid: 'campaign' }];
-      const campaignsPage = pageBuilder()
-        .with('results', invalidCampaigns)
-        .with('count', 1)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.resolve({ data: campaignsPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns`)
-        .expect(500)
-        .expect({
-          statusCode: 500,
-          message: 'Internal server error',
-        });
-    });
-
-    it('should forward the pagination parameters', async () => {
-      const limit = faker.number.int({ min: 1, max: 10 });
-      const offset = faker.number.int({ min: 1, max: 10 });
-      const campaignsPage = pageBuilder<Campaign>()
-        .with('results', [campaignBuilder().build()])
-        .with('count', 1)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.resolve({ data: campaignsPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(
-          `/v1/locking/campaigns?cursor=limit%3D${limit}%26offset%3D${offset}`,
-        )
-        .expect(200)
-        .expect({
-          count: 1,
-          next: null,
-          previous: null,
-          results: campaignsPage.results.map(campaignToJson),
-        });
-
-      expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaigns`,
-        networkRequest: {
-          params: {
-            limit,
-            offset,
-          },
-        },
-      });
-    });
-
-    it('should forward errors from the service', async () => {
-      const statusCode = faker.internet.httpStatusCode({
-        types: ['clientError', 'serverError'],
-      });
-      const errorMessage = faker.word.words();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.reject(
-              new NetworkResponseError(
-                new URL(`${lockingBaseUri}/api/v1/campaigns`),
-                {
-                  status: statusCode,
-                } as Response,
-                { message: errorMessage, status: statusCode },
-              ),
-            );
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns`)
-        .expect(statusCode)
-        .expect({
-          message: errorMessage,
-          code: statusCode,
-        });
-    });
-  });
-
-  describe('GET leaderboard by campaign', () => {
-    it('should get the leaderboard by campaign', async () => {
-      const campaign = campaignBuilder().build();
-      const campaignRankPage = pageBuilder<CampaignRank>()
-        .with('results', [
-          campaignRankBuilder().build(),
-          campaignRankBuilder().build(),
-        ])
-        .with('count', 2)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
-            return Promise.resolve({ data: campaignRankPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns/${campaign.campaignId}/leaderboard`)
-        .expect(200)
-        .expect({
-          count: 2,
-          next: null,
-          previous: null,
-          results: campaignRankPage.results,
-        });
-    });
-
-    it('should validate the response', async () => {
-      const campaign = campaignBuilder().build();
-      const invalidCampaignRanks = [{ invalid: 'campaignRank' }];
-      const campaignRankPage = pageBuilder()
-        .with('results', invalidCampaignRanks)
-        .with('count', invalidCampaignRanks.length)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
-            return Promise.resolve({ data: campaignRankPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns/${campaign.campaignId}/leaderboard`)
-        .expect(500)
-        .expect({
-          statusCode: 500,
-          message: 'Internal server error',
-        });
-    });
-
-    it('should forward the pagination parameters', async () => {
-      const limit = faker.number.int({ min: 1, max: 10 });
-      const offset = faker.number.int({ min: 1, max: 10 });
-      const campaign = campaignBuilder().build();
-      const campaignRankPage = pageBuilder<CampaignRank>()
-        .with('results', [
-          campaignRankBuilder().build(),
-          campaignRankBuilder().build(),
-        ])
-        .with('count', 2)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
-            return Promise.resolve({ data: campaignRankPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(
-          `/v1/locking/campaigns/${campaign.campaignId}/leaderboard?cursor=limit%3D${limit}%26offset%3D${offset}`,
-        )
-        .expect(200)
-        .expect({
-          count: 2,
-          next: null,
-          previous: null,
-          results: campaignRankPage.results,
-        });
-
-      expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`,
-        networkRequest: {
-          params: {
-            limit,
-            offset,
-          },
-        },
-      });
-    });
-
-    it('should forward errors from the service', async () => {
-      const campaign = campaignBuilder().build();
-      const statusCode = faker.internet.httpStatusCode({
-        types: ['clientError', 'serverError'],
-      });
-      const errorMessage = faker.word.words();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
-            return Promise.reject(
-              new NetworkResponseError(
-                new URL(url),
-                {
-                  status: statusCode,
-                } as Response,
-                { message: errorMessage, status: statusCode },
-              ),
-            );
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/campaigns/${campaign.campaignId}/leaderboard`)
-        .expect(statusCode)
-        .expect({
-          message: errorMessage,
-          code: statusCode,
-        });
-    });
-  });
-
-  describe('GET rank', () => {
-    it('should get the rank', async () => {
-      const rank = rankBuilder().build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard/${rank.holder}`:
-            return Promise.resolve({ data: rank, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/rank/${rank.holder}`)
-        .expect(200)
-        .expect(rank);
-    });
-
-    it('should validate the Safe address in URL', async () => {
-      const safeAddress = faker.string.alphanumeric();
+  describe('GET /locking/leaderboard/rank/:safeAddress', () => {
+    it('should return 302 and redirect to the new endpoint', async () => {
+      const safeAddress = faker.finance.ethereumAddress();
 
       await request(app.getHttpServer())
         .get(`/v1/locking/leaderboard/rank/${safeAddress}`)
-        .expect(422)
-        .expect({
-          statusCode: 422,
-          code: 'custom',
-          message: 'Invalid address',
-          path: [],
-        });
-    });
-
-    it('should validate the response', async () => {
-      const safeAddress = getAddress(faker.finance.ethereumAddress());
-      const rank = { invalid: 'rank' };
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
-            return Promise.resolve({ data: rank, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/rank/${safeAddress}`)
-        .expect(500)
-        .expect({
-          statusCode: 500,
-          message: 'Internal server error',
-        });
-    });
-
-    it('should forward an error from the service', async () => {
-      const safeAddress = getAddress(faker.finance.ethereumAddress());
-      const statusCode = faker.internet.httpStatusCode({
-        types: ['clientError', 'serverError'],
-      });
-      const errorMessage = faker.word.words();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
-            return Promise.reject(
-              new NetworkResponseError(
-                new URL(`${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`),
-                {
-                  status: statusCode,
-                } as Response,
-                { message: errorMessage, status: statusCode },
-              ),
-            );
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard/rank/${safeAddress}`)
-        .expect(statusCode)
-        .expect({
-          message: errorMessage,
-          code: statusCode,
+        .expect(308)
+        .expect((res) => {
+          expect(res.get('location')).toBe(
+            `/v1/community/locking/${safeAddress}/rank`,
+          );
         });
     });
   });
 
-  describe('GET leaderboard', () => {
-    it('should get the leaderboard', async () => {
-      const leaderboard = pageBuilder()
-        .with('results', [rankBuilder().build()])
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.resolve({ data: leaderboard, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
+  describe('GET /locking/leaderboard', () => {
+    it('should return 302 and redirect to the new endpoint', async () => {
       await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard`)
-        .expect(200)
-        .expect(({ body }) => {
-          expect(body).toEqual({
-            count: leaderboard.count,
-            next: expect.any(String),
-            previous: expect.any(String),
-            results: leaderboard.results,
-          });
-        });
-
-      expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/leaderboard`,
-        networkRequest: {
-          params: {
-            limit: PaginationData.DEFAULT_LIMIT,
-            offset: PaginationData.DEFAULT_OFFSET,
-          },
-        },
-      });
-    });
-
-    it('should forward the pagination parameters', async () => {
-      const limit = faker.number.int({ min: 1, max: 10 });
-      const offset = faker.number.int({ min: 1, max: 10 });
-      const leaderboard = pageBuilder()
-        .with('results', [rankBuilder().build()])
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.resolve({ data: leaderboard, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(
-          `/v1/locking/leaderboard?cursor=limit%3D${limit}%26offset%3D${offset}`,
-        )
-        .expect(200)
-        .expect(({ body }) => {
-          expect(body).toEqual({
-            count: leaderboard.count,
-            next: expect.any(String),
-            previous: expect.any(String),
-            results: leaderboard.results,
-          });
-        });
-
-      expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/leaderboard`,
-        networkRequest: {
-          params: {
-            limit,
-            offset,
-          },
-        },
-      });
-    });
-
-    it('should validate the response', async () => {
-      const leaderboard = pageBuilder()
-        .with('results', [{ invalid: 'rank' }])
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.resolve({ data: leaderboard, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard`)
-        .expect(500)
-        .expect({
-          statusCode: 500,
-          message: 'Internal server error',
+        .get('/v1/locking/leaderboard')
+        .expect(308)
+        .expect((res) => {
+          expect(res.get('location')).toBe('/v1/community/locking/leaderboard');
         });
     });
 
-    it('should forward an error from the service', async () => {
-      const statusCode = faker.internet.httpStatusCode({
-        types: ['clientError', 'serverError'],
-      });
-      const errorMessage = faker.word.words();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.reject(
-              new NetworkResponseError(
-                new URL(`${lockingBaseUri}/api/v1/leaderboard`),
-                {
-                  status: statusCode,
-                } as Response,
-                { message: errorMessage, status: statusCode },
-              ),
-            );
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
+    it('should return 302 and redirect to the new endpoint with cursor', async () => {
+      const cursor = 'limit%3Daa%26offset%3D2';
 
       await request(app.getHttpServer())
-        .get(`/v1/locking/leaderboard`)
-        .expect(statusCode)
-        .expect({
-          message: errorMessage,
-          code: statusCode,
+        .get(`/v1/locking/leaderboard/?cursor=${cursor}`)
+        .expect(308)
+        .expect((res) => {
+          expect(res.get('location')).toBe(
+            `/v1/community/locking/leaderboard/?cursor=${cursor}`,
+          );
         });
     });
   });
 
-  describe('GET locking history', () => {
-    it('should get locking history', async () => {
+  describe('GET /locking/:safeAddress/history', () => {
+    it('should return 302 and redirect to the new endpoint', async () => {
       const safeAddress = faker.finance.ethereumAddress();
-      const lockingHistory = [
-        lockEventItemBuilder().build(),
-        unlockEventItemBuilder().build(),
-        withdrawEventItemBuilder().build(),
-      ];
-      const lockingHistoryPage = pageBuilder<LockingEvent>()
-        .with('results', lockingHistory)
-        .with('count', lockingHistory.length)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          // Service will have checksummed address
-          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
 
       await request(app.getHttpServer())
         .get(`/v1/locking/${safeAddress}/history`)
-        .expect(200)
-        .expect({
-          count: lockingHistoryPage.count,
-          next: null,
-          previous: null,
-          results: lockingHistoryPage.results.map(lockingEventToJson),
+        .expect(308)
+        .expect((res) => {
+          expect(res.get('location')).toBe(
+            `/v1/community/locking/${safeAddress}/history`,
+          );
         });
-
-      expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`,
-        networkRequest: {
-          params: {
-            limit: PaginationData.DEFAULT_LIMIT,
-            offset: PaginationData.DEFAULT_OFFSET,
-          },
-        },
-      });
     });
 
-    it('should forward the pagination parameters', async () => {
+    it('should return 302 and redirect to the new endpoint with cursor', async () => {
       const safeAddress = faker.finance.ethereumAddress();
-      const limit = faker.number.int({ min: 1, max: 10 });
-      const offset = faker.number.int({ min: 1, max: 10 });
-      const lockingHistory = [
-        lockEventItemBuilder().build(),
-        unlockEventItemBuilder().build(),
-        withdrawEventItemBuilder().build(),
-      ];
-      const lockingHistoryPage = pageBuilder<LockingEvent>()
-        .with('results', lockingHistory)
-        .with('count', lockingHistory.length)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          // Service will have checksummed address
-          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
+      const cursor = 'limit%3Daa%26offset%3D2';
 
       await request(app.getHttpServer())
-        .get(
-          `/v1/locking/${safeAddress}/history?cursor=limit%3D${limit}%26offset%3D${offset}`,
-        )
-        .expect(200)
-        .expect({
-          count: lockingHistoryPage.count,
-          next: null,
-          previous: null,
-          results: lockingHistoryPage.results.map(lockingEventToJson),
-        });
-
-      expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`,
-        networkRequest: {
-          params: {
-            limit,
-            offset,
-          },
-        },
-      });
-    });
-
-    it('should validate the Safe address in URL', async () => {
-      const safeAddress = faker.string.alphanumeric();
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/${safeAddress}/history`)
-        .expect(422)
-        .expect({
-          statusCode: 422,
-          code: 'custom',
-          message: 'Invalid address',
-          path: [],
-        });
-    });
-
-    it('should validate the response', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
-      const invalidLockingHistory = [{ invalid: 'value' }];
-      const lockingHistoryPage = pageBuilder()
-        .with('results', invalidLockingHistory)
-        .with('count', invalidLockingHistory.length)
-        .with('previous', null)
-        .with('next', null)
-        .build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          // Service will have checksummed address
-          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/${safeAddress}/history`)
-        .expect(500)
-        .expect({
-          statusCode: 500,
-          message: 'Internal server error',
-        });
-    });
-
-    it('should forward an error from the service', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
-      const statusCode = faker.internet.httpStatusCode({
-        types: ['clientError', 'serverError'],
-      });
-      const errorMessage = faker.word.words();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.reject(
-              new NetworkResponseError(
-                new URL(`${lockingBaseUri}/v1/locking/${safeAddress}/history`),
-                {
-                  status: statusCode,
-                } as Response,
-                { message: errorMessage, status: statusCode },
-              ),
-            );
-          default:
-            return Promise.reject(`No matching rule for url: ${url}`);
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get(`/v1/locking/${safeAddress}/history`)
-        .expect(statusCode)
-        .expect({
-          message: errorMessage,
-          code: statusCode,
+        .get(`/v1/locking/${safeAddress}/history/?cursor=${cursor}`)
+        .expect(308)
+        .expect((res) => {
+          expect(res.get('location')).toBe(
+            `/v1/community/locking/${safeAddress}/history/?cursor=${cursor}`,
+          );
         });
     });
   });

--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -1,17 +1,21 @@
 import { LockingEventPage } from '@/routes/locking/entities/locking-event.page.entity';
 import { Rank } from '@/routes/locking/entities/rank.entity';
-import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
-import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
 import { RankPage } from '@/routes/locking/entities/rank.page.entity';
-import { PaginationData } from '@/routes/common/pagination/pagination.data';
-import { LockingService } from '@/routes/locking/locking.service';
-import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { ValidationPipe } from '@/validation/pipes/validation.pipe';
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
-import { Campaign } from '@/routes/locking/entities/campaign.entity';
-import { CampaignPage } from '@/routes/locking/entities/campaign.page.entity';
-import { CampaignRankPage } from '@/routes/locking/entities/campaign-rank.page.entity';
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  Param,
+  Redirect,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
 
 @ApiTags('locking')
 @Controller({
@@ -19,89 +23,48 @@ import { CampaignRankPage } from '@/routes/locking/entities/campaign-rank.page.e
   version: '1',
 })
 export class LockingController {
-  constructor(private readonly lockingService: LockingService) {}
-
-  @ApiOkResponse({ type: Campaign })
-  @Get('/campaigns/:campaignId')
-  async getCampaignById(
-    @Param('campaignId') campaignId: string,
-  ): Promise<Campaign> {
-    return this.lockingService.getCampaignById(campaignId);
-  }
-
-  @ApiOkResponse({ type: CampaignPage })
-  @ApiQuery({
-    name: 'cursor',
-    required: false,
-    type: String,
-  })
-  @Get('/campaigns')
-  async getCampaigns(
-    @RouteUrlDecorator() routeUrl: URL,
-    @PaginationDataDecorator() paginationData: PaginationData,
-  ): Promise<CampaignPage> {
-    return this.lockingService.getCampaigns({ routeUrl, paginationData });
-  }
-
-  @ApiOkResponse({ type: CampaignRankPage })
-  @ApiQuery({
-    name: 'cursor',
-    required: false,
-    type: String,
-  })
-  @Get('/campaigns/:campaignId/leaderboard')
-  async getCampaignLeaderboard(
-    @Param('campaignId') campaignId: string,
-    @RouteUrlDecorator() routeUrl: URL,
-    @PaginationDataDecorator() paginationData: PaginationData,
-  ): Promise<CampaignRankPage> {
-    return this.lockingService.getCampaignLeaderboard({
-      campaignId,
-      routeUrl,
-      paginationData,
-    });
-  }
-
+  @ApiOperation({ deprecated: true })
   @ApiOkResponse({ type: Rank })
+  @Redirect(undefined, HttpStatus.PERMANENT_REDIRECT)
   @Get('/leaderboard/rank/:safeAddress')
-  async getRank(
-    @Param('safeAddress', new ValidationPipe(AddressSchema))
+  getRank(
+    @Param('safeAddress')
     safeAddress: `0x${string}`,
-  ): Promise<Rank> {
-    return this.lockingService.getRank(safeAddress);
+  ): { url: string } {
+    return { url: `/v1/community/locking/${safeAddress}/rank` };
   }
 
+  @ApiOperation({ deprecated: true })
   @ApiOkResponse({ type: RankPage })
   @ApiQuery({
     name: 'cursor',
     required: false,
     type: String,
   })
+  @Redirect(undefined, HttpStatus.PERMANENT_REDIRECT)
   @Get('/leaderboard')
-  async getLeaderboard(
-    @RouteUrlDecorator() routeUrl: URL,
-    @PaginationDataDecorator() paginationData: PaginationData,
-  ): Promise<RankPage> {
-    return this.lockingService.getLeaderboard({ routeUrl, paginationData });
+  getLeaderboard(@Req() request: Request): { url: string } {
+    const newUrl = '/v1/community/locking/leaderboard';
+    const search = request.url.split('?')[1];
+    return {
+      url: search ? `${newUrl}/?${search}` : newUrl,
+    };
   }
 
+  @ApiOperation({ deprecated: true })
   @ApiOkResponse({ type: LockingEventPage })
   @ApiQuery({
     name: 'cursor',
     required: false,
     type: String,
   })
+  @Redirect(undefined, HttpStatus.PERMANENT_REDIRECT)
   @Get('/:safeAddress/history')
-  async getLockingHistory(
-    @Param('safeAddress', new ValidationPipe(AddressSchema))
-    safeAddress: `0x${string}`,
-    @RouteUrlDecorator() routeUrl: URL,
-    @PaginationDataDecorator() paginationData: PaginationData,
-  ): Promise<LockingEventPage> {
-    return this.lockingService.getLockingHistory({
-      safeAddress,
-      routeUrl,
-      paginationData,
-    });
+  getLockingHistory(@Req() request: Request): { url: string } {
+    const newUrl = `/v1/community/locking/${request.params.safeAddress}/history`;
+    const search = request.url.split('?')[1];
+    return {
+      url: search ? `${newUrl}/?${search}` : newUrl,
+    };
   }
 }

--- a/src/routes/locking/locking.module.ts
+++ b/src/routes/locking/locking.module.ts
@@ -1,11 +1,9 @@
 import { Module } from '@nestjs/common';
 import { LockingController } from '@/routes/locking/locking.controller';
-import { LockingService } from '@/routes/locking/locking.service';
 import { LockingDomainModule } from '@/domain/locking/locking.domain.module';
 
 @Module({
   imports: [LockingDomainModule],
-  providers: [LockingService],
   controllers: [LockingController],
 })
 export class LockingModule {}


### PR DESCRIPTION
## Summary

The Locking Service was previously only locking-related. As such, we located all routes of the Service under `/locking`. As we are now serving `/campaigns`, it does not make sense to have them located under `/locking`.

This moves all Locking Service-related routes under `/community`, aligning with the domain of the Activity Program.

Note: the aforementioned deprecations redirect requests to their relative new route. They will be removed once the client has migrated

## Changes

- Rename `Locking-` module, controller, service to `Community-`.
- Rename the following (as of yet unused) routes:
  - `GET` `/v1/locking/campaigns` ->`/v1/community/campaigns`
  - `GET` `/v1/locking/campaigns/:campaignId` ->`/v1/community/campaigns/:campaignId`
  - `GET` `/v1/locking/campaigns/:campaignId/leaderboard` -> `/v1/community/campaigns/:campaignId/leaderboard`
- Rename the following (and deprecate with a redirection of the currently used) routes:
  - `GET` `/v1/locking/leaderboard` -> `/v1/community/locking/leaderboard`
  - `GET` `/v1/locking/leaderboard/rank/:safeAddress` -> `/v1/community/locking/:safeAddress/rank`
  - `GET` `/v1/locking/:safeAddress/history` -> `/v1/community/locking/:safeAddress/history`