### PR TITLE
Add campaign rank route

### DIFF
--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -170,7 +170,7 @@ describe('LockingApi', () => {
 
       expect(result).toEqual(campaignRank);
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`,
       });
     });
 
@@ -180,7 +180,7 @@ describe('LockingApi', () => {
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
       const error = new NetworkResponseError(
         new URL(
-          `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+          `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`,
         ),
         {
           status,

--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -156,6 +156,49 @@ describe('LockingApi', () => {
     });
   });
 
+  describe('getCampaignRank', () => {
+    it('should get campaign rank', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const campaignRank = campaignRankBuilder().build();
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: campaignRank,
+        status: 200,
+      });
+
+      const result = await service.getCampaignRank({ resourceId, safeAddress });
+
+      expect(result).toEqual(campaignRank);
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+      });
+    });
+
+    it('should forward error', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const status = faker.internet.httpStatusCode({ types: ['serverError'] });
+      const error = new NetworkResponseError(
+        new URL(
+          `${lockingBaseUri}/api/v1/campaign/${resourceId}/leaderboard/${safeAddress}`,
+        ),
+        {
+          status,
+        } as Response,
+        {
+          message: 'Unexpected error',
+        },
+      );
+      mockNetworkService.get.mockRejectedValueOnce(error);
+
+      await expect(
+        service.getCampaignRank({ resourceId, safeAddress }),
+      ).rejects.toThrow(new DataSourceError('Unexpected error', status));
+
+      expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getLockingRank', () => {
     it('should get locking rank', async () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -57,6 +57,19 @@ export class LockingApi implements ILockingApi {
     }
   }
 
+  async getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank> {
+    try {
+      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/${args.safeAddress}`;
+      const { data } = await this.networkService.get<CampaignRank>({ url });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -62,7 +62,7 @@ export class LockingApi implements ILockingApi {
     safeAddress: `0x${string}`;
   }): Promise<CampaignRank> {
     try {
-      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/${args.safeAddress}`;
+      const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard/${args.safeAddress}`;
       const { data } = await this.networkService.get<CampaignRank>({ url });
       return data;
     } catch (error) {

--- a/src/domain/community/community.repository.interface.ts
+++ b/src/domain/community/community.repository.interface.ts
@@ -27,6 +27,11 @@ export interface ICommunityRepository {
     offset?: number;
   }): Promise<Page<CampaignRank>>;
 
+  getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank>;
+
   getLockingHistory(args: {
     safeAddress: `0x${string}`;
     offset?: number;

--- a/src/domain/community/community.repository.ts
+++ b/src/domain/community/community.repository.ts
@@ -8,6 +8,7 @@ import {
 import {
   CampaignRank,
   CampaignRankPageSchema,
+  CampaignRankSchema,
 } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
 import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
@@ -59,6 +60,14 @@ export class CommunityRepository implements ICommunityRepository {
   }): Promise<Page<CampaignRank>> {
     const page = await this.lockingApi.getCampaignLeaderboard(args);
     return CampaignRankPageSchema.parse(page);
+  }
+
+  async getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank> {
+    const campaignRank = await this.lockingApi.getCampaignRank(args);
+    return CampaignRankSchema.parse(campaignRank);
   }
 
   async getLockingHistory(args: {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -27,6 +27,11 @@ export interface ILockingApi {
     offset?: number;
   }): Promise<Page<CampaignRank>>;
 
+  getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank>;
+
   getLockingHistory(args: {
     safeAddress: `0x${string}`;
     limit?: number;

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -413,6 +413,100 @@ describe('Community (Unit)', () => {
     });
   });
 
+  describe('GET /community/campaigns/:resourceId/leaderboard/:safeAddress', () => {
+    it('should get the campaign rank', async () => {
+      const resourceId = faker.string.uuid();
+      const campaignRank = campaignRankBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`:
+            return Promise.resolve({ data: campaignRank, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${resourceId}/leaderboard/${safeAddress}`)
+        .expect(200)
+        .expect(campaignRank);
+    });
+
+    it('should validate the Safe address in URL', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = faker.string.alphanumeric();
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${resourceId}/leaderboard/${safeAddress}`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'Invalid address',
+          path: [],
+        });
+    });
+
+    it('should validate the response', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const campaignRank = { invalid: 'campaignRank' };
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`:
+            return Promise.resolve({ data: campaignRank, status: 200 });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${resourceId}/leaderboard/${safeAddress}`)
+        .expect(500)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    it('should forward an error from the service', async () => {
+      const resourceId = faker.string.uuid();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const campaignRank = { invalid: 'campaignRank' };
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`:
+            return Promise.reject(
+              new NetworkResponseError(
+                new URL(
+                  `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`,
+                ),
+                {
+                  status: statusCode,
+                } as Response,
+                { message: errorMessage, status: statusCode },
+              ),
+            );
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/community/campaigns/${resourceId}/leaderboard/${safeAddress}`)
+        .expect(statusCode)
+        .expect({
+          message: errorMessage,
+          code: statusCode,
+        });
+    });
+  });
+
   describe('GET /community/locking/leaderboard', () => {
     it('should get the leaderboard', async () => {
       const leaderboard = pageBuilder()

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -473,7 +473,6 @@ describe('Community (Unit)', () => {
     it('should forward an error from the service', async () => {
       const resourceId = faker.string.uuid();
       const safeAddress = getAddress(faker.finance.ethereumAddress());
-      const campaignRank = { invalid: 'campaignRank' };
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
       });

--- a/src/routes/community/community.controller.ts
+++ b/src/routes/community/community.controller.ts
@@ -2,6 +2,7 @@ import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.d
 import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { CommunityService } from '@/routes/community/community.service';
+import { CampaignRank } from '@/routes/locking/entities/campaign-rank.entity';
 import { CampaignRankPage } from '@/routes/locking/entities/campaign-rank.page.entity';
 import { Campaign } from '@/routes/locking/entities/campaign.entity';
 import { CampaignPage } from '@/routes/locking/entities/campaign.page.entity';
@@ -60,6 +61,16 @@ export class CommunityController {
       routeUrl,
       paginationData,
     });
+  }
+
+  @ApiOkResponse({ type: CampaignRank })
+  @Get('/campaigns/:resourceId/leaderboard/:safeAddress')
+  async getCampaignRank(
+    @Param('resourceId') resourceId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+  ): Promise<CampaignRank> {
+    return this.communityService.getCampaignRank({ resourceId, safeAddress });
   }
 
   @ApiOkResponse({ type: LockingRankPage })

--- a/src/routes/community/community.service.ts
+++ b/src/routes/community/community.service.ts
@@ -68,6 +68,13 @@ export class CommunityService {
     };
   }
 
+  async getCampaignRank(args: {
+    resourceId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CampaignRank> {
+    return this.communityRepository.getCampaignRank(args);
+  }
+
   async getLockingLeaderboard(args: {
     routeUrl: URL;
     paginationData: PaginationData;


### PR DESCRIPTION
## Summary

This adds a new route for retrieving the rank of the specified address of the specified campaign:

`GET` `/v1/community/campaigns/:campaignId/leaderboard/:safeAddress`

## Changes

- Add `ICommunityRespository['getCampaignRank']` and implementation
- Add `CommunityController['getCampaignRank`]` under aforementioned route
- Add associated tests