### PR TITLE
Check fiatCode before getting Zerion balances

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -61,7 +61,7 @@ export default (): ReturnType<typeof configuration> => ({
           ]),
         ),
         limitPeriodSeconds: faker.number.int({ min: 1, max: 10 }),
-        limitCalls: faker.number.int({ min: 1, max: 10 }),
+        limitCalls: faker.number.int({ min: 1, max: 5 }),
       },
     },
   },

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -92,7 +92,7 @@ export class ZerionBalancesApi implements IBalancesApi {
     safeAddress: `0x${string}`;
     fiatCode: string;
   }): Promise<Balance[]> {
-    // TODO: check the fiatCode is supported.
+    this._checkFiatCode(args.fiatCode);
     const cacheDir = CacheRouter.getZerionBalancesCacheDir(args);
     const chainName = this._getChainName(args.chainId);
     const cached = await this.cacheService.get(cacheDir);
@@ -353,5 +353,10 @@ export class ZerionBalancesApi implements IBalancesApi {
       this.limitPeriodSeconds,
     );
     if (current > this.limitCalls) throw new LimitReachedError();
+  }
+
+  private _checkFiatCode(fiatCode: string): void {
+    if (!this.fiatCodes.includes(fiatCode.toUpperCase()))
+      throw new DataSourceError(`Unsupported currency code: ${fiatCode}`, 400);
   }
 }

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -92,7 +92,13 @@ export class ZerionBalancesApi implements IBalancesApi {
     safeAddress: `0x${string}`;
     fiatCode: string;
   }): Promise<Balance[]> {
-    this._checkFiatCode(args.fiatCode);
+    if (!this.fiatCodes.includes(args.fiatCode.toUpperCase())) {
+      throw new DataSourceError(
+        `Unsupported currency code: ${args.fiatCode}`,
+        400,
+      );
+    }
+
     const cacheDir = CacheRouter.getZerionBalancesCacheDir(args);
     const chainName = this._getChainName(args.chainId);
     const cached = await this.cacheService.get(cacheDir);
@@ -353,10 +359,5 @@ export class ZerionBalancesApi implements IBalancesApi {
       this.limitPeriodSeconds,
     );
     if (current > this.limitCalls) throw new LimitReachedError();
-  }
-
-  private _checkFiatCode(fiatCode: string): void {
-    if (!this.fiatCodes.includes(fiatCode.toUpperCase()))
-      throw new DataSourceError(`Unsupported currency code: ${fiatCode}`, 400);
   }
 }

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -34,6 +34,7 @@ import { getAddress } from 'viem';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { Server } from 'net';
+import { sample } from 'lodash';
 
 describe('Balances Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -41,6 +42,7 @@ describe('Balances Controller (Unit)', () => {
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let zerionBaseUri: string;
   let zerionChainIds: string[];
+  let zerionCurrencies: string[];
   let configurationService: jest.MockedObjectDeep<IConfigurationService>;
 
   beforeEach(async () => {
@@ -85,6 +87,10 @@ describe('Balances Controller (Unit)', () => {
     zerionChainIds = configurationService.getOrThrow(
       'features.zerionBalancesChainIds',
     );
+    zerionCurrencies = configurationService.getOrThrow(
+      'balances.providers.zerion.currencies',
+    );
+
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -96,11 +102,11 @@ describe('Balances Controller (Unit)', () => {
   });
 
   describe('Balances provider: Zerion', () => {
-    describe('GET /balances (externalized)', () => {
+    describe('GET /balances', () => {
       it(`maps native coin + ERC20 token balance correctly, and sorts balances by fiatBalance`, async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
         const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const currency = faker.finance.currencyCode();
+        const currency = sample(zerionCurrencies);
         const chainName = configurationService.getOrThrow<string>(
           `balances.providers.zerion.chains.${chain.chainId}.chainName`,
         );
@@ -237,7 +243,7 @@ describe('Balances Controller (Unit)', () => {
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
-            currency: currency.toLowerCase(),
+            currency: currency?.toLowerCase(),
             sort: 'value',
           },
         });
@@ -246,7 +252,7 @@ describe('Balances Controller (Unit)', () => {
       it('returns large numbers as is (not in scientific notation)', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
         const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const currency = faker.finance.currencyCode();
+        const currency = sample(zerionCurrencies);
         const chainName = configurationService.getOrThrow<string>(
           `balances.providers.zerion.chains.${chain.chainId}.chainName`,
         );
@@ -384,10 +390,37 @@ describe('Balances Controller (Unit)', () => {
           headers: { Authorization: `Basic ${apiKey}` },
           params: {
             'filter[chain_ids]': chainName,
-            currency: currency.toLowerCase(),
+            currency: currency?.toLowerCase(),
             sort: 'value',
           },
         });
+      });
+
+      it('fails when an unsupported fiatCode is provided', async () => {
+        const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const unsupportedCurrency = faker.string.alpha({
+          length: { min: 4, max: 4 },
+          exclude: zerionCurrencies,
+        });
+        networkService.get.mockImplementation(({ url }) => {
+          switch (url) {
+            case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+              return Promise.resolve({ data: chain, status: 200 });
+            default:
+              return Promise.reject(new Error(`Could not match ${url}`));
+          }
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${unsupportedCurrency}`,
+          )
+          .expect(400)
+          .expect({
+            code: 400,
+            message: `Unsupported currency code: ${unsupportedCurrency}`,
+          });
       });
     });
 
@@ -434,7 +467,7 @@ describe('Balances Controller (Unit)', () => {
       it(`500 error response`, async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
         const safeAddress = faker.finance.ethereumAddress();
-        const currency = faker.finance.currencyCode();
+        const currency = sample(zerionCurrencies);
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -462,7 +495,7 @@ describe('Balances Controller (Unit)', () => {
       it('does not trigger a rate-limit error', async () => {
         const chain = chainBuilder().with('chainId', zerionChainIds[0]).build();
         const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const currency = faker.finance.currencyCode();
+        const currency = sample(zerionCurrencies);
         const chainName = configurationService.getOrThrow<string>(
           `balances.providers.zerion.chains.${chain.chainId}.chainName`,
         );
@@ -584,17 +617,21 @@ describe('Balances Controller (Unit)', () => {
         const limitCalls = configurationService.getOrThrow<number>(
           'balances.providers.zerion.limitCalls',
         );
+
+        // Note: each request use a different currency code to avoid cache hits.
+        // The last request will trigger the rate limit error.
+        // This assumes the configuration follow the rule: zerionCurrencies.length > limitCalls
         for (let i = 0; i < limitCalls; i++) {
           await request(app.getHttpServer())
             .get(
-              `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${crypto.randomUUID()}`,
+              `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${zerionCurrencies[i]}`,
             )
             .expect(200);
         }
 
         await request(app.getHttpServer())
           .get(
-            `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${crypto.randomUUID()}`,
+            `/v1/chains/${chain.chainId}/safes/${safeAddress}/balances/${zerionCurrencies[limitCalls]}`,
           )
           .expect(429);
 

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -620,7 +620,7 @@ describe('Balances Controller (Unit)', () => {
 
         // Note: each request use a different currency code to avoid cache hits.
         // The last request will trigger the rate limit error.
-        // This assumes the configuration follow the rule: zerionCurrencies.length > limitCalls
+        // This assumes the test configuration follows the rule: zerionCurrencies.length > limitCalls
         for (let i = 0; i < limitCalls; i++) {
           await request(app.getHttpServer())
             .get(


### PR DESCRIPTION
## Changes
- Adds a `fiatCode` check before calling the Zerion's balances endpoint.
