### PR TITLE
Cache Safe existence check for counterfactual balances

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -12,7 +12,6 @@ import { getAddress } from 'viem';
 import { sample } from 'lodash';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
-import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 
 const configurationService = {
   getOrThrow: jest.fn(),
@@ -43,7 +42,7 @@ const transactionApiManagerMock = {
 } as jest.MockedObjectDeep<ITransactionApiManager>;
 
 const transactionApiMock = {
-  getSafe: jest.fn(),
+  isSafe: jest.fn(),
 } as jest.MockedObjectDeep<ITransactionApi>;
 
 const zerionBalancesApi = {
@@ -115,9 +114,7 @@ describe('Balances API Manager Tests', () => {
       transactionApiManagerMock.getTransactionApi.mockResolvedValue(
         transactionApiMock,
       );
-      transactionApiMock.getSafe.mockImplementation(() => {
-        throw new Error();
-      });
+      transactionApiMock.isSafe.mockResolvedValue(false);
 
       const result = await manager.getBalancesApi(
         faker.string.numeric({ exclude: ZERION_BALANCES_CHAIN_IDS }),
@@ -175,7 +172,7 @@ describe('Balances API Manager Tests', () => {
       transactionApiManagerMock.getTransactionApi.mockResolvedValue(
         transactionApiMock,
       );
-      transactionApiMock.getSafe.mockResolvedValue(safeBuilder().build());
+      transactionApiMock.isSafe.mockResolvedValue(true);
 
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const safeBalancesApi = await balancesApiManager.getBalancesApi(

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -22,6 +22,7 @@ export class CacheRouter {
   private static readonly SAFE_APPS_KEY = 'safe_apps';
   private static readonly SAFE_BALANCES_KEY = 'safe_balances';
   private static readonly SAFE_COLLECTIBLES_KEY = 'safe_collectibles';
+  private static readonly SAFE_EXISTS_KEY = 'safe_exists';
   private static readonly SAFE_FIAT_CODES_KEY = 'safe_fiat_codes';
   private static readonly SAFE_KEY = 'safe';
   private static readonly SINGLETONS_KEY = 'singletons';
@@ -114,6 +115,23 @@ export class CacheRouter {
     safeAddress: `0x${string}`;
   }): string {
     return `${args.chainId}_${CacheRouter.SAFE_KEY}_${args.safeAddress}`;
+  }
+
+  static getIsSafeCacheDir(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): CacheDir {
+    return new CacheDir(
+      `${args.chainId}_${CacheRouter.SAFE_EXISTS_KEY}_${args.safeAddress}`,
+      '',
+    );
+  }
+
+  static getIsSafeCacheKey(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): string {
+    return `${args.chainId}_${CacheRouter.SAFE_EXISTS_KEY}_${args.safeAddress}`;
   }
 
   static getContractCacheDir(args: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -121,10 +121,7 @@ export class CacheRouter {
     chainId: string;
     safeAddress: `0x${string}`;
   }): CacheDir {
-    return new CacheDir(
-      `${args.chainId}_${CacheRouter.SAFE_EXISTS_KEY}_${args.safeAddress}`,
-      '',
-    );
+    return new CacheDir(CacheRouter.getIsSafeCacheKey(args), '');
   }
 
   static getIsSafeCacheKey(args: {

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -6,6 +6,7 @@ import { INetworkService } from '@/datasources/network/network.service.interface
 import { TransactionApiManager } from '@/datasources/transaction-api/transaction-api.manager';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import { ILoggingService } from '@/logging/logging.interface';
 import { faker } from '@faker-js/faker';
 
 const configurationService = {
@@ -31,6 +32,10 @@ const cacheService = {} as jest.MockedObjectDeep<ICacheService>;
 const httpErrorFactory = {} as jest.MockedObjectDeep<HttpErrorFactory>;
 
 const networkService = {} as jest.MockedObjectDeep<INetworkService>;
+
+const mockLoggingService = {
+  debug: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
 
 describe('Transaction API Manager Tests', () => {
   beforeEach(() => {
@@ -77,6 +82,7 @@ describe('Transaction API Manager Tests', () => {
       cacheService,
       httpErrorFactory,
       networkService,
+      mockLoggingService,
     );
 
     const transactionApi = await target.getTransactionApi(chain.chainId);

--- a/src/datasources/transaction-api/transaction-api.manager.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.ts
@@ -14,6 +14,7 @@ import { TransactionApi } from '@/datasources/transaction-api/transaction-api.se
 import { Chain } from '@/domain/chains/entities/chain.entity';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 
 @Injectable()
 export class TransactionApiManager implements ITransactionApiManager {
@@ -29,6 +30,7 @@ export class TransactionApiManager implements ITransactionApiManager {
     @Inject(CacheService) private readonly cacheService: ICacheService,
     private readonly httpErrorFactory: HttpErrorFactory,
     @Inject(NetworkService) private readonly networkService: INetworkService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
     this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
       'safeTransaction.useVpcUrl',
@@ -48,6 +50,7 @@ export class TransactionApiManager implements ITransactionApiManager {
       this.configurationService,
       this.httpErrorFactory,
       this.networkService,
+      this.loggingService,
     );
     return this.transactionApiMap[chainId];
   }

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -59,7 +59,7 @@ describe('TransactionApi', () => {
   const baseUrl = faker.internet.url({ appendSlash: false });
   let httpErrorFactory: HttpErrorFactory;
   let service: TransactionApi;
-  let indefiniteExpirationTime = -1;
+  const indefiniteExpirationTime = -1;
   let defaultExpirationTimeInSeconds: number;
   let notFoundExpireTimeSeconds: number;
   let ownersTtlSeconds: number;

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -352,6 +352,12 @@ describe('TransactionApi', () => {
       expect(networkService.get).toHaveBeenCalledWith({
         url: `${baseUrl}/api/v1/safes/${safe.address}`,
       });
+      expect(cacheService.set).toHaveBeenCalledTimes(1);
+      expect(cacheService.set).toHaveBeenCalledWith(
+        cacheDir,
+        'true',
+        indefiniteExpirationTime,
+      );
     });
 
     it('should return the cached value', async () => {
@@ -370,6 +376,7 @@ describe('TransactionApi', () => {
       expect(cacheService.get).toHaveBeenCalledTimes(1);
       expect(cacheService.get).toHaveBeenCalledWith(cacheDir);
       expect(networkService.get).not.toHaveBeenCalled();
+      expect(cacheService.set).not.toHaveBeenCalledTimes(1);
     });
 
     it('should return false if Safe does not exist', async () => {
@@ -390,6 +397,12 @@ describe('TransactionApi', () => {
       expect(networkService.get).toHaveBeenCalledWith({
         url: `${baseUrl}/api/v1/safes/${safe.address}`,
       });
+      expect(cacheService.set).toHaveBeenCalledTimes(1);
+      expect(cacheService.set).toHaveBeenCalledWith(
+        cacheDir,
+        'false',
+        indefiniteExpirationTime,
+      );
     });
 
     const errorMessage = faker.word.words();

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -401,7 +401,7 @@ describe('TransactionApi', () => {
       expect(cacheService.set).toHaveBeenCalledWith(
         cacheDir,
         'false',
-        indefiniteExpirationTime,
+        defaultExpirationTimeInSeconds,
       );
     });
 
@@ -439,6 +439,7 @@ describe('TransactionApi', () => {
       expect(networkService.get).toHaveBeenCalledWith({
         url: `${baseUrl}/api/v1/safes/${safe.address}`,
       });
+      expect(cacheService.set).not.toHaveBeenCalled();
     });
   });
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -197,9 +197,10 @@ export class TransactionApi implements ITransactionApi {
     await this.cacheService.set(
       cacheDir,
       JSON.stringify(isSafe),
-      // We can indefinitely cache this as an address cannot "un-Safe" itself
-      // and invalidation (clearIsSafe) is called on SAFE_CREATED event
-      TransactionApi.INDEFINITE_EXPIRATION_TIME,
+      isSafe
+        ? // We can indefinitely cache this as an address cannot "un-Safe" itself
+          TransactionApi.INDEFINITE_EXPIRATION_TIME
+        : this.defaultExpirationTimeInSeconds,
     );
 
     return isSafe;

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -26,10 +26,12 @@ import { Transfer } from '@/domain/safe/entities/transfer.entity';
 import { Token } from '@/domain/tokens/entities/token.entity';
 import { AddConfirmationDto } from '@/domain/transactions/entities/add-confirmation.dto.entity';
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
+import { ILoggingService } from '@/logging/logging.interface';
 import { get } from 'lodash';
 
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
+  private static readonly INDEFINITE_EXPIRATION_TIME = -1;
 
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
@@ -45,6 +47,7 @@ export class TransactionApi implements ITransactionApi {
     private readonly configurationService: IConfigurationService,
     private readonly httpErrorFactory: HttpErrorFactory,
     private readonly networkService: INetworkService,
+    private readonly loggingService: ILoggingService,
   ) {
     this.defaultExpirationTimeInSeconds =
       this.configurationService.getOrThrow<number>(
@@ -141,6 +144,69 @@ export class TransactionApi implements ITransactionApi {
 
   async clearSafe(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getSafeCacheKey({
+      chainId: this.chainId,
+      safeAddress,
+    });
+    await this.cacheService.deleteByKey(key);
+  }
+
+  // TODO: this replicates logic from the CacheFirstDataSource.get method to avoid
+  // implementation of response remapping but we should refactor it to avoid duplication
+  async isSafe(safeAddress: `0x${string}`): Promise<boolean> {
+    const cacheDir = CacheRouter.getIsSafeCacheDir({
+      chainId: this.chainId,
+      safeAddress,
+    });
+
+    const cached = await this.cacheService.get(cacheDir).catch(() => null);
+
+    if (cached != null) {
+      this.loggingService.debug({
+        type: 'cache_hit',
+        ...cacheDir,
+      });
+
+      return cached === 'true';
+    } else {
+      this.loggingService.debug({
+        type: 'cache_miss',
+        ...cacheDir,
+      });
+    }
+
+    const isSafe = await (async (): Promise<boolean> => {
+      try {
+        const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
+        const { data } = await this.networkService.get({
+          url,
+        });
+
+        return !!data;
+      } catch (error) {
+        if (
+          error instanceof NetworkResponseError &&
+          // Transaction Service returns 404 when address is not of a Safe
+          error.response.status === 404
+        ) {
+          return false;
+        }
+        throw this.httpErrorFactory.from(this.mapError(error));
+      }
+    })();
+
+    await this.cacheService.set(
+      cacheDir,
+      JSON.stringify(isSafe),
+      // We can indefinitely cache this as an address cannot "un-Safe" itself
+      // and invalidation (clearIsSafe) is called on SAFE_CREATED event
+      TransactionApi.INDEFINITE_EXPIRATION_TIME,
+    );
+
+    return isSafe;
+  }
+
+  async clearIsSafe(safeAddress: `0x${string}`): Promise<void> {
+    const key = CacheRouter.getIsSafeCacheKey({
       chainId: this.chainId,
       safeAddress,
     });

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -33,6 +33,10 @@ export interface ITransactionApi {
 
   clearSafe(address: `0x${string}`): Promise<void>;
 
+  isSafe(address: `0x${string}`): Promise<boolean>;
+
+  clearIsSafe(address: `0x${string}`): Promise<void>;
+
   getContract(contractAddress: `0x${string}`): Promise<Contract>;
 
   getDelegates(args: {

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -20,6 +20,10 @@ export interface ISafeRepository {
 
   clearSafe(args: { chainId: string; address: `0x${string}` }): Promise<void>;
 
+  isSafe(args: { chainId: string; address: `0x${string}` }): Promise<boolean>;
+
+  clearIsSafe(args: { chainId: string; address: `0x${string}` }): Promise<void>;
+
   isOwner(args: {
     chainId: string;
     safeAddress: `0x${string}`;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -30,6 +30,7 @@ import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
 import { CreationTransactionSchema } from '@/domain/safe/entities/schemas/creation-transaction.schema';
 import { SafeSchema } from '@/domain/safe/entities/schemas/safe.schema';
+import { z } from 'zod';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
@@ -49,6 +50,25 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const safe = await transactionService.getSafe(args.address);
     return SafeSchema.parse(safe);
+  }
+
+  async isSafe(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<boolean> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const isSafe = await transactionService.isSafe(args.address);
+    return z.boolean().parse(isSafe);
+  }
+
+  async clearIsSafe(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<void> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.clearIsSafe(args.address);
   }
 
   async clearSafe(args: {

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -26,6 +26,7 @@ import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { Server } from 'net';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { safeCreatedEventBuilder } from '@/routes/cache-hooks/entities/__tests__/safe-created.build';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication<Server>;
@@ -180,6 +181,9 @@ describe('Post Hook Events (Unit)', () => {
     },
     {
       type: 'SAFE_CREATED',
+      chainId: faker.string.numeric(),
+      address: faker.finance.ethereumAddress(),
+      blockNumber: faker.number.int(),
     },
   ])('accepts $type', async (payload) => {
     const chainId = faker.string.numeric();
@@ -961,4 +965,40 @@ describe('Post Hook Events (Unit)', () => {
       await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
     },
   );
+
+  it.each([
+    {
+      type: 'SAFE_CREATED',
+    },
+  ])('$type clears Safe existence', async (payload) => {
+    const data = safeCreatedEventBuilder().build();
+    const cacheDir = new CacheDir(
+      `${data.chainId}_safe_exists_${data.address}`,
+      '',
+    );
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${data.chainId}`:
+          return Promise.resolve({
+            data: chainBuilder().with('chainId', data.chainId).build(),
+            status: 200,
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    await fakeCacheService.set(
+      cacheDir,
+      faker.string.alpha(),
+      faker.number.int({ min: 1 }),
+    );
+
+    await request(app.getHttpServer())
+      .post(`/hooks/events`)
+      .set('Authorization', `Basic ${authToken}`)
+      .send(data)
+      .expect(202);
+
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
+  });
 });

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -181,7 +181,6 @@ describe('Post Hook Events (Unit)', () => {
     },
     {
       type: 'SAFE_CREATED',
-      chainId: faker.string.numeric(),
       address: faker.finance.ethereumAddress(),
       blockNumber: faker.number.int(),
     },

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -970,7 +970,7 @@ describe('Post Hook Events (Unit)', () => {
     {
       type: 'SAFE_CREATED',
     },
-  ])('$type clears Safe existence', async (payload) => {
+  ])('$type clears Safe existence', async () => {
     const data = safeCreatedEventBuilder().build();
     const cacheDir = new CacheDir(
       `${data.chainId}_safe_exists_${data.address}`,

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -321,8 +321,8 @@ export class CacheHooksService implements OnModuleInit {
         promises.push(this.safeAppsRepository.clearSafeApps(event.chainId));
         this._logEvent(event);
         break;
-      // A new Safe created does not trigger any action
       case EventType.SAFE_CREATED:
+        promises.push(this.safeRepository.clearIsSafe(event));
         break;
     }
     return Promise.all(promises);

--- a/src/routes/cache-hooks/entities/__tests__/safe-created.build.ts
+++ b/src/routes/cache-hooks/entities/__tests__/safe-created.build.ts
@@ -2,9 +2,12 @@ import { Builder, IBuilder } from '@/__tests__/builder';
 import { EventType } from '@/routes/cache-hooks/entities/event-type.entity';
 import { SafeCreated } from '@/routes/cache-hooks/entities/safe-created.entity';
 import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
 
 export function safeCreatedEventBuilder(): IBuilder<SafeCreated> {
   return new Builder<SafeCreated>()
     .with('type', EventType.SAFE_CREATED)
-    .with('chainId', faker.string.numeric());
+    .with('chainId', faker.string.numeric())
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('blockNumber', faker.number.int());
 }

--- a/src/routes/cache-hooks/entities/schemas/__tests__/safe-created.schema.spec.ts
+++ b/src/routes/cache-hooks/entities/schemas/__tests__/safe-created.schema.spec.ts
@@ -2,6 +2,7 @@ import { safeCreatedEventBuilder } from '@/routes/cache-hooks/entities/__tests__
 import { EventType } from '@/routes/cache-hooks/entities/event-type.entity';
 import { SafeCreatedEventSchema } from '@/routes/cache-hooks/entities/schemas/safe-created.schema';
 import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
 import { ZodError } from 'zod';
 
 describe('SafeCreatedEventSchema', () => {
@@ -11,6 +12,19 @@ describe('SafeCreatedEventSchema', () => {
     const result = SafeCreatedEventSchema.safeParse(safeCreatedEvent);
 
     expect(result.success).toBe(true);
+  });
+
+  it('should checksum the address', () => {
+    const nonChecksummedAddress = faker.finance.ethereumAddress().toLowerCase();
+    const safeCreatedEvent = safeCreatedEventBuilder()
+      .with('address', nonChecksummedAddress as `0x${string}`)
+      .build();
+
+    const result = SafeCreatedEventSchema.safeParse(safeCreatedEvent);
+
+    expect(result.success && result.data.address).toBe(
+      getAddress(nonChecksummedAddress),
+    );
   });
 
   it('should not allow a non-SAFE_CREATED event', () => {

--- a/src/routes/cache-hooks/entities/schemas/safe-created.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/safe-created.schema.ts
@@ -1,7 +1,10 @@
 import { EventType } from '@/routes/cache-hooks/entities/event-type.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
 
 export const SafeCreatedEventSchema = z.object({
   type: z.literal(EventType.SAFE_CREATED),
   chainId: z.string(),
+  address: AddressSchema,
+  blockNumber: z.number(),
 });


### PR DESCRIPTION
## Summary

In order to determine which datasource we use for balances, we need to know whether the Safe is yet deployed. As such, we currently called the Transaction Service, returning the Zerion API if the call fails (the Safe does not exist). This is detrimental as we _always_ make this request.

This introduces a new `isSafe` method on the `TransactionApi` that returns an _indefinitely_ cached `boolean` regarding deployment state. The cache is invalidated on the `SAFE_CREATED` event.

## Changes

- Check `isSafe` within `BalancesApiManager` accordingly and propagate
- Add new `${chainId}_safe_exists_${address}` cache routing
- Add/update tests accordingly