### PR TITLE
Remove unnecessary log from test

### DIFF
--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -577,7 +577,6 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
     ];
 
     networkService.get.mockImplementation(({ url }) => {
-      console.log('=>', url);
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
         return Promise.resolve({ data: chain, status: 200 });
       }


### PR DESCRIPTION
## Summary

An unnecessary log is present in the imitation test. This removes it.

## Changes

- Remove log from test