### PR TITLE
Add campaign rank retrieval to locking API

### DIFF
--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -170,7 +170,7 @@ describe('LockingApi', () => {
 
       expect(result).toEqual(campaignRank);
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`,
       });
     });
 
@@ -180,7 +180,7 @@ describe('LockingApi', () => {
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
       const error = new NetworkResponseError(
         new URL(
-          `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+          `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`,
         ),
         {
           status,

--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -156,6 +156,49 @@ describe('LockingApi', () => {
     });
   });
 
+  describe('getCampaignRank', () => {
+    it('should get campaign rank', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const campaignRank = campaignRankBuilder().build();
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: campaignRank,
+        status: 200,
+      });
+
+      const result = await service.getCampaignRank({ resourceId, safeAddress });
+
+      expect(result).toEqual(campaignRank);
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+      });
+    });
+
+    it('should forward error', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const status = faker.internet.httpStatusCode({ types: ['serverError'] });
+      const error = new NetworkResponseError(
+        new URL(
+          `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+        ),
+        {
+          status,
+        } as Response,
+        {
+          message: 'Unexpected error',
+        },
+      );
+      mockNetworkService.get.mockRejectedValueOnce(error);
+
+      await expect(
+        service.getCampaignRank({ resourceId, safeAddress }),
+      ).rejects.toThrow(new DataSourceError('Unexpected error', status));
+
+      expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getLockingRank', () => {
     it('should get locking rank', async () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -57,6 +57,19 @@ export class LockingApi implements ILockingApi {
     }
   }
 
+  async getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank> {
+    try {
+      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/${args.safeAddress}`;
+      const { data } = await this.networkService.get<CampaignRank>({ url });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -62,7 +62,7 @@ export class LockingApi implements ILockingApi {
     safeAddress: `0x${string}`;
   }): Promise<CampaignRank> {
     try {
-      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/${args.safeAddress}`;
+      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard/${args.safeAddress}`;
       const { data } = await this.networkService.get<CampaignRank>({ url });
       return data;
     } catch (error) {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -27,6 +27,11 @@ export interface ILockingApi {
     offset?: number;
   }): Promise<Page<CampaignRank>>;
 
+  getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank>;
+
   getLockingHistory(args: {
     safeAddress: `0x${string}`;
     limit?: number;


### PR DESCRIPTION
## Summary

We want to show the rank of a particular address per campaign. This adds the correct mapping to the locking API according to the Locking Service:

`GET` `/api/v1/campaigns/:campaignId/leaderboard/:safeAddress`

## Changes

- Add `ILockingApi['getCampaignRank']`
- Add associated tests