### PR TITLE
Specify rank as lock specific

### DIFF
--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -12,7 +12,7 @@ import {
   withdrawEventItemBuilder,
 } from '@/domain/community/entities/__tests__/locking-event.builder';
 import { getAddress } from 'viem';
-import { rankBuilder } from '@/domain/community/entities/__tests__/rank.builder';
+import { lockingRankBuilder } from '@/domain/community/entities/__tests__/locking-rank.builder';
 import { campaignBuilder } from '@/domain/community/entities/__tests__/campaign.builder';
 import { campaignRankBuilder } from '@/domain/community/entities/__tests__/campaign-rank.builder';
 import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
@@ -156,20 +156,18 @@ describe('LockingApi', () => {
     });
   });
 
-  describe('getRank', () => {
-    it('should get rank', async () => {
+  describe('getLockingRank', () => {
+    it('should get locking rank', async () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
-      const rank = rankBuilder().build();
+      const lockingRank = lockingRankBuilder().build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: {
-          rank,
-        },
+        data: lockingRank,
         status: 200,
       });
 
-      const result = await service.getRank(safeAddress);
+      const result = await service.getLockingRank(safeAddress);
 
-      expect(result).toEqual({ rank });
+      expect(result).toEqual(lockingRank);
       expect(mockNetworkService.get).toHaveBeenCalledWith({
         url: `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`,
       });
@@ -189,7 +187,7 @@ describe('LockingApi', () => {
       );
       mockNetworkService.get.mockRejectedValueOnce(error);
 
-      await expect(service.getRank(safeAddress)).rejects.toThrow(
+      await expect(service.getLockingRank(safeAddress)).rejects.toThrow(
         new DataSourceError('Unexpected error', status),
       );
 
@@ -200,7 +198,7 @@ describe('LockingApi', () => {
   describe('getLeaderboard', () => {
     it('should get leaderboard', async () => {
       const leaderboardPage = pageBuilder()
-        .with('results', [rankBuilder().build()])
+        .with('results', [lockingRankBuilder().build()])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
         data: leaderboardPage,
@@ -225,7 +223,7 @@ describe('LockingApi', () => {
       const limit = faker.number.int();
       const offset = faker.number.int();
       const leaderboardPage = pageBuilder()
-        .with('results', [rankBuilder().build()])
+        .with('results', [lockingRankBuilder().build()])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
         data: leaderboardPage,

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -9,7 +9,7 @@ import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
 import { Campaign } from '@/domain/community/entities/campaign.entity';
 import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
-import { Rank } from '@/domain/community/entities/rank.entity';
+import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { Inject } from '@nestjs/common';
 
 export class LockingApi implements ILockingApi {
@@ -57,10 +57,10 @@ export class LockingApi implements ILockingApi {
     }
   }
 
-  async getRank(safeAddress: `0x${string}`): Promise<Rank> {
+  async getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;
-      const { data } = await this.networkService.get<Rank>({ url });
+      const { data } = await this.networkService.get<LockingRank>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -70,10 +70,10 @@ export class LockingApi implements ILockingApi {
   async getLeaderboard(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Rank>> {
+  }): Promise<Page<LockingRank>> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard`;
-      const { data } = await this.networkService.get<Page<Rank>>({
+      const { data } = await this.networkService.get<Page<LockingRank>>({
         url,
         networkRequest: {
           params: {

--- a/src/domain/community/community.repository.interface.ts
+++ b/src/domain/community/community.repository.interface.ts
@@ -2,7 +2,7 @@ import { Page } from '@/domain/entities/page.entity';
 import { Campaign } from '@/domain/community/entities/campaign.entity';
 import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
-import { Rank } from '@/domain/community/entities/rank.entity';
+import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 
 export const ICommunityRepository = Symbol('ICommunityRepository');
 
@@ -14,12 +14,12 @@ export interface ICommunityRepository {
     offset?: number;
   }): Promise<Page<Campaign>>;
 
-  getRank(safeAddress: `0x${string}`): Promise<Rank>;
+  getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank>;
 
   getLeaderboard(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Rank>>;
+  }): Promise<Page<LockingRank>>;
 
   getCampaignLeaderboard(args: {
     campaignId: string;

--- a/src/domain/community/community.repository.ts
+++ b/src/domain/community/community.repository.ts
@@ -10,12 +10,12 @@ import {
   CampaignRankPageSchema,
 } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
-import { Rank } from '@/domain/community/entities/rank.entity';
+import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { LockingEventPageSchema } from '@/domain/community/entities/schemas/locking-event.schema';
 import {
-  RankPageSchema,
-  RankSchema,
-} from '@/domain/community/entities/schemas/rank.schema';
+  LockingRankPageSchema,
+  LockingRankSchema,
+} from '@/domain/community/entities/schemas/locking-rank.schema';
 import { ICommunityRepository } from '@/domain/community/community.repository.interface';
 import { Inject, Injectable } from '@nestjs/common';
 
@@ -39,17 +39,17 @@ export class CommunityRepository implements ICommunityRepository {
     return CampaignPageSchema.parse(page);
   }
 
-  async getRank(safeAddress: `0x${string}`): Promise<Rank> {
-    const rank = await this.lockingApi.getRank(safeAddress);
-    return RankSchema.parse(rank);
+  async getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank> {
+    const lockingRank = await this.lockingApi.getLockingRank(safeAddress);
+    return LockingRankSchema.parse(lockingRank);
   }
 
   async getLeaderboard(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Rank>> {
+  }): Promise<Page<LockingRank>> {
     const page = await this.lockingApi.getLeaderboard(args);
-    return RankPageSchema.parse(page);
+    return LockingRankPageSchema.parse(page);
   }
 
   async getCampaignLeaderboard(args: {

--- a/src/domain/community/entities/__tests__/locking-rank.builder.ts
+++ b/src/domain/community/entities/__tests__/locking-rank.builder.ts
@@ -1,10 +1,10 @@
 import { IBuilder, Builder } from '@/__tests__/builder';
-import { Rank } from '@/domain/community/entities/rank.entity';
+import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 
-export function rankBuilder(): IBuilder<Rank> {
-  return new Builder<Rank>()
+export function lockingRankBuilder(): IBuilder<LockingRank> {
+  return new Builder<LockingRank>()
     .with('holder', getAddress(faker.finance.ethereumAddress()))
     .with('position', faker.number.int())
     .with('lockedAmount', faker.string.numeric())

--- a/src/domain/community/entities/locking-rank.entity.ts
+++ b/src/domain/community/entities/locking-rank.entity.ts
@@ -1,0 +1,4 @@
+import { LockingRankSchema } from '@/domain/community/entities/schemas/locking-rank.schema';
+import { z } from 'zod';
+
+export type LockingRank = z.infer<typeof LockingRankSchema>;

--- a/src/domain/community/entities/rank.entity.ts
+++ b/src/domain/community/entities/rank.entity.ts
@@ -1,4 +1,0 @@
-import { RankSchema } from '@/domain/community/entities/schemas/rank.schema';
-import { z } from 'zod';
-
-export type Rank = z.infer<typeof RankSchema>;

--- a/src/domain/community/entities/schemas/__tests__/locking-rank.schema.spec.ts
+++ b/src/domain/community/entities/schemas/__tests__/locking-rank.schema.spec.ts
@@ -1,14 +1,14 @@
-import { rankBuilder } from '@/domain/community/entities/__tests__/rank.builder';
-import { RankSchema } from '@/domain/community/entities/schemas/rank.schema';
+import { lockingRankBuilder } from '@/domain/community/entities/__tests__/locking-rank.builder';
+import { LockingRankSchema } from '@/domain/community/entities/schemas/locking-rank.schema';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 import { ZodError } from 'zod';
 
 describe('RankSchema', () => {
-  it('should validate a valid rank', () => {
-    const rank = rankBuilder().build();
+  it('should validate a valid locking rank', () => {
+    const lockingRank = lockingRankBuilder().build();
 
-    const result = RankSchema.safeParse(rank);
+    const result = LockingRankSchema.safeParse(lockingRank);
 
     expect(result.success).toBe(true);
   });
@@ -17,19 +17,21 @@ describe('RankSchema', () => {
     const nonChecksummedAddress = faker.finance
       .ethereumAddress()
       .toLowerCase() as `0x${string}`;
-    const rank = rankBuilder().with('holder', nonChecksummedAddress).build();
+    const lockingRank = lockingRankBuilder()
+      .with('holder', nonChecksummedAddress)
+      .build();
 
-    const result = RankSchema.safeParse(rank);
+    const result = LockingRankSchema.safeParse(lockingRank);
 
     expect(result.success && result.data.holder).toBe(
       getAddress(nonChecksummedAddress),
     );
   });
 
-  it('should not validate an invalid rank', () => {
-    const rank = { invalid: 'rank' };
+  it('should not validate an invalid locking rank', () => {
+    const lockingRank = { invalid: 'lockingRank' };
 
-    const result = RankSchema.safeParse(rank);
+    const result = LockingRankSchema.safeParse(lockingRank);
 
     expect(!result.success && result.error).toStrictEqual(
       new ZodError([

--- a/src/domain/community/entities/schemas/locking-rank.schema.ts
+++ b/src/domain/community/entities/schemas/locking-rank.schema.ts
@@ -3,7 +3,7 @@ import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
-export const RankSchema = z.object({
+export const LockingRankSchema = z.object({
   holder: AddressSchema,
   position: z.number(),
   lockedAmount: NumericStringSchema,
@@ -11,4 +11,4 @@ export const RankSchema = z.object({
   withdrawnAmount: NumericStringSchema,
 });
 
-export const RankPageSchema = buildPageSchema(RankSchema);
+export const LockingRankPageSchema = buildPageSchema(LockingRankSchema);

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -2,7 +2,7 @@ import { Page } from '@/domain/entities/page.entity';
 import { Campaign } from '@/domain/community/entities/campaign.entity';
 import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
-import { Rank } from '@/domain/community/entities/rank.entity';
+import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 
 export const ILockingApi = Symbol('ILockingApi');
 
@@ -14,12 +14,12 @@ export interface ILockingApi {
     offset?: number;
   }): Promise<Page<Campaign>>;
 
-  getRank(safeAddress: `0x${string}`): Promise<Rank>;
+  getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank>;
 
   getLeaderboard(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Rank>>;
+  }): Promise<Page<LockingRank>>;
 
   getCampaignLeaderboard(args: {
     campaignId: string;

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -28,7 +28,7 @@ import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { getAddress } from 'viem';
-import { rankBuilder } from '@/domain/community/entities/__tests__/rank.builder';
+import { lockingRankBuilder } from '@/domain/community/entities/__tests__/locking-rank.builder';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
@@ -416,7 +416,7 @@ describe('Community (Unit)', () => {
   describe('GET /community/locking/leaderboard', () => {
     it('should get the leaderboard', async () => {
       const leaderboard = pageBuilder()
-        .with('results', [rankBuilder().build()])
+        .with('results', [lockingRankBuilder().build()])
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
@@ -454,7 +454,7 @@ describe('Community (Unit)', () => {
       const limit = faker.number.int({ min: 1, max: 10 });
       const offset = faker.number.int({ min: 1, max: 10 });
       const leaderboard = pageBuilder()
-        .with('results', [rankBuilder().build()])
+        .with('results', [lockingRankBuilder().build()])
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
@@ -545,21 +545,21 @@ describe('Community (Unit)', () => {
   });
 
   describe('GET /community/locking/:safeAddress/rank', () => {
-    it('should get the rank', async () => {
-      const rank = rankBuilder().build();
+    it('should get the locking rank', async () => {
+      const lockingRank = lockingRankBuilder().build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/leaderboard/${rank.holder}`:
-            return Promise.resolve({ data: rank, status: 200 });
+          case `${lockingBaseUri}/api/v1/leaderboard/${lockingRank.holder}`:
+            return Promise.resolve({ data: lockingRank, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/locking/${rank.holder}/rank`)
+        .get(`/v1/community/locking/${lockingRank.holder}/rank`)
         .expect(200)
-        .expect(rank);
+        .expect(lockingRank);
     });
 
     it('should validate the Safe address in URL', async () => {
@@ -578,11 +578,11 @@ describe('Community (Unit)', () => {
 
     it('should validate the response', async () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
-      const rank = { invalid: 'rank' };
+      const lockingRank = { invalid: 'lockingRank' };
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
-            return Promise.resolve({ data: rank, status: 200 });
+            return Promise.resolve({ data: lockingRank, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }

--- a/src/routes/community/community.controller.ts
+++ b/src/routes/community/community.controller.ts
@@ -6,8 +6,8 @@ import { CampaignRankPage } from '@/routes/locking/entities/campaign-rank.page.e
 import { Campaign } from '@/routes/locking/entities/campaign.entity';
 import { CampaignPage } from '@/routes/locking/entities/campaign.page.entity';
 import { LockingEventPage } from '@/routes/locking/entities/locking-event.page.entity';
-import { Rank } from '@/routes/locking/entities/rank.entity';
-import { RankPage } from '@/routes/locking/entities/rank.page.entity';
+import { LockingRank } from '@/routes/locking/entities/locking-rank.entity';
+import { LockingRankPage } from '@/routes/locking/entities/locking-rank.page.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { Controller, Get, Param } from '@nestjs/common';
@@ -62,7 +62,7 @@ export class CommunityController {
     });
   }
 
-  @ApiOkResponse({ type: RankPage })
+  @ApiOkResponse({ type: LockingRankPage })
   @ApiQuery({
     name: 'cursor',
     required: false,
@@ -72,19 +72,19 @@ export class CommunityController {
   async getLeaderboard(
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
-  ): Promise<RankPage> {
+  ): Promise<LockingRankPage> {
     return this.communityService.getLockingLeaderboard({
       routeUrl,
       paginationData,
     });
   }
 
-  @ApiOkResponse({ type: Rank })
+  @ApiOkResponse({ type: LockingRank })
   @Get('/locking/:safeAddress/rank')
-  async getRank(
+  async getLockingRank(
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: `0x${string}`,
-  ): Promise<Rank> {
+  ): Promise<LockingRank> {
     return this.communityService.getLockingRank(safeAddress);
   }
 

--- a/src/routes/community/community.service.ts
+++ b/src/routes/community/community.service.ts
@@ -2,7 +2,7 @@ import { Page } from '@/domain/entities/page.entity';
 import { Campaign } from '@/domain/community/entities/campaign.entity';
 import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
-import { Rank } from '@/domain/community/entities/rank.entity';
+import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { ICommunityRepository } from '@/domain/community/community.repository.interface';
 import {
   PaginationData,
@@ -71,7 +71,7 @@ export class CommunityService {
   async getLockingLeaderboard(args: {
     routeUrl: URL;
     paginationData: PaginationData;
-  }): Promise<Page<Rank>> {
+  }): Promise<Page<LockingRank>> {
     const result = await this.communityRepository.getLeaderboard(
       args.paginationData,
     );
@@ -90,8 +90,8 @@ export class CommunityService {
     };
   }
 
-  async getLockingRank(safeAddress: `0x${string}`): Promise<Rank> {
-    return this.communityRepository.getRank(safeAddress);
+  async getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank> {
+    return this.communityRepository.getLockingRank(safeAddress);
   }
 
   async getLockingHistory(args: {

--- a/src/routes/locking/entities/locking-rank.entity.ts
+++ b/src/routes/locking/entities/locking-rank.entity.ts
@@ -1,7 +1,7 @@
-import { Rank as DomainRank } from '@/domain/community/entities/rank.entity';
+import { LockingRank as DomainLockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class Rank implements DomainRank {
+export class LockingRank implements DomainLockingRank {
   @ApiProperty()
   holder!: `0x${string}`;
   @ApiProperty()

--- a/src/routes/locking/entities/locking-rank.page.entity.ts
+++ b/src/routes/locking/entities/locking-rank.page.entity.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Page } from '@/routes/common/entities/page.entity';
+import { LockingRank } from '@/routes/locking/entities/locking-rank.entity';
+
+export class LockingRankPage extends Page<LockingRank> {
+  @ApiProperty({ type: LockingRank })
+  results!: Array<LockingRank>;
+}

--- a/src/routes/locking/entities/rank.page.entity.ts
+++ b/src/routes/locking/entities/rank.page.entity.ts
@@ -1,8 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Page } from '@/routes/common/entities/page.entity';
-import { Rank } from '@/routes/locking/entities/rank.entity';
-
-export class RankPage extends Page<Rank> {
-  @ApiProperty({ type: Rank })
-  results!: Array<Rank>;
-}

--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -1,6 +1,6 @@
 import { LockingEventPage } from '@/routes/locking/entities/locking-event.page.entity';
-import { Rank } from '@/routes/locking/entities/rank.entity';
-import { RankPage } from '@/routes/locking/entities/rank.page.entity';
+import { LockingRank } from '@/routes/locking/entities/locking-rank.entity';
+import { LockingRankPage } from '@/routes/locking/entities/locking-rank.page.entity';
 import {
   Controller,
   Get,
@@ -24,7 +24,7 @@ import { Request } from 'express';
 })
 export class LockingController {
   @ApiOperation({ deprecated: true })
-  @ApiOkResponse({ type: Rank })
+  @ApiOkResponse({ type: LockingRank })
   @Redirect(undefined, HttpStatus.PERMANENT_REDIRECT)
   @Get('/leaderboard/rank/:safeAddress')
   getRank(
@@ -35,7 +35,7 @@ export class LockingController {
   }
 
   @ApiOperation({ deprecated: true })
-  @ApiOkResponse({ type: RankPage })
+  @ApiOkResponse({ type: LockingRankPage })
   @ApiQuery({
     name: 'cursor',
     required: false,


### PR DESCRIPTION
## Summary

Now that we have campaign ranks, the existing "rank" is unclear. This renames all instances of "rank" to be lock-specific.

## Changes

- Rename:
  - `ILockingApi['getRank']` -> `ILockingApi['getLockingRank']`
  - `ICommunityRepository['getRank']` -> `ICommunityRepository['getLockingRank']`
  - `RankSchema` -> `LockingRankSchema`
  - `RankPageSchema` -> `LockingRankPageSchema`
  - `Rank` -> `LockingRank`
  - `RankPage` -> `LockingRankPage`
  - `rankBuilder` -> `lockRankBuilder`