### PR TITLE
Checksum addresses in email routes and propagate type

### DIFF
--- a/src/domain/account/account.repository.interface.ts
+++ b/src/domain/account/account.repository.interface.ts
@@ -6,14 +6,14 @@ export const IAccountRepository = Symbol('IAccountRepository');
 export interface IAccountRepository {
   getAccount(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     signer: `0x${string}`;
     authPayload: AuthPayload;
   }): Promise<Account>;
 
   getAccounts(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     onlyVerified: boolean;
   }): Promise<Account[]>;
 
@@ -28,7 +28,7 @@ export interface IAccountRepository {
    */
   createAccount(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     emailAddress: string;
     signer: `0x${string}`;
     authPayload: AuthPayload;
@@ -48,8 +48,8 @@ export interface IAccountRepository {
    */
   resendEmailVerification(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<void>;
 
   /**
@@ -65,8 +65,8 @@ export interface IAccountRepository {
    */
   verifyEmailAddress(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
     code: string;
   }): Promise<void>;
 
@@ -80,7 +80,7 @@ export interface IAccountRepository {
    */
   deleteAccount(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     signer: `0x${string}`;
     authPayload: AuthPayload;
   }): Promise<void>;
@@ -98,7 +98,7 @@ export interface IAccountRepository {
    */
   editEmail(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     emailAddress: string;
     signer: `0x${string}`;
     authPayload: AuthPayload;

--- a/src/domain/account/errors/account-does-not-exist.error.ts
+++ b/src/domain/account/errors/account-does-not-exist.error.ts
@@ -1,7 +1,11 @@
 export class AccountDoesNotExistError extends Error {
-  readonly signer: string;
+  readonly signer: `0x${string}`;
 
-  constructor(chainId: string, safeAddress: string, signer: string) {
+  constructor(
+    chainId: string,
+    safeAddress: `0x${string}`,
+    signer: `0x${string}`,
+  ) {
     super(
       `Account for ${signer} of ${safeAddress} on chain ${chainId} does not exist.`,
     );

--- a/src/domain/account/errors/account-save.error.ts
+++ b/src/domain/account/errors/account-save.error.ts
@@ -1,5 +1,9 @@
 export class AccountSaveError extends Error {
-  constructor(chainId: string, safeAddress: string, signer: string) {
+  constructor(
+    chainId: string,
+    safeAddress: `0x${string}`,
+    signer: `0x${string}`,
+  ) {
     super(
       `Error while creating account. Account was not created. chainId=${chainId}, safeAddress=${safeAddress}, signer=${signer}`,
     );

--- a/src/domain/account/errors/email-already-verified.error.ts
+++ b/src/domain/account/errors/email-already-verified.error.ts
@@ -1,7 +1,11 @@
 export class EmailAlreadyVerifiedError extends Error {
   readonly signer: string;
 
-  constructor(args: { chainId: string; safeAddress: string; signer: string }) {
+  constructor(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
+  }) {
     super(
       `The email address is already verified. chainId=${args.chainId}, safeAddress=${args.safeAddress}, signer=${args.signer}`,
     );

--- a/src/domain/account/errors/email-edit-matches.error.ts
+++ b/src/domain/account/errors/email-edit-matches.error.ts
@@ -1,5 +1,9 @@
 export class EmailEditMatchesError extends Error {
-  constructor(args: { chainId: string; safeAddress: string; signer: string }) {
+  constructor(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
+  }) {
     super(
       `The provided email address matches that set for the Safe owner. chainId=${args.chainId}, safeAddress=${args.safeAddress}, signer=${args.signer}`,
     );

--- a/src/domain/account/errors/invalid-verification-code.error.ts
+++ b/src/domain/account/errors/invalid-verification-code.error.ts
@@ -1,5 +1,9 @@
 export class InvalidVerificationCodeError extends Error {
-  constructor(args: { chainId: string; safeAddress: string; signer: string }) {
+  constructor(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
+  }) {
     super(
       `The verification code is invalid. chainId=${args.chainId}, safeAddress=${args.safeAddress}, signer=${args.signer} `,
     );

--- a/src/domain/account/errors/verification-timeframe.error.ts
+++ b/src/domain/account/errors/verification-timeframe.error.ts
@@ -1,8 +1,8 @@
 export class ResendVerificationTimespanError extends Error {
   constructor(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
     timespanMs: number;
     lockWindowMs: number;
   }) {

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -127,7 +127,7 @@ export class AlertsRepository implements IAlertsRepository {
    */
   private async _getSubscribedAccounts(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<Account[]> {
     const accounts = await this.accountRepository.getAccounts({
       chainId: args.chainId,

--- a/src/routes/email/email.controller.ts
+++ b/src/routes/email/email.controller.ts
@@ -43,7 +43,8 @@ export class EmailController {
   @UseFilters(AccountDoesNotExistExceptionFilter)
   async getEmail(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Param('signer', new ValidationPipe(AddressSchema)) signer: `0x${string}`,
     @Auth() authPayload: AuthPayload,
   ): Promise<Email> {
@@ -59,7 +60,8 @@ export class EmailController {
   @UseGuards(AuthGuard)
   async saveEmail(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Body(new ValidationPipe(SaveEmailDtoSchema)) saveEmailDto: SaveEmailDto,
     @Auth() authPayload: AuthPayload,
   ): Promise<void> {
@@ -77,8 +79,9 @@ export class EmailController {
   @HttpCode(HttpStatus.ACCEPTED)
   async resendVerification(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
-    @Param('signer') signer: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+    @Param('signer', new ValidationPipe(AddressSchema)) signer: `0x${string}`,
   ): Promise<void> {
     await this.service.resendVerification({
       chainId,
@@ -92,8 +95,9 @@ export class EmailController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async verifyEmailAddress(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
-    @Param('signer') signer: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+    @Param('signer', new ValidationPipe(AddressSchema)) signer: `0x${string}`,
     @Body() verifyEmailDto: VerifyEmailDto,
   ): Promise<void> {
     await this.service.verifyEmailAddress({
@@ -110,7 +114,8 @@ export class EmailController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteEmail(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Param('signer', new ValidationPipe(AddressSchema)) signer: `0x${string}`,
     @Auth() authPayload: AuthPayload,
   ): Promise<void> {
@@ -131,7 +136,8 @@ export class EmailController {
   @HttpCode(HttpStatus.ACCEPTED)
   async editEmail(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Param('signer', new ValidationPipe(AddressSchema)) signer: `0x${string}`,
     @Body() editEmailDto: EditEmailDto,
     @Auth() authPayload: AuthPayload,

--- a/src/routes/email/email.service.ts
+++ b/src/routes/email/email.service.ts
@@ -23,7 +23,7 @@ export class EmailService {
 
   async saveEmail(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     emailAddress: string;
     signer: `0x${string}`;
     authPayload: AuthPayload;
@@ -35,8 +35,8 @@ export class EmailService {
 
   async resendVerification(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
   }): Promise<void> {
     return this.repository
       .resendEmailVerification(args)
@@ -45,8 +45,8 @@ export class EmailService {
 
   async verifyEmailAddress(args: {
     chainId: string;
-    safeAddress: string;
-    signer: string;
+    safeAddress: `0x${string}`;
+    signer: `0x${string}`;
     code: string;
   }): Promise<void> {
     return this.repository
@@ -56,7 +56,7 @@ export class EmailService {
 
   async deleteEmail(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     signer: `0x${string}`;
     authPayload: AuthPayload;
   }): Promise<void> {
@@ -67,7 +67,7 @@ export class EmailService {
 
   async editEmail(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     signer: `0x${string}`;
     emailAddress: string;
     authPayload: AuthPayload;
@@ -79,7 +79,7 @@ export class EmailService {
 
   async getEmail(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     signer: `0x${string}`;
     authPayload: AuthPayload;
   }): Promise<Email> {


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `signer`/`safeAddress` of `EmailController` and propagates the stricter (`0x${string}`) type throughout the project accordingly. These were done together as emails are experimental.

## Changes

- Checksum addresses in `EmailController`
- Increase strictness of addresses in `EmailService`
- Increase strictness of addresses in `IAccountRepository` and its implementation
- Increase strictness of addresses in account exceptions contructors