### PR TITLE
Checksum `ownerAddress` when fetching owned Safe(s) and propagate type

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -357,7 +357,7 @@ export class CacheRouter {
 
   static getSafesByOwnerCacheDir(args: {
     chainId: string;
-    ownerAddress: string;
+    ownerAddress: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
       `${args.chainId}_${CacheRouter.OWNERS_SAFE_KEY}_${args.ownerAddress}`,

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -1876,7 +1876,7 @@ describe('TransactionApi', () => {
 
   describe('getSafesByOwner', () => {
     it('should return retrieved safe', async () => {
-      const owner = faker.finance.ethereumAddress();
+      const owner = getAddress(faker.finance.ethereumAddress());
       const safeList = {
         safes: [
           faker.finance.ethereumAddress(),
@@ -1904,7 +1904,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const owner = faker.finance.ethereumAddress();
+      const owner = getAddress(faker.finance.ethereumAddress());
       const getSafesByOwnerUrl = `${baseUrl}/api/v1/owners/${owner}/safes/`;
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -755,7 +755,7 @@ export class TransactionApi implements ITransactionApi {
 
   // Important: there is no hook which invalidates this endpoint,
   // Therefore, this data will live in cache until [ownersExpirationTimeSeconds]
-  async getSafesByOwner(ownerAddress: string): Promise<SafeList> {
+  async getSafesByOwner(ownerAddress: `0x${string}`): Promise<SafeList> {
     try {
       const cacheDir = CacheRouter.getSafesByOwnerCacheDir({
         chainId: this.chainId,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -179,7 +179,7 @@ export interface ITransactionApi {
 
   getTokens(args: { limit?: number; offset?: number }): Promise<Page<Token>>;
 
-  getSafesByOwner(ownerAddress: string): Promise<SafeList>;
+  getSafesByOwner(ownerAddress: `0x${string}`): Promise<SafeList>;
 
   postDeviceRegistration(args: {
     device: Device;

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -163,8 +163,12 @@ export interface ISafeRepository {
 
   getSafesByOwner(args: {
     chainId: string;
-    ownerAddress: string;
+    ownerAddress: `0x${string}`;
   }): Promise<SafeList>;
+
+  getAllSafesByOwner(args: {
+    ownerAddress: `0x${string}`;
+  }): Promise<{ [chainId: string]: Array<string> }>;
 
   getLastTransactionSortedByNonce(args: {
     chainId: string;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -368,7 +368,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getSafesByOwner(args: {
     chainId: string;
-    ownerAddress: string;
+    ownerAddress: `0x${string}`;
   }): Promise<SafeList> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
@@ -380,7 +380,7 @@ export class SafeRepository implements ISafeRepository {
   }
 
   async getAllSafesByOwner(args: {
-    ownerAddress: string;
+    ownerAddress: `0x${string}`;
   }): Promise<{ [chainId: string]: Array<string> }> {
     // Note: does not take pagination into account but we do not support
     // enough chains for it to be an issue

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -129,7 +129,8 @@ describe('Owners Controller (Unit)', () => {
       });
       const error = new NetworkResponseError(
         new URL(
-          `${chainResponse.transactionService}/v1/chains/${chainId}/owners/${ownerAddress}/safes`,
+          // ValidationPipe checksums ownerAddress param
+          `${chainResponse.transactionService}/v1/chains/${chainId}/owners/${getAddress(ownerAddress)}/safes`,
         ),
         {
           status: 500,
@@ -150,7 +151,8 @@ describe('Owners Controller (Unit)', () => {
         url: `${safeConfigUrl}/api/v1/chains/${chainId}`,
       });
       expect(networkService.get).toHaveBeenCalledWith({
-        url: `${chainResponse.transactionService}/api/v1/owners/${ownerAddress}/safes/`,
+        // ValidationPipe checksums ownerAddress param
+        url: `${chainResponse.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`,
       });
     });
 
@@ -228,14 +230,15 @@ describe('Owners Controller (Unit)', () => {
             });
           }
 
-          case `${chain1.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
+          // ValidationPipe checksums ownerAddress param
+          case `${chain1.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`: {
             return Promise.resolve({
               data: { safes: safesOnChain1 },
               status: 200,
             });
           }
 
-          case `${chain2.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
+          case `${chain2.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`: {
             return Promise.resolve({
               data: { safes: safesOnChain2 },
               status: 200,

--- a/src/routes/owners/owners.controller.ts
+++ b/src/routes/owners/owners.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Param } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { SafeList } from '@/routes/owners/entities/safe-list.entity';
 import { OwnersService } from '@/routes/owners/owners.service';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('owners')
 @Controller({
@@ -15,7 +17,8 @@ export class OwnersController {
   @Get('chains/:chainId/owners/:ownerAddress/safes')
   async getSafesByOwner(
     @Param('chainId') chainId: string,
-    @Param('ownerAddress') ownerAddress: string,
+    @Param('ownerAddress', new ValidationPipe(AddressSchema))
+    ownerAddress: `0x${string}`,
   ): Promise<SafeList> {
     return this.ownersService.getSafesByOwner({ chainId, ownerAddress });
   }
@@ -23,7 +26,8 @@ export class OwnersController {
   @ApiOkResponse({ type: SafeList })
   @Get('owners/:ownerAddress/safes')
   async getAllSafesByOwner(
-    @Param('ownerAddress') ownerAddress: string,
+    @Param('ownerAddress', new ValidationPipe(AddressSchema))
+    ownerAddress: `0x${string}`,
   ): Promise<{ [chainId: string]: Array<string> }> {
     return this.ownersService.getAllSafesByOwner({ ownerAddress });
   }

--- a/src/routes/owners/owners.service.ts
+++ b/src/routes/owners/owners.service.ts
@@ -12,13 +12,13 @@ export class OwnersService {
 
   async getSafesByOwner(args: {
     chainId: string;
-    ownerAddress: string;
+    ownerAddress: `0x${string}`;
   }): Promise<SafeList> {
     return this.safeRepository.getSafesByOwner(args);
   }
 
   async getAllSafesByOwner(args: {
-    ownerAddress: string;
+    ownerAddress: `0x${string}`;
   }): Promise<{ [chainId: string]: Array<string> }> {
     return this.safeRepository.getAllSafesByOwner(args);
   }


### PR DESCRIPTION
In order to maintain a strict type and checksummed address throughout the project, we should validate the incoming addresses. In newer controllers, we started doing this by adding an `AddressSchema` to address. This adds it to the `OwnersController`.

This checksums the incoming `ownerAddress` of `OwnersController` and propagates the stricter (`0x${string}`) type throughout the project accordingly.

## Changes

- Checksum the `ownerAddress` in `OwnersController`
- Increase strictness of `ownerAddress` in `OwnersService` and `SafeRepository`
- Increase strictness of `ownerAddress` in `ITransactionApi['getSafesByOwner']` and its implementation
- Increase strictness of `ownerAddress` in relative cache dir/key
- Update tests accordingly