### PR TITLE
Checksum `delegateAddress` when deleting delegate and propagate type

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -157,9 +157,9 @@ export class CacheRouter {
 
   static getDelegatesCacheDir(args: {
     chainId: string;
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -168,9 +168,9 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getDelegates(args: {
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;
@@ -202,9 +202,9 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getDelegatesV2(args: {
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;
@@ -284,8 +284,8 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async deleteDelegate(args: {
-    delegate: string;
-    delegator: string;
+    delegate: `0x${string}`;
+    delegator: `0x${string}`;
     signature: string;
   }): Promise<unknown> {
     try {
@@ -304,8 +304,8 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async deleteSafeDelegate(args: {
-    delegate: string;
-    safeAddress: string;
+    delegate: `0x${string}`;
+    safeAddress: `0x${string}`;
     signature: string;
   }): Promise<unknown> {
     try {

--- a/src/domain/delegate/delegate.repository.interface.ts
+++ b/src/domain/delegate/delegate.repository.interface.ts
@@ -9,9 +9,9 @@ export const IDelegateRepository = Symbol('IDelegateRepository');
 export interface IDelegateRepository {
   getDelegates(args: {
     chainId: string;
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;
@@ -28,15 +28,15 @@ export interface IDelegateRepository {
 
   deleteDelegate(args: {
     chainId: string;
-    delegate: string;
-    delegator: string;
+    delegate: `0x${string}`;
+    delegator: `0x${string}`;
     signature: string;
   }): Promise<unknown>;
 
   deleteSafeDelegate(args: {
     chainId: string;
-    delegate: string;
-    safeAddress: string;
+    delegate: `0x${string}`;
+    safeAddress: `0x${string}`;
     signature: string;
   }): Promise<unknown>;
 }

--- a/src/domain/delegate/delegate.repository.ts
+++ b/src/domain/delegate/delegate.repository.ts
@@ -14,9 +14,9 @@ export class DelegateRepository implements IDelegateRepository {
 
   async getDelegates(args: {
     chainId: string;
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;
@@ -56,8 +56,8 @@ export class DelegateRepository implements IDelegateRepository {
 
   async deleteDelegate(args: {
     chainId: string;
-    delegate: string;
-    delegator: string;
+    delegate: `0x${string}`;
+    delegator: `0x${string}`;
     signature: string;
   }): Promise<unknown> {
     const transactionService =
@@ -71,8 +71,8 @@ export class DelegateRepository implements IDelegateRepository {
 
   async deleteSafeDelegate(args: {
     chainId: string;
-    delegate: string;
-    safeAddress: string;
+    delegate: `0x${string}`;
+    safeAddress: `0x${string}`;
     signature: string;
   }): Promise<unknown> {
     const transactionService =

--- a/src/domain/delegate/v2/delegates.v2.repository.ts
+++ b/src/domain/delegate/v2/delegates.v2.repository.ts
@@ -14,9 +14,9 @@ export class DelegatesV2Repository implements IDelegatesV2Repository {
 
   async getDelegates(args: {
     chainId: string;
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -36,18 +36,18 @@ export interface ITransactionApi {
   getContract(contractAddress: `0x${string}`): Promise<Contract>;
 
   getDelegates(args: {
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<Delegate>>;
 
   getDelegatesV2(args: {
-    safeAddress?: string;
-    delegate?: string;
-    delegator?: string;
+    safeAddress?: `0x${string}`;
+    delegate?: `0x${string}`;
+    delegator?: `0x${string}`;
     label?: string;
     limit?: number;
     offset?: number;
@@ -70,14 +70,14 @@ export interface ITransactionApi {
   }): Promise<void>;
 
   deleteDelegate(args: {
-    delegate: string;
-    delegator: string;
+    delegate: `0x${string}`;
+    delegator: `0x${string}`;
     signature: string;
   }): Promise<unknown>;
 
   deleteSafeDelegate(args: {
-    delegate: string;
-    safeAddress: string;
+    delegate: `0x${string}`;
+    safeAddress: `0x${string}`;
     signature: string;
   }): Promise<unknown>;
 

--- a/src/routes/delegates/delegates.controller.ts
+++ b/src/routes/delegates/delegates.controller.ts
@@ -30,6 +30,7 @@ import { GetDelegateDtoSchema } from '@/routes/delegates/entities/schemas/get-de
 import { CreateDelegateDtoSchema } from '@/routes/delegates/entities/schemas/create-delegate.dto.schema';
 import { DeleteDelegateDtoSchema } from '@/routes/delegates/entities/schemas/delete-delegate.dto.schema';
 import { DeleteSafeDelegateDtoSchema } from '@/routes/delegates/entities/schemas/delete-safe-delegate.dto.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('delegates')
 @Controller({
@@ -96,7 +97,8 @@ export class DelegatesController {
   @Delete('chains/:chainId/delegates/:delegateAddress')
   async deleteDelegate(
     @Param('chainId') chainId: string,
-    @Param('delegateAddress') delegateAddress: string,
+    @Param('delegateAddress', new ValidationPipe(AddressSchema))
+    delegateAddress: `0x${string}`,
     @Body(new ValidationPipe(DeleteDelegateDtoSchema))
     deleteDelegateDto: DeleteDelegateDto,
   ): Promise<unknown> {

--- a/src/routes/delegates/delegates.service.ts
+++ b/src/routes/delegates/delegates.service.ts
@@ -64,7 +64,7 @@ export class DelegatesService {
 
   async deleteDelegate(args: {
     chainId: string;
-    delegateAddress: string;
+    delegateAddress: `0x${string}`;
     deleteDelegateDto: DeleteDelegateDto;
   }): Promise<unknown> {
     return await this.repository.deleteDelegate({


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `delegateAddress` of `ContractsController['getContract']` and propagates the stricter (`0x${string}`) type throughout the project accordingly

## Changes

- Checksum `delegateAddress` in `DelegatesController['deleteDelegate']`
- Increase strictness of `delegateAddress` in `DelegatesService['deleteDelegate']`
- Increase strictness of addresses in `IDelegateRepository`/`IDelegatesV2Repository` and their implementations
- Increase strictness of delegate fetching from `ITransactionApi` and its implementation
- Increase strictness of cache dir accordingly