### PR TITLE
Add FF_COUNTERFACTUAL_BALANCES

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -117,6 +117,7 @@ export default (): ReturnType<typeof configuration> => ({
     confirmationView: false,
     eventsQueue: false,
     delegatesV2: false,
+    counterFactualBalances: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -117,7 +117,7 @@ export default (): ReturnType<typeof configuration> => ({
     confirmationView: false,
     eventsQueue: false,
     delegatesV2: false,
-    counterFactualBalances: false,
+    counterfactualBalances: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -183,7 +183,7 @@ export default () => ({
       process.env.FF_CONFIRMATION_VIEW?.toLowerCase() === 'true',
     eventsQueue: process.env.FF_EVENTS_QUEUE?.toLowerCase() === 'true',
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
-    counterFactualBalances:
+    counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
   },
   httpClient: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -183,6 +183,8 @@ export default () => ({
       process.env.FF_CONFIRMATION_VIEW?.toLowerCase() === 'true',
     eventsQueue: process.env.FF_EVENTS_QUEUE?.toLowerCase() === 'true',
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
+    counterFactualBalances:
+      process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -73,6 +73,7 @@ beforeEach(() => {
   configurationServiceMock.getOrThrow.mockImplementation((key) => {
     if (key === 'features.zerionBalancesChainIds')
       return ZERION_BALANCES_CHAIN_IDS;
+    if (key === 'features.counterFactualBalances') return true;
   });
 });
 
@@ -156,6 +157,7 @@ describe('Balances API Manager Tests', () => {
           return notFoundExpireTimeSeconds;
         else if (key === 'features.zerionBalancesChainIds')
           return ZERION_BALANCES_CHAIN_IDS;
+        else if (key === 'features.counterFactualBalances') return true;
         throw new Error(`Unexpected key: ${key}`);
       });
       configApiMock.getChain.mockResolvedValue(chain);

--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -73,7 +73,7 @@ beforeEach(() => {
   configurationServiceMock.getOrThrow.mockImplementation((key) => {
     if (key === 'features.zerionBalancesChainIds')
       return ZERION_BALANCES_CHAIN_IDS;
-    if (key === 'features.counterFactualBalances') return true;
+    if (key === 'features.counterfactualBalances') return true;
   });
 });
 
@@ -157,7 +157,7 @@ describe('Balances API Manager Tests', () => {
           return notFoundExpireTimeSeconds;
         else if (key === 'features.zerionBalancesChainIds')
           return ZERION_BALANCES_CHAIN_IDS;
-        else if (key === 'features.counterFactualBalances') return true;
+        else if (key === 'features.counterfactualBalances') return true;
         throw new Error(`Unexpected key: ${key}`);
       });
       configApiMock.getChain.mockResolvedValue(chain);

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -37,7 +37,7 @@ export class BalancesApiManager implements IBalancesApiManager {
   ) {
     this.isCounterFactualBalancesEnabled =
       this.configurationService.getOrThrow<boolean>(
-        'features.counterFactualBalances',
+        'features.counterfactualBalances',
       );
     this.zerionChainIds = this.configurationService.getOrThrow<string[]>(
       'features.zerionBalancesChainIds',

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -62,6 +62,10 @@ describe('Balances Controller (Unit)', () => {
           },
         },
       },
+      features: {
+        ...defaultConfiguration.features,
+        counterFactualBalances: true,
+      },
     });
 
     const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -64,7 +64,7 @@ describe('Balances Controller (Unit)', () => {
       },
       features: {
         ...defaultConfiguration.features,
-        counterFactualBalances: true,
+        counterfactualBalances: true,
       },
     });
 

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -43,7 +43,7 @@ describe('Balances Controller (Unit)', () => {
       ...defaultConfiguration,
       features: {
         ...defaultConfiguration.features,
-        counterFactualBalances: true,
+        counterfactualBalances: true,
       },
     });
 

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -38,8 +38,17 @@ describe('Balances Controller (Unit)', () => {
   beforeEach(async () => {
     jest.resetAllMocks();
 
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        counterFactualBalances: true,
+      },
+    });
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(testConfiguration)],
     })
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -44,8 +44,17 @@ describe('Collectibles Controller (Unit)', () => {
   beforeEach(async () => {
     jest.resetAllMocks();
 
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        counterFactualBalances: false,
+      },
+    });
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(testConfiguration)],
     })
       .overrideModule(AccountDataSourceModule)
       .useModule(TestAccountDataSourceModule)
@@ -154,7 +163,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: {
           limit: 10,
           offset: 20,
@@ -200,7 +209,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(networkService.get.mock.calls[2][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[1][0].networkRequest).toStrictEqual({
         params: {
           limit: PaginationData.DEFAULT_LIMIT,
           offset: PaginationData.DEFAULT_OFFSET,

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -49,7 +49,7 @@ describe('Collectibles Controller (Unit)', () => {
       ...defaultConfiguration,
       features: {
         ...defaultConfiguration.features,
-        counterFactualBalances: false,
+        counterfactualBalances: false,
       },
     });
 

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -54,7 +54,7 @@ describe('Safes Controller Overview (Unit)', () => {
       },
       features: {
         ...configuration().features,
-        counterFactualBalances: true,
+        counterfactualBalances: true,
       },
     });
 

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -52,6 +52,10 @@ describe('Safes Controller Overview (Unit)', () => {
           maxOverviews: 3,
         },
       },
+      features: {
+        ...configuration().features,
+        counterFactualBalances: true,
+      },
     });
 
     const moduleFixture: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
## Summary
Counterfactual balances are being retrieved when the Safe doesn't exist (it is not known by the Safe Transaction Service). This PR set that as an optional behavior, so the existence of a Safe and the use of an alternative source for the balances associated can be (de)activated via this FF.

## Changes
- Adds `FF_COUNTERFACTUAL_BALANCES` feature flag.
