### PR TITLE
Add `transaction_hash` query to `module-transactions`

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -215,13 +215,14 @@ export class CacheRouter {
     chainId: string;
     safeAddress: `0x${string}`;
     to?: string;
+    txHash?: string;
     module?: string;
     limit?: number;
     offset?: number;
   }): CacheDir {
     return new CacheDir(
       CacheRouter.getModuleTransactionsCacheKey(args),
-      `${args.to}_${args.module}_${args.limit}_${args.offset}`,
+      `${args.to}_${args.module}_${args.txHash}_${args.limit}_${args.offset}`,
     );
   }
 

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -1177,7 +1177,7 @@ describe('TransactionApi', () => {
       const getModuleTransactionsUrl = `${baseUrl}/api/v1/safes/${moduleTransaction.safe}/module-transactions/`;
       const cacheDir = new CacheDir(
         `${chainId}_module_transactions_${moduleTransaction.safe}`,
-        `${moduleTransaction.to}_${moduleTransaction.module}_${limit}_${offset}`,
+        `${moduleTransaction.to}_${moduleTransaction.module}_${moduleTransaction.transactionHash}_${limit}_${offset}`,
       );
       mockDataSource.get.mockResolvedValueOnce(moduleTransactionsPage);
 
@@ -1185,6 +1185,7 @@ describe('TransactionApi', () => {
         safeAddress: moduleTransaction.safe,
         to: moduleTransaction.to,
         module: moduleTransaction.module,
+        txHash: moduleTransaction.transactionHash,
         limit,
         offset,
       });
@@ -1200,6 +1201,7 @@ describe('TransactionApi', () => {
           params: {
             to: moduleTransaction.to,
             module: moduleTransaction.module,
+            transaction_hash: moduleTransaction.transactionHash,
             limit,
             offset,
           },
@@ -1222,7 +1224,7 @@ describe('TransactionApi', () => {
       const expected = new DataSourceError(errorMessage, statusCode);
       const cacheDir = new CacheDir(
         `${chainId}_module_transactions_${moduleTransaction.safe}`,
-        `${moduleTransaction.to}_${moduleTransaction.module}_${limit}_${offset}`,
+        `${moduleTransaction.to}_${moduleTransaction.module}_${moduleTransaction.transactionHash}_${limit}_${offset}`,
       );
       mockDataSource.get.mockRejectedValueOnce(
         new NetworkResponseError(
@@ -1239,6 +1241,7 @@ describe('TransactionApi', () => {
           safeAddress: moduleTransaction.safe,
           to: moduleTransaction.to,
           module: moduleTransaction.module,
+          txHash: moduleTransaction.transactionHash,
           limit,
           offset,
         }),
@@ -1254,6 +1257,7 @@ describe('TransactionApi', () => {
           params: {
             to: moduleTransaction.to,
             module: moduleTransaction.module,
+            transaction_hash: moduleTransaction.transactionHash,
             limit,
             offset,
           },

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -502,6 +502,7 @@ export class TransactionApi implements ITransactionApi {
   async getModuleTransactions(args: {
     safeAddress: `0x${string}`;
     to?: string;
+    txHash?: string;
     module?: string;
     limit?: number;
     offset?: number;
@@ -519,6 +520,7 @@ export class TransactionApi implements ITransactionApi {
         networkRequest: {
           params: {
             to: args.to,
+            transaction_hash: args.txHash,
             module: args.module,
             limit: args.limit,
             offset: args.offset,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -125,6 +125,7 @@ export interface ITransactionApi {
   getModuleTransactions(args: {
     safeAddress: `0x${string}`;
     to?: string;
+    txHash?: string;
     module?: string;
     limit?: number;
     offset?: number;

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -67,6 +67,7 @@ export interface ISafeRepository {
     chainId: string;
     safeAddress: `0x${string}`;
     to?: string;
+    txHash?: string;
     module?: string;
     limit?: number;
     offset?: number;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -151,6 +151,7 @@ export class SafeRepository implements ISafeRepository {
     chainId: string;
     safeAddress: `0x${string}`;
     to?: string;
+    txHash?: string;
     module?: string;
     limit?: number;
     offset?: number;

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -124,12 +124,14 @@ export class TransactionsController {
     safeAddress: `0x${string}`,
     @Query('to') to?: string,
     @Query('module') module?: string,
+    @Query('transaction_hash') txHash?: string,
   ): Promise<Page<ModuleTransaction>> {
     return this.transactionsService.getModuleTransactions({
       chainId,
       routeUrl,
       safeAddress,
       to,
+      txHash,
       module,
       paginationData,
     });

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -222,6 +222,7 @@ export class TransactionsService {
     safeAddress: `0x${string}`;
     to?: string;
     module?: string;
+    txHash?: string;
     paginationData?: PaginationData;
   }): Promise<Page<ModuleTransaction>> {
     const domainTransactions = await this.safeRepository.getModuleTransactions({


### PR DESCRIPTION
## Summary

For role-based execution on the Web, it is [necessary to query for module transactions via transaction hash](https://github.com/safe-global/safe-wallet-web/pull/3768#discussion_r1622213573). This is possible directly via the Transaction Service as the `module-transactions` endpoint accepts the `transaction_hash` query. However, we do not expose this on the Gateway.

As such, this add and forwards a `transaction_hash` query to the `module-transactions` endpoint.

Note: the clients also split the `txId` to fetch the `moduleId` of the transaction in question. We should ideally return this within the `Transaction` entity so that they need not reference our constructed ID. This would be better tackled in https://github.com/safe-global/safe-client-gateway/issues/1613, however.

## Changes

- Add `transaction_hash` query to `module-transactions` endpoint and propagate it to Transaction Service
- Add `txHash` value to field of module transaction cache
- Update tests accordingly