### PR TITLE
Checksum `safeAddress` of collectibles fetching and propagate type

### DIFF
--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -78,7 +78,7 @@ export class SafeBalancesApi implements IBalancesApi {
   }
 
   async getCollectibles(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
     trusted?: boolean;
@@ -109,7 +109,7 @@ export class SafeBalancesApi implements IBalancesApi {
     }
   }
 
-  async clearCollectibles(args: { safeAddress: string }): Promise<void> {
+  async clearCollectibles(args: { safeAddress: `0x${string}` }): Promise<void> {
     const key = CacheRouter.getCollectiblesKey({
       chainId: this.chainId,
       safeAddress: args.safeAddress,

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -143,7 +143,7 @@ export class ZerionBalancesApi implements IBalancesApi {
    */
   async getCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Collectible>> {
@@ -187,7 +187,7 @@ export class ZerionBalancesApi implements IBalancesApi {
 
   async clearCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const key = CacheRouter.getZerionCollectiblesCacheKey(args);
     await this.cacheService.deleteByKey(key);

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -81,14 +81,14 @@ export class CacheRouter {
 
   static getZerionCollectiblesCacheKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.ZERION_COLLECTIBLES_KEY}_${args.safeAddress}`;
   }
 
   static getZerionCollectiblesCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): CacheDir {
@@ -136,7 +136,7 @@ export class CacheRouter {
 
   static getCollectiblesCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
     trusted?: boolean;
@@ -150,7 +150,7 @@ export class CacheRouter {
 
   static getCollectiblesKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.SAFE_COLLECTIBLES_KEY}_${args.safeAddress}`;
   }

--- a/src/domain/collectibles/collectibles.repository.interface.ts
+++ b/src/domain/collectibles/collectibles.repository.interface.ts
@@ -9,7 +9,7 @@ export const ICollectiblesRepository = Symbol('ICollectiblesRepository');
 export interface ICollectiblesRepository {
   getCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
     trusted?: boolean;
@@ -18,7 +18,7 @@ export interface ICollectiblesRepository {
 
   clearCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 }
 

--- a/src/domain/collectibles/collectibles.repository.ts
+++ b/src/domain/collectibles/collectibles.repository.ts
@@ -14,7 +14,7 @@ export class CollectiblesRepository implements ICollectiblesRepository {
 
   async getCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
     trusted?: boolean;
@@ -27,7 +27,7 @@ export class CollectiblesRepository implements ICollectiblesRepository {
 
   async clearCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const api = await this.balancesApiManager.getBalancesApi(args.chainId);
     await api.clearCollectibles(args);

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -15,7 +15,7 @@ export interface IBalancesApi {
   clearBalances(args: { chainId: string; safeAddress: string }): Promise<void>;
 
   getCollectibles(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     chainId?: string;
     limit?: number;
     offset?: number;
@@ -25,7 +25,7 @@ export interface IBalancesApi {
 
   clearCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 
   getFiatCodes(): Promise<string[]>;

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -74,7 +74,7 @@ describe('Zerion Collectibles Controller', () => {
     describe('GET /v2/collectibles', () => {
       it('successfully gets collectibles from Zerion', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const aTokenAddress = faker.finance.ethereumAddress();
         const aNFTName = faker.string.sample();
         const aUrl = faker.internet.url({ appendSlash: false });
@@ -254,7 +254,7 @@ describe('Zerion Collectibles Controller', () => {
       });
       it('successfully maps pagination option (no limit)', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const inputPaginationCursor = `cursor=${encodeURIComponent(`&offset=10`)}`;
         const zerionNext = `${faker.internet.url({ appendSlash: false })}?page%5Bsize%5D=20&page%5Bafter%5D=IjMwIg==`;
         const expectedNext = `${encodeURIComponent(`limit=20&offset=30`)}`;
@@ -318,7 +318,7 @@ describe('Zerion Collectibles Controller', () => {
 
       it('successfully maps pagination option (no offset)', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const paginationLimit = 4;
         const inputPaginationCursor = `cursor=${encodeURIComponent(`limit=${paginationLimit}`)}`;
         const zerionNext = `${faker.internet.url({ appendSlash: false })}?page%5Bsize%5D=4&page%5Bafter%5D=IjQi`;
@@ -382,7 +382,7 @@ describe('Zerion Collectibles Controller', () => {
 
       it('successfully maps pagination option (both limit and offset)', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         const paginationLimit = 4;
         const inputPaginationCursor = `cursor=${encodeURIComponent(`limit=${paginationLimit}&offset=20`)}`;
         const zerionNext = `${faker.internet.url({ appendSlash: false })}?page%5Bsize%5D=4&page%5Bafter%5D=IjMwIg==`;
@@ -449,7 +449,7 @@ describe('Zerion Collectibles Controller', () => {
     describe('Zerion Balances API Error', () => {
       it(`500 error response`, async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
-        const safeAddress = faker.finance.ethereumAddress();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -32,6 +32,7 @@ import { AccountDataSourceModule } from '@/datasources/account/account.datasourc
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import { getAddress } from 'viem';
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication;
@@ -71,7 +72,7 @@ describe('Collectibles Controller (Unit)', () => {
   describe('GET /v2/collectibles', () => {
     it('is successful', async () => {
       const chainId = faker.string.numeric();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const pageLimit = 1;
       const collectiblesResponse = pageBuilder<Collectible>()
@@ -112,7 +113,7 @@ describe('Collectibles Controller (Unit)', () => {
 
     it('pagination data is forwarded to tx service', async () => {
       const chainId = faker.string.numeric();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const limit = 10;
       const offset = 20;
@@ -156,7 +157,7 @@ describe('Collectibles Controller (Unit)', () => {
 
     it('excludeSpam and trusted params are forwarded to tx service', async () => {
       const chainId = faker.string.numeric();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const excludeSpam = true;
       const trusted = true;
@@ -200,7 +201,7 @@ describe('Collectibles Controller (Unit)', () => {
 
     it('tx service collectibles returns 400', async () => {
       const chainId = faker.string.numeric();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const transactionServiceUrl = `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`;
       const transactionServiceError = new NetworkResponseError(
@@ -233,7 +234,7 @@ describe('Collectibles Controller (Unit)', () => {
 
     it('tx service collectibles does not return a response', async () => {
       const chainId = faker.string.numeric();
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const transactionServiceUrl = `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`;
       const transactionServiceError = new NetworkRequestError(

--- a/src/routes/collectibles/collectibles.controller.ts
+++ b/src/routes/collectibles/collectibles.controller.ts
@@ -14,6 +14,8 @@ import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.d
 import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
 import { Page } from '@/routes/common/entities/page.entity';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('collectibles')
 @Controller({
@@ -41,7 +43,8 @@ export class CollectiblesController {
   @Get('chains/:chainId/safes/:safeAddress/collectibles')
   async getCollectibles(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('trusted', new DefaultValuePipe(false), ParseBoolPipe)

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -16,7 +16,7 @@ export class CollectiblesService {
 
   async getCollectibles(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     routeUrl: Readonly<URL>;
     paginationData: PaginationData;
     trusted: boolean;


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `safeAddress` of `BalancesController['getCollectibles']` and propagates the stricter (`0x${string}`) type throughout the project accordingly

## Changes

- Add validation pipe checksum to incoming `safeAddress` of `BalancesController['getCollectibles']`
- Update `safeAddress` argument of `BalancesService['getCollectibles | clearCollectibles']`
- Update `safeAddress` argument type of `IBalancesRepository['getCollectibles | clearCollectibles']` and all implementor
- Update `safeAddress` argument type of `IBalancesApi['getCollectibles']` and all implementors (Safe/Zerion)
- Update `safeAddress` type of Safe/Zerion balance cache
- Update types/tests accordingly