### PR TITLE
Validate campaign retrieved by ID

### DIFF
--- a/src/domain/locking/locking.repository.ts
+++ b/src/domain/locking/locking.repository.ts
@@ -3,6 +3,7 @@ import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
 import {
   Campaign,
   CampaignPageSchema,
+  CampaignSchema,
 } from '@/domain/locking/entities/campaign.entity';
 import {
   CampaignRank,
@@ -26,7 +27,8 @@ export class LockingRepository implements ILockingRepository {
   ) {}
 
   async getCampaignById(campaignId: string): Promise<Campaign> {
-    return this.lockingApi.getCampaignById(campaignId);
+    const campaign = await this.lockingApi.getCampaignById(campaignId);
+    return CampaignSchema.parse(campaign);
   }
 
   async getCampaigns(args: {

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -220,8 +220,7 @@ describe('Community (Unit)', () => {
         .expect(campaignToJson(campaign) as Campaign);
     });
 
-    // TODO: Enable when validation is implemented
-    it.skip('should validate the response', async () => {
+    it('should validate the response', async () => {
       const invalidCampaign = {
         campaignId: faker.string.uuid(),
         invalid: 'campaign',


### PR DESCRIPTION
## Summary

All entities returned by the Locking Service are being validated, apart from campaigns retrieved by ID. This adds the relevant schema validation call.

## Changes

- Add `CampaignSchema` parsing to `ILockingService['getCampaignById']`
- Unskip relevant test