### PR TITLE
Fix getAddress unhandled error in TransactionsService

### DIFF
--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -35,7 +35,7 @@ import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transact
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
-import { getAddress } from 'viem';
+import { getAddress, isAddress } from 'viem';
 
 @Injectable()
 export class TransactionsService {
@@ -70,13 +70,10 @@ export class TransactionsService {
       }
 
       case TRANSFER_PREFIX: {
-        // We can't checksum outside of case as some IDs don't contain addresses
-        let address;
-        try {
-          address = getAddress(safeAddress);
-        } catch (err) {
+        if (!isAddress(safeAddress)) {
           throw new BadRequestException('Invalid transaction ID');
         }
+
         const [transfer, safe] = await Promise.all([
           this.safeRepository.getTransfer({
             chainId: args.chainId,
@@ -84,7 +81,8 @@ export class TransactionsService {
           }),
           this.safeRepository.getSafe({
             chainId: args.chainId,
-            address,
+            // We can't checksum outside of case as some IDs don't contain addresses
+            address: getAddress(safeAddress),
           }),
         ]);
         return this.transferDetailsMapper.mapDetails(
@@ -95,13 +93,10 @@ export class TransactionsService {
       }
 
       case MULTISIG_TRANSACTION_PREFIX: {
-        // We can't checksum outside of case as some IDs don't contain addresses
-        let address;
-        try {
-          address = getAddress(safeAddress);
-        } catch (err) {
+        if (!isAddress(safeAddress)) {
           throw new BadRequestException('Invalid transaction ID');
         }
+
         const [tx, safe] = await Promise.all([
           this.safeRepository.getMultiSigTransaction({
             chainId: args.chainId,
@@ -109,7 +104,8 @@ export class TransactionsService {
           }),
           this.safeRepository.getSafe({
             chainId: args.chainId,
-            address,
+            // We can't checksum outside of case as some IDs don't contain addresses
+            address: getAddress(safeAddress),
           }),
         ]);
         return this.multisigTransactionDetailsMapper.mapDetails(

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { MultisigTransaction as DomainMultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { SafeRepository } from '@/domain/safe/safe.repository';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
@@ -70,6 +70,13 @@ export class TransactionsService {
       }
 
       case TRANSFER_PREFIX: {
+        // We can't checksum outside of case as some IDs don't contain addresses
+        let address;
+        try {
+          address = getAddress(safeAddress);
+        } catch (err) {
+          throw new BadRequestException('Invalid transaction ID');
+        }
         const [transfer, safe] = await Promise.all([
           this.safeRepository.getTransfer({
             chainId: args.chainId,
@@ -77,8 +84,7 @@ export class TransactionsService {
           }),
           this.safeRepository.getSafe({
             chainId: args.chainId,
-            // We can't checksum outside of case as some IDs don't contain addresses
-            address: getAddress(safeAddress),
+            address,
           }),
         ]);
         return this.transferDetailsMapper.mapDetails(
@@ -89,6 +95,13 @@ export class TransactionsService {
       }
 
       case MULTISIG_TRANSACTION_PREFIX: {
+        // We can't checksum outside of case as some IDs don't contain addresses
+        let address;
+        try {
+          address = getAddress(safeAddress);
+        } catch (err) {
+          throw new BadRequestException('Invalid transaction ID');
+        }
         const [tx, safe] = await Promise.all([
           this.safeRepository.getMultiSigTransaction({
             chainId: args.chainId,
@@ -96,8 +109,7 @@ export class TransactionsService {
           }),
           this.safeRepository.getSafe({
             chainId: args.chainId,
-            // We can't checksum outside of case as some IDs don't contain addresses
-            address: getAddress(safeAddress),
+            address,
           }),
         ]);
         return this.multisigTransactionDetailsMapper.mapDetails(


### PR DESCRIPTION
## Changes
- Adds a `try-catch` block to the `TransactionsService.getById` to make error handling safer.
