### PR TITLE
Fall back to indexed name of contract if none is set

### DIFF
--- a/src/routes/common/__tests__/address-info.helper.spec.ts
+++ b/src/routes/common/__tests__/address-info.helper.spec.ts
@@ -1,0 +1,178 @@
+import { ContractsRepository } from '@/domain/contracts/contracts.repository';
+import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import { TokenRepository } from '@/domain/tokens/token.repository';
+import { ILoggingService } from '@/logging/logging.interface';
+import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+describe('AddressInfoHelper', () => {
+  let target: AddressInfoHelper;
+
+  const contractsRepository = jest.mocked({
+    getContract: jest.fn(),
+  } as jest.MockedObjectDeep<ContractsRepository>);
+  const tokenRepository = jest.mocked({
+    getToken: jest.fn(),
+  } as jest.MockedObjectDeep<TokenRepository>);
+  const loggingService = jest.mocked({
+    debug: jest.fn(),
+  } as jest.MockedObjectDeep<ILoggingService>);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    target = new AddressInfoHelper(
+      contractsRepository,
+      tokenRepository,
+      loggingService,
+    );
+  });
+
+  describe('get', () => {
+    it('should return the first source if found', async () => {
+      const chainId = faker.string.numeric();
+      const contract = contractBuilder()
+        .with('displayName', faker.word.sample())
+        .build();
+      contractsRepository.getContract.mockResolvedValue(contract);
+
+      const result = await target.get(chainId, contract.address, [
+        'CONTRACT',
+        'TOKEN',
+      ]);
+
+      expect(result).toEqual({
+        value: contract.address,
+        name: contract.displayName,
+        logoUri: contract.logoUri,
+      });
+      expect(contractsRepository.getContract).toHaveBeenCalledWith({
+        chainId,
+        contractAddress: contract.address,
+      });
+    });
+
+    it('should return the next source if the first one fails', async () => {
+      const chainId = faker.string.numeric();
+      const token = tokenBuilder().build();
+      contractsRepository.getContract.mockRejectedValue(new Error('Not found'));
+      tokenRepository.getToken.mockResolvedValue(token);
+
+      const result = await target.get(chainId, token.address, [
+        'CONTRACT',
+        'TOKEN',
+      ]);
+
+      expect(result).toEqual({
+        value: token.address,
+        name: token.name,
+        logoUri: token.logoUri,
+      });
+      expect(contractsRepository.getContract).toHaveBeenCalledWith({
+        chainId,
+        contractAddress: token.address,
+      });
+      expect(tokenRepository.getToken).toHaveBeenCalledWith({
+        chainId,
+        address: token.address,
+      });
+    });
+
+    it('should fall back to returning the name of contracts if displayName is not available', async () => {
+      const chainId = faker.string.numeric();
+      const contract = contractBuilder().with('displayName', '').build();
+      contractsRepository.getContract.mockResolvedValue(contract);
+
+      const result = await target.get(chainId, contract.address, ['CONTRACT']);
+
+      expect(result).toEqual({
+        value: contract.address,
+        name: contract.name,
+        logoUri: contract.logoUri,
+      });
+      expect(contractsRepository.getContract).toHaveBeenCalledWith({
+        chainId,
+        contractAddress: contract.address,
+      });
+    });
+  });
+
+  // Note: we do not test the intricacies of `get` here as it is covered above
+  describe('getOrDefault', () => {
+    it('should return a default if no source is found', async () => {
+      const chainId = faker.string.numeric();
+      const address = getAddress(faker.finance.ethereumAddress());
+      contractsRepository.getContract.mockRejectedValue(new Error('Not found'));
+
+      const result = await target.getOrDefault(chainId, address, ['CONTRACT']);
+
+      expect(result).toEqual({
+        value: address,
+        name: null,
+        logoUri: null,
+      });
+      expect(contractsRepository.getContract).toHaveBeenCalledWith({
+        chainId,
+        contractAddress: address,
+      });
+    });
+  });
+
+  // Note: we do not test the intricacies of `getOrDefault` here as it is covered above
+  describe('getCollection', () => {
+    it('should return a collection of addresses', async () => {
+      const chainId = faker.string.numeric();
+      const contract1 = contractBuilder().build();
+      const contract2 = contractBuilder().build();
+      const token = tokenBuilder().build();
+      contractsRepository.getContract
+        .mockResolvedValueOnce(contract1)
+        .mockResolvedValueOnce(contract2)
+        .mockRejectedValueOnce(new Error('Not found'));
+      tokenRepository.getToken.mockResolvedValue(token);
+
+      const result = await target.getCollection(
+        chainId,
+        [contract1.address, contract2.address, token.address],
+        ['CONTRACT', 'TOKEN'],
+      );
+
+      expect(result).toEqual([
+        {
+          value: contract1.address,
+          name: contract1.displayName,
+          logoUri: contract1.logoUri,
+        },
+        {
+          value: contract2.address,
+          name: contract2.displayName,
+          logoUri: contract2.logoUri,
+        },
+        {
+          value: token.address,
+          name: token.name,
+          logoUri: token.logoUri,
+        },
+      ]);
+      expect(contractsRepository.getContract).toHaveBeenCalledTimes(3);
+      expect(tokenRepository.getToken).toHaveBeenCalledTimes(1);
+      expect(contractsRepository.getContract).toHaveBeenNthCalledWith(1, {
+        chainId,
+        contractAddress: contract1.address,
+      });
+      expect(contractsRepository.getContract).toHaveBeenNthCalledWith(2, {
+        chainId,
+        contractAddress: contract2.address,
+      });
+      expect(contractsRepository.getContract).toHaveBeenNthCalledWith(3, {
+        chainId,
+        contractAddress: token.address,
+      });
+      expect(tokenRepository.getToken).toHaveBeenNthCalledWith(1, {
+        chainId,
+        address: token.address,
+      });
+    });
+  });
+});

--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -100,7 +100,10 @@ export class AddressInfoHelper {
       case 'CONTRACT':
         return this.contractsRepository
           .getContract({ chainId, contractAddress: address })
-          .then((c) => new AddressInfo(c.address, c.displayName, c.logoUri));
+          .then((c) => {
+            const name = c.displayName || c.name;
+            return new AddressInfo(c.address, name, c.logoUri);
+          });
       case 'TOKEN':
         return this.tokenRepository
           .getToken({ chainId, address })


### PR DESCRIPTION
## Summary

When fetching the `AddressInfo` of an address, we fetch the respective details from either the contract or token repositories. In particular, only the `displayName` of a contract is returned for `AddressInfo['name']`. As not all contracts have this set, but likely an indexed name, this adds `name` as a fallback value for `AddressInfo['name']`

## Changes

- Fall back to `name` of a contract if no `displayName` is set
- Add test coverage for `AddressInfoHelper['get' | 'getOrDefault' | 'getCollection']`