### PR TITLE
Add and validate against schema for `AssetPrice`

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -1,7 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
-import { AssetPrice } from '@/datasources/balances-api/entities/asset-price.entity';
+import {
+  AssetPrice,
+  AssetPriceSchema,
+} from '@/datasources/balances-api/entities/asset-price.entity';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { CacheRouter } from '../cache/cache.router';
 import { DataSourceError } from '@/domain/errors/data-source.error';
@@ -246,8 +249,7 @@ export class CoingeckoApi implements IPricesApi {
       const { key, field } = cacheDir;
       if (cached != null) {
         this.loggingService.debug({ type: 'cache_hit', key, field });
-        // TODO: build an AssetPrice validator or a type guard to ensure the cache value is valid.
-        const cachedAssetPrice: AssetPrice = JSON.parse(cached);
+        const cachedAssetPrice = AssetPriceSchema.parse(JSON.parse(cached));
         result.push(cachedAssetPrice);
       } else {
         this.loggingService.debug({ type: 'cache_miss', key, field });

--- a/src/datasources/balances-api/entities/__tests__/asset-price.schema.spec.ts
+++ b/src/datasources/balances-api/entities/__tests__/asset-price.schema.spec.ts
@@ -16,4 +16,45 @@ describe('AssetPriceSchema', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('should not validate an object with non-object values', () => {
+    const address = faker.finance.ethereumAddress();
+    const assetPrice = {
+      [address]: faker.number.int(),
+    };
+
+    const result = AssetPriceSchema.safeParse(assetPrice);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'object',
+        message: 'Expected object, received number',
+        path: [address],
+        received: 'number',
+      },
+    ]);
+  });
+
+  it('should not validate an object with non-number or null values in the nested object', () => {
+    const address = faker.finance.ethereumAddress();
+    const currency = faker.finance.currencyCode();
+    const assetPrice = {
+      [address]: {
+        [currency]: faker.string.alphanumeric(),
+      },
+    };
+
+    const result = AssetPriceSchema.safeParse(assetPrice);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Expected number, received string',
+        path: [address, currency],
+        received: 'string',
+      },
+    ]);
+  });
 });

--- a/src/datasources/balances-api/entities/__tests__/asset-price.schema.spec.ts
+++ b/src/datasources/balances-api/entities/__tests__/asset-price.schema.spec.ts
@@ -1,0 +1,19 @@
+import { AssetPriceSchema } from '@/datasources/balances-api/entities/asset-price.entity';
+import { faker } from '@faker-js/faker';
+
+describe('AssetPriceSchema', () => {
+  it('should allow an object with string keys and a mixture of number and null values', () => {
+    const assetPrice = {
+      [faker.finance.ethereumAddress()]: {
+        [faker.finance.currencyCode()]: faker.helpers.arrayElement([
+          faker.number.float(),
+          null,
+        ]),
+      },
+    };
+
+    const result = AssetPriceSchema.safeParse(assetPrice);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/datasources/balances-api/entities/asset-price.entity.ts
+++ b/src/datasources/balances-api/entities/asset-price.entity.ts
@@ -1,3 +1,6 @@
-export interface AssetPrice {
-  [assetName: string]: Record<string, number | null>;
-}
+import { z } from 'zod';
+
+export type AssetPrice = z.infer<typeof AssetPriceSchema>;
+
+// TODO: Enforce Ethereum address keys (and maybe checksum them)
+export const AssetPriceSchema = z.record(z.record(z.number().nullable()));


### PR DESCRIPTION
## Summary

When fetching `AssetPrice`s from the CoinGecko cache, we are blindly trusting `JSON.parse`. As it returns an `unknown` type, it is currently being asserted to `AssetPrice`. Whilst we can be relatively confident that the cache only has these, it is better to test these values.

This adds an `AssetPriceSchema` for validating against (with test coverage) and usage of it in the `CoingeckoApi`.

## Changes

- Create `AssetPriceSchema` (with test)
- Validate cache against it