### PR TITLE
Checksum incoming `address` for estimation and propagate type

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -104,14 +104,14 @@ export class CacheRouter {
 
   static getSafeCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): CacheDir {
     return new CacheDir(CacheRouter.getSafeCacheKey(args), '');
   }
 
   static getSafeCacheKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.SAFE_KEY}_${args.safeAddress}`;
   }
@@ -300,7 +300,7 @@ export class CacheRouter {
 
   static getCreationTransactionCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
       `${args.chainId}_${CacheRouter.CREATION_TRANSACTION_KEY}_${args.safeAddress}`,
@@ -310,7 +310,7 @@ export class CacheRouter {
 
   static getAllTransactionsCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     ordering?: string;
     executed?: boolean;
     queued?: boolean;
@@ -325,7 +325,7 @@ export class CacheRouter {
 
   static getAllTransactionsKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.ALL_TRANSACTIONS_KEY}_${args.safeAddress}`;
   }
@@ -381,14 +381,14 @@ export class CacheRouter {
 
   static getMessagesBySafeCacheKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.MESSAGES_KEY}_${args.safeAddress}`;
   }
 
   static getMessagesBySafeCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): CacheDir {

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -314,7 +314,7 @@ describe('TransactionApi', () => {
 
   describe('clearSafe', () => {
     it('should clear the Safe cache', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearSafe(safeAddress);
 
@@ -1561,7 +1561,7 @@ describe('TransactionApi', () => {
 
   describe('getCreationTransaction', () => {
     it('should return the creation transaction retrieved', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const creationTransaction = creationTransactionBuilder().build();
       const getCreationTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/creation/`;
       const cacheDir = new CacheDir(
@@ -1587,7 +1587,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const getCreationTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/creation/`;
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
@@ -1623,7 +1623,7 @@ describe('TransactionApi', () => {
 
   describe('getAllTransactions', () => {
     it('should return all transactions retrieved', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const ordering = faker.word.noun();
       const executed = faker.datatype.boolean();
       const queued = faker.datatype.boolean();
@@ -1675,7 +1675,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const ordering = faker.word.noun();
       const executed = faker.datatype.boolean();
       const queued = faker.datatype.boolean();
@@ -1733,7 +1733,7 @@ describe('TransactionApi', () => {
 
   describe('clearAllTransactions', () => {
     it('should clear the all transactions cache', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearAllTransactions(safeAddress);
 
@@ -2116,7 +2116,7 @@ describe('TransactionApi', () => {
 
   describe('getEstimation', () => {
     it('should return the estimation received', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const to = getAddress(faker.finance.ethereumAddress());
       const value = faker.string.numeric();
       const data = faker.string.hexadecimal() as `0x${string}`;
@@ -2153,7 +2153,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const to = getAddress(faker.finance.ethereumAddress());
       const value = faker.string.numeric();
       const data = faker.string.hexadecimal() as `0x${string}`;
@@ -2251,7 +2251,7 @@ describe('TransactionApi', () => {
 
   describe('getMessagesBySafe', () => {
     it('should return the message hash received', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const limit = faker.number.int();
       const offset = faker.number.int();
       const getMessageBySafeUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
@@ -2289,7 +2289,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const limit = faker.number.int();
       const offset = faker.number.int();
       const getMessageBySafeUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
@@ -2542,7 +2542,7 @@ describe('TransactionApi', () => {
 
   describe('clearMessagesBySafe', () => {
     it('should clear the messages cache by Safe address', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearMessagesBySafe({ safeAddress });
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -121,7 +121,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getSafe(safeAddress: string): Promise<Safe> {
+  async getSafe(safeAddress: `0x${string}`): Promise<Safe> {
     try {
       const cacheDir = CacheRouter.getSafeCacheDir({
         chainId: this.chainId,
@@ -139,7 +139,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearSafe(safeAddress: string): Promise<void> {
+  async clearSafe(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getSafeCacheKey({
       chainId: this.chainId,
       safeAddress,
@@ -642,7 +642,7 @@ export class TransactionApi implements ITransactionApi {
   // Important: there is no hook which invalidates this endpoint,
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
   async getCreationTransaction(
-    safeAddress: string,
+    safeAddress: `0x${string}`,
   ): Promise<CreationTransaction> {
     try {
       const cacheDir = CacheRouter.getCreationTransactionCacheDir({
@@ -662,7 +662,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getAllTransactions(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     ordering?: string;
     executed?: boolean;
     queued?: boolean;
@@ -696,7 +696,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearAllTransactions(safeAddress: string): Promise<void> {
+  async clearAllTransactions(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getAllTransactionsKey({
       chainId: this.chainId,
       safeAddress,
@@ -821,7 +821,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getEstimation(args: {
-    address: string;
+    address: `0x${string}`;
     getEstimationDto: GetEstimationDto;
   }): Promise<Estimation> {
     try {
@@ -860,7 +860,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getMessagesBySafe(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number | undefined;
     offset?: number | undefined;
   }): Promise<Page<Message>> {
@@ -957,7 +957,9 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearMessagesBySafe(args: { safeAddress: string }): Promise<void> {
+  async clearMessagesBySafe(args: {
+    safeAddress: `0x${string}`;
+  }): Promise<void> {
     const key = CacheRouter.getMessagesBySafeCacheKey({
       chainId: this.chainId,
       safeAddress: args.safeAddress,

--- a/src/domain/estimations/estimations.repository.interface.ts
+++ b/src/domain/estimations/estimations.repository.interface.ts
@@ -9,7 +9,7 @@ export const IEstimationsRepository = Symbol('IEstimationsRepository');
 export interface IEstimationsRepository {
   getEstimation(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
     getEstimationDto: GetEstimationDto;
   }): Promise<Estimation>;
 }

--- a/src/domain/estimations/estimations.repository.ts
+++ b/src/domain/estimations/estimations.repository.ts
@@ -14,7 +14,7 @@ export class EstimationsRepository implements IEstimationsRepository {
 
   async getEstimation(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
     getEstimationDto: GetEstimationDto;
   }): Promise<Estimation> {
     const api = await this.transactionApiManager.getTransactionApi(

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -29,9 +29,9 @@ export interface ITransactionApi {
 
   getSingletons(): Promise<Singleton[]>;
 
-  getSafe(safeAddress: string): Promise<Safe>;
+  getSafe(safeAddress: `0x${string}`): Promise<Safe>;
 
-  clearSafe(address: string): Promise<void>;
+  clearSafe(address: `0x${string}`): Promise<void>;
 
   getContract(contractAddress: string): Promise<Contract>;
 
@@ -144,7 +144,7 @@ export interface ITransactionApi {
   clearMultisigTransaction(safeTransactionHash: string): Promise<void>;
 
   getMultisigTransactions(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     ordering?: string;
     executed?: boolean;
     trusted?: boolean;
@@ -160,10 +160,12 @@ export interface ITransactionApi {
 
   clearMultisigTransactions(safeAddress: string): Promise<void>;
 
-  getCreationTransaction(safeAddress: string): Promise<CreationTransaction>;
+  getCreationTransaction(
+    safeAddress: `0x${string}`,
+  ): Promise<CreationTransaction>;
 
   getAllTransactions(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     ordering?: string;
     executed?: boolean;
     queued?: boolean;
@@ -171,7 +173,7 @@ export interface ITransactionApi {
     offset?: number;
   }): Promise<Page<Transaction>>;
 
-  clearAllTransactions(safeAddress: string): Promise<void>;
+  clearAllTransactions(safeAddress: `0x${string}`): Promise<void>;
 
   getToken(address: string): Promise<Token>;
 
@@ -193,14 +195,14 @@ export interface ITransactionApi {
   }): Promise<void>;
 
   getEstimation(args: {
-    address: string;
+    address: `0x${string}`;
     getEstimationDto: GetEstimationDto;
   }): Promise<Estimation>;
 
   getMessageByHash(messageHash: string): Promise<Message>;
 
   getMessagesBySafe(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Message>>;
@@ -222,7 +224,7 @@ export interface ITransactionApi {
     signature: `0x${string}`;
   }): Promise<unknown>;
 
-  clearMessagesBySafe(args: { safeAddress: string }): Promise<void>;
+  clearMessagesBySafe(args: { safeAddress: `0x${string}` }): Promise<void>;
 
   clearMessagesByHash(args: { messageHash: string }): Promise<void>;
 }

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -27,7 +27,7 @@ export class MessagesRepository implements IMessagesRepository {
 
   async getMessagesBySafe(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number | undefined;
     offset?: number | undefined;
   }): Promise<Page<Message>> {
@@ -76,7 +76,7 @@ export class MessagesRepository implements IMessagesRepository {
 
   async clearMessagesBySafe(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const api = await this.transactionApiManager.getTransactionApi(
       args.chainId,

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -16,19 +16,19 @@ import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api
 export const ISafeRepository = Symbol('ISafeRepository');
 
 export interface ISafeRepository {
-  getSafe(args: { chainId: string; address: string }): Promise<Safe>;
+  getSafe(args: { chainId: string; address: `0x${string}` }): Promise<Safe>;
 
-  clearSafe(args: { chainId: string; address: string }): Promise<void>;
+  clearSafe(args: { chainId: string; address: `0x${string}` }): Promise<void>;
 
   isOwner(args: {
     chainId: string;
-    safeAddress: string;
-    address: string;
+    safeAddress: `0x${string}`;
+    address: `0x${string}`;
   }): Promise<boolean>;
 
   getCollectibleTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Transfer>>;
@@ -65,7 +65,7 @@ export interface ISafeRepository {
 
   getModuleTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     to?: string;
     module?: string;
     limit?: number;
@@ -104,12 +104,12 @@ export interface ISafeRepository {
 
   getCreationTransaction(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<CreationTransaction>;
 
   getTransactionHistory(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Transaction>>;
@@ -121,7 +121,7 @@ export interface ISafeRepository {
 
   clearAllExecutedTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 
   clearMultisigTransaction(args: {
@@ -136,7 +136,7 @@ export interface ISafeRepository {
 
   getMultisigTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executed?: boolean;
     executionDateGte?: string;
     executionDateLte?: string;
@@ -157,7 +157,7 @@ export interface ISafeRepository {
 
   getTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
   }): Promise<Page<Transfer>>;
 
@@ -168,7 +168,7 @@ export interface ISafeRepository {
 
   getLastTransactionSortedByNonce(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<MultisigTransaction | null>;
 
   proposeTransaction(args: {
@@ -189,7 +189,7 @@ export interface ISafeRepository {
    */
   getNonces(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<{ currentNonce: number; recommendedNonce: number }>;
 
   getSafesByModule(args: {

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -26,7 +26,6 @@ import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 import { TransactionTypePageSchema } from '@/domain/safe/entities/schemas/transaction-type.schema';
 import { AddConfirmationDto } from '@/domain/transactions/entities/add-confirmation.dto.entity';
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
-import { getAddress } from 'viem';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
 import { CreationTransactionSchema } from '@/domain/safe/entities/schemas/creation-transaction.schema';
@@ -42,14 +41,20 @@ export class SafeRepository implements ISafeRepository {
     private readonly chainsRepository: IChainsRepository,
   ) {}
 
-  async getSafe(args: { chainId: string; address: string }): Promise<Safe> {
+  async getSafe(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<Safe> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const safe = await transactionService.getSafe(args.address);
     return SafeSchema.parse(safe);
   }
 
-  async clearSafe(args: { chainId: string; address: string }): Promise<void> {
+  async clearSafe(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
     return transactionService.clearSafe(args.address);
@@ -57,16 +62,14 @@ export class SafeRepository implements ISafeRepository {
 
   async isOwner(args: {
     chainId: string;
-    safeAddress: string;
-    address: string;
+    safeAddress: `0x${string}`;
+    address: `0x${string}`;
   }): Promise<boolean> {
     const safe = await this.getSafe({
       chainId: args.chainId,
       address: args.safeAddress,
     });
-    const owner = getAddress(args.address);
-    const owners = safe.owners.map((rawAddress) => getAddress(rawAddress));
-    return owners.includes(owner);
+    return safe.owners.includes(args.address);
   }
 
   async getCollectibleTransfers(args: {
@@ -215,7 +218,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getCreationTransaction(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<CreationTransaction> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
@@ -227,7 +230,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getTransactionHistory(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Transaction>> {
@@ -236,7 +239,7 @@ export class SafeRepository implements ISafeRepository {
 
   private async getAllExecutedTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     ordering?: string;
     limit?: number;
     offset?: number;
@@ -255,7 +258,7 @@ export class SafeRepository implements ISafeRepository {
 
   async clearAllExecutedTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
@@ -321,7 +324,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getMultisigTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executed?: boolean;
     executionDateGte?: string;
     executionDateLte?: string;
@@ -406,7 +409,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getLastTransactionSortedByNonce(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<MultisigTransaction | null> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
@@ -439,7 +442,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getNonces(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<{ currentNonce: number; recommendedNonce: number }> {
     const safe = await this.getSafe({
       chainId: args.chainId,

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -29,6 +29,7 @@ import { AccountDataSourceModule } from '@/datasources/account/account.datasourc
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import { getAddress } from 'viem';
 
 describe('Estimations Controller (Unit)', () => {
   let app: INestApplication;
@@ -204,8 +205,9 @@ describe('Estimations Controller (Unit)', () => {
       .build();
     networkService.get.mockImplementation(({ url }) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
-      const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
+      // Param ValidationPipe checksums address
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}`;
+      const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/`;
       if (url === chainsUrl) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -224,7 +226,8 @@ describe('Estimations Controller (Unit)', () => {
       return Promise.reject(`No matching rule for url: ${url}`);
     });
     networkService.post.mockImplementation(({ url }) => {
-      const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
+      // Param ValidationPipe checksums address
+      const estimationsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation, status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
@@ -255,8 +258,9 @@ describe('Estimations Controller (Unit)', () => {
     const estimation = estimationBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
-      const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
+      // Param ValidationPipe checksums address
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}`;
+      const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/`;
       if (url === chainsUrl) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -272,7 +276,8 @@ describe('Estimations Controller (Unit)', () => {
       return Promise.reject(`No matching rule for url: ${url}`);
     });
     networkService.post.mockImplementation(({ url }) => {
-      const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
+      // Param ValidationPipe checksums address
+      const estimationsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation, status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
@@ -306,8 +311,9 @@ describe('Estimations Controller (Unit)', () => {
       .build();
     networkService.get.mockImplementation(({ url }) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
-      const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
+      // Param ValidationPipe checksums address
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}`;
+      const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/`;
       if (url === chainsUrl) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -326,7 +332,8 @@ describe('Estimations Controller (Unit)', () => {
       return Promise.reject(`No matching rule for url: ${url}`);
     });
     networkService.post.mockImplementation(({ url }) => {
-      const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
+      // Param ValidationPipe checksums address
+      const estimationsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation, status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);

--- a/src/routes/estimations/estimations.controller.ts
+++ b/src/routes/estimations/estimations.controller.ts
@@ -18,7 +18,7 @@ export class EstimationsController {
   @ApiOkResponse({ type: EstimationResponse })
   @HttpCode(200)
   @Post('chains/:chainId/safes/:address/multisig-transactions/estimations')
-  async getContract(
+  async getEstimation(
     @Param('chainId') chainId: string,
     @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
     @Body(new ValidationPipe(GetEstimationDtoSchema))

--- a/src/routes/estimations/estimations.controller.ts
+++ b/src/routes/estimations/estimations.controller.ts
@@ -5,6 +5,7 @@ import { GetEstimationDto } from '@/routes/estimations/entities/get-estimation.d
 import { EstimationsService } from '@/routes/estimations/estimations.service';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { GetEstimationDtoSchema } from '@/routes/estimations/entities/schemas/get-estimation.dto.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('estimations')
 @Controller({
@@ -19,7 +20,7 @@ export class EstimationsController {
   @Post('chains/:chainId/safes/:address/multisig-transactions/estimations')
   async getContract(
     @Param('chainId') chainId: string,
-    @Param('address') address: string,
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
     @Body(new ValidationPipe(GetEstimationDtoSchema))
     getEstimationDto: GetEstimationDto,
   ): Promise<EstimationResponse> {

--- a/src/routes/estimations/estimations.service.ts
+++ b/src/routes/estimations/estimations.service.ts
@@ -26,7 +26,7 @@ export class EstimationsService {
    */
   async getEstimation(args: {
     chainId: string;
-    address: string;
+    address: `0x${string}`;
     getEstimationDto: GetEstimationDto;
   }): Promise<EstimationResponse> {
     const estimation = await this.estimationsRepository.getEstimation(args);

--- a/src/routes/messages/messages.controller.ts
+++ b/src/routes/messages/messages.controller.ts
@@ -14,6 +14,7 @@ import { MessagesService } from '@/routes/messages/messages.service';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { UpdateMessageSignatureDtoSchema } from '@/routes/messages/entities/schemas/update-message-signature.dto.schema';
 import { CreateMessageDtoSchema } from '@/routes/messages/entities/schemas/create-message.dto.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('messages')
 @Controller({
@@ -37,7 +38,8 @@ export class MessagesController {
   @ApiQuery({ name: 'cursor', required: false, type: String })
   async getMessagesBySafe(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Page<DateLabel | MessageItem>> {

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -41,7 +41,7 @@ export class MessagesService {
 
   async getMessagesBySafe(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     paginationData: PaginationData;
     routeUrl: Readonly<URL>;
   }): Promise<Page<DateLabel | MessageItem>> {

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -26,7 +26,8 @@ export class SafesController {
   @Get('chains/:chainId/safes/:safeAddress')
   async getSafe(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
   ): Promise<SafeState> {
     return this.service.getSafeInfo({ chainId, safeAddress });
   }
@@ -35,7 +36,8 @@ export class SafesController {
   @Get('chains/:chainId/safes/:safeAddress/nonces')
   async getNonces(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
   ): Promise<SafeNonces> {
     return this.service.getNonces({ chainId, safeAddress });
   }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -50,7 +50,7 @@ export class SafesService {
 
   async getSafeInfo(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<SafeState> {
     const [safe, { recommendedMasterCopyVersion }, supportedSingletons] =
       await Promise.all([
@@ -197,7 +197,7 @@ export class SafesService {
 
   public async getNonces(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<SafeNonces> {
     const nonce = await this.safeRepository.getNonces(args);
     return new SafeNonces(nonce);
@@ -231,7 +231,7 @@ export class SafesService {
 
   private async getCollectiblesTag(
     chainId: string,
-    safeAddress: string,
+    safeAddress: `0x${string}`,
   ): Promise<Date | null> {
     const lastCollectibleTransfer = await this.safeRepository
       .getCollectibleTransfers({
@@ -273,7 +273,7 @@ export class SafesService {
    */
   private async getTxHistoryTagDate(
     chainId: string,
-    safeAddress: string,
+    safeAddress: `0x${string}`,
   ): Promise<Date | null> {
     const txPages = await Promise.allSettled([
       this.safeRepository.getMultisigTransactions({
@@ -318,7 +318,7 @@ export class SafesService {
 
   private async modifiedMessageTag(
     chainId: string,
-    safeAddress: string,
+    safeAddress: `0x${string}`,
   ): Promise<Date | null> {
     const messages = await this.messagesRepository.getMessagesBySafe({
       chainId,

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -112,7 +112,8 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     });
     const error = new NetworkResponseError(
       new URL(
-        `${chainResponse.transactionService}/v1/chains/${chainId}/safes/${safeAddress}/incoming-transfers/?cursor=limit%3D${limit}%26offset%3D${offset}`,
+        // Param ValidationPipe checksums address
+        `${chainResponse.transactionService}/v1/chains/${chainId}/safes/${getAddress(safeAddress)}/incoming-transfers/?cursor=limit%3D${limit}%26offset%3D${offset}`,
       ),
       { status: 500 } as Response,
     );
@@ -133,7 +134,8 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
     });
     expect(networkService.get).toHaveBeenCalledWith({
-      url: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`,
+      // Param ValidationPipe checksums address
+      url: `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/incoming-transfers/`,
       networkRequest: expect.objectContaining({
         params: expect.objectContaining({ offset, limit }),
       }),

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -109,7 +109,8 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     });
     const error = new NetworkResponseError(
       new URL(
-        `${safeConfigUrl}/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`,
+        // Param ValidationPipe checksums address
+        `${safeConfigUrl}/v1/chains/${chainId}/safes/${getAddress(safeAddress)}/multisig-transactions`,
       ),
       { status: 500 } as Response,
     );
@@ -128,11 +129,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
     });
     expect(networkService.get).toHaveBeenCalledWith({
-      url: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`,
+      // Param ValidationPipe checksums address
+      url: `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/multisig-transactions/`,
       networkRequest: expect.objectContaining({
         params: expect.objectContaining({
           ordering: '-nonce',
-          safe: safeAddress,
+          safe: getAddress(safeAddress),
           trusted: true,
         }),
       }),

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -150,7 +150,8 @@ describe('Transactions History Controller (Unit)', () => {
     const chainId = chainResponse.chainId;
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
@@ -177,7 +178,8 @@ describe('Transactions History Controller (Unit)', () => {
     const page = pageBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-      const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chain.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chain, status: 200 });
       }
@@ -213,9 +215,10 @@ describe('Transactions History Controller (Unit)', () => {
     const creationTransaction = creationTransactionBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
-      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
-      const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/creation/`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
+      const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/creation/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
@@ -341,8 +344,9 @@ describe('Transactions History Controller (Unit)', () => {
     };
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
-      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
@@ -396,8 +400,9 @@ describe('Transactions History Controller (Unit)', () => {
     };
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
-      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
@@ -654,10 +659,11 @@ describe('Transactions History Controller (Unit)', () => {
       .build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
-      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       const getContractUrl = `${chainResponse.transactionService}/api/v1/contracts/`;
-      const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/creation/`;
+      const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/creation/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
@@ -735,8 +741,9 @@ describe('Transactions History Controller (Unit)', () => {
     };
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
-      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      // Param ValidationPipe checksums address
+      const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse, status: 200 });
       }
@@ -766,7 +773,8 @@ describe('Transactions History Controller (Unit)', () => {
       url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
     });
     expect(networkService.get).toHaveBeenCalledWith({
-      url: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`,
+      // Param ValidationPipe checksums address
+      url: `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`,
       networkRequest: {
         params: {
           executed: true,
@@ -774,7 +782,8 @@ describe('Transactions History Controller (Unit)', () => {
           limit: limit + 1,
           ordering: undefined,
           queued: false,
-          safe: safeAddress,
+          // Param ValidationPipe checksums address
+          safe: getAddress(safeAddress),
         },
       },
     });

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -38,6 +38,7 @@ import { TransactionsService } from '@/routes/transactions/transactions.service'
 import { DeleteTransactionDto } from '@/routes/transactions/entities/delete-transaction.dto.entity';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { DeleteTransactionDtoSchema } from '@/routes/transactions/entities/schemas/delete-transaction.dto.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('transactions')
 @Controller({
@@ -72,7 +73,8 @@ export class TransactionsController {
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
     @Query('to') to?: string,
@@ -159,7 +161,8 @@ export class TransactionsController {
   async getIncomingTransfers(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
     trusted: boolean,
@@ -188,7 +191,8 @@ export class TransactionsController {
   @Post('chains/:chainId/transactions/:safeAddress/preview')
   async previewTransaction(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Body(new ValidationPipe(PreviewTransactionDtoSchema))
     previewTransactionDto: PreviewTransactionDto,
   ): Promise<TransactionPreview> {
@@ -206,7 +210,8 @@ export class TransactionsController {
   async getTransactionQueue(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
     trusted: boolean,
@@ -227,7 +232,8 @@ export class TransactionsController {
   async getTransactionsHistory(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @PaginationDataDecorator() paginationData: PaginationData,
     @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
     timezoneOffsetMs: number,
@@ -252,7 +258,8 @@ export class TransactionsController {
   @Post('chains/:chainId/transactions/:safeAddress/propose')
   async proposeTransaction(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Body(new ValidationPipe(ProposeTransactionDtoSchema))
     proposeTransactionDto: ProposeTransactionDto,
   ): Promise<TransactionDetails> {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -35,6 +35,7 @@ import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transact
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class TransactionsService {
@@ -76,7 +77,8 @@ export class TransactionsService {
           }),
           this.safeRepository.getSafe({
             chainId: args.chainId,
-            address: safeAddress,
+            // We can't checksum outside of case as some IDs don't contain addresses
+            address: getAddress(safeAddress),
           }),
         ]);
         return this.transferDetailsMapper.mapDetails(
@@ -94,7 +96,8 @@ export class TransactionsService {
           }),
           this.safeRepository.getSafe({
             chainId: args.chainId,
-            address: safeAddress,
+            // We can't checksum outside of case as some IDs don't contain addresses
+            address: getAddress(safeAddress),
           }),
         ]);
         return this.multisigTransactionDetailsMapper.mapDetails(
@@ -127,7 +130,7 @@ export class TransactionsService {
     chainId: string;
     routeUrl: Readonly<URL>;
     paginationData: PaginationData;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
     to?: string;
@@ -250,7 +253,7 @@ export class TransactionsService {
   async getIncomingTransfers(args: {
     chainId: string;
     routeUrl: Readonly<URL>;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
     to?: string;
@@ -293,7 +296,7 @@ export class TransactionsService {
 
   async previewTransaction(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     previewTransactionDto: PreviewTransactionDto;
   }): Promise<TransactionPreview> {
     const safe = await this.safeRepository.getSafe({
@@ -310,7 +313,7 @@ export class TransactionsService {
   async getTransactionQueue(args: {
     chainId: string;
     routeUrl: Readonly<URL>;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     paginationData: PaginationData;
     trusted?: boolean;
   }): Promise<Page<QueuedItem>> {
@@ -360,7 +363,7 @@ export class TransactionsService {
   async getTransactionHistory(args: {
     chainId: string;
     routeUrl: Readonly<URL>;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     paginationData: PaginationData;
     timezoneOffsetMs: number;
     onlyTrusted: boolean;
@@ -409,7 +412,7 @@ export class TransactionsService {
 
   async proposeTransaction(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     proposeTransactionDto: ProposeTransactionDto;
   }): Promise<TransactionDetails> {
     await this.safeRepository.proposeTransaction(args);


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `address` of `EstimationsController['getEstimation']` and propagates the stricter (`0x${string}`) type throughout the project accordingly.

## Changes

- Increase strictness of `IEstimationsRepository['getEstimation']` `address` argument and implementation.
- Increase strictness of all related methods across domain/controllers and implementations:
  - Messages
  - Safe
  - Transactions
- Increase strictness of all relevant cache keys and dirs.
- Update tests accordingly.