### PR TITLE
Update `ActivityMetadata` entity

### DIFF
--- a/src/domain/community/entities/__tests__/activity-metadata.builder.ts
+++ b/src/domain/community/entities/__tests__/activity-metadata.builder.ts
@@ -4,8 +4,7 @@ import { faker } from '@faker-js/faker';
 
 export function activityMetadataBuilder(): IBuilder<ActivityMetadata> {
   return new Builder<ActivityMetadata>()
-    .with('resourceId', faker.string.uuid())
     .with('name', faker.word.words())
     .with('description', faker.lorem.sentence())
-    .with('maxPoints', faker.string.numeric());
+    .with('maxPoints', faker.number.int());
 }

--- a/src/domain/community/entities/activity-metadata.entity.ts
+++ b/src/domain/community/entities/activity-metadata.entity.ts
@@ -1,11 +1,9 @@
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
 export type ActivityMetadata = z.infer<typeof ActivityMetadataSchema>;
 
 export const ActivityMetadataSchema = z.object({
-  resourceId: z.string(),
   name: z.string(),
   description: z.string(),
-  maxPoints: NumericStringSchema,
+  maxPoints: z.number(),
 });

--- a/src/domain/community/entities/schemas/__tests__/activity-metadata.schema.spec.ts
+++ b/src/domain/community/entities/schemas/__tests__/activity-metadata.schema.spec.ts
@@ -1,6 +1,5 @@
 import { activityMetadataBuilder } from '@/domain/community/entities/__tests__/activity-metadata.builder';
 import { ActivityMetadataSchema } from '@/domain/community/entities/activity-metadata.entity';
-import { faker } from '@faker-js/faker';
 import { ZodError } from 'zod';
 
 describe('ActivityMetadataSchema', () => {
@@ -12,24 +11,6 @@ describe('ActivityMetadataSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should not allow a non-numeric string for maxPoints', () => {
-    const activityMetadata = activityMetadataBuilder()
-      .with('maxPoints', faker.string.alpha())
-      .build();
-
-    const result = ActivityMetadataSchema.safeParse(activityMetadata);
-
-    expect(!result.success && result.error).toStrictEqual(
-      new ZodError([
-        {
-          code: 'custom',
-          message: 'Invalid base-10 numeric string',
-          path: ['maxPoints'],
-        },
-      ]),
-    );
-  });
-
   it('should not validate an invalid activity metadata', () => {
     const activityMetadata = { invalid: 'activity metadata' };
 
@@ -37,13 +18,6 @@ describe('ActivityMetadataSchema', () => {
 
     expect(!result.success && result.error).toStrictEqual(
       new ZodError([
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          received: 'undefined',
-          path: ['resourceId'],
-          message: 'Required',
-        },
         {
           code: 'invalid_type',
           expected: 'string',
@@ -60,7 +34,7 @@ describe('ActivityMetadataSchema', () => {
         },
         {
           code: 'invalid_type',
-          expected: 'string',
+          expected: 'number',
           received: 'undefined',
           path: ['maxPoints'],
           message: 'Required',

--- a/src/routes/locking/entities/activity-metadata.entity.ts
+++ b/src/routes/locking/entities/activity-metadata.entity.ts
@@ -3,11 +3,9 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class ActivityMetadata implements DomainActivityMetadata {
   @ApiProperty()
-  resourceId!: string;
-  @ApiProperty()
   name!: string;
   @ApiProperty()
   description!: string;
   @ApiProperty()
-  maxPoints!: string;
+  maxPoints!: number;
 }


### PR DESCRIPTION
## Summary

The `ActivityMetadata` was defined whilst it was being developed on the Locking Service. Now that the service has included it, it does not match and therefore does not pass validation.

This aligns entity by removing `resourceId` and changing `maxPoints` to a number.

## Changes

- Remove `resourceId` and change `maxPoints` to number in `ActivityMetadataSchema`
- Update `ActivityMetadata` to reflect changes
- Update tests accordingly