### PR TITLE
Checksum `safeAddress` when creating a message and propagate type

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -2404,7 +2404,7 @@ describe('TransactionApi', () => {
 
   describe('postMessage', () => {
     it('should post message', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const message = faker.word.words();
       const safeAppId = faker.number.int();
       const signature = faker.string.hexadecimal();
@@ -2437,7 +2437,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const message = faker.word.words();
       const safeAppId = faker.number.int();
       const signature = faker.string.hexadecimal();

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -918,7 +918,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async postMessage(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     message: unknown;
     safeAppId: number | null;
     signature: string;

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -213,7 +213,7 @@ export interface ITransactionApi {
   }): Promise<unknown>;
 
   postMessage(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     message: unknown;
     safeAppId: number | null;
     signature: string;

--- a/src/domain/messages/messages.repository.interface.ts
+++ b/src/domain/messages/messages.repository.interface.ts
@@ -14,14 +14,14 @@ export interface IMessagesRepository {
 
   getMessagesBySafe(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Message>>;
 
   createMessage(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     message: unknown;
     safeAppId: number;
     signature: string;
@@ -35,7 +35,7 @@ export interface IMessagesRepository {
 
   clearMessagesBySafe(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 
   clearMessagesByHash(args: {

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -44,7 +44,7 @@ export class MessagesRepository implements IMessagesRepository {
 
   async createMessage(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     message: unknown;
     safeAppId: number | null;
     signature: string;

--- a/src/routes/messages/messages.controller.ts
+++ b/src/routes/messages/messages.controller.ts
@@ -55,7 +55,8 @@ export class MessagesController {
   @Post('chains/:chainId/safes/:safeAddress/messages')
   async createMessage(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Body(new ValidationPipe(CreateMessageDtoSchema))
     createMessageDto: CreateMessageDto,
   ): Promise<unknown> {

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -123,7 +123,7 @@ export class MessagesService {
 
   async createMessage(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     createMessageDto: CreateMessageDto;
   }): Promise<unknown> {
     return await this.messagesRepository.createMessage({


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `safeAddress` of `MessagesController` and propagates the stricter (`0x${string}`) type throughout the project accordingly. These were done together as emails are experimental.

## Changes

- Checksum addresses in `MessagesController['createMessage']`
- Increase strictness of `safeAddress` in `MessageService['createMessage']` and `IMessagesRepository['createMessage']` and its implementation
- Increase strictness of`safeAddress` in `ITransactionApi['postMessage']` and its implementation
- Update tests accordingly