### PR TITLE
Checksum `safeAddress` of balance fetching and propagate type

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -8,6 +8,7 @@ import { IBalancesApi } from '@/domain/interfaces/balances-api.interface';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
 import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
 
 const configurationService = {
   getOrThrow: jest.fn(),
@@ -121,7 +122,7 @@ describe('Balances API Manager Tests', () => {
       const safeBalancesApi = await balancesApiManager.getBalancesApi(
         chain.chainId,
       );
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const trusted = faker.datatype.boolean();
       const excludeSpam = faker.datatype.boolean();
 

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -38,7 +38,7 @@ export class SafeBalancesApi implements IBalancesApi {
   }
 
   async getBalances(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
     chain: Chain;
     trusted?: boolean;

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -69,7 +69,7 @@ export class SafeBalancesApi implements IBalancesApi {
     }
   }
 
-  async clearBalances(args: { safeAddress: string }): Promise<void> {
+  async clearBalances(args: { safeAddress: `0x${string}` }): Promise<void> {
     const key = CacheRouter.getBalancesCacheKey({
       chainId: this.chainId,
       safeAddress: args.safeAddress,

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -254,7 +254,7 @@ export class ZerionBalancesApi implements IBalancesApi {
 
   async clearBalances(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const key = CacheRouter.getZerionBalancesCacheKey(args);
     await this.cacheService.deleteByKey(key);

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -89,7 +89,7 @@ export class ZerionBalancesApi implements IBalancesApi {
 
   async getBalances(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
   }): Promise<Balance[]> {
     const cacheDir = CacheRouter.getZerionBalancesCacheDir(args);

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -44,7 +44,7 @@ export class CacheRouter {
 
   static getBalancesCacheKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.SAFE_BALANCES_KEY}_${args.safeAddress}`;
   }
@@ -63,7 +63,7 @@ export class CacheRouter {
 
   static getZerionBalancesCacheKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.ZERION_BALANCES_KEY}_${args.safeAddress}`;
   }

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -51,7 +51,7 @@ export class CacheRouter {
 
   static getBalancesCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     trusted?: boolean;
     excludeSpam?: boolean;
   }): CacheDir {
@@ -70,7 +70,7 @@ export class CacheRouter {
 
   static getZerionBalancesCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
   }): CacheDir {
     return new CacheDir(

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -22,7 +22,10 @@ export interface IBalancesRepository {
   /**
    * Clears any stored local balance data of {@link safeAddress} on {@link chainId}
    */
-  clearBalances(args: { chainId: string; safeAddress: string }): Promise<void>;
+  clearBalances(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<void>;
 
   /**
    * Gets the list of supported fiat codes.

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -13,7 +13,7 @@ export interface IBalancesRepository {
    */
   getBalances(args: {
     chain: Chain;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
     trusted?: boolean;
     excludeSpam?: boolean;

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -14,7 +14,7 @@ export class BalancesRepository implements IBalancesRepository {
 
   async getBalances(args: {
     chain: Chain;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
     trusted?: boolean;
     excludeSpam?: boolean;

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -28,7 +28,7 @@ export class BalancesRepository implements IBalancesRepository {
 
   async clearBalances(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const api = await this.balancesApiManager.getBalancesApi(args.chainId);
     await api.clearBalances(args);

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -12,7 +12,10 @@ export interface IBalancesApi {
     excludeSpam?: boolean;
   }): Promise<Balance[]>;
 
-  clearBalances(args: { chainId: string; safeAddress: string }): Promise<void>;
+  clearBalances(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<void>;
 
   getCollectibles(args: {
     safeAddress: string;

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -5,7 +5,7 @@ import { Page } from '@/domain/entities/page.entity';
 
 export interface IBalancesApi {
   getBalances(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
     chain?: Chain;
     trusted?: boolean;

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -98,7 +98,7 @@ describe('Balances Controller (Unit)', () => {
     describe('GET /balances (externalized)', () => {
       it(`maps native coin + ERC20 token balance correctly, and sorts balances by fiatBalance`, async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const currency = faker.finance.currencyCode();
         const chainName = app
           .get(IConfigurationService)
@@ -246,7 +246,7 @@ describe('Balances Controller (Unit)', () => {
 
       it('returns large numbers as is (not in scientific notation)', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const currency = faker.finance.currencyCode();
         const chainName = app
           .get(IConfigurationService)
@@ -464,7 +464,7 @@ describe('Balances Controller (Unit)', () => {
     describe('Rate Limit error', () => {
       it('does not trigger a rate-limit error', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const currency = faker.finance.currencyCode();
         const chainName = app
           .get(IConfigurationService)
@@ -535,7 +535,7 @@ describe('Balances Controller (Unit)', () => {
 
       it('triggers a rate-limit error', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const chainName = app
           .get(IConfigurationService)
           .getOrThrow(

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -69,7 +69,7 @@ describe('Balances Controller (Unit)', () => {
   describe('GET /balances', () => {
     it(`maps native coin + ERC20 token balance correctly, and sorts balances by fiatBalance`, async () => {
       const chain = chainBuilder().with('chainId', '10').build();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const tokenAddress = faker.finance.ethereumAddress();
       const secondTokenAddress = faker.finance.ethereumAddress();
       const transactionApiBalancesResponse = [
@@ -225,7 +225,7 @@ describe('Balances Controller (Unit)', () => {
 
     it(`excludeSpam and trusted params are forwarded to tx service`, async () => {
       const chain = chainBuilder().with('chainId', '10').build();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const tokenAddress = faker.finance.ethereumAddress();
       const transactionApiBalancesResponse = [
         balanceBuilder()
@@ -277,7 +277,7 @@ describe('Balances Controller (Unit)', () => {
 
     it(`maps native token correctly`, async () => {
       const chain = chainBuilder().with('chainId', '10').build();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const transactionApiBalancesResponse = [
         balanceBuilder()
           .with('tokenAddress', null)
@@ -340,7 +340,7 @@ describe('Balances Controller (Unit)', () => {
 
     it('returns large numbers as is (not in scientific notation)', async () => {
       const chain = chainBuilder().with('chainId', '10').build();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const tokenAddress = faker.finance.ethereumAddress();
       const transactionApiBalancesResponse = [
         balanceBuilder()
@@ -420,7 +420,7 @@ describe('Balances Controller (Unit)', () => {
     describe('Config API Error', () => {
       it(`500 error response`, async () => {
         const chainId = '1';
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const error = new NetworkResponseError(
           new URL(
             `${safeConfigUrl}/v1/chains/${chainId}/safes/${safeAddress}/balances/usd`,
@@ -446,7 +446,7 @@ describe('Balances Controller (Unit)', () => {
     describe('Prices provider API Error', () => {
       it(`should return a 0-balance when an error is thrown by the provider`, async () => {
         const chain = chainBuilder().with('chainId', '10').build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const tokenAddress = faker.finance.ethereumAddress();
         const transactionApiBalancesResponse = [
           balanceBuilder()
@@ -505,7 +505,7 @@ describe('Balances Controller (Unit)', () => {
 
       it(`should return a 0-balance when a validation error happens`, async () => {
         const chain = chainBuilder().with('chainId', '10').build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const tokenAddress = getAddress(faker.finance.ethereumAddress());
         const transactionApiBalancesResponse = [
           balanceBuilder()
@@ -570,7 +570,7 @@ describe('Balances Controller (Unit)', () => {
     describe('Transaction API Error', () => {
       it(`500 error response`, async () => {
         const chainId = '1';
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const chainResponse = chainBuilder().with('chainId', chainId).build();
         const transactionServiceUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/`;
         networkService.get.mockImplementation(({ url }) => {
@@ -603,7 +603,7 @@ describe('Balances Controller (Unit)', () => {
 
     it(`500 error if validation fails`, async () => {
       const chainId = '1';
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {

--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -9,6 +9,8 @@ import {
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { BalancesService } from '@/routes/balances/balances.service';
 import { Balances } from '@/routes/balances/entities/balances.entity';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('balances')
 @Controller({
@@ -22,7 +24,8 @@ export class BalancesController {
   @Get('chains/:chainId/safes/:safeAddress/balances/:fiatCode')
   async getBalances(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Param('fiatCode') fiatCode: string,
     @Query('trusted', new DefaultValuePipe(false), ParseBoolPipe)
     trusted: boolean,

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -21,7 +21,7 @@ export class BalancesService {
 
   async getBalances(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     fiatCode: string;
     trusted: boolean;
     excludeSpam: boolean;

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
@@ -7,6 +7,7 @@ import { faker } from '@faker-js/faker';
 import { Controller, Get, INestApplication, Query } from '@nestjs/common';
 import { TestingModule, Test } from '@nestjs/testing';
 import * as request from 'supertest';
+import { getAddress } from 'viem';
 
 @Controller()
 class TestController {
@@ -35,7 +36,7 @@ describe('Caip10AddressesPipe', () => {
     await app.close();
   });
 
-  it('returns parsed CAIP-10 addresses', async () => {
+  it('returns parsed, checksummed CAIP-10 addresses', async () => {
     const chainId1 = faker.string.numeric();
     const chainId2 = faker.string.numeric();
     const chainId3 = faker.string.numeric();
@@ -49,9 +50,9 @@ describe('Caip10AddressesPipe', () => {
       )
       .expect(200)
       .expect([
-        { chainId: chainId1, address: address1 },
-        { chainId: chainId2, address: address2 },
-        { chainId: chainId3, address: address3 },
+        { chainId: chainId1, address: getAddress(address1) },
+        { chainId: chainId2, address: getAddress(address2) },
+        { chainId: chainId3, address: getAddress(address3) },
       ]);
   });
 

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.ts
@@ -1,4 +1,5 @@
 import { PipeTransform, Injectable } from '@nestjs/common';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class Caip10AddressesPipe
@@ -11,7 +12,7 @@ export class Caip10AddressesPipe
     const addresses = data.split(',').map((caip10Address: string) => {
       const [chainId, address] = caip10Address.split(':');
 
-      return { chainId, address };
+      return { chainId, address: getAddress(address) };
     });
 
     if (addresses.length === 0 || !addresses[0].address) {

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -45,7 +45,7 @@ export class SafesController {
   async getSafeOverview(
     @Query('currency') currency: string,
     @Query('safes', new Caip10AddressesPipe())
-    addresses: Array<{ chainId: string; address: string }>,
+    addresses: Array<{ chainId: string; address: `0x${string}` }>,
     @Query('trusted', new DefaultValuePipe(false), ParseBoolPipe)
     trusted: boolean,
     @Query('exclude_spam', new DefaultValuePipe(true), ParseBoolPipe)

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -129,7 +129,7 @@ export class SafesService {
 
   async getSafeOverview(args: {
     currency: string;
-    addresses: Array<{ chainId: string; address: string }>;
+    addresses: Array<{ chainId: string; address: `0x${string}` }>;
     trusted: boolean;
     excludeSpam: boolean;
     walletAddress?: `0x${string}`;


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `safeAddress` of `BalancesController['getBalances']` and propagates the stricter (`0x${string}`) type throughout the project accordingly

## Changes

- Add validation pipe checksum to incoming `safeAddress` of `BalancesController['getBalances']`
- Update `safeAddress` argument of `BalancesService['getBalances | clearBalance']`
- Update `safeAddress` argument type of `IBalancesRepository['getBalances | clearBalance']` and all implementor
- Update `safeAddress` argument type of `IBalancesApi['getBalances']` and all implementors (Safe/Zerion)
- Update `safeAddress` type of Safe/Zerion balance cache
- Propagate type through getting Safe overviews, after checksumming address in `Caip10AddressesPipe`
- Update types/tests accordingly