### PR TITLE
Fix `@typescript-eslint/no-unsafe-enum-comparison` instances

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,7 +34,6 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-enum-comparison': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',

--- a/src/domain/human-description/entities/human-description-template.entity.ts
+++ b/src/domain/human-description/entities/human-description-template.entity.ts
@@ -102,7 +102,7 @@ export class HumanDescriptionTemplate {
     const value = args[index];
 
     switch (tokenType) {
-      case ValueType.TokenValue: {
+      case 'tokenValue': {
         if (typeof value !== 'bigint') {
           throw Error(
             `Invalid token type amount. tokenType=${tokenType}, amount=${value}`,
@@ -114,7 +114,7 @@ export class HumanDescriptionTemplate {
           value: { amount: value, address: to },
         };
       }
-      case ValueType.Address: {
+      case 'address': {
         if (!isHex(value)) {
           throw Error(
             `Invalid token type value. tokenType=${tokenType}, address=${value}`,
@@ -126,7 +126,7 @@ export class HumanDescriptionTemplate {
           value,
         };
       }
-      case ValueType.Number: {
+      case 'number': {
         if (typeof value !== 'bigint') {
           throw Error(
             `Invalid token type value. tokenType=${tokenType}, address=${value}`,

--- a/src/routes/transactions/entities/transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transfer-transaction-info.entity.ts
@@ -19,14 +19,14 @@ export class TransferTransactionInfo extends TransactionInfo {
   @ApiProperty()
   recipient: AddressInfo;
   @ApiProperty()
-  direction: string;
+  direction: TransferDirection;
   @ApiProperty()
   transferInfo: Transfer;
 
   constructor(
     sender: AddressInfo,
     recipient: AddressInfo,
-    direction: string,
+    direction: TransferDirection,
     transferInfo: Transfer,
     humanDescription: string | null,
     richDecodedInfo: RichDecodedInfo | null | undefined,

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
@@ -10,6 +10,7 @@ import {
   TRANSACTIONS_PARAMETER_NAME,
 } from '@/routes/transactions/constants';
 import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 
 @Injectable()
 export class CustomTransactionMapper {
@@ -77,7 +78,7 @@ export class CustomTransactionMapper {
         to === safe &&
         dataSize === 0 &&
         (!value || Number(value) === 0) &&
-        operation === 0 &&
+        operation === Operation.CALL &&
         (!baseGas || Number(baseGas) === 0) &&
         (!gasPrice || Number(gasPrice) === 0) &&
         (!gasToken || gasToken === NULL_ADDRESS) &&

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -5,7 +5,7 @@ import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import { TokenRepository } from '@/domain/tokens/token.repository';
 import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
-import { TokenType } from '@/routes/balances/entities/token-type.entity';
+import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { DataDecodedParameter } from '@/routes/data-decode/entities/data-decoded-parameter.entity';
 import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
 import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
@@ -223,7 +223,7 @@ export class MultisigTransactionInfoMapper {
     dataSize: number,
     operation: Operation,
   ): boolean {
-    return (value > 0 && dataSize > 0) || operation !== 0;
+    return (value > 0 && dataSize > 0) || operation !== Operation.CALL;
   }
 
   private isNativeCoinTransfer(value: number, dataSize: number): boolean {


### PR DESCRIPTION
## Summary

In the process of updating to ESLint 9, some rules were temporarily ignored due to changes in their recommendations. One of these rules was the [`@typescript-eslint/no-unsafe-enum-comparison`](https://typescript-eslint.io/rules/no-unsafe-enum-comparison) rule.

This PR re-enables the `@typescript-eslint/no-unsafe-enum-comparison` rule and addresses instances where "unsafe" enum comparison occurs.

## Changes

- Enable `@typescript-eslint/no-unsafe-enum-comparison` rule in `eslint.config.mjs`
- Fix all "unsafe" enum comparison