### PR TITLE
Add swaps API for Arbitrum

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -240,6 +240,7 @@ export default (): ReturnType<typeof configuration> => ({
     api: {
       1: faker.internet.url(),
       100: faker.internet.url(),
+      42161: faker.internet.url(),
       11155111: faker.internet.url(),
     },
     explorerBaseUri: faker.internet.url(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -265,6 +265,7 @@ export default () => ({
     api: {
       1: 'https://api.cow.fi/mainnet',
       100: 'https://api.cow.fi/xdai',
+      42161: 'https://api.cow.fi/arbitrum_one',
       11155111: 'https://api.cow.fi/sepolia',
     },
     explorerBaseUri:


### PR DESCRIPTION
## Summary

Arbitrum will soon be supported by CoW Swap. In order to acommodate for "native" support, we need to include the relevant order book API.

This adds the [Arbitrum One order book API URL](https://docs.cow.fi/cow-protocol/reference/apis/orderbook) to the swaps configuration.

## Changes

- Add `https://api.cow.fi/arbitrum_one` to `swaps.api[42161]` configuration