### PR TITLE
Add Counterfactual Safes ERC-20 balances

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -9,6 +9,7 @@ import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
+import { sample } from 'lodash';
 
 const configurationService = {
   getOrThrow: jest.fn(),
@@ -51,17 +52,22 @@ const coingeckoApi = {
 } as IPricesApi;
 
 const coingeckoApiMock = jest.mocked(coingeckoApi);
+const ZERION_BALANCES_CHAIN_IDS: string[] = Array.from(
+  { length: faker.number.int({ min: 1, max: 10 }) },
+  () => faker.string.numeric(),
+);
 
 beforeEach(() => {
   jest.resetAllMocks();
   configurationServiceMock.getOrThrow.mockImplementation((key) => {
-    if (key === 'features.zerionBalancesChainIds') return ['1', '2', '3'];
+    if (key === 'features.zerionBalancesChainIds')
+      return ZERION_BALANCES_CHAIN_IDS;
   });
 });
 
 describe('Balances API Manager Tests', () => {
   describe('getBalancesApi checks', () => {
-    it('should return the Zerion API', async () => {
+    it('should return the Zerion API if the chainId is one of zerionBalancesChainIds', async () => {
       const manager = new BalancesApiManager(
         configurationService,
         configApiMock,
@@ -72,7 +78,9 @@ describe('Balances API Manager Tests', () => {
         coingeckoApiMock,
       );
 
-      const result = await manager.getBalancesApi('2');
+      const result = await manager.getBalancesApi(
+        sample(ZERION_BALANCES_CHAIN_IDS) as string,
+      );
 
       expect(result).toEqual(zerionBalancesApi);
     });
@@ -88,10 +96,12 @@ describe('Balances API Manager Tests', () => {
       [true, vpcTxServiceUrl],
       [false, txServiceUrl],
     ])('vpcUrl is %s', async (useVpcUrl, expectedUrl) => {
-      const zerionChainIds = ['1', '2', '3'];
       const fiatCode = faker.finance.currencyCode();
       const chain = chainBuilder()
-        .with('chainId', '4')
+        .with(
+          'chainId',
+          faker.string.numeric({ exclude: ZERION_BALANCES_CHAIN_IDS }),
+        )
         .with('transactionService', txServiceUrl)
         .with('vpcTransactionService', vpcTxServiceUrl)
         .build();
@@ -104,7 +114,7 @@ describe('Balances API Manager Tests', () => {
         else if (key === 'expirationTimeInSeconds.notFound.default')
           return notFoundExpireTimeSeconds;
         else if (key === 'features.zerionBalancesChainIds')
-          return zerionChainIds;
+          return ZERION_BALANCES_CHAIN_IDS;
         throw new Error(`Unexpected key: ${key}`);
       });
       configApiMock.getChain.mockResolvedValue(chain);

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -51,6 +51,8 @@ export class BalancesApiManager implements IBalancesApiManager {
       return this.zerionBalancesApi;
     }
 
+    // SafeBalancesApi will be returned only if TransactionApi returns the Safe data.
+    // Otherwise ZerionBalancesApi will be returned as the Safe is considered counterfactual/not deployed.
     try {
       const transactionApi =
         await this.transactionApiManager.getTransactionApi(chainId);

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -43,7 +43,6 @@ export class BalancesApiManager implements IBalancesApiManager {
     this.zerionBalancesApi = zerionBalancesApi;
   }
 
-  // TODO: document and refactor.
   async getBalancesApi(
     chainId: string,
     safeAddress: `0x${string}`,
@@ -56,10 +55,19 @@ export class BalancesApiManager implements IBalancesApiManager {
       const transactionApi =
         await this.transactionApiManager.getTransactionApi(chainId);
       await transactionApi.getSafe(safeAddress);
+      return this._getSafeBalancesApi(chainId);
     } catch (err) {
       return this.zerionBalancesApi;
     }
+  }
 
+  async getFiatCodes(): Promise<string[]> {
+    const zerionFiatCodes = await this.zerionBalancesApi.getFiatCodes();
+    const safeFiatCodes = await this.coingeckoApi.getFiatCodes();
+    return intersection(zerionFiatCodes, safeFiatCodes).sort();
+  }
+
+  private async _getSafeBalancesApi(chainId: string): Promise<SafeBalancesApi> {
     const safeBalancesApi = this.safeBalancesApiMap[chainId];
     if (safeBalancesApi !== undefined) return safeBalancesApi;
 
@@ -74,11 +82,5 @@ export class BalancesApiManager implements IBalancesApiManager {
       this.coingeckoApi,
     );
     return this.safeBalancesApiMap[chainId];
-  }
-
-  async getFiatCodes(): Promise<string[]> {
-    const zerionFiatCodes = await this.zerionBalancesApi.getFiatCodes();
-    const safeFiatCodes = await this.coingeckoApi.getFiatCodes();
-    return intersection(zerionFiatCodes, safeFiatCodes).sort();
   }
 }

--- a/src/datasources/balances-api/balances-api.module.ts
+++ b/src/datasources/balances-api/balances-api.module.ts
@@ -10,9 +10,14 @@ import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { CoingeckoApi } from '@/datasources/balances-api/coingecko-api.service';
 import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
 import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
+import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
 
 @Module({
-  imports: [CacheFirstDataSourceModule, ConfigApiModule],
+  imports: [
+    CacheFirstDataSourceModule,
+    ConfigApiModule,
+    TransactionApiManagerModule,
+  ],
   providers: [
     HttpErrorFactory,
     { provide: IBalancesApiManager, useClass: BalancesApiManager },

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -92,6 +92,7 @@ export class ZerionBalancesApi implements IBalancesApi {
     safeAddress: `0x${string}`;
     fiatCode: string;
   }): Promise<Balance[]> {
+    // TODO: check the fiatCode is supported.
     const cacheDir = CacheRouter.getZerionBalancesCacheDir(args);
     const chainName = this._getChainName(args.chainId);
     const cached = await this.cacheService.get(cacheDir);

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -21,6 +21,7 @@ export class BalancesRepository implements IBalancesRepository {
   }): Promise<Balance[]> {
     const api = await this.balancesApiManager.getBalancesApi(
       args.chain.chainId,
+      args.safeAddress,
     );
     const balances = await api.getBalances(args);
     return balances.map((balance) => BalanceSchema.parse(balance));
@@ -30,7 +31,10 @@ export class BalancesRepository implements IBalancesRepository {
     chainId: string;
     safeAddress: `0x${string}`;
   }): Promise<void> {
-    const api = await this.balancesApiManager.getBalancesApi(args.chainId);
+    const api = await this.balancesApiManager.getBalancesApi(
+      args.chainId,
+      args.safeAddress,
+    );
     await api.clearBalances(args);
   }
 

--- a/src/domain/collectibles/collectibles.repository.ts
+++ b/src/domain/collectibles/collectibles.repository.ts
@@ -20,7 +20,10 @@ export class CollectiblesRepository implements ICollectiblesRepository {
     trusted?: boolean;
     excludeSpam?: boolean;
   }): Promise<Page<Collectible>> {
-    const api = await this.balancesApiManager.getBalancesApi(args.chainId);
+    const api = await this.balancesApiManager.getBalancesApi(
+      args.chainId,
+      args.safeAddress,
+    );
     const page = await api.getCollectibles(args);
     return CollectiblePageSchema.parse(page);
   }
@@ -29,7 +32,10 @@ export class CollectiblesRepository implements ICollectiblesRepository {
     chainId: string;
     safeAddress: `0x${string}`;
   }): Promise<void> {
-    const api = await this.balancesApiManager.getBalancesApi(args.chainId);
+    const api = await this.balancesApiManager.getBalancesApi(
+      args.chainId,
+      args.safeAddress,
+    );
     await api.clearCollectibles(args);
   }
 }

--- a/src/domain/interfaces/balances-api.manager.interface.ts
+++ b/src/domain/interfaces/balances-api.manager.interface.ts
@@ -8,11 +8,11 @@ export interface IBalancesApiManager {
    * Each chain is associated with an implementation (i.e.: to a balances
    * provider) via configuration.
    *
-   * Note: if the Safe entity associated with the passed safeAddress cannot be retrieved
-   * by the TransactionApi for the input chain ID, then the Zerion API will be used.
+   * Note: if the Safe entity associated with the safeAddress cannot be retrieved
+   * from the TransactionApi for the chainId, then the ZerionApi will be used.
    *
    * @param chainId - the chain identifier to check.
-   * @param safeAddress - the safe address to check.
+   * @param safeAddress - the Safe address to check.
    * @returns {@link IBalancesApi} configured for the input chain ID.
    */
   getBalancesApi(

--- a/src/domain/interfaces/balances-api.manager.interface.ts
+++ b/src/domain/interfaces/balances-api.manager.interface.ts
@@ -9,9 +9,13 @@ export interface IBalancesApiManager {
    * provider) via configuration.
    *
    * @param chainId - the chain identifier to check.
+   * @param safeAddress - the safe address to check.
    * @returns {@link IBalancesApi} configured for the input chain ID.
    */
-  getBalancesApi(chainId: string): Promise<IBalancesApi>;
+  getBalancesApi(
+    chainId: string,
+    safeAddress: `0x${string}`,
+  ): Promise<IBalancesApi>;
 
   /**
    * Gets the list of supported fiat codes.

--- a/src/domain/interfaces/balances-api.manager.interface.ts
+++ b/src/domain/interfaces/balances-api.manager.interface.ts
@@ -8,6 +8,9 @@ export interface IBalancesApiManager {
    * Each chain is associated with an implementation (i.e.: to a balances
    * provider) via configuration.
    *
+   * Note: if the Safe entity associated with the passed safeAddress cannot be retrieved
+   * by the TransactionApi for the input chain ID, then the Zerion API will be used.
+   *
    * @param chainId - the chain identifier to check.
    * @param safeAddress - the safe address to check.
    * @returns {@link IBalancesApi} configured for the input chain ID.

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -27,6 +27,7 @@ import { getAddress } from 'viem';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { Server } from 'net';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 
 describe('Balances Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -107,6 +108,11 @@ describe('Balances Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({
+              data: safeBuilder().build(),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
               data: transactionApiBalancesResponse,
@@ -184,21 +190,24 @@ describe('Balances Controller (Unit)', () => {
         });
 
       // 4 Network calls are expected
-      // (1. Chain data, 2. Balances, 3. Coingecko native coin, 4. Coingecko tokens)
-      expect(networkService.get.mock.calls.length).toBe(4);
+      // (1. Chain data, 2. Safe data, 3. Balances, 4. Coingecko native coin, 5. Coingecko tokens)
+      expect(networkService.get.mock.calls.length).toBe(5);
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeAddress}`,
+      );
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`,
       );
-      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[2][0].url).toBe(
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -208,10 +217,10 @@ describe('Balances Controller (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': apiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
@@ -241,6 +250,11 @@ describe('Balances Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({
+              data: safeBuilder().build(),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
               data: transactionApiBalancesResponse,
@@ -263,7 +277,7 @@ describe('Balances Controller (Unit)', () => {
         .expect(200);
 
       // trusted and exclude_spam params are passed
-      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: {
           trusted,
           exclude_spam: excludeSpam,
@@ -291,6 +305,11 @@ describe('Balances Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({
+              data: safeBuilder().build(),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
               data: transactionApiBalancesResponse,
@@ -352,6 +371,11 @@ describe('Balances Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain, status: 200 });
+          case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({
+              data: safeBuilder().build(),
+              status: 200,
+            });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
               data: transactionApiBalancesResponse,
@@ -394,18 +418,21 @@ describe('Balances Controller (Unit)', () => {
         });
 
       // 3 Network calls are expected
-      // (1. Chain data, 2. Balances, 3. Coingecko token)
-      expect(networkService.get.mock.calls.length).toBe(3);
+      // (1. Chain data, 2. Safe data, 3. Balances, 4. Coingecko token)
+      expect(networkService.get.mock.calls.length).toBe(4);
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeAddress}`,
+      );
+      expect(networkService.get.mock.calls[2][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`,
       );
-      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[2][0].url).toBe(
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
     });
@@ -452,6 +479,11 @@ describe('Balances Controller (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
+            case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+              return Promise.resolve({
+                data: safeBuilder().build(),
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
               return Promise.resolve({
                 data: transactionApiBalancesResponse,
@@ -492,7 +524,7 @@ describe('Balances Controller (Unit)', () => {
             ],
           });
 
-        expect(networkService.get.mock.calls.length).toBe(3);
+        expect(networkService.get.mock.calls.length).toBe(4);
       });
 
       it(`should return a 0-balance when a validation error happens`, async () => {
@@ -511,6 +543,11 @@ describe('Balances Controller (Unit)', () => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
               return Promise.resolve({ data: chain, status: 200 });
+            case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+              return Promise.resolve({
+                data: safeBuilder().build(),
+                status: 200,
+              });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
               return Promise.resolve({
                 data: transactionApiBalancesResponse,
@@ -554,7 +591,7 @@ describe('Balances Controller (Unit)', () => {
             ],
           });
 
-        expect(networkService.get.mock.calls.length).toBe(3);
+        expect(networkService.get.mock.calls.length).toBe(4);
       });
     });
 
@@ -567,6 +604,14 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
             return Promise.resolve({ data: chainResponse, status: 200 });
+          } else if (
+            url ==
+            `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`
+          ) {
+            return Promise.resolve({
+              data: safeBuilder().build(),
+              status: 200,
+            });
           } else if (url == transactionServiceUrl) {
             const error = new NetworkResponseError(
               new URL(transactionServiceUrl),
@@ -588,7 +633,7 @@ describe('Balances Controller (Unit)', () => {
             code: 500,
           });
 
-        expect(networkService.get.mock.calls.length).toBe(2);
+        expect(networkService.get.mock.calls.length).toBe(3);
       });
     });
 
@@ -607,6 +652,14 @@ describe('Balances Controller (Unit)', () => {
             data: [{ invalid: 'data' }],
             status: 200,
           });
+        } else if (
+          url ==
+          `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`
+        ) {
+          return Promise.resolve({
+            data: safeBuilder().build(),
+            status: 200,
+          });
         } else {
           return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -620,7 +673,7 @@ describe('Balances Controller (Unit)', () => {
           message: 'Internal server error',
         });
 
-      expect(networkService.get.mock.calls.length).toBe(3);
+      expect(networkService.get.mock.calls.length).toBe(4);
     });
   });
 

--- a/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/cache-hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -22,6 +22,8 @@ describe('Events queue processing e2e tests', () => {
   const cacheKeyPrefix = crypto.randomUUID();
   const queue = crypto.randomUUID();
   const chainId = '1'; // Mainnet
+  // TODO: use a proper "test" safe address
+  const safeAddress = getAddress('0x9a8FEe232DCF73060Af348a1B62Cdb0a19852d13');
 
   beforeAll(async () => {
     const defaultConfiguration = configuration();
@@ -80,7 +82,6 @@ describe('Events queue processing e2e tests', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears balances', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_safe_balances_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -123,7 +124,6 @@ describe('Events queue processing e2e tests', () => {
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears multisig transactions', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_multisig_transactions_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -166,7 +166,6 @@ describe('Events queue processing e2e tests', () => {
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears multisig transaction', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_multisig_transaction_${payload.safeTxHash}`,
       faker.string.alpha(),
@@ -201,7 +200,6 @@ describe('Events queue processing e2e tests', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears safe info', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_safe_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -241,7 +239,6 @@ describe('Events queue processing e2e tests', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears safe collectibles', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_safe_collectibles_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -281,7 +278,6 @@ describe('Events queue processing e2e tests', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears safe collectible transfers', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_transfers_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -316,7 +312,6 @@ describe('Events queue processing e2e tests', () => {
       value: faker.string.numeric(),
     },
   ])('$type clears incoming transfers', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_incoming_transfers_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -346,7 +341,6 @@ describe('Events queue processing e2e tests', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears module transactions', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_module_transactions_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -401,7 +395,6 @@ describe('Events queue processing e2e tests', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears all transactions', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_all_transactions_${getAddress(safeAddress)}`,
       faker.string.alpha(),
@@ -434,7 +427,6 @@ describe('Events queue processing e2e tests', () => {
       messageHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears messages', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const cacheDir = new CacheDir(
       `${chainId}_messages_${getAddress(safeAddress)}`,
       faker.string.alpha(),

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -25,6 +25,7 @@ import { getAddress } from 'viem';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { Server } from 'net';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication<Server>;
@@ -274,14 +275,16 @@ describe('Post Hook Events (Unit)', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears balances', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const chainId = faker.string.numeric({
       exclude: configurationService.getOrThrow(
         'features.zerionBalancesChainIds',
       ),
     });
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const safe = safeBuilder().build();
+    const safeAddress = getAddress(safe.address);
     const cacheDir = new CacheDir(
-      `${chainId}_safe_balances_${getAddress(safeAddress)}`,
+      `${chainId}_safe_balances_${safeAddress}`,
       faker.string.alpha(),
     );
     await fakeCacheService.set(
@@ -298,9 +301,11 @@ describe('Post Hook Events (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: chain,
             status: 200,
           });
+        case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -495,14 +500,16 @@ describe('Post Hook Events (Unit)', () => {
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
   ])('$type clears safe collectibles', async (payload) => {
-    const safeAddress = faker.finance.ethereumAddress();
     const chainId = faker.string.numeric({
       exclude: configurationService.getOrThrow(
         'features.zerionBalancesChainIds',
       ),
     });
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const safe = safeBuilder().build();
+    const safeAddress = getAddress(safe.address);
     const cacheDir = new CacheDir(
-      `${chainId}_safe_collectibles_${getAddress(safeAddress)}`,
+      `${chainId}_safe_collectibles_${safeAddress}`,
       faker.string.alpha(),
     );
     await fakeCacheService.set(
@@ -519,9 +526,11 @@ describe('Post Hook Events (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: chain,
             status: 200,
           });
+        case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
+          return Promise.resolve({ data: safe, status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -34,6 +34,7 @@ import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { Server } from 'net';
 import { getAddress } from 'viem';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -76,6 +77,7 @@ describe('Collectibles Controller (Unit)', () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const pageLimit = 1;
+      const safeResponse = safeBuilder().build();
       const collectiblesResponse = pageBuilder<Collectible>()
         .with('next', limitAndOffsetUrlFactory(pageLimit, 0))
         .with('previous', limitAndOffsetUrlFactory(pageLimit, 0))
@@ -90,6 +92,8 @@ describe('Collectibles Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
+          case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({ data: safeResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
             return Promise.resolve({ data: collectiblesResponse, status: 200 });
           default:
@@ -118,7 +122,7 @@ describe('Collectibles Controller (Unit)', () => {
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const limit = 10;
       const offset = 20;
-
+      const safeResponse = safeBuilder().build();
       const collectiblesResponse = pageBuilder<Collectible>()
         .with('next', null)
         .with('previous', null)
@@ -133,6 +137,8 @@ describe('Collectibles Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
+          case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({ data: safeResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
             return Promise.resolve({ data: collectiblesResponse, status: 200 });
           default:
@@ -146,7 +152,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: {
           limit: 10,
           offset: 20,
@@ -162,7 +168,7 @@ describe('Collectibles Controller (Unit)', () => {
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const excludeSpam = true;
       const trusted = true;
-
+      const safeResponse = safeBuilder().build();
       const collectiblesResponse = pageBuilder<Collectible>()
         .with('next', null)
         .with('previous', null)
@@ -177,6 +183,8 @@ describe('Collectibles Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
+          case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({ data: safeResponse, status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
             return Promise.resolve({ data: collectiblesResponse, status: 200 });
           default:
@@ -190,7 +198,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
         params: {
           limit: PaginationData.DEFAULT_LIMIT,
           offset: PaginationData.DEFAULT_OFFSET,
@@ -204,6 +212,7 @@ describe('Collectibles Controller (Unit)', () => {
       const chainId = faker.string.numeric();
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
+      const safeResponse = safeBuilder().build();
       const transactionServiceUrl = `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`;
       const transactionServiceError = new NetworkResponseError(
         new URL(transactionServiceUrl),
@@ -216,6 +225,8 @@ describe('Collectibles Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
+          case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({ data: safeResponse, status: 200 });
           case transactionServiceUrl:
             return Promise.reject(transactionServiceError);
           default:
@@ -237,6 +248,7 @@ describe('Collectibles Controller (Unit)', () => {
       const chainId = faker.string.numeric();
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const chainResponse = chainBuilder().with('chainId', chainId).build();
+      const safeResponse = safeBuilder().build();
       const transactionServiceUrl = `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`;
       const transactionServiceError = new NetworkRequestError(
         new URL(transactionServiceUrl),
@@ -245,6 +257,8 @@ describe('Collectibles Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse, status: 200 });
+          case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
+            return Promise.resolve({ data: safeResponse, status: 200 });
           case transactionServiceUrl:
             return Promise.reject(transactionServiceError);
           default:

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -203,7 +203,7 @@ describe('Safes Controller Overview (Unit)', () => {
           ]),
         );
 
-      expect(networkService.get.mock.calls.length).toBe(6);
+      expect(networkService.get.mock.calls.length).toBe(7);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
@@ -212,15 +212,18 @@ describe('Safes Controller Overview (Unit)', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[2][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -230,17 +233,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
@@ -372,7 +375,7 @@ describe('Safes Controller Overview (Unit)', () => {
           ]),
         );
 
-      expect(networkService.get.mock.calls.length).toBe(6);
+      expect(networkService.get.mock.calls.length).toBe(7);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
@@ -381,15 +384,18 @@ describe('Safes Controller Overview (Unit)', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[2][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -399,17 +405,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
@@ -964,7 +970,7 @@ describe('Safes Controller Overview (Unit)', () => {
           },
         ]);
 
-      expect(networkService.get.mock.calls.length).toBe(6);
+      expect(networkService.get.mock.calls.length).toBe(7);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
@@ -973,15 +979,18 @@ describe('Safes Controller Overview (Unit)', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[2][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -991,17 +1000,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });
@@ -1111,7 +1120,7 @@ describe('Safes Controller Overview (Unit)', () => {
           },
         ]);
 
-      expect(networkService.get.mock.calls.length).toBe(6);
+      expect(networkService.get.mock.calls.length).toBe(7);
 
       expect(networkService.get.mock.calls[0][0].url).toBe(
         `${safeConfigUrl}/api/v1/chains/${chain.chainId}`,
@@ -1120,16 +1129,19 @@ describe('Safes Controller Overview (Unit)', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[2][0].url).toBe(
+        `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
+      );
+      expect(networkService.get.mock.calls[3][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
         // Forwarded params
         params: { trusted: true, exclude_spam: false },
       });
-      expect(networkService.get.mock.calls[3][0].url).toBe(
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -1139,17 +1151,17 @@ describe('Safes Controller Overview (Unit)', () => {
           ].join(','),
         },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`,
       );
     });


### PR DESCRIPTION
## Summary
Currently, counterfactual Safes are not being indexed by Safe{Core}, and therefore their asset balances can only be obtained by calling `eth_getBalance` directly on a RPC. This approach faces a limitation: only the chain native balances are returned by the RPC call.

This PR leverages the Zerion API to get the balances (both native and ERC-20) of any undeployed (counterfactual) Safe.

## Changes
- `BalancesApiManager.getBalancesApi`now returns the injected `ZerionBalancesApi` when the Safe data is unavailable through the Safe Transaction Service. To accomplish that, the Safe address is now also passed to the function.
- A test to verify this behavior was added.
- Existing tests were modified accordingly to reflect this extra call to the Transaction Service API.