### PR TITLE
Checksum `contractAddress` of contract fetching and propagate type

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -118,7 +118,7 @@ export class CacheRouter {
 
   static getContractCacheDir(args: {
     chainId: string;
-    contractAddress: string;
+    contractAddress: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
       `${args.chainId}_${CacheRouter.CONTRACT_KEY}_${args.contractAddress}`,

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -352,7 +352,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const contract = faker.finance.ethereumAddress();
+      const contract = getAddress(faker.finance.ethereumAddress());
       const getContractUrl = `${baseUrl}/api/v1/contracts/${contract}`;
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -149,7 +149,7 @@ export class TransactionApi implements ITransactionApi {
 
   // Important: there is no hook which invalidates this endpoint,
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
-  async getContract(contractAddress: string): Promise<Contract> {
+  async getContract(contractAddress: `0x${string}`): Promise<Contract> {
     try {
       const cacheDir = CacheRouter.getContractCacheDir({
         chainId: this.chainId,

--- a/src/domain/contracts/contracts.repository.interface.ts
+++ b/src/domain/contracts/contracts.repository.interface.ts
@@ -11,7 +11,7 @@ export interface IContractsRepository {
    */
   getContract(args: {
     chainId: string;
-    contractAddress: string;
+    contractAddress: `0x${string}`;
   }): Promise<Contract>;
 }
 

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -13,7 +13,7 @@ export class ContractsRepository implements IContractsRepository {
 
   async getContract(args: {
     chainId: string;
-    contractAddress: string;
+    contractAddress: `0x${string}`;
   }): Promise<Contract> {
     const api = await this.transactionApiManager.getTransactionApi(
       args.chainId,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -33,7 +33,7 @@ export interface ITransactionApi {
 
   clearSafe(address: `0x${string}`): Promise<void>;
 
-  getContract(contractAddress: string): Promise<Contract>;
+  getContract(contractAddress: `0x${string}`): Promise<Contract>;
 
   getDelegates(args: {
     safeAddress?: string;

--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -32,7 +32,7 @@ export class AddressInfoHelper {
 
   async get(
     chainId: string,
-    address: string,
+    address: `0x${string}`,
     sources: Source[],
   ): Promise<AddressInfo> {
     for (const source of sources) {
@@ -61,7 +61,7 @@ export class AddressInfoHelper {
    */
   getOrDefault(
     chainId: string,
-    address: string,
+    address: `0x${string}`,
     sources: Source[],
   ): Promise<AddressInfo> {
     return this.get(chainId, address, sources).catch(
@@ -78,7 +78,7 @@ export class AddressInfoHelper {
    */
   getCollection(
     chainId: string,
-    addresses: string[],
+    addresses: `0x${string}`[],
     sources: Source[],
   ): Promise<Array<AddressInfo>> {
     return Promise.allSettled(
@@ -93,7 +93,7 @@ export class AddressInfoHelper {
 
   private _getFromSource(
     chainId: string,
-    address: string,
+    address: `0x${string}`,
     source: Source,
   ): Promise<AddressInfo> {
     switch (source) {

--- a/src/routes/contracts/contracts.controller.ts
+++ b/src/routes/contracts/contracts.controller.ts
@@ -3,6 +3,8 @@ import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { ContractsService } from '@/routes/contracts/contracts.service';
 import { Contract as ApiContract } from '@/routes/contracts/entities/contract.entity';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('contracts')
 @Controller({
@@ -16,7 +18,8 @@ export class ContractsController {
   @Get('chains/:chainId/contracts/:contractAddress')
   async getContract(
     @Param('chainId') chainId: string,
-    @Param('contractAddress') contractAddress: string,
+    @Param('contractAddress', new ValidationPipe(AddressSchema))
+    contractAddress: `0x${string}`,
   ): Promise<Contract> {
     return this.contractsService.getContract({ chainId, contractAddress });
   }

--- a/src/routes/contracts/contracts.service.ts
+++ b/src/routes/contracts/contracts.service.ts
@@ -12,7 +12,7 @@ export class ContractsService {
 
   async getContract(args: {
     chainId: string;
-    contractAddress: string;
+    contractAddress: `0x${string}`;
   }): Promise<Contract> {
     return this.contractsRepository.getContract(args);
   }

--- a/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
@@ -9,6 +9,7 @@ import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer
 import { Erc20Transfer } from '@/routes/transactions/entities/transfers/erc20-transfer.entity';
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { getTransferDirection } from '@/routes/transactions/mappers/common/transfer-direction.helper';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class Erc20TransferMapper {
@@ -36,13 +37,13 @@ export class Erc20TransferMapper {
     const direction = getTransferDirection(transaction.safe, sender, recipient);
     const senderAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      sender,
+      getAddress(sender),
       ['TOKEN', 'CONTRACT'],
     );
 
     const recipientAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      recipient,
+      getAddress(recipient),
       ['TOKEN', 'CONTRACT'],
     );
 

--- a/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
@@ -9,6 +9,7 @@ import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer
 import { Erc721Transfer } from '@/routes/transactions/entities/transfers/erc721-transfer.entity';
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { getTransferDirection } from '@/routes/transactions/mappers/common/transfer-direction.helper';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class Erc721TransferMapper {
@@ -36,13 +37,13 @@ export class Erc721TransferMapper {
     const direction = getTransferDirection(transaction.safe, sender, recipient);
     const senderAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      sender,
+      getAddress(sender),
       ['TOKEN', 'CONTRACT'],
     );
 
     const recipientAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      recipient,
+      getAddress(recipient),
       ['TOKEN', 'CONTRACT'],
     );
 

--- a/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
@@ -205,9 +205,7 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
         dataDecodedBuilder()
           .with('method', 'enableModule')
           .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('value', faker.string.numeric())
-              .build(),
+            dataDecodedParameterBuilder().with('value', moduleAddress).build(),
           ])
           .build(),
       )
@@ -234,7 +232,7 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
           .with('method', 'disableModule')
           .with('parameters', [
             dataDecodedParameterBuilder()
-              .with('value', faker.string.numeric())
+              .with('value', faker.finance.ethereumAddress())
               .build(),
             dataDecodedParameterBuilder().with('value', moduleAddress).build(),
           ])

--- a/src/routes/transactions/mappers/common/settings-change.mapper.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.ts
@@ -17,6 +17,7 @@ import { SetGuard } from '@/routes/transactions/entities/settings-changes/set-gu
 import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 import { SwapOwner } from '@/routes/transactions/entities/settings-changes/swap-owner.entity';
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class SettingsChangeMapper {
@@ -58,7 +59,7 @@ export class SettingsChangeMapper {
     if (typeof handler !== 'string') return null;
     const addressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      handler,
+      getAddress(handler),
       ['CONTRACT'],
     );
     return new SetFallbackHandler(addressInfo);
@@ -123,7 +124,7 @@ export class SettingsChangeMapper {
 
     const implementationInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      implementation,
+      getAddress(implementation),
       ['CONTRACT'],
     );
     return new ChangeMasterCopy(implementationInfo);
@@ -142,7 +143,7 @@ export class SettingsChangeMapper {
 
     const moduleInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      module,
+      getAddress(module),
       ['CONTRACT'],
     );
     return new EnableModule(moduleInfo);
@@ -161,7 +162,7 @@ export class SettingsChangeMapper {
 
     const moduleInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
-      module,
+      getAddress(module),
       ['CONTRACT'],
     );
     return new DisableModule(moduleInfo);
@@ -193,7 +194,7 @@ export class SettingsChangeMapper {
     if (guardValue !== NULL_ADDRESS) {
       const guardAddressInfo = await this.addressInfoHelper.getOrDefault(
         chainId,
-        guardValue,
+        getAddress(guardValue),
         ['CONTRACT'],
       );
       return new SetGuard(guardAddressInfo);

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
@@ -12,6 +12,7 @@ import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { MULTI_SEND_METHOD_NAME } from '@/routes/transactions/constants';
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { TransactionDataMapper } from '@/routes/transactions/mappers/common/transaction-data.mapper';
+import { getAddress } from 'viem';
 
 const addressInfoHelper = jest.mocked({
   get: jest.fn(),
@@ -42,7 +43,7 @@ describe('Transaction Data Mapper (Unit)', () => {
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
         0,
-        faker.finance.ethereumAddress(),
+        getAddress(faker.finance.ethereumAddress()),
         dataDecodedBuilder().build(),
       );
       expect(actual).toBeNull();
@@ -57,7 +58,7 @@ describe('Transaction Data Mapper (Unit)', () => {
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
         Operation.DELEGATE,
-        faker.finance.ethereumAddress(),
+        getAddress(faker.finance.ethereumAddress()),
         null,
       );
 
@@ -69,7 +70,7 @@ describe('Transaction Data Mapper (Unit)', () => {
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
         1,
-        faker.finance.ethereumAddress(),
+        getAddress(faker.finance.ethereumAddress()),
         dataDecodedBuilder().build(),
       );
       expect(actual).toBe(false);
@@ -82,7 +83,7 @@ describe('Transaction Data Mapper (Unit)', () => {
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
         1,
-        faker.finance.ethereumAddress(),
+        getAddress(faker.finance.ethereumAddress()),
         dataDecodedBuilder().build(),
       );
       expect(actual).toBe(false);
@@ -96,7 +97,7 @@ describe('Transaction Data Mapper (Unit)', () => {
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
         1,
-        faker.finance.ethereumAddress(),
+        getAddress(faker.finance.ethereumAddress()),
         dataDecodedBuilder().build(),
       );
       expect(actual).toBe(true);
@@ -110,7 +111,7 @@ describe('Transaction Data Mapper (Unit)', () => {
       const actual = await mapper.isTrustedDelegateCall(
         faker.string.numeric(),
         1,
-        faker.finance.ethereumAddress(),
+        getAddress(faker.finance.ethereumAddress()),
         dataDecodedBuilder().build(),
       );
       expect(actual).toBe(false);
@@ -316,7 +317,7 @@ describe('Transaction Data Mapper (Unit)', () => {
     });
 
     it('should build an address info index for a nested multiSend (2)', async () => {
-      const contractAddress = faker.finance.ethereumAddress();
+      const contractAddress = getAddress(faker.finance.ethereumAddress());
       const contractAddressInfo = new AddressInfo(
         contractAddress,
         faker.word.sample(),

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -16,6 +16,7 @@ import { PreviewTransactionDto } from '@/routes/transactions/entities/preview-tr
 import { TransactionData } from '@/routes/transactions/entities/transaction-data.entity';
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class TransactionDataMapper {
@@ -73,7 +74,7 @@ export class TransactionDataMapper {
   async isTrustedDelegateCall(
     chainId: string,
     operation: Operation,
-    to: string,
+    to: `0x${string}`,
     dataDecoded: DataDecoded | null,
   ): Promise<boolean | null> {
     if (operation !== Operation.DELEGATE) return null;
@@ -173,7 +174,7 @@ export class TransactionDataMapper {
   ): Promise<AddressInfo | null> {
     if (typeof value === 'string' && value !== NULL_ADDRESS) {
       const addressInfo = await this.addressInfoHelper
-        .get(chainId, value, ['TOKEN', 'CONTRACT'])
+        .get(chainId, getAddress(value), ['TOKEN', 'CONTRACT'])
         .catch(() => null);
       return addressInfo?.name ? addressInfo : null;
     }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -93,7 +93,7 @@ export class MultisigTransactionDetailsMapper {
    */
   private async _getRecipientAddressInfo(
     chainId: string,
-    address: string,
+    address: `0x${string}`,
   ): Promise<AddressInfo> {
     return await this.addressInfoHelper.getOrDefault(chainId, address, [
       'TOKEN',

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -587,7 +587,10 @@ describe('Transactions History Controller (Unit)', () => {
                 txInfo: {
                   type: 'Transfer',
                   sender: { value: multisigTransaction.safe },
-                  recipient: { value: multisigTransactionToAddress },
+                  // Decoder checksums address (although Transaction Service likely returns it checksummed)
+                  recipient: {
+                    value: getAddress(multisigTransactionToAddress),
+                  },
                   direction: 'OUTGOING',
                   transferInfo: {
                     type: 'ERC20',


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `contractAddress` of `ContractsController['getContract']` and propagates the stricter (`0x${string}`) type throughout the project accordingly

## Changes

- Add validation pipe checksum to incoming `contractAddress` of `ContractsController['getContract']`
- Make the `contractAddress` type of `ContractsService['getContract']` stricter
- Checksum the `sender` and `recipient` addresses in `Erc20TransferMapper`/`Erc721TransferMapper`
- Checksum address mapping values in `Erc20TransferMapper`, `Erc721TransferMapper`, `SettingsChangeMapper`and `TransactionDataMapper`
- Make the `contractAddress` type of `ITransactionApi['getContract']` (and it's implementation) stricter
- Make the `address` type of `AddressInfoHelper['get' | 'getOrDefault' | 'getCollection' | '_getFromSource']` stricter
- Make the `contractAddress` type of `IContractsRepository['getContract']` (and it's implementation) stricter
- Make contracts cache dir `contractAddress` type stricter
- Update types/tests accordingly