### PR TITLE
Fix `@typescript-eslint/require-await` instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,7 +38,6 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',
-      '@typescript-eslint/require-await': 'off',
       '@typescript-eslint/unbound-method': 'off',
     },
   },

--- a/src/__tests__/amqp-client.factory.ts
+++ b/src/__tests__/amqp-client.factory.ts
@@ -1,10 +1,10 @@
 import amqp, { ChannelWrapper } from 'amqp-connection-manager';
 import { Channel } from 'amqplib';
 
-export async function amqpClientFactory(queue?: string): Promise<{
+export function amqpClientFactory(queue?: string): {
   channel: ChannelWrapper;
   queueName: string;
-}> {
+} {
   const { AMQP_URL, AMQP_EXCHANGE_NAME, AMQP_EXCHANGE_MODE, AMQP_QUEUE } =
     process.env;
 

--- a/src/config/__tests__/fake.configuration.service.spec.ts
+++ b/src/config/__tests__/fake.configuration.service.spec.ts
@@ -3,11 +3,11 @@ import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.
 describe('FakeConfigurationService', () => {
   let configurationService: FakeConfigurationService;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     configurationService = new FakeConfigurationService();
   });
 
-  it(`Setting key should store its value`, async () => {
+  it(`Setting key should store its value`, () => {
     configurationService.set('aaa', 'bbb');
 
     const result = configurationService.get('aaa');
@@ -16,7 +16,7 @@ describe('FakeConfigurationService', () => {
     expect(result).toBe('bbb');
   });
 
-  it(`Retrieving unknown key should return undefined`, async () => {
+  it(`Retrieving unknown key should return undefined`, () => {
     configurationService.set('aaa', 'bbb');
 
     const result = configurationService.get('unknown_key');
@@ -24,7 +24,7 @@ describe('FakeConfigurationService', () => {
     expect(result).toBe(undefined);
   });
 
-  it(`Retrieving unknown key should throw`, async () => {
+  it(`Retrieving unknown key should throw`, () => {
     configurationService.set('aaa', 'bbb');
 
     const result = (): void => {

--- a/src/config/nest.configuration.service.spec.ts
+++ b/src/config/nest.configuration.service.spec.ts
@@ -11,12 +11,12 @@ const configServiceMock = jest.mocked(configService);
 describe('NestConfigurationService', () => {
   let target: NestConfigurationService;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
     target = new NestConfigurationService(configServiceMock);
   });
 
-  it(`get key is successful`, async () => {
+  it(`get key is successful`, () => {
     const key = faker.string.sample();
     const value = { some: { value: 10 } };
     configServiceMock.get.mockReturnValue(value);
@@ -29,7 +29,7 @@ describe('NestConfigurationService', () => {
     expect(result).toBe(value);
   });
 
-  it(`get key returns undefined when no key is found`, async () => {
+  it(`get key returns undefined when no key is found`, () => {
     const key = faker.string.sample();
     configServiceMock.get.mockReturnValue(undefined);
 
@@ -41,7 +41,7 @@ describe('NestConfigurationService', () => {
     expect(result).toBe(undefined);
   });
 
-  it(`getOrThrow key is successful`, async () => {
+  it(`getOrThrow key is successful`, () => {
     const key = faker.string.sample();
     const value = { some: { value: 10 } };
     configServiceMock.getOrThrow.mockReturnValue(value);
@@ -54,7 +54,7 @@ describe('NestConfigurationService', () => {
     expect(result).toBe(value);
   });
 
-  it(`getOrThrow key throws error`, async () => {
+  it(`getOrThrow key throws error`, () => {
     const key = faker.string.sample();
     configServiceMock.getOrThrow.mockImplementation(() => {
       throw new Error('some error');

--- a/src/datasources/alerts-api/tenderly-api.service.spec.ts
+++ b/src/datasources/alerts-api/tenderly-api.service.spec.ts
@@ -25,7 +25,7 @@ describe('TenderlyApi', () => {
   let tenderlyAccount: string;
   let tenderlyProject: string;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
 
     tenderlyBaseUri = faker.internet.url({ appendSlash: false });
@@ -48,7 +48,7 @@ describe('TenderlyApi', () => {
     );
   });
 
-  it('should error if configuration is not defined', async () => {
+  it('should error if configuration is not defined', () => {
     const fakeConfigurationService = new FakeConfigurationService();
     const httpErrorFactory = new HttpErrorFactory();
 

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -41,7 +41,7 @@ describe('CoingeckoAPI', () => {
   const defaultExpirationTimeInSeconds = faker.number.int();
   const notFoundExpirationTimeInSeconds = faker.number.int();
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set(

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -222,7 +222,8 @@ export class ZerionBalancesApi implements IBalancesApi {
   }
 
   async getFiatCodes(): Promise<string[]> {
-    return this.fiatCodes;
+    // Resolving to conform with interface
+    return Promise.resolve(this.fiatCodes);
   }
 
   private _mapErc20Balance(

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -5,7 +5,7 @@ import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 describe('FakeCacheService', () => {
   let target: FakeCacheService;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     target = new FakeCacheService();
   });
 

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -35,7 +35,7 @@ describe('RedisCacheService with a Key Prefix', () => {
   let defaultExpirationTimeInSeconds: number;
   const keyPrefix = faker.string.uuid();
 
-  beforeEach(async () => {
+  beforeEach(() => {
     clearAllMocks();
     defaultExpirationTimeInSeconds = faker.number.int();
     mockConfigurationService.getOrThrow.mockImplementation((key) => {

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -32,7 +32,7 @@ describe('ConfigApi', () => {
   let fakeConfigurationService: FakeConfigurationService;
   let service: ConfigApi;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('safeConfig.baseUri', baseUri);
     fakeConfigurationService.set(
@@ -45,7 +45,7 @@ describe('ConfigApi', () => {
     );
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
     service = new ConfigApi(
       dataSource,

--- a/src/datasources/email-api/pushwoosh-api.service.spec.ts
+++ b/src/datasources/email-api/pushwoosh-api.service.spec.ts
@@ -23,7 +23,7 @@ describe('PushwooshApi', () => {
   let pushwooshFromEmail: string;
   let pushwooshFromName: string;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
 
     pushwooshApplicationCode = faker.string.alphanumeric();
@@ -49,7 +49,7 @@ describe('PushwooshApi', () => {
     );
   });
 
-  it('should error if configuration is not defined', async () => {
+  it('should error if configuration is not defined', () => {
     const fakeConfigurationService = new FakeConfigurationService();
 
     expect(

--- a/src/datasources/errors/http-error-factory.spec.ts
+++ b/src/datasources/errors/http-error-factory.spec.ts
@@ -8,7 +8,7 @@ import { faker } from '@faker-js/faker';
 describe('HttpErrorFactory', () => {
   const httpErrorFactory: HttpErrorFactory = new HttpErrorFactory();
 
-  it('should create an DataSourceError when there is an error with the response', async () => {
+  it('should create an DataSourceError when there is an error with the response', () => {
     const httpError = new NetworkResponseError(
       new URL(faker.internet.url()),
       {
@@ -27,7 +27,7 @@ describe('HttpErrorFactory', () => {
     );
   });
 
-  it('should create an DataSourceError with 503 status when there is an error with the request URL', async () => {
+  it('should create an DataSourceError with 503 status when there is an error with the request URL', () => {
     const httpError = new NetworkRequestError(null, undefined);
 
     const actual = httpErrorFactory.from(httpError);
@@ -36,7 +36,7 @@ describe('HttpErrorFactory', () => {
     expect(actual.message).toBe('Service unavailable');
   });
 
-  it('should create an DataSourceError with 503 status when there is an error with the request', async () => {
+  it('should create an DataSourceError with 503 status when there is an error with the request', () => {
     const httpError = new NetworkRequestError(
       new URL(faker.internet.url()),
       new Error('Failed to fetch'),
@@ -48,7 +48,7 @@ describe('HttpErrorFactory', () => {
     expect(actual.message).toBe('Service unavailable');
   });
 
-  it('should create an DataSourceError with 503 status when an arbitrary error happens', async () => {
+  it('should create an DataSourceError with 503 status when an arbitrary error happens', () => {
     const errMessage = 'Service unavailable';
     const randomError = new Error();
 

--- a/src/datasources/network/fetch.network.service.spec.ts
+++ b/src/datasources/network/fetch.network.service.spec.ts
@@ -19,7 +19,7 @@ const loggingServiceMock = jest.mocked(loggingService);
 describe('FetchNetworkService', () => {
   let target: FetchNetworkService;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
     target = new FetchNetworkService(fetchClientMock, loggingServiceMock);
   });

--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -21,7 +21,7 @@ describe('GelatoApi', () => {
   let ttlSeconds: number;
   let httpErrorFactory: HttpErrorFactory;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
 
     httpErrorFactory = new HttpErrorFactory();

--- a/src/datasources/siwe-api/siwe-api.service.spec.ts
+++ b/src/datasources/siwe-api/siwe-api.service.spec.ts
@@ -18,7 +18,7 @@ describe('SiweApiService', () => {
   let fakeCacheService: FakeCacheService;
   const nonceTtlInSeconds = faker.number.int();
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
     fakeConfigurationService = new FakeConfigurationService();
     fakeCacheService = new FakeCacheService();

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -98,7 +98,7 @@ export class AlertsRepository implements IAlertsRepository {
         decodedEvent.args.data,
       );
 
-      const newSafeState = await this._mapSafeSetup({
+      const newSafeState = this._mapSafeSetup({
         safe,
         decodedTransactions,
       });
@@ -188,10 +188,10 @@ export class AlertsRepository implements IAlertsRepository {
     return decoded;
   }
 
-  private async _mapSafeSetup(args: {
+  private _mapSafeSetup(args: {
     safe: Safe;
     decodedTransactions: Array<ReturnType<SafeDecoder['decodeFunctionData']>>;
-  }): Promise<Safe> {
+  }): Safe {
     return args.decodedTransactions.reduce((newSafe, decodedTransaction) => {
       switch (decodedTransaction.functionName) {
         case 'addOwnerWithThreshold': {

--- a/src/routes/alerts/alerts.controller.ts
+++ b/src/routes/alerts/alerts.controller.ts
@@ -37,10 +37,10 @@ export class AlertsController {
   @UseGuards(TenderlySignatureGuard)
   @Post()
   @HttpCode(202)
-  async postAlert(
+  postAlert(
     @Body(new ValidationPipe(AlertSchema))
     alertPayload: Alert,
-  ): Promise<void> {
+  ): void {
     // TODO: we return immediately but we should consider a pub/sub system to tackle received alerts
     //  which were not handled correctly (e.g. due to other 3rd parties being unavailable)
     this.alertsService

--- a/src/routes/auth/guards/auth.guard.spec.ts
+++ b/src/routes/auth/guards/auth.guard.spec.ts
@@ -23,7 +23,7 @@ import jwtConfiguration from '@/datasources/jwt/configuration/__tests__/jwt.conf
 class TestController {
   @Get('valid')
   @UseGuards(AuthGuard)
-  async validRoute(): Promise<{ secret: string }> {
+  validRoute(): { secret: string } {
     return { secret: 'This is a secret message' };
   }
 }

--- a/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Events queue processing e2e tests', () => {
     app = await new TestAppProvider().provide(moduleRef);
     await app.init();
     redisClient = await redisClientFactory();
-    const amqpClient = await amqpClientFactory(queue);
+    const amqpClient = amqpClientFactory(queue);
     channel = amqpClient.channel;
     queueName = amqpClient.queueName;
   });

--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -46,9 +46,7 @@ export class CacheHooksController {
   @Post('/hooks/events')
   @UseFilters(EventProtocolChangedFilter)
   @HttpCode(202)
-  async postEvent(
-    @Body(new ValidationPipe(WebHookSchema)) event: Event,
-  ): Promise<void> {
+  postEvent(@Body(new ValidationPipe(WebHookSchema)) event: Event): void {
     if (!this.isEventsQueueEnabled || this.isHttpEvent(event)) {
       this.service.onEvent(event).catch((error) => {
         this.loggingService.error(error);

--- a/src/routes/cache-hooks/entities/schemas/__tests__/safe-created.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/safe-created.schema.spec.ts
@@ -33,7 +33,7 @@ describe('SafeCreatedEventSchema', () => {
     );
   });
 
-  it('should not allow a missing chainId', async () => {
+  it('should not allow a missing chainId', () => {
     const safeCreatedEvent = safeCreatedEventBuilder().build();
     // @ts-expect-error - inferred types don't allow optional fields
     delete safeCreatedEvent.chainId;

--- a/src/routes/common/filters/global-error.filter.spec.ts
+++ b/src/routes/common/filters/global-error.filter.spec.ts
@@ -17,7 +17,7 @@ import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 @Controller({})
 class TestController {
   @Get('http-exception')
-  async httpException(): Promise<void> {
+  httpException(): void {
     throw new HttpException(
       { message: 'Some http exception' },
       HttpStatus.BAD_GATEWAY,
@@ -25,7 +25,7 @@ class TestController {
   }
 
   @Get('non-http-exception')
-  async nonHttpException(): Promise<void> {
+  nonHttpException(): void {
     throw new Error('Some random error');
   }
 }

--- a/src/routes/common/filters/zod-error.filter.spec.ts
+++ b/src/routes/common/filters/zod-error.filter.spec.ts
@@ -32,30 +32,30 @@ const ZodNestedUnionSchema = z.union([
 @Controller({})
 class TestController {
   @Post('zod-exception')
-  async zodError(
+  zodError(
     @Body(new ValidationPipe(ZodSchema)) body: z.infer<typeof ZodSchema>,
-  ): Promise<z.infer<typeof ZodSchema>> {
+  ): z.infer<typeof ZodSchema> {
     return body;
   }
 
   @Post('zod-union-exception')
-  async zodUnionError(
+  zodUnionError(
     @Body(new ValidationPipe(ZodUnionSchema))
     body: z.infer<typeof ZodUnionSchema>,
-  ): Promise<z.infer<typeof ZodUnionSchema>> {
+  ): z.infer<typeof ZodUnionSchema> {
     return body;
   }
 
   @Post('zod-nested-union-exception')
-  async zodNestedUnionError(
+  zodNestedUnionError(
     @Body(new ValidationPipe(ZodNestedUnionSchema))
     body: z.infer<typeof ZodNestedUnionSchema>,
-  ): Promise<z.infer<typeof ZodNestedUnionSchema>> {
+  ): z.infer<typeof ZodNestedUnionSchema> {
     return body;
   }
 
   @Get('non-zod-exception')
-  async nonZodException(): Promise<void> {
+  nonZodException(): void {
     throw new Error('Some random error');
   }
 }

--- a/src/routes/common/pagination/pagination.data.spec.ts
+++ b/src/routes/common/pagination/pagination.data.spec.ts
@@ -8,7 +8,7 @@ import {
 
 describe('PaginationData', () => {
   describe('fromCursor', () => {
-    it('url with cursor, limit and offset', async () => {
+    it('url with cursor, limit and offset', () => {
       const url = new URL('https://safe.global/?cursor=limit%3D1%26offset%3D2');
 
       const actual = PaginationData.fromCursor(url);
@@ -17,7 +17,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(2);
     });
 
-    it('url with cursor, limit but no offset', async () => {
+    it('url with cursor, limit but no offset', () => {
       const url = new URL('https://safe.global/?cursor=limit%3D1%26');
 
       const actual = PaginationData.fromCursor(url);
@@ -26,7 +26,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(PaginationData.DEFAULT_OFFSET);
     });
 
-    it('url with cursor, offset but no limit', async () => {
+    it('url with cursor, offset but no limit', () => {
       const url = new URL('https://safe.global/?cursor=offset%3D1%26');
 
       const actual = PaginationData.fromCursor(url);
@@ -35,7 +35,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(1);
     });
 
-    it('url with no cursor', async () => {
+    it('url with no cursor', () => {
       const url = new URL('https://safe.global/?another_query=offset%3D1%26');
 
       const actual = PaginationData.fromCursor(url);
@@ -44,7 +44,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(PaginationData.DEFAULT_OFFSET);
     });
 
-    it('limit is not a number', async () => {
+    it('limit is not a number', () => {
       const url = new URL(
         'https://safe.global/?cursor=limit%3Daa%26offset%3D2',
       );
@@ -55,7 +55,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(2);
     });
 
-    it('offset is not a number', async () => {
+    it('offset is not a number', () => {
       const url = new URL(
         'https://safe.global/?cursor=limit%3D1%26offset%3Daa',
       );
@@ -68,7 +68,7 @@ describe('PaginationData', () => {
   });
 
   describe('fromLimitAndOffset', () => {
-    it('url with limit and offset', async () => {
+    it('url with limit and offset', () => {
       const url = new URL('https://safe.global/?limit=10&offset=20');
 
       const actual = PaginationData.fromLimitAndOffset(url);
@@ -77,7 +77,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(20);
     });
 
-    it('url with limit but no offset', async () => {
+    it('url with limit but no offset', () => {
       const url = new URL('https://safe.global/?limit=10');
 
       const actual = PaginationData.fromLimitAndOffset(url);
@@ -86,7 +86,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(PaginationData.DEFAULT_OFFSET);
     });
 
-    it('url with offset but no limit', async () => {
+    it('url with offset but no limit', () => {
       const url = new URL('https://safe.global/?offset=20');
 
       const actual = PaginationData.fromLimitAndOffset(url);
@@ -95,7 +95,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(20);
     });
 
-    it('url with neither limit no offset', async () => {
+    it('url with neither limit no offset', () => {
       const url = new URL('https://safe.global/?another_query=test');
 
       const actual = PaginationData.fromLimitAndOffset(url);
@@ -104,7 +104,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(PaginationData.DEFAULT_OFFSET);
     });
 
-    it('limit is not a number', async () => {
+    it('limit is not a number', () => {
       const url = new URL('https://safe.global/?limit=aa&offset=20');
 
       const actual = PaginationData.fromLimitAndOffset(url);
@@ -113,7 +113,7 @@ describe('PaginationData', () => {
       expect(actual.offset).toBe(20);
     });
 
-    it('offset is not a number', async () => {
+    it('offset is not a number', () => {
       const url = new URL('https://safe.global/?limit=10&offset=aa');
 
       const actual = PaginationData.fromLimitAndOffset(url);
@@ -124,7 +124,7 @@ describe('PaginationData', () => {
   });
 
   describe('cursorUrlFromLimitAndOffset', () => {
-    it('url is generated correctly', async () => {
+    it('url is generated correctly', () => {
       const fromUrl = 'https://safe.global/?limit=10&offset=2';
       const baseUrl = 'https://base.url/';
 
@@ -136,7 +136,7 @@ describe('PaginationData', () => {
       expect(actual?.href).toStrictEqual(expected.href);
     });
 
-    it('cursor is updated', async () => {
+    it('cursor is updated', () => {
       const fromUrl = 'https://safe.global/?limit=10&offset=2';
       // base url has limit=0 and offset=1
       const baseUrl = 'https://base.url/?cursor=limit%3D0%26offset%3D1';
@@ -149,7 +149,7 @@ describe('PaginationData', () => {
       expect(actual?.href).toStrictEqual(expected.href);
     });
 
-    it('returns null when from is null', async () => {
+    it('returns null when from is null', () => {
       const baseUrl = 'https://base.url/';
 
       const actual = cursorUrlFromLimitAndOffset(baseUrl, null);
@@ -159,7 +159,7 @@ describe('PaginationData', () => {
   });
 
   describe('buildNextPageURL', () => {
-    it('next url is the default if no cursor is passed', async () => {
+    it('next url is the default if no cursor is passed', () => {
       const currentUrl = faker.internet.url({ appendSlash: false });
       const expected = new URL(
         `${currentUrl}/?cursor=limit%3D${
@@ -177,7 +177,7 @@ describe('PaginationData', () => {
       expect(actual?.href).toStrictEqual(expected.href);
     });
 
-    it('next url is the default if an invalid cursor is passed', async () => {
+    it('next url is the default if an invalid cursor is passed', () => {
       const base = faker.internet.url({ appendSlash: false });
       const currentUrl = new URL(`${base}/?cursor=${faker.word.sample()}`);
       const expected = new URL(
@@ -194,7 +194,7 @@ describe('PaginationData', () => {
       expect(actual?.href).toStrictEqual(expected.href);
     });
 
-    it('next url is null if an invalid cursor is passed but there is no next page', async () => {
+    it('next url is null if an invalid cursor is passed but there is no next page', () => {
       const currentUrl = new URL(
         `${faker.internet.url({
           appendSlash: false,
@@ -209,7 +209,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('next url is null if items count is equal to next offset', async () => {
+    it('next url is null if items count is equal to next offset', () => {
       const limit = faker.number.int({ min: 1, max: 100 });
       const offset = faker.number.int({ min: 1, max: 100 });
       const itemsCount = limit + offset;
@@ -224,7 +224,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('next url is null if items count is less than next offset', async () => {
+    it('next url is null if items count is less than next offset', () => {
       const limit = faker.number.int({ min: 1, max: 100 });
       const offset = faker.number.int({ min: 1, max: 100 });
       const itemsCount = faker.number.int({ max: limit + offset - 1 });
@@ -239,7 +239,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('next url contains a new offset and the same limit', async () => {
+    it('next url contains a new offset and the same limit', () => {
       const limit = faker.number.int({ min: 1, max: 100 });
       const offset = faker.number.int({ min: 1, max: 100 });
       const expectedOffset = limit + offset;
@@ -259,7 +259,7 @@ describe('PaginationData', () => {
   });
 
   describe('buildPreviousPageURL', () => {
-    it('previous url is null if no cursor is passed', async () => {
+    it('previous url is null if no cursor is passed', () => {
       const currentUrl = new URL(
         `${faker.internet.url({ appendSlash: false })}`,
       );
@@ -269,7 +269,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('previous url is null if an invalid cursor is passed', async () => {
+    it('previous url is null if an invalid cursor is passed', () => {
       const currentUrl = new URL(
         `${faker.internet.url({
           appendSlash: false,
@@ -281,7 +281,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('previous url is null if an invalid cursor is passed (2)', async () => {
+    it('previous url is null if an invalid cursor is passed (2)', () => {
       const currentUrl = new URL(
         `${faker.internet.url({
           appendSlash: false,
@@ -293,7 +293,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('previous url is null if offset is zero', async () => {
+    it('previous url is null if offset is zero', () => {
       const currentUrl = new URL(
         `${faker.internet.url({
           appendSlash: false,
@@ -305,7 +305,7 @@ describe('PaginationData', () => {
       expect(actual).toStrictEqual(null);
     });
 
-    it('previous url contains a zero offset if limit >= offset', async () => {
+    it('previous url contains a zero offset if limit >= offset', () => {
       const limit = faker.number.int({ min: 2, max: 100 });
       const offset = faker.number.int({ min: 1, max: limit });
       const base = faker.internet.url({ appendSlash: false });
@@ -319,7 +319,7 @@ describe('PaginationData', () => {
       expect(actual?.href).toStrictEqual(expected.href);
     });
 
-    it('previous url contains a new offset and the same limit', async () => {
+    it('previous url contains a new offset and the same limit', () => {
       const limit = faker.number.int({ min: 1, max: 100 });
       const offset = faker.number.int({ min: limit + 1 });
       const expectedOffset = offset - limit;

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
@@ -11,10 +11,10 @@ import * as request from 'supertest';
 @Controller()
 class TestController {
   @Get('test')
-  async route(
+  route(
     @Query('addresses', new Caip10AddressesPipe())
     addresses: Array<{ chainId: string; address: string }>,
-  ): Promise<Array<{ chainId: string; address: string }>> {
+  ): Array<{ chainId: string; address: string }> {
     return addresses;
   }
 }

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -21,7 +21,7 @@ describe('SafeAppInfo mapper (Unit)', () => {
 
   let mapper: SafeAppInfoMapper;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
     mapper = new SafeAppInfoMapper(safeAppsRepositoryMock, mockLoggingService);
   });

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,4 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export default async () => {
+export default () => {
   process.env.TZ = 'UTC';
 };


### PR DESCRIPTION
## Summary

In the process of updating to ESLint 9, some rules were temporarily ignored due to changes in their recommendations. One of these rules was the [`@typescript-eslint/require-await`](https://typescript-eslint.io/rules/require-await) rule.

This PR re-enables the `@typescript-eslint/require-await` rule and addresses instances where unnecessary `async` is used.

## Changes

- Enable `@typescript-eslint/require-await` rule in `eslint.config.mjs`
- Remove all unnecessary uses of `async` and associated changes