### PR TITLE
Checksum `safeAddress` when fetching module transactions and propagate type

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -213,7 +213,7 @@ export class CacheRouter {
 
   static getModuleTransactionsCacheDir(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     to?: string;
     module?: string;
     limit?: number;
@@ -227,7 +227,7 @@ export class CacheRouter {
 
   static getModuleTransactionsCacheKey(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.MODULE_TRANSACTIONS_KEY}_${args.safeAddress}`;
   }

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -1264,7 +1264,7 @@ describe('TransactionApi', () => {
 
   describe('clearModuleTransactions', () => {
     it('should clear the module transactions cache', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearModuleTransactions(safeAddress);
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -500,7 +500,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getModuleTransactions(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     to?: string;
     module?: string;
     limit?: number;
@@ -531,7 +531,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearModuleTransactions(safeAddress: string): Promise<void> {
+  async clearModuleTransactions(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getModuleTransactionsCacheKey({
       chainId: this.chainId,
       safeAddress,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -123,14 +123,14 @@ export interface ITransactionApi {
   getModuleTransaction(moduleTransactionId: string): Promise<ModuleTransaction>;
 
   getModuleTransactions(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     to?: string;
     module?: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<ModuleTransaction>>;
 
-  clearModuleTransactions(safeAddress: string): Promise<void>;
+  clearModuleTransactions(safeAddress: `0x${string}`): Promise<void>;
 
   getMultisigTransaction(
     safeTransactionHash: string,

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -74,7 +74,7 @@ export interface ISafeRepository {
 
   clearModuleTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 
   /**

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -149,7 +149,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getModuleTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     to?: string;
     module?: string;
     limit?: number;
@@ -163,7 +163,7 @@ export class SafeRepository implements ISafeRepository {
 
   async clearModuleTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -120,7 +120,8 @@ export class TransactionsController {
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
-    @Param('safeAddress') safeAddress: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
     @Query('to') to?: string,
     @Query('module') module?: string,
   ): Promise<Page<ModuleTransaction>> {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -211,7 +211,7 @@ export class TransactionsService {
   async getModuleTransactions(args: {
     chainId: string;
     routeUrl: Readonly<URL>;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     to?: string;
     module?: string;
     paginationData?: PaginationData;


### PR DESCRIPTION
## Summary

In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This begins adding it to "existing" controllers.

This checksums the incoming `safeAddress` of `TransactionsController['getModuleTransactions']` and propagates the stricter (`0x${string}`) type throughout the project accordingly.

## Changes

- Checksum the `safeAddress` in `TransactionsController['getModuleTransactions']`
- Increase strictness of `safeAddress` in `TransactionsService['getModuleTransactions']`
- Increase strictness of `safeAddress` in `ITransactionApi['getModuleTransactions']` and its implementation
- Increase strictness of `safeAddress` in relative cache dir/key
- Update tests accordingly