### PR TITLE
Fallback to `threshold` if `confirmationsRequired` of transaction is `null`

### DIFF
--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -46,7 +46,7 @@ export const MultisigTransactionSchema = z.object({
   gasUsed: z.number().nullish().default(null),
   fee: NumericStringSchema.nullish().default(null),
   origin: z.string().nullish().default(null),
-  confirmationsRequired: z.number(),
+  confirmationsRequired: z.number().nullish().default(null),
   confirmations: z.array(ConfirmationSchema).nullish().default(null),
   signatures: HexSchema.nullish().default(null),
   trusted: z.boolean(),

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -248,6 +248,167 @@ describe('Safes Controller Overview (Unit)', () => {
       );
     });
 
+    it('overview with transactions awaiting confirmation is correctly serialised from threshold if confirmationsRequired is null', async () => {
+      const chain = chainBuilder().with('chainId', '10').build();
+      const safeInfo = safeBuilder().build();
+      const tokenAddress = faker.finance.ethereumAddress();
+      const secondTokenAddress = faker.finance.ethereumAddress();
+      const transactionApiBalancesResponse = [
+        balanceBuilder()
+          .with('tokenAddress', null)
+          .with('balance', '3000000000000000000')
+          .with('token', null)
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(tokenAddress))
+          .with('balance', '4000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+        balanceBuilder()
+          .with('tokenAddress', getAddress(secondTokenAddress))
+          .with('balance', '3000000000000000000')
+          .with('token', balanceTokenBuilder().with('decimals', 17).build())
+          .build(),
+      ];
+      const currency = faker.finance.currencyCode();
+      const nativeCoinPriceProviderResponse = {
+        // @ts-expect-error - TODO: remove after migration
+        [chain.pricesProvider.nativeCoin!]: {
+          [currency.toLowerCase()]: 1536.75,
+        },
+      };
+      const tokenPriceProviderResponse = {
+        [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
+        [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
+      };
+      const walletAddress = getAddress(faker.finance.ethereumAddress());
+      const multisigTransactions = [
+        multisigTransactionToJson(
+          multisigTransactionBuilder()
+            .with('confirmationsRequired', null)
+            .with('confirmations', [
+              // Signature provided
+              confirmationBuilder().with('owner', walletAddress).build(),
+            ])
+            .build(),
+        ),
+        multisigTransactionToJson(multisigTransactionBuilder().build()),
+      ];
+      const queuedTransactions = pageBuilder()
+        .with('results', multisigTransactions)
+        .with('count', multisigTransactions.length)
+        .build();
+
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: safeInfo, status: 200 });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
+            return Promise.resolve({
+              data: transactionApiBalancesResponse,
+              status: 200,
+            });
+          }
+          case `${pricesProviderUrl}/simple/price`: {
+            return Promise.resolve({
+              data: nativeCoinPriceProviderResponse,
+              status: 200,
+            });
+          }
+          // @ts-expect-error - TODO: remove after migration
+          case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
+            return Promise.resolve({
+              data: tokenPriceProviderResponse,
+              status: 200,
+            });
+          }
+          case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: queuedTransactions,
+              status: 200,
+            });
+          }
+          default: {
+            return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/safes?currency=${currency}&safes=${chain.chainId}:${safeInfo.address}&wallet_address=${walletAddress}`,
+        )
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject([
+            {
+              address: {
+                value: safeInfo.address,
+                name: null,
+                logoUri: null,
+              },
+              chainId: chain.chainId,
+              threshold: safeInfo.threshold,
+              owners: safeInfo.owners.map((owner) => ({
+                value: owner,
+                name: null,
+                logoUri: null,
+              })),
+              fiatTotal: '5410.25',
+              queued: 2,
+              awaitingConfirmation: 1,
+            },
+          ]),
+        );
+
+      expect(networkService.get.mock.calls.length).toBe(6);
+
+      expect(networkService.get.mock.calls[0][0].url).toBe(
+        `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
+      );
+      expect(networkService.get.mock.calls[1][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[2][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
+      );
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+        params: { trusted: false, exclude_spam: true },
+      });
+      expect(networkService.get.mock.calls[3][0].url).toBe(
+        // @ts-expect-error - TODO: remove after migration
+        `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
+      );
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: {
+          vs_currencies: currency.toLowerCase(),
+          contract_addresses: [
+            tokenAddress.toLowerCase(),
+            secondTokenAddress.toLowerCase(),
+          ].join(','),
+        },
+      });
+      expect(networkService.get.mock.calls[4][0].url).toBe(
+        `${pricesProviderUrl}/simple/price`,
+      );
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+        headers: { 'x-cg-pro-api-key': pricesApiKey },
+        params: {
+          // @ts-expect-error - TODO: remove after migration
+          ids: chain.pricesProvider.nativeCoin,
+          vs_currencies: currency.toLowerCase(),
+        },
+      });
+      expect(networkService.get.mock.calls[5][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+    });
+
     it('should not return awaiting confirmations if no more confirmations are required', async () => {
       const chain = chainBuilder().with('chainId', '10').build();
       const safeInfo = safeBuilder().build();

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -165,6 +165,7 @@ export class SafesService {
           ? this.computeAwaitingConfirmation({
               transactions: queue.results,
               walletAddress: args.walletAddress,
+              threshold: safe.threshold,
             })
           : null;
 
@@ -206,11 +207,13 @@ export class SafesService {
   private computeAwaitingConfirmation(args: {
     transactions: Array<MultisigTransaction>;
     walletAddress: `0x${string}`;
+    threshold: number;
   }): number {
     return args.transactions.reduce(
       (acc, { confirmationsRequired, confirmations }) => {
         const isConfirmed =
-          !!confirmations && confirmations.length >= confirmationsRequired;
+          !!confirmations &&
+          confirmations.length >= (confirmationsRequired ?? args.threshold);
         const isSignable =
           !isConfirmed &&
           !confirmations?.some((confirmation) => {

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.spec.ts
@@ -15,129 +15,266 @@ describe('Multisig Transaction execution info mapper (Unit)', () => {
     mapper = new MultisigTransactionExecutionInfoMapper();
   });
 
-  it('should return a MultiSigExecutionInfo with no missing signers', () => {
-    const safe = safeBuilder().build();
-    const proposer = faker.finance.ethereumAddress();
-    const transaction = multisigTransactionBuilder()
-      .with('proposer', getAddress(proposer))
-      .build();
+  describe('based on confirmationsRequired', () => {
+    it('should return a MultiSigExecutionInfo with no missing signers', () => {
+      const safe = safeBuilder().build();
+      const proposer = faker.finance.ethereumAddress();
+      const transaction = multisigTransactionBuilder()
+        .with('proposer', getAddress(proposer))
+        .build();
 
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.Success,
-    );
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.Success,
+      );
 
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        Number(transaction.confirmations?.length),
-        null,
-      ),
-    );
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          transaction.confirmationsRequired!,
+          Number(transaction.confirmations?.length),
+          null,
+        ),
+      );
+    });
+
+    it('should return a MultiSigExecutionInfo with no missing signers and zero confirmations', () => {
+      const safe = safeBuilder().build();
+      const transaction = multisigTransactionBuilder()
+        .with('confirmations', null)
+        .build();
+
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.Success,
+      );
+
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          transaction.confirmationsRequired!,
+          0,
+          null,
+        ),
+      );
+    });
+
+    it('should return a MultiSigExecutionInfo with empty missing signers', () => {
+      const safe = safeBuilder().with('owners', []).build();
+      const transaction = multisigTransactionBuilder().build();
+
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.AwaitingConfirmations,
+      );
+
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          transaction.confirmationsRequired!,
+          Number(transaction.confirmations?.length),
+          [],
+        ),
+      );
+    });
+
+    it('should return a MultiSigExecutionInfo with all safe owners as missing signers', () => {
+      const transaction = multisigTransactionBuilder().build();
+      const safe = safeBuilder()
+        .with('owners', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.AwaitingConfirmations,
+      );
+
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          transaction.confirmationsRequired!,
+          Number(transaction.confirmations?.length),
+          safe.owners.map((address) => new AddressInfo(address)),
+        ),
+      );
+    });
+
+    it('should return a MultiSigExecutionInfo with some safe owners as missing signers', () => {
+      const confirmations = [
+        confirmationBuilder()
+          .with('owner', getAddress(faker.finance.ethereumAddress()))
+          .build(),
+        confirmationBuilder()
+          .with('owner', getAddress(faker.finance.ethereumAddress()))
+          .build(),
+      ];
+      const transaction = multisigTransactionBuilder()
+        .with('proposer', getAddress(confirmations[0].owner))
+        .with('confirmations', confirmations)
+        .build();
+      const safe = safeBuilder()
+        .with('owners', [
+          getAddress(confirmations[0].owner),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.AwaitingConfirmations,
+      );
+
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          transaction.confirmationsRequired!,
+          Number(transaction.confirmations?.length),
+          [new AddressInfo(safe.owners[1])],
+        ),
+      );
+    });
   });
 
-  it('should return a MultiSigExecutionInfo with no missing signers and zero confirmations', () => {
-    const safe = safeBuilder().build();
-    const transaction = multisigTransactionBuilder()
-      .with('confirmations', null)
-      .build();
+  describe('based on threshold when confirmationsRequired is null', () => {
+    it('should return a MultiSigExecutionInfo with no missing signers', () => {
+      const safe = safeBuilder().build();
+      const proposer = faker.finance.ethereumAddress();
+      const transaction = multisigTransactionBuilder()
+        .with('proposer', getAddress(proposer))
+        .with('confirmationsRequired', null)
+        .build();
 
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.Success,
-    );
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.Success,
+      );
 
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        0,
-        null,
-      ),
-    );
-  });
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          safe.threshold,
+          Number(transaction.confirmations?.length),
+          null,
+        ),
+      );
+    });
 
-  it('should return a MultiSigExecutionInfo with empty missing signers', () => {
-    const safe = safeBuilder().with('owners', []).build();
-    const transaction = multisigTransactionBuilder().build();
+    it('should return a MultiSigExecutionInfo with no missing signers and zero confirmations', () => {
+      const safe = safeBuilder().build();
+      const transaction = multisigTransactionBuilder()
+        .with('confirmations', null)
+        .with('confirmationsRequired', null)
+        .build();
 
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.AwaitingConfirmations,
-    );
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.Success,
+      );
 
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        Number(transaction.confirmations?.length),
-        [],
-      ),
-    );
-  });
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(transaction.nonce, safe.threshold, 0, null),
+      );
+    });
 
-  it('should return a MultiSigExecutionInfo with all safe owners as missing signers', () => {
-    const transaction = multisigTransactionBuilder().build();
-    const safe = safeBuilder()
-      .with('owners', [
-        getAddress(faker.finance.ethereumAddress()),
-        getAddress(faker.finance.ethereumAddress()),
-      ])
-      .build();
+    it('should return a MultiSigExecutionInfo with empty missing signers', () => {
+      const safe = safeBuilder()
+        .with('owners', [])
+        .with('threshold', 0)
+        .build();
+      const transaction = multisigTransactionBuilder()
+        .with('confirmationsRequired', null)
+        .build();
 
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.AwaitingConfirmations,
-    );
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.AwaitingConfirmations,
+      );
 
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        Number(transaction.confirmations?.length),
-        safe.owners.map((address) => new AddressInfo(address)),
-      ),
-    );
-  });
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          safe.threshold,
+          Number(transaction.confirmations?.length),
+          [],
+        ),
+      );
+    });
 
-  it('should return a MultiSigExecutionInfo with some safe owners as missing signers', () => {
-    const confirmations = [
-      confirmationBuilder()
-        .with('owner', getAddress(faker.finance.ethereumAddress()))
-        .build(),
-      confirmationBuilder()
-        .with('owner', getAddress(faker.finance.ethereumAddress()))
-        .build(),
-    ];
-    const transaction = multisigTransactionBuilder()
-      .with('proposer', getAddress(confirmations[0].owner))
-      .with('confirmations', confirmations)
-      .build();
-    const safe = safeBuilder()
-      .with('owners', [
-        getAddress(confirmations[0].owner),
-        getAddress(faker.finance.ethereumAddress()),
-      ])
-      .build();
+    it('should return a MultiSigExecutionInfo with all safe owners as missing signers', () => {
+      const transaction = multisigTransactionBuilder()
+        .with('confirmationsRequired', null)
+        .build();
+      const safe = safeBuilder()
+        .with('owners', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .with('threshold', 2)
+        .build();
 
-    const executionInfo = mapper.mapExecutionInfo(
-      transaction,
-      safe,
-      TransactionStatus.AwaitingConfirmations,
-    );
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.AwaitingConfirmations,
+      );
 
-    expect(executionInfo).toEqual(
-      new MultisigExecutionInfo(
-        transaction.nonce,
-        transaction.confirmationsRequired,
-        Number(transaction.confirmations?.length),
-        [new AddressInfo(safe.owners[1])],
-      ),
-    );
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          safe.threshold,
+          Number(transaction.confirmations?.length),
+          safe.owners.map((address) => new AddressInfo(address)),
+        ),
+      );
+    });
+
+    it('should return a MultiSigExecutionInfo with some safe owners as missing signers', () => {
+      const confirmations = [
+        confirmationBuilder()
+          .with('owner', getAddress(faker.finance.ethereumAddress()))
+          .build(),
+        confirmationBuilder()
+          .with('owner', getAddress(faker.finance.ethereumAddress()))
+          .build(),
+      ];
+      const transaction = multisigTransactionBuilder()
+        .with('proposer', getAddress(confirmations[0].owner))
+        .with('confirmations', confirmations)
+        .with('confirmationsRequired', null)
+        .build();
+      const safe = safeBuilder()
+        .with('owners', [
+          getAddress(confirmations[0].owner),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .with('threshold', 2)
+        .build();
+
+      const executionInfo = mapper.mapExecutionInfo(
+        transaction,
+        safe,
+        TransactionStatus.AwaitingConfirmations,
+      );
+
+      expect(executionInfo).toEqual(
+        new MultisigExecutionInfo(
+          transaction.nonce,
+          safe.threshold,
+          Number(transaction.confirmations?.length),
+          [new AddressInfo(safe.owners[1])],
+        ),
+      );
+    });
   });
 });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper.ts
@@ -19,7 +19,7 @@ export class MultisigTransactionExecutionInfoMapper {
 
     return new MultisigExecutionInfo(
       transaction.nonce,
-      transaction.confirmationsRequired,
+      transaction.confirmationsRequired ?? safe.threshold,
       transaction?.confirmations?.length || 0,
       missingSigners,
     );

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.spec.ts
@@ -64,7 +64,7 @@ describe('Multisig Transaction status mapper (Unit)', () => {
     );
   });
 
-  it('should return an AWAITING_EXECUTION status', () => {
+  it('should return an AWAITING_EXECUTION status based on confirmationsRequired', () => {
     const transaction = multisigTransactionBuilder()
       .with('isExecuted', false)
       .with('nonce', 4)
@@ -75,6 +75,23 @@ describe('Multisig Transaction status mapper (Unit)', () => {
       .with('confirmationsRequired', 1)
       .build();
     const safe = { ...safeBuilder().build(), nonce: 3 };
+
+    expect(mapper.mapTransactionStatus(transaction, safe)).toBe(
+      TransactionStatus.AwaitingExecution,
+    );
+  });
+
+  it('should return an AWAITING_EXECUTION status based on threshold if confirmationsRequired is null', () => {
+    const transaction = multisigTransactionBuilder()
+      .with('isExecuted', false)
+      .with('nonce', 4)
+      .with('confirmations', [
+        confirmationBuilder().build(),
+        confirmationBuilder().build(),
+      ])
+      .with('confirmationsRequired', null)
+      .build();
+    const safe = safeBuilder().with('nonce', 3).with('threshold', 1).build();
 
     expect(mapper.mapTransactionStatus(transaction, safe)).toBe(
       TransactionStatus.AwaitingExecution,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper.ts
@@ -19,7 +19,7 @@ export class MultisigTransactionStatusMapper {
     }
     if (
       (transaction.confirmations?.length || 0) <
-      transaction.confirmationsRequired
+      (transaction.confirmationsRequired ?? safe.threshold)
     ) {
       return TransactionStatus.AwaitingConfirmations;
     }


### PR DESCRIPTION
## Summary

We validate fetched multisig transactions to ensure they are as expected. The `MultisigTransactionSchema` expected `confirmationsRequired` to be a number but it can also be `null`.

This changes the validation to also expect nullish values and default to `null` is no number is returned.

## Changes

- Change `MultisigTransactionSchema['confirmationsRequired']` to expect a number or nullish values, defaulting to `null`
- Update instances where `confirmationsRequired` is references, falling back to the threshold of the Safe
- Add relative test coverage