### PR TITLE
Change CAIP-10 parsing error message

### DIFF
--- a/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
@@ -75,6 +75,10 @@ describe('Caip10AddressesPipe', () => {
       .expect(500);
   });
 
+  it('throws for no params', async () => {
+    await request(app.getHttpServer()).get('/test').expect(500);
+  });
+
   it('throws for missing params', async () => {
     await request(app.getHttpServer()).get('/test?addresses=').expect(500);
   });
@@ -89,5 +93,9 @@ describe('Caip10AddressesPipe', () => {
     await request(app.getHttpServer())
       .get(`/test?addresses=${chainId}:`)
       .expect(500);
+  });
+
+  it('throws for splittable values', async () => {
+    await request(app.getHttpServer()).get('/test?addresses=,').expect(500);
   });
 });

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.ts
@@ -24,9 +24,7 @@ export class Caip10AddressesPipe
     });
 
     if (addresses.length === 0) {
-      throw new Error(
-        'Provided addresses do not conform to the CAIP-10 standard',
-      );
+      throw new Error('No addresses provided. At least one is required.');
     }
 
     return addresses;


### PR DESCRIPTION
## Summary

Our `Caip10AddressesPipe` parses a string of comma separated CAIP-10 addresses into a validated `Array<{ chainId: string, address: 0x${string} }>`. The logic splits the string by comma then parses each CAIP-10 address. If no string is provided at all, there will effectively be no addresses to parse. We are correctly throwing if there are no addresses after parsing but the message is "incorrect". Currently, it implies that the value provided is invalid. However, it only throws when an "empty" value is provided. It is therefore confusing in our logs.

This changes the wording to correctly match the exception.

## Changes

- Update error message
- Adds further test coverage