### PR TITLE
Improve CAIP-10 address parsing

### DIFF
--- a/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
@@ -56,6 +56,24 @@ describe('Caip10AddressesPipe', () => {
       ]);
   });
 
+  it('throws for non-numerical chainIds', async () => {
+    const chainId = faker.string.alpha();
+    const address = faker.finance.ethereumAddress();
+
+    await request(app.getHttpServer())
+      .get(`/test?addresses=${chainId}:${address}`)
+      .expect(500);
+  });
+
+  it('throws for non-address addresses', async () => {
+    const chainId = faker.string.numeric();
+    const address = faker.number.int();
+
+    await request(app.getHttpServer())
+      .get(`/test?addresses=${chainId}:${address}`)
+      .expect(500);
+  });
+
   it('throws for missing params', async () => {
     await request(app.getHttpServer()).get('/test?addresses=').expect(500);
   });

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.ts
@@ -1,21 +1,29 @@
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { PipeTransform, Injectable } from '@nestjs/common';
-import { getAddress } from 'viem';
+import { z } from 'zod';
+
+const Caip10AddressPipeSchema = z.object({
+  chainId: NumericStringSchema,
+  address: AddressSchema,
+});
 
 @Injectable()
 export class Caip10AddressesPipe
-  implements PipeTransform<string, Array<{ chainId: string; address: string }>>
+  implements
+    PipeTransform<string, Array<{ chainId: string; address: `0x${string}` }>>
 {
   transform(data: string): Array<{
     chainId: string;
-    address: string;
+    address: `0x${string}`;
   }> {
     const addresses = data.split(',').map((caip10Address: string) => {
       const [chainId, address] = caip10Address.split(':');
 
-      return { chainId, address: getAddress(address) };
+      return Caip10AddressPipeSchema.parse({ chainId, address });
     });
 
-    if (addresses.length === 0 || !addresses[0].address) {
+    if (addresses.length === 0) {
       throw new Error(
         'Provided addresses do not conform to the CAIP-10 standard',
       );


### PR DESCRIPTION
## Summary

With https://github.com/safe-global/safe-client-gateway/pull/1567, we increased the strictness of incoming addresses. Whilst [we added](https://github.com/safe-global/safe-client-gateway/pull/1567/files#diff-41bbc2da066ecb6f33b015e8764195bf3f6a82c3bf1ca89b5796ae3d271f1f93R15) checksumming of addresses correctly, it does not match the "standard" implementation of schema-reliance.

This pivots from using `getAddress` to parsing against a designated schema instead. It also adds verification of the `chainId`.

## Changes

- Create `Caip10AddressPipeSchema`
- Parse incoming CAIP-10 addresses against schema
- Add test coverage