### PR TITLE
Remove unnecessary fallback for `confirmationsRequired`

### DIFF
--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -30,8 +30,6 @@ export class MultisigTransactionExecutionDetailsMapper {
   ): Promise<MultisigExecutionDetails> {
     const signers = safe.owners.map((owner) => new AddressInfo(owner));
     const gasToken = transaction.gasToken ?? NULL_ADDRESS;
-    const confirmationsRequired =
-      transaction.confirmationsRequired ?? safe.threshold;
     const confirmations = !transaction.confirmations
       ? []
       : transaction.confirmations.map(
@@ -75,7 +73,7 @@ export class MultisigTransactionExecutionDetailsMapper {
       transaction.safeTxHash,
       executor,
       signers,
-      confirmationsRequired,
+      transaction.confirmationsRequired,
       confirmations,
       rejectors,
       gasTokenInfo,


### PR DESCRIPTION
## Summary

`MultisigTransaction['confirmationsRequired']` is the given threshold of a Safe at the time of a transaction. Considering this and that it is always defined, we should not need a fallback value for it.

This removes the fallback value for it when returning `MultisigExecutionDetails`.

## Changes

- Remove fallback value for `MultisigTransaction['confirmationsRequired']`