### PR TITLE
Rename `campaignId` to `resourceId`

### DIFF
--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -47,7 +47,7 @@ describe('LockingApi', () => {
   });
 
   describe('getCampaignById', () => {
-    it('should get a campaign by campaignId', async () => {
+    it('should get a campaign by resourceId', async () => {
       const campaign = campaignBuilder().build();
 
       mockNetworkService.get.mockResolvedValueOnce({
@@ -55,11 +55,11 @@ describe('LockingApi', () => {
         status: 200,
       });
 
-      const result = await service.getCampaignById(campaign.campaignId);
+      const result = await service.getCampaignById(campaign.resourceId);
 
       expect(result).toEqual(campaign);
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}`,
       });
     });
 
@@ -67,7 +67,7 @@ describe('LockingApi', () => {
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
       const campaign = campaignBuilder().build();
       const error = new NetworkResponseError(
-        new URL(`${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`),
+        new URL(`${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}`),
         {
           status,
         } as Response,
@@ -78,7 +78,7 @@ describe('LockingApi', () => {
       mockNetworkService.get.mockRejectedValueOnce(error);
 
       await expect(
-        service.getCampaignById(campaign.campaignId),
+        service.getCampaignById(campaign.resourceId),
       ).rejects.toThrow(new DataSourceError('Unexpected error', status));
 
       expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
@@ -266,7 +266,7 @@ describe('LockingApi', () => {
 
   describe('getCampaignLeaderboard', () => {
     it('should get leaderboard by campaign', async () => {
-      const campaignId = faker.string.uuid();
+      const resourceId = faker.string.uuid();
       const campaignRankPage = pageBuilder<CampaignRank>()
         .with('results', [
           campaignRankBuilder().build(),
@@ -278,11 +278,11 @@ describe('LockingApi', () => {
         status: 200,
       });
 
-      const result = await service.getCampaignLeaderboard({ campaignId });
+      const result = await service.getCampaignLeaderboard({ resourceId });
 
       expect(result).toEqual(campaignRankPage);
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaigns/${campaignId}/leaderboard`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard`,
         networkRequest: {
           params: {
             limit: undefined,
@@ -295,7 +295,7 @@ describe('LockingApi', () => {
     it('should forward pagination queries', async () => {
       const limit = faker.number.int();
       const offset = faker.number.int();
-      const campaignId = faker.string.uuid();
+      const resourceId = faker.string.uuid();
       const campaignRankPage = pageBuilder<CampaignRank>()
         .with('results', [
           campaignRankBuilder().build(),
@@ -307,10 +307,10 @@ describe('LockingApi', () => {
         status: 200,
       });
 
-      await service.getCampaignLeaderboard({ campaignId, limit, offset });
+      await service.getCampaignLeaderboard({ resourceId, limit, offset });
 
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaigns/${campaignId}/leaderboard`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard`,
         networkRequest: {
           params: {
             limit,
@@ -322,9 +322,9 @@ describe('LockingApi', () => {
 
     it('should forward error', async () => {
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
-      const campaignId = faker.string.uuid();
+      const resourceId = faker.string.uuid();
       const error = new NetworkResponseError(
-        new URL(`${lockingBaseUri}/api/v1/campaigns/${campaignId}/leaderboard`),
+        new URL(`${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard`),
         {
           status,
         } as Response,
@@ -335,7 +335,7 @@ describe('LockingApi', () => {
       mockNetworkService.get.mockRejectedValueOnce(error);
 
       await expect(
-        service.getCampaignLeaderboard({ campaignId }),
+        service.getCampaignLeaderboard({ resourceId }),
       ).rejects.toThrow(new DataSourceError('Unexpected error', status));
 
       expect(mockNetworkService.get).toHaveBeenCalledTimes(1);

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -26,9 +26,9 @@ export class LockingApi implements ILockingApi {
       this.configurationService.getOrThrow<string>('locking.baseUri');
   }
 
-  async getCampaignById(campaignId: string): Promise<Campaign> {
+  async getCampaignById(resourceId: string): Promise<Campaign> {
     try {
-      const url = `${this.baseUri}/api/v1/campaigns/${campaignId}`;
+      const url = `${this.baseUri}/api/v1/campaigns/${resourceId}`;
       const { data } = await this.networkService.get<Campaign>({ url });
       return data;
     } catch (error) {
@@ -89,12 +89,12 @@ export class LockingApi implements ILockingApi {
   }
 
   async getCampaignLeaderboard(args: {
-    campaignId: string;
+    resourceId: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<CampaignRank>> {
     try {
-      const url = `${this.baseUri}/api/v1/campaigns/${args.campaignId}/leaderboard`;
+      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard`;
       const { data } = await this.networkService.get<Page<CampaignRank>>({
         url,
         networkRequest: {

--- a/src/domain/community/community.repository.interface.ts
+++ b/src/domain/community/community.repository.interface.ts
@@ -7,7 +7,7 @@ import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 export const ICommunityRepository = Symbol('ICommunityRepository');
 
 export interface ICommunityRepository {
-  getCampaignById(campaignId: string): Promise<Campaign>;
+  getCampaignById(resourceId: string): Promise<Campaign>;
 
   getCampaigns(args: {
     limit?: number;
@@ -22,7 +22,7 @@ export interface ICommunityRepository {
   }): Promise<Page<LockingRank>>;
 
   getCampaignLeaderboard(args: {
-    campaignId: string;
+    resourceId: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<CampaignRank>>;

--- a/src/domain/community/community.repository.ts
+++ b/src/domain/community/community.repository.ts
@@ -26,8 +26,8 @@ export class CommunityRepository implements ICommunityRepository {
     private readonly lockingApi: ILockingApi,
   ) {}
 
-  async getCampaignById(campaignId: string): Promise<Campaign> {
-    const campaign = await this.lockingApi.getCampaignById(campaignId);
+  async getCampaignById(resourceId: string): Promise<Campaign> {
+    const campaign = await this.lockingApi.getCampaignById(resourceId);
     return CampaignSchema.parse(campaign);
   }
 
@@ -53,7 +53,7 @@ export class CommunityRepository implements ICommunityRepository {
   }
 
   async getCampaignLeaderboard(args: {
-    campaignId: string;
+    resourceId: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<CampaignRank>> {

--- a/src/domain/community/entities/__tests__/activity-metadata.builder.ts
+++ b/src/domain/community/entities/__tests__/activity-metadata.builder.ts
@@ -4,7 +4,7 @@ import { faker } from '@faker-js/faker';
 
 export function activityMetadataBuilder(): IBuilder<ActivityMetadata> {
   return new Builder<ActivityMetadata>()
-    .with('campaignId', faker.string.uuid())
+    .with('resourceId', faker.string.uuid())
     .with('name', faker.word.words())
     .with('description', faker.lorem.sentence())
     .with('maxPoints', faker.string.numeric());

--- a/src/domain/community/entities/__tests__/campaign.builder.ts
+++ b/src/domain/community/entities/__tests__/campaign.builder.ts
@@ -5,7 +5,7 @@ import { faker } from '@faker-js/faker';
 
 export function campaignBuilder(): IBuilder<Campaign> {
   return new Builder<Campaign>()
-    .with('campaignId', faker.string.uuid())
+    .with('resourceId', faker.string.uuid())
     .with('name', faker.word.words())
     .with('description', faker.lorem.sentence())
     .with('startDate', faker.date.recent())

--- a/src/domain/community/entities/activity-metadata.entity.ts
+++ b/src/domain/community/entities/activity-metadata.entity.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 export type ActivityMetadata = z.infer<typeof ActivityMetadataSchema>;
 
 export const ActivityMetadataSchema = z.object({
-  campaignId: z.string(),
+  resourceId: z.string(),
   name: z.string(),
   description: z.string(),
   maxPoints: NumericStringSchema,

--- a/src/domain/community/entities/campaign.entity.ts
+++ b/src/domain/community/entities/campaign.entity.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 export type Campaign = z.infer<typeof CampaignSchema>;
 
 export const CampaignSchema = z.object({
-  campaignId: z.string(),
+  resourceId: z.string(),
   name: z.string(),
   description: z.string(),
   startDate: z.coerce.date(),

--- a/src/domain/community/entities/schemas/__tests__/activity-metadata.schema.spec.ts
+++ b/src/domain/community/entities/schemas/__tests__/activity-metadata.schema.spec.ts
@@ -41,7 +41,7 @@ describe('ActivityMetadataSchema', () => {
           code: 'invalid_type',
           expected: 'string',
           received: 'undefined',
-          path: ['campaignId'],
+          path: ['resourceId'],
           message: 'Required',
         },
         {

--- a/src/domain/community/entities/schemas/__tests__/campaign.schema.spec.ts
+++ b/src/domain/community/entities/schemas/__tests__/campaign.schema.spec.ts
@@ -63,7 +63,7 @@ describe('CampaignSchema', () => {
           code: 'invalid_type',
           expected: 'string',
           received: 'undefined',
-          path: ['campaignId'],
+          path: ['resourceId'],
           message: 'Required',
         },
         {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -7,7 +7,7 @@ import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 export const ILockingApi = Symbol('ILockingApi');
 
 export interface ILockingApi {
-  getCampaignById(campaignId: string): Promise<Campaign>;
+  getCampaignById(resourceId: string): Promise<Campaign>;
 
   getCampaigns(args: {
     limit?: number;
@@ -22,7 +22,7 @@ export interface ILockingApi {
   }): Promise<Page<LockingRank>>;
 
   getCampaignLeaderboard(args: {
-    campaignId: string;
+    resourceId: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<CampaignRank>>;

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -202,12 +202,12 @@ describe('Community (Unit)', () => {
     });
   });
 
-  describe('GET /community/campaigns/:campaignId', () => {
+  describe('GET /community/campaigns/:resourceId', () => {
     it('should get a campaign by ID', async () => {
       const campaign = campaignBuilder().build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}`:
             return Promise.resolve({ data: campaign, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -215,19 +215,19 @@ describe('Community (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/campaigns/${campaign.campaignId}`)
+        .get(`/v1/community/campaigns/${campaign.resourceId}`)
         .expect(200)
         .expect(campaignToJson(campaign) as Campaign);
     });
 
     it('should validate the response', async () => {
       const invalidCampaign = {
-        campaignId: faker.string.uuid(),
+        resourceId: faker.string.uuid(),
         invalid: 'campaign',
       };
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${invalidCampaign.campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${invalidCampaign.resourceId}`:
             return Promise.resolve({ data: invalidCampaign, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -235,7 +235,7 @@ describe('Community (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/campaigns/${invalidCampaign.campaignId}`)
+        .get(`/v1/community/campaigns/${invalidCampaign.resourceId}`)
         .expect(500)
         .expect({
           statusCode: 500,
@@ -244,17 +244,17 @@ describe('Community (Unit)', () => {
     });
 
     it('should forward an error from the service', async () => {
-      const campaignId = faker.string.uuid();
+      const resourceId = faker.string.uuid();
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
       });
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${resourceId}`:
             return Promise.reject(
               new NetworkResponseError(
-                new URL(`${lockingBaseUri}/api/v1/campaigns/${campaignId}`),
+                new URL(`${lockingBaseUri}/api/v1/campaigns/${resourceId}`),
                 {
                   status: statusCode,
                 } as Response,
@@ -267,7 +267,7 @@ describe('Community (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/campaigns/${campaignId}`)
+        .get(`/v1/community/campaigns/${resourceId}`)
         .expect(statusCode)
         .expect({
           message: errorMessage,
@@ -276,7 +276,7 @@ describe('Community (Unit)', () => {
     });
   });
 
-  describe('GET /community/campaigns/:campaignId/leaderboard', () => {
+  describe('GET /community/campaigns/:resourceId/leaderboard', () => {
     it('should get the leaderboard by campaign ID', async () => {
       const campaign = campaignBuilder().build();
       const campaignRankPage = pageBuilder<CampaignRank>()
@@ -290,7 +290,7 @@ describe('Community (Unit)', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
             return Promise.resolve({ data: campaignRankPage, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -298,7 +298,7 @@ describe('Community (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/campaigns/${campaign.campaignId}/leaderboard`)
+        .get(`/v1/community/campaigns/${campaign.resourceId}/leaderboard`)
         .expect(200)
         .expect({
           count: 2,
@@ -319,7 +319,7 @@ describe('Community (Unit)', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
             return Promise.resolve({ data: campaignRankPage, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -327,7 +327,7 @@ describe('Community (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/campaigns/${campaign.campaignId}/leaderboard`)
+        .get(`/v1/community/campaigns/${campaign.resourceId}/leaderboard`)
         .expect(500)
         .expect({
           statusCode: 500,
@@ -350,7 +350,7 @@ describe('Community (Unit)', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
             return Promise.resolve({ data: campaignRankPage, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -359,7 +359,7 @@ describe('Community (Unit)', () => {
 
       await request(app.getHttpServer())
         .get(
-          `/v1/community/campaigns/${campaign.campaignId}/leaderboard?cursor=limit%3D${limit}%26offset%3D${offset}`,
+          `/v1/community/campaigns/${campaign.resourceId}/leaderboard?cursor=limit%3D${limit}%26offset%3D${offset}`,
         )
         .expect(200)
         .expect({
@@ -370,7 +370,7 @@ describe('Community (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`,
         networkRequest: {
           params: {
             limit,
@@ -388,7 +388,7 @@ describe('Community (Unit)', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
             return Promise.reject(
               new NetworkResponseError(
                 new URL(url),
@@ -404,7 +404,7 @@ describe('Community (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/v1/community/campaigns/${campaign.campaignId}/leaderboard`)
+        .get(`/v1/community/campaigns/${campaign.resourceId}/leaderboard`)
         .expect(statusCode)
         .expect({
           message: errorMessage,

--- a/src/routes/community/community.controller.ts
+++ b/src/routes/community/community.controller.ts
@@ -36,11 +36,11 @@ export class CommunityController {
   }
 
   @ApiOkResponse({ type: Campaign })
-  @Get('/campaigns/:campaignId')
+  @Get('/campaigns/:resourceId')
   async getCampaignById(
-    @Param('campaignId') campaignId: string,
+    @Param('resourceId') resourceId: string,
   ): Promise<Campaign> {
-    return this.communityService.getCampaignById(campaignId);
+    return this.communityService.getCampaignById(resourceId);
   }
 
   @ApiOkResponse({ type: CampaignRankPage })
@@ -49,14 +49,14 @@ export class CommunityController {
     required: false,
     type: String,
   })
-  @Get('/campaigns/:campaignId/leaderboard')
+  @Get('/campaigns/:resourceId/leaderboard')
   async getCampaignLeaderboard(
-    @Param('campaignId') campaignId: string,
+    @Param('resourceId') resourceId: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<CampaignRankPage> {
     return this.communityService.getCampaignLeaderboard({
-      campaignId,
+      resourceId,
       routeUrl,
       paginationData,
     });

--- a/src/routes/community/community.service.ts
+++ b/src/routes/community/community.service.ts
@@ -39,17 +39,17 @@ export class CommunityService {
     };
   }
 
-  async getCampaignById(campaignId: string): Promise<Campaign> {
-    return this.communityRepository.getCampaignById(campaignId);
+  async getCampaignById(resourceId: string): Promise<Campaign> {
+    return this.communityRepository.getCampaignById(resourceId);
   }
 
   async getCampaignLeaderboard(args: {
-    campaignId: string;
+    resourceId: string;
     routeUrl: URL;
     paginationData: PaginationData;
   }): Promise<Page<CampaignRank>> {
     const result = await this.communityRepository.getCampaignLeaderboard({
-      campaignId: args.campaignId,
+      resourceId: args.resourceId,
       limit: args.paginationData.limit,
       offset: args.paginationData.offset,
     });

--- a/src/routes/locking/entities/activity-metadata.entity.ts
+++ b/src/routes/locking/entities/activity-metadata.entity.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class ActivityMetadata implements DomainActivityMetadata {
   @ApiProperty()
-  campaignId!: string;
+  resourceId!: string;
   @ApiProperty()
   name!: string;
   @ApiProperty()

--- a/src/routes/locking/entities/campaign.entity.ts
+++ b/src/routes/locking/entities/campaign.entity.ts
@@ -4,7 +4,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class Campaign implements DomainCampaign {
   @ApiProperty()
-  campaignId!: string;
+  resourceId!: string;
   @ApiProperty()
   name!: string;
   @ApiProperty()


### PR DESCRIPTION
## Summary

The of campaigns [on the Locking Service](https://github.com/safe-global/safe-locking-service/blob/6d47603e2559fd00ff614400cafaf34ba864396c/safe_locking_service/campaigns/serializers.py#L13) are no longer `campaignId` but `resourceId`. This renames `campaignId` to  `resourceId` across the project for consistency.

## Changes

- Rename all instances of `campaignId` to `resourceId` across the project