### PR TITLE
Improve flakiness of `TransactionsViewController` tests

### DIFF
--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -361,7 +361,8 @@ describe('TransactionsViewController tests', () => {
     const preSignature = preSignatureEncoder.build();
     const order = orderBuilder()
       .with('uid', preSignature.orderUid)
-      .with('fullAppData', `{ "appCode": "${faker.company.buzzNoun()}" }`)
+      // We don't use buzzNoun here as it can generate the same value as verifiedApp
+      .with('fullAppData', `{ "appCode": "restrited app code" }`)
       .build();
     const buyToken = tokenBuilder().with('address', order.buyToken).build();
     const sellToken = tokenBuilder().with('address', order.sellToken).build();


### PR DESCRIPTION
## Summary

The "Gets Generic confirmation view if swap app is restricted" of the `TransactionsViewController` tests were intermittently failing. This was happening because `faker` was returning the same value for the `appCode` as that specified as verified. This changes the mock value to a value which is definitively not that of `verifiedApp`.

Note: it would be ideal to continue use of `faker.company.buzzNoun` but it does not allow the exclusion of values. Therefore a static value was chosen instead.

## Changes

- Change value of `appCode` for `fullAppData` to never be the same of `verifiedApp` in test