### PR TITLE
Enable `@typescript-eslint/no-unsafe-call` lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,6 @@ export default tseslint.config(
       '@typescript-eslint/no-floating-promises': 'warn',
       // TODO: Address these rules: (added to update to ESLint 9)
       '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',

--- a/src/__tests__/deployments.helper.ts
+++ b/src/__tests__/deployments.helper.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import path from 'path';
+import fs from 'fs';
 
 /**
  * This generates a map of contract names to chain IDs to a versions array

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -3,7 +3,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { json } from 'express';
-import * as cookieParser from 'cookie-parser';
+import cookieParser from 'cookie-parser';
 
 function configureVersioning(app: INestApplication): void {
   app.enableVersioning({

--- a/src/datasources/account/account.datasource.spec.ts
+++ b/src/datasources/account/account.datasource.spec.ts
@@ -1,9 +1,9 @@
 import { AccountDataSource } from '@/datasources/account/account.datasource';
-import * as postgres from 'postgres';
+import postgres from 'postgres';
 import { PostgresError } from 'postgres';
 import { faker } from '@faker-js/faker';
 import { AccountDoesNotExistError } from '@/domain/account/errors/account-does-not-exist.error';
-import * as shift from 'postgres-shift';
+import shift from 'postgres-shift';
 import configuration from '@/config/entities/__tests__/configuration';
 import {
   Account,

--- a/src/datasources/account/account.datasource.ts
+++ b/src/datasources/account/account.datasource.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import * as postgres from 'postgres';
+import postgres from 'postgres';
 import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
 import { AccountDoesNotExistError } from '@/domain/account/errors/account-does-not-exist.error';
 import {

--- a/src/datasources/db/postgres-database.migration.hook.ts
+++ b/src/datasources/db/postgres-database.migration.hook.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import * as shift from 'postgres-shift';
+import shift from 'postgres-shift';
 import postgres from 'postgres';
 
 /**

--- a/src/datasources/db/postgres-database.module.ts
+++ b/src/datasources/db/postgres-database.module.ts
@@ -1,9 +1,9 @@
-import * as postgres from 'postgres';
+import postgres from 'postgres';
 import { Module } from '@nestjs/common';
 import { PostgresDatabaseShutdownHook } from '@/datasources/db/postgres-database.shutdown.hook';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { PostgresDatabaseMigrationHook } from '@/datasources/db/postgres-database.migration.hook';
-import * as fs from 'fs';
+import fs from 'fs';
 
 function dbFactory(configurationService: IConfigurationService): postgres.Sql {
   const caPath = configurationService.get<string>('db.postgres.ssl.caPath');

--- a/src/datasources/human-description-api/json/index.ts
+++ b/src/datasources/human-description-api/json/index.ts
@@ -1,3 +1,3 @@
-import * as ContractDescriptions from '@/datasources/human-description-api/json/contract-descriptions.json';
+import ContractDescriptions from '@/datasources/human-description-api/json/contract-descriptions.json';
 
 export default ContractDescriptions;

--- a/src/datasources/jwt/jwt.module.ts
+++ b/src/datasources/jwt/jwt.module.ts
@@ -1,4 +1,4 @@
-import * as jwt from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import { Module } from '@nestjs/common';
 import { JwtService } from '@/datasources/jwt/jwt.service';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';

--- a/src/datasources/network/network.module.spec.ts
+++ b/src/datasources/network/network.module.spec.ts
@@ -38,9 +38,13 @@ describe('NetworkModule', () => {
       ],
     }).compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
     fetchClient = moduleFixture.get('FetchClient');
-    httpClientTimeout = configurationService.get('httpClient.requestTimeout');
+    httpClientTimeout = configurationService.getOrThrow(
+      'httpClient.requestTimeout',
+    );
 
     app = moduleFixture.createNestApplication();
     await app.init();

--- a/src/domain/account/account.repository.ts
+++ b/src/domain/account/account.repository.ts
@@ -14,7 +14,7 @@ import { EmailAlreadyVerifiedError } from '@/domain/account/errors/email-already
 import { InvalidVerificationCodeError } from '@/domain/account/errors/invalid-verification-code.error';
 import { EmailEditMatchesError } from '@/domain/account/errors/email-edit-matches.error';
 import { IEmailApi } from '@/domain/interfaces/email-api.interface';
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import { ISubscriptionRepository } from '@/domain/subscriptions/subscription.repository.interface';
 import { SubscriptionRepository } from '@/domain/subscriptions/subscription.repository';
 import { AccountDoesNotExistError } from '@/domain/account/errors/account-does-not-exist.error';

--- a/src/domain/account/code-generator.ts
+++ b/src/domain/account/code-generator.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 
 /**
  * Generates a random number up to six digits

--- a/src/logging/logging.module.ts
+++ b/src/logging/logging.module.ts
@@ -1,6 +1,6 @@
 import { Global, Module } from '@nestjs/common';
-import * as winston from 'winston';
-import * as Transport from 'winston-transport';
+import winston from 'winston';
+import Transport from 'winston-transport';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { LoggingService } from '@/logging/logging.interface';
 import { RequestScopedLoggingService } from '@/logging/logging.service';

--- a/src/logging/logging.service.spec.ts
+++ b/src/logging/logging.service.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { ClsService } from 'nestjs-cls';
-import * as winston from 'winston';
+import winston from 'winston';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { RequestScopedLoggingService } from '@/logging/logging.service';
 

--- a/src/routes/about/__tests__/get-about.e2e-spec.ts
+++ b/src/routes/about/__tests__/get-about.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '@/app.module';
 import { expect } from '@jest/globals';
 import '@/__tests__/matchers/to-be-string-or-null';

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -1,8 +1,8 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';

--- a/src/routes/alerts/guards/tenderly-signature.guard.ts
+++ b/src/routes/alerts/guards/tenderly-signature.guard.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { Request } from 'express';
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 
 @Injectable()

--- a/src/routes/auth/auth.controller.spec.ts
+++ b/src/routes/auth/auth.controller.spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';

--- a/src/routes/auth/decorators/auth.decorator.spec.ts
+++ b/src/routes/auth/decorators/auth.decorator.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '@nestjs/common';
 import { TestingModule, Test } from '@nestjs/testing';
 import { Server } from 'net';
-import * as request from 'supertest';
+import request from 'supertest';
 
 describe('Auth decorator', () => {
   let app: INestApplication<Server>;

--- a/src/routes/auth/guards/auth.guard.spec.ts
+++ b/src/routes/auth/guards/auth.guard.spec.ts
@@ -10,7 +10,7 @@ import { AuthGuard } from '@/routes/auth/guards/auth.guard';
 import { faker } from '@faker-js/faker';
 import { Controller, Get, INestApplication, UseGuards } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AuthRepositoryModule } from '@/domain/auth/auth.repository.interface';
 import { getSecondsUntil } from '@/domain/common/utils/time';
 import {

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AppModule } from '@/app.module';
 import { IConfigurationService } from '@/config/configuration.service.interface';

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -53,9 +53,11 @@ describe('Balances Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
-    pricesProviderUrl = configurationService.get(
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    pricesProviderUrl = configurationService.getOrThrow(
       'balances.providers.safe.prices.baseUri',
     );
     networkService = moduleFixture.get(NetworkService);
@@ -92,7 +94,7 @@ describe('Balances Controller (Unit)', () => {
           .build(),
       ];
       const apiKey = app
-        .get(IConfigurationService)
+        .get<IConfigurationService>(IConfigurationService)
         .getOrThrow('balances.providers.safe.prices.apiKey');
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AppModule } from '@/app.module';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -70,11 +70,13 @@ describe('Chains Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
-    name = configurationService.get('about.name');
-    version = configurationService.get('about.version');
-    buildNumber = configurationService.get('about.buildNumber');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    name = configurationService.getOrThrow('about.name');
+    version = configurationService.getOrThrow('about.version');
+    buildNumber = configurationService.getOrThrow('about.buildNumber');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AppModule } from '@/app.module';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -54,11 +54,13 @@ describe('Zerion Collectibles Controller', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    zerionBaseUri = configurationService.get(
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    zerionBaseUri = configurationService.getOrThrow(
       'balances.providers.zerion.baseUri',
     );
-    zerionChainIds = configurationService.get(
+    zerionChainIds = configurationService.getOrThrow(
       'features.zerionBalancesChainIds',
     );
     networkService = moduleFixture.get(NetworkService);
@@ -125,12 +127,12 @@ describe('Zerion Collectibles Controller', () => {
           ])
           .build();
         const chainName = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(
             `balances.providers.zerion.chains.${chain.chainId}.chainName`,
           );
         const apiKey = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
@@ -267,12 +269,12 @@ describe('Zerion Collectibles Controller', () => {
           .with('links', { next: zerionNext })
           .build();
         const chainName = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(
             `balances.providers.zerion.chains.${chain.chainId}.chainName`,
           );
         const apiKey = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
@@ -332,12 +334,12 @@ describe('Zerion Collectibles Controller', () => {
           .with('links', { next: zerionNext })
           .build();
         const chainName = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(
             `balances.providers.zerion.chains.${chain.chainId}.chainName`,
           );
         const apiKey = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
@@ -396,12 +398,12 @@ describe('Zerion Collectibles Controller', () => {
           .with('links', { next: zerionNext })
           .build();
         const chainName = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(
             `balances.providers.zerion.chains.${chain.chainId}.chainName`,
           );
         const apiKey = app
-          .get(IConfigurationService)
+          .get<IConfigurationService>(IConfigurationService)
           .getOrThrow(`balances.providers.zerion.apiKey`);
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AppModule } from '@/app.module';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -59,8 +59,10 @@ describe('Collectibles Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.spec.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, INestApplication, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { Server } from 'net';

--- a/src/routes/common/filters/global-error.filter.spec.ts
+++ b/src/routes/common/filters/global-error.filter.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import * as request from 'supertest';
+import request from 'supertest';
 import { APP_FILTER } from '@nestjs/core';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '@/config/configuration.module';

--- a/src/routes/common/filters/zod-error.filter.spec.ts
+++ b/src/routes/common/filters/zod-error.filter.spec.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, INestApplication, Post } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import * as request from 'supertest';
+import request from 'supertest';
 import { APP_FILTER } from '@nestjs/core';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '@/config/configuration.module';

--- a/src/routes/common/interceptors/cache-control.interceptor.spec.ts
+++ b/src/routes/common/interceptors/cache-control.interceptor.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { CacheControlInterceptor } from '@/routes/common/interceptors/cache-control.interceptor';
 import { Test } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { Server } from 'net';
 
 @Controller()

--- a/src/routes/common/interceptors/cache-control.interceptor.ts
+++ b/src/routes/common/interceptors/cache-control.interceptor.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { Observable, tap } from 'rxjs';
 
 /**
@@ -17,7 +18,7 @@ export class CacheControlInterceptor implements NestInterceptor {
   ): Observable<unknown> | Promise<Observable<unknown>> {
     return next.handle().pipe(
       tap(() => {
-        const response = context.switchToHttp().getResponse();
+        const response: Response = context.switchToHttp().getResponse();
         response.header('Cache-Control', 'no-cache');
       }),
     );

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -7,7 +7,7 @@ import {
   HttpStatus,
   INestApplication,
 } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { faker } from '@faker-js/faker';
 import { RouteLoggerInterceptor } from '@/routes/common/interceptors/route-logger.interceptor';

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -64,8 +64,10 @@ describe('Community (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    lockingBaseUri = configurationService.get('locking.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    lockingBaseUri = configurationService.getOrThrow('locking.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest';
+import request from 'supertest';
 import { RedisClientType } from 'redis';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -47,8 +47,10 @@ describe('Contracts controller', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '@/app.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -54,8 +54,10 @@ describe('Delegates controller', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/delegates/v2/delegates.v2.controller.spec.ts
+++ b/src/routes/delegates/v2/delegates.v2.controller.spec.ts
@@ -27,7 +27,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
 import { Server } from 'net';
-import * as request from 'supertest';
+import request from 'supertest';
 import { getAddress } from 'viem';
 
 describe('Delegates controller', () => {
@@ -62,8 +62,10 @@ describe('Delegates controller', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/email/email.controller.delete-email.spec.ts
+++ b/src/routes/email/email.controller.delete-email.spec.ts
@@ -10,7 +10,7 @@ import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { authPayloadDtoBuilder } from '@/domain/auth/entities/__tests__/auth-payload-dto.entity.builder';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -71,8 +71,10 @@ describe('Email controller delete email tests', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     accountDataSource = moduleFixture.get(IAccountDataSource);
     emailApi = moduleFixture.get(IEmailApi);
     networkService = moduleFixture.get(NetworkService);

--- a/src/routes/email/email.controller.edit-email.spec.ts
+++ b/src/routes/email/email.controller.edit-email.spec.ts
@@ -10,7 +10,7 @@ import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import {
@@ -86,8 +86,10 @@ describe('Email controller edit email tests', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     accountDataSource = moduleFixture.get(IAccountDataSource);
     networkService = moduleFixture.get(NetworkService);
     jwtService = moduleFixture.get<IJwtService>(IJwtService);

--- a/src/routes/email/email.controller.get-email.spec.ts
+++ b/src/routes/email/email.controller.get-email.spec.ts
@@ -12,7 +12,7 @@ import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import * as request from 'supertest';
+import request from 'supertest';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { authPayloadDtoBuilder } from '@/domain/auth/entities/__tests__/auth-payload-dto.entity.builder';

--- a/src/routes/email/email.controller.resend-verification.spec.ts
+++ b/src/routes/email/email.controller.resend-verification.spec.ts
@@ -10,7 +10,7 @@ import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';
 import { INestApplication } from '@nestjs/common';

--- a/src/routes/email/email.controller.save-email.spec.ts
+++ b/src/routes/email/email.controller.save-email.spec.ts
@@ -10,7 +10,7 @@ import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { authPayloadDtoBuilder } from '@/domain/auth/entities/__tests__/auth-payload-dto.entity.builder';
 import { IConfigurationService } from '@/config/configuration.service.interface';

--- a/src/routes/email/email.controller.verify-email.spec.ts
+++ b/src/routes/email/email.controller.verify-email.spec.ts
@@ -10,7 +10,7 @@ import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { IAccountDataSource } from '@/domain/interfaces/account.datasource.interface';
 import { EmailControllerModule } from '@/routes/email/email.controller.module';

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -55,8 +55,10 @@ describe('Estimations Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '@/app.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { CacheKeyPrefix } from '@/datasources/cache/constants';

--- a/src/routes/health/health.controller.spec.ts
+++ b/src/routes/health/health.controller.spec.ts
@@ -11,7 +11,7 @@ import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { INestApplication } from '@nestjs/common';
 import { CacheService } from '@/datasources/cache/cache.service.interface';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -59,8 +59,10 @@ describe('Messages controller', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
@@ -51,8 +51,10 @@ describe('Notifications Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { RedisClientType } from 'redis';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '@/app.module';
 import { redisClientFactory } from '@/__tests__/redis-client.factory';
 import { CacheKeyPrefix } from '@/datasources/cache/constants';

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -49,8 +49,10 @@ describe('Owners Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/recovery/recovery.controller.spec.ts
+++ b/src/routes/recovery/recovery.controller.spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -89,11 +89,13 @@ describe('Recovery (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    alertsUrl = configurationService.get('alerts-api.baseUri');
-    alertsAccount = configurationService.get('alerts-api.account');
-    alertsProject = configurationService.get('alerts-api.project');
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    alertsUrl = configurationService.getOrThrow('alerts-api.baseUri');
+    alertsAccount = configurationService.getOrThrow('alerts-api.account');
+    alertsProject = configurationService.getOrThrow('alerts-api.project');
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
     jwtService = moduleFixture.get<IJwtService>(IJwtService);
 

--- a/src/routes/relay/entities/schemas/relay.dto.schema.ts
+++ b/src/routes/relay/entities/schemas/relay.dto.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import * as semver from 'semver';
+import semver from 'semver';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '@/app.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';

--- a/src/routes/root/root.controller.spec.ts
+++ b/src/routes/root/root.controller.spec.ts
@@ -5,7 +5,7 @@ import configuration from '@/config/entities/__tests__/configuration';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { CacheModule } from '@/datasources/cache/cache.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AccountDataSourceModule } from '@/datasources/account/account.datasource.module';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { RedisClientType } from 'redis';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '@/app.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { redisClientFactory } from '@/__tests__/redis-client.factory';
@@ -42,6 +42,7 @@ describe('Get Safe Apps e2e test', () => {
       .expect(200)
       .expect(({ body }) => {
         expect(body).toBeInstanceOf(Array);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         body.forEach((safeApp: SafeApp) =>
           expect(safeApp).toEqual(
             expect.objectContaining({

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -49,8 +49,10 @@ describe('Safe Apps Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
+++ b/src/routes/safes/pipes/caip-10-addresses.pipe.spec.ts
@@ -7,7 +7,7 @@ import { faker } from '@faker-js/faker';
 import { Controller, Get, INestApplication, Query } from '@nestjs/common';
 import { TestingModule, Test } from '@nestjs/testing';
 import { Server } from 'net';
-import * as request from 'supertest';
+import request from 'supertest';
 import { getAddress } from 'viem';
 
 @Controller()

--- a/src/routes/safes/safes.controller.nonces.spec.ts
+++ b/src/routes/safes/safes.controller.nonces.spec.ts
@@ -13,7 +13,7 @@ import {
   NetworkService,
 } from '@/datasources/network/network.service.interface';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import * as request from 'supertest';
+import request from 'supertest';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import {

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
@@ -69,7 +69,9 @@ describe('Safes Controller Overview (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     pricesProviderUrl = configurationService.getOrThrow(
       'balances.providers.safe.prices.baseUri',

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
-import * as request from 'supertest';
+import request from 'supertest';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { singletonBuilder } from '@/domain/chains/entities/__tests__/singleton.builder';
@@ -68,8 +68,10 @@ describe('Safes Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { max } from 'lodash';
-import * as semver from 'semver';
+import semver from 'semver';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
 import { Singleton } from '@/domain/chains/entities/singleton.entity';
 import { MessagesRepository } from '@/domain/messages/messages.repository';

--- a/src/routes/subscriptions/subscription.controller.spec.ts
+++ b/src/routes/subscriptions/subscription.controller.spec.ts
@@ -11,7 +11,7 @@ import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { NetworkModule } from '@/datasources/network/network.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import * as request from 'supertest';
+import request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { Subscription } from '@/domain/account/entities/subscription.entity';
 import { TestAccountDataSourceModule } from '@/datasources/account/__tests__/test.account.datasource.module';

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -49,8 +49,10 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       ],
     }).compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -56,8 +56,10 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
     fakeCacheService = moduleFixture.get(CacheService);
 

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -67,8 +67,10 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
@@ -64,8 +64,10 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -53,8 +53,10 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
@@ -63,8 +63,10 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -47,8 +47,10 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       ],
     }).compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -55,8 +55,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
@@ -57,8 +57,10 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
@@ -831,8 +831,9 @@ describe('Transactions History Controller (Unit)', () => {
       )
       .expect(200)
       .then(({ body }) => {
-        // the amount of TransactionItems is limited to the max value
         expect(
+          // the amount of TransactionItems is limited to the max value
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           body.results.filter(
             (item: TransactionItem) => item.type === 'TRANSACTION',
           ),

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
@@ -91,8 +91,10 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -16,7 +16,7 @@ import { NetworkModule } from '@/datasources/network/network.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
-import * as request from 'supertest';
+import request from 'supertest';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
@@ -67,9 +67,11 @@ describe('TransactionsViewController tests', () => {
       .useModule(TestQueuesApiModule)
       .compile();
 
-    const configurationService = moduleFixture.get(IConfigurationService);
-    safeConfigUrl = configurationService.get('safeConfig.baseUri');
-    swapsApiUrl = configurationService.get('swaps.api.1');
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    swapsApiUrl = configurationService.getOrThrow('swaps.api.1');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);

--- a/src/types/postgres-shift.d.ts
+++ b/src/types/postgres-shift.d.ts
@@ -1,1 +1,12 @@
-declare module 'postgres-shift';
+declare module 'postgres-shift' {
+  import { Sql } from 'postgres';
+
+  // https://github.com/porsager/postgres-shift/blob/master/index.js
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  export default async (options: {
+    sql: Sql;
+    path?: string;
+    before?: boolean | null;
+    after?: boolean | null;
+  }): Promise<unknown> => {};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "esModuleInterop": true,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
## Summary

With ESLint 9 the recommended rules were updated. As such, we disabled a few to prevent the upgrade spanning the entire codebase.

This reenables the `@typescript-eslint/no-unsafe-call` rule that was disabled.

Note: the `esModuleInterop` compiler option of TypeScript was enabled after defining the types for `postgres-shift`. Enabling it required all `import * as example from ...` to be changed to `import example from ...`.

## Changes

- Enable `@typescript-eslint/no-unsafe-call` lint rule
- Update respective errors