### PR TITLE
Checksum `safeAddress` when fetching remaining relays and propagate type

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -420,13 +420,16 @@ export class CacheRouter {
     return new CacheDir(CacheRouter.getChainCacheKey(chainId), '');
   }
 
-  static getRelayKey(args: { chainId: string; address: string }): string {
+  static getRelayKey(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): string {
     return `${args.chainId}_${CacheRouter.RELAY_KEY}_${args.address}`;
   }
 
   static getRelayCacheDir(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): CacheDir {
     return new CacheDir(CacheRouter.getRelayKey(args), '');
   }

--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -11,8 +11,6 @@ import {
   CacheService,
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
-import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
-import { getAddress } from 'viem';
 
 @Injectable()
 export class GelatoApi implements IRelayApi {
@@ -42,7 +40,7 @@ export class GelatoApi implements IRelayApi {
 
   async relay(args: {
     chainId: string;
-    to: string;
+    to: `0x${string}`;
     data: string;
     gasLimit: bigint | null;
   }): Promise<{ taskId: string }> {
@@ -76,34 +74,23 @@ export class GelatoApi implements IRelayApi {
 
   async getRelayCount(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): Promise<number> {
-    const cacheDir = this.getRelayCacheKey(args);
+    const cacheDir = CacheRouter.getRelayCacheDir(args);
     const count = await this.cacheService.get(cacheDir);
     return count ? parseInt(count) : 0;
   }
 
   async setRelayCount(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
     count: number;
   }): Promise<void> {
-    const cacheDir = this.getRelayCacheKey(args);
+    const cacheDir = CacheRouter.getRelayCacheDir(args);
     await this.cacheService.set(
       cacheDir,
       args.count.toString(),
       this.ttlSeconds,
     );
-  }
-
-  private getRelayCacheKey(args: {
-    chainId: string;
-    address: string;
-  }): CacheDir {
-    return CacheRouter.getRelayCacheDir({
-      chainId: args.chainId,
-      // Ensure address is checksummed to always have a consistent cache key
-      address: getAddress(args.address),
-    });
   }
 }

--- a/src/domain/interfaces/relay-api.interface.ts
+++ b/src/domain/interfaces/relay-api.interface.ts
@@ -3,16 +3,19 @@ export const IRelayApi = Symbol('IRelayApi');
 export interface IRelayApi {
   relay(args: {
     chainId: string;
-    to: string;
+    to: `0x${string}`;
     data: string;
     gasLimit: bigint | null;
   }): Promise<{ taskId: string }>;
 
-  getRelayCount(args: { chainId: string; address: string }): Promise<number>;
+  getRelayCount(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<number>;
 
   setRelayCount(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
     count: number;
   }): Promise<void>;
 }

--- a/src/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder.ts
+++ b/src/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder.ts
@@ -1,12 +1,12 @@
 import { faker } from '@faker-js/faker';
-import { Hex, encodeFunctionData, getAddress, erc20Abi } from 'viem';
+import { encodeFunctionData, getAddress, erc20Abi } from 'viem';
 import { Builder } from '@/__tests__/builder';
 import { IEncoder } from '@/__tests__/encoder-builder';
 
 // transfer
 
 type Erc20TransferArgs = {
-  to: Hex;
+  to: `0x${string}`;
   value: bigint;
 };
 
@@ -14,7 +14,7 @@ class Erc20TransferEncoder<T extends Erc20TransferArgs>
   extends Builder<T>
   implements IEncoder
 {
-  encode(): Hex {
+  encode(): `0x${string}` {
     const args = this.build();
 
     return encodeFunctionData({
@@ -34,8 +34,8 @@ export function erc20TransferEncoder(): Erc20TransferEncoder<Erc20TransferArgs> 
 // transferFrom
 
 type Erc20TransferFromArgs = {
-  sender: Hex;
-  recipient: Hex;
+  sender: `0x${string}`;
+  recipient: `0x${string}`;
   amount: bigint;
 };
 
@@ -43,7 +43,7 @@ class Erc20TransferFromEncoder<T extends Erc20TransferFromArgs>
   extends Builder<T>
   implements IEncoder
 {
-  encode(): Hex {
+  encode(): `0x${string}` {
     const args = this.build();
 
     return encodeFunctionData({
@@ -64,7 +64,7 @@ export function erc20TransferFromEncoder(): Erc20TransferFromEncoder<Erc20Transf
 // transferFrom
 
 type Erc20ApproveArgs = {
-  spender: Hex;
+  spender: `0x${string}`;
   amount: bigint;
 };
 
@@ -72,7 +72,7 @@ class Erc20ApproveEncoder<T extends Erc20ApproveArgs>
   extends Builder<T>
   implements IEncoder
 {
-  encode(): Hex {
+  encode(): `0x${string}` {
     const args = this.build();
 
     return encodeFunctionData({

--- a/src/domain/relay/contracts/__tests__/encoders/proxy-factory-encoder.builder.ts
+++ b/src/domain/relay/contracts/__tests__/encoders/proxy-factory-encoder.builder.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { encodeFunctionData, getAddress, Hex } from 'viem';
+import { encodeFunctionData, getAddress } from 'viem';
 import ProxyFactory130 from '@/abis/safe/v1.3.0/GnosisSafeProxyFactory.abi';
 import { IEncoder } from '@/__tests__/encoder-builder';
 import { Builder } from '@/__tests__/builder';
@@ -8,8 +8,8 @@ import { setupEncoder } from '@/domain/contracts/__tests__/encoders/safe-encoder
 // createProxyWithNonce
 
 type CreateProxyWithNonceArgs = {
-  singleton: Hex;
-  initializer: Hex;
+  singleton: `0x${string}`;
+  initializer: `0x${string}`;
   saltNonce: bigint;
 };
 
@@ -17,7 +17,7 @@ class SetupEncoder<T extends CreateProxyWithNonceArgs>
   extends Builder<T>
   implements IEncoder
 {
-  encode(): Hex {
+  encode(): `0x${string}` {
     const args = this.build();
 
     return encodeFunctionData({

--- a/src/domain/relay/contracts/decoders/__tests__/erc20-decoder.helper.spec.ts
+++ b/src/domain/relay/contracts/decoders/__tests__/erc20-decoder.helper.spec.ts
@@ -1,4 +1,3 @@
-import { Hex } from 'viem';
 import { faker } from '@faker-js/faker';
 import { Erc20Decoder } from '@/domain/relay/contracts/decoders/erc-20-decoder.helper';
 import { erc20TransferEncoder } from '@/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder';
@@ -23,7 +22,7 @@ describe('Erc20Decoder', () => {
   });
 
   it('throws if the function call cannot be decoded', () => {
-    const data = faker.string.hexadecimal({ length: 138 }) as Hex;
+    const data = faker.string.hexadecimal({ length: 138 }) as `0x${string}`;
 
     expect(() => target.decodeFunctionData({ data })).toThrow();
   });

--- a/src/domain/relay/contracts/decoders/__tests__/proxy-factory-decoder.helper.spec.ts
+++ b/src/domain/relay/contracts/decoders/__tests__/proxy-factory-decoder.helper.spec.ts
@@ -1,4 +1,3 @@
-import { Hex } from 'viem';
 import { faker } from '@faker-js/faker';
 import { ProxyFactoryDecoder } from '@/domain/relay/contracts/decoders/proxy-factory-decoder.helper';
 import { createProxyWithNonceEncoder } from '@/domain/relay/contracts/__tests__/encoders/proxy-factory-encoder.builder';
@@ -27,7 +26,7 @@ describe('ProxyFactoryDecoder', () => {
   });
 
   it('throws if the function call cannot be decoded', () => {
-    const data = faker.string.hexadecimal({ length: 138 }) as Hex;
+    const data = faker.string.hexadecimal({ length: 138 }) as `0x${string}`;
 
     expect(() => target.decodeFunctionData({ data })).toThrow();
   });

--- a/src/domain/relay/errors/relay-limit-reached.error.ts
+++ b/src/domain/relay/errors/relay-limit-reached.error.ts
@@ -1,9 +1,8 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { Hex } from 'viem';
 
 export class RelayLimitReachedError extends HttpException {
   constructor(
-    readonly address: Hex,
+    readonly address: `0x${string}`,
     readonly current: number,
     readonly limit: number,
   ) {

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Hex } from 'viem/types/misc';
 import { Erc20Decoder } from '@/domain/relay/contracts/decoders/erc-20-decoder.helper';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
@@ -32,9 +31,9 @@ export class LimitAddressesMapper {
   async getLimitAddresses(args: {
     version: string;
     chainId: string;
-    to: Hex;
-    data: Hex;
-  }): Promise<readonly Hex[]> {
+    to: `0x${string}`;
+    data: `0x${string}`;
+  }): Promise<readonly `0x${string}`[]> {
     // Calldata matches that of execTransaction and meets validity requirements
     if (
       this.isValidExecTransactionCall({
@@ -109,7 +108,10 @@ export class LimitAddressesMapper {
     throw new InvalidTransferError();
   }
 
-  private isValidExecTransactionCall(args: { to: Hex; data: Hex }): boolean {
+  private isValidExecTransactionCall(args: {
+    to: `0x${string}`;
+    data: `0x${string}`;
+  }): boolean {
     const execTransactionArgs = this.getExecTransactionArgs(args.data);
     // Not a valid execTransaction call
     if (!execTransactionArgs) {
@@ -149,10 +151,10 @@ export class LimitAddressesMapper {
     return isCancellation || this.safeDecoder.isCall(execTransactionArgs.data);
   }
 
-  private getExecTransactionArgs(data: Hex): {
-    to: Hex;
+  private getExecTransactionArgs(data: `0x${string}`): {
+    to: `0x${string}`;
     value: bigint;
-    data: Hex;
+    data: `0x${string}`;
   } | null {
     try {
       const safeDecodedData = this.safeDecoder.decodeFunctionData({
@@ -173,7 +175,10 @@ export class LimitAddressesMapper {
     }
   }
 
-  private isValidErc20Transfer(args: { to: Hex; data: Hex }): boolean {
+  private isValidErc20Transfer(args: {
+    to: `0x${string}`;
+    data: `0x${string}`;
+  }): boolean {
     // Can throw but called after this.erc20Decoder.helpers.isTransfer
     const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
       data: args.data,
@@ -188,7 +193,10 @@ export class LimitAddressesMapper {
     return to !== args.to;
   }
 
-  private isValidErc20TransferFrom(args: { to: Hex; data: Hex }): boolean {
+  private isValidErc20TransferFrom(args: {
+    to: `0x${string}`;
+    data: `0x${string}`;
+  }): boolean {
     // Can throw but called after this.erc20Decoder.helpers.isTransferFrom
     const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
       data: args.data,
@@ -205,7 +213,7 @@ export class LimitAddressesMapper {
 
   private async isOfficialMastercopy(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): Promise<boolean> {
     try {
       await this.safeRepository.getSafe(args);
@@ -218,7 +226,7 @@ export class LimitAddressesMapper {
   private isOfficialMultiSendDeployment(args: {
     version: string;
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): boolean {
     const multiSendCallOnlyDeployment = getMultiSendCallOnlyDeployment({
       version: args.version,
@@ -244,7 +252,9 @@ export class LimitAddressesMapper {
     );
   }
 
-  private getSafeAddressFromMultiSend = (data: Hex): Hex => {
+  private getSafeAddressFromMultiSend = (
+    data: `0x${string}`,
+  ): `0x${string}` => {
     // Decode transactions within MultiSend
     const transactions = this.multiSendDecoder.mapMultiSendTransactions(data);
 
@@ -274,7 +284,7 @@ export class LimitAddressesMapper {
   private isOfficialProxyFactoryDeployment(args: {
     version: string;
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): boolean {
     const proxyFactoryDeployment = getProxyFactoryDeployment({
       version: args.version,
@@ -290,7 +300,7 @@ export class LimitAddressesMapper {
   private isValidCreateProxyWithNonceCall(args: {
     version: string;
     chainId: string;
-    data: Hex;
+    data: `0x${string}`;
   }): boolean {
     let singleton: string | null = null;
 
@@ -325,7 +335,9 @@ export class LimitAddressesMapper {
     return isL1Singleton || isL2Singleton;
   }
 
-  private getOwnersFromCreateProxyWithNonce(data: Hex): readonly Hex[] {
+  private getOwnersFromCreateProxyWithNonce(
+    data: `0x${string}`,
+  ): readonly `0x${string}`[] {
     const decodedProxyFactory = this.proxyFactoryDecoder.decodeFunctionData({
       data,
     });

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -64,14 +64,14 @@ export class RelayRepository {
 
   async getRelayCount(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): Promise<number> {
     return this.relayApi.getRelayCount(args);
   }
 
   private async canRelay(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): Promise<{ result: boolean; currentCount: number }> {
     const currentCount = await this.getRelayCount(args);
     return { result: currentCount < this.limit, currentCount };
@@ -79,7 +79,7 @@ export class RelayRepository {
 
   private async incrementRelayCount(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }): Promise<void> {
     const currentCount = await this.getRelayCount(args);
     const incremented = currentCount + 1;

--- a/src/routes/relay/entities/relay.dto.entity.ts
+++ b/src/routes/relay/entities/relay.dto.entity.ts
@@ -1,6 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { z } from 'zod';
-import { Hex } from 'viem';
 import { RelayDtoSchema } from '@/routes/relay/entities/schemas/relay.dto.schema';
 
 export class RelayDto implements z.infer<typeof RelayDtoSchema> {
@@ -8,10 +7,10 @@ export class RelayDto implements z.infer<typeof RelayDtoSchema> {
   version!: string;
 
   @ApiProperty()
-  to!: Hex;
+  to!: `0x${string}`;
 
   @ApiProperty()
-  data!: Hex;
+  data!: `0x${string}`;
 
   @ApiPropertyOptional({
     type: String,

--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -10,6 +10,7 @@ import { UnofficialMasterCopyExceptionFilter } from '@/domain/relay/exception-fi
 import { UnofficialMultiSendExceptionFilter } from '@/domain/relay/exception-filters/unofficial-multisend.error';
 import { UnofficialProxyFactoryExceptionFilter } from '@/domain/relay/exception-filters/unofficial-proxy-factory.exception-filter';
 import { RelayDtoSchema } from '@/routes/relay/entities/schemas/relay.dto.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('relay')
 @Controller({
@@ -39,7 +40,8 @@ export class RelayController {
   @Get(':safeAddress')
   async getRelaysRemaining(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
   ): Promise<{
     remaining: number;
     limit: number;

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -30,7 +30,7 @@ export class RelayService {
 
   async getRelaysRemaining(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<{ remaining: number; limit: number }> {
     const currentCount = await this.relayRepository.getRelayCount({
       chainId: args.chainId,


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `safeAddress` of `RelayController['getRelaysRemaining']` and propagates the stricter (`0x${string}`) type throughout the project accordingly

## Changes

- Add checksumming and validation to `RelayController['getRelaysRemaining']`
- Propagate type scrictness across:
  - relay-related cache keys
  - `IRelayApi` and its implementors (`GelatoApi`)
  - relay-related builders/encoders
  - `RelayLimitReachedError['address']`
  - `LimitAddressesMapper`
  - `RelayRepository`
  - `RelayDto`
  - `RelayController`
  - `RelayService