### PR TITLE
Simplify and use `AbiDecoder` function selector helpers

### DIFF
--- a/src/domain/contracts/decoders/abi-decoder.helper.ts
+++ b/src/domain/contracts/decoders/abi-decoder.helper.ts
@@ -7,6 +7,7 @@ import {
   Hex,
   decodeEventLog as _decodeEventLog,
   decodeFunctionData as _decodeFunctionData,
+  toFunctionSelector,
 } from 'viem';
 
 type Helper<TAbi extends Abi> = `is${Capitalize<ContractFunctionName<TAbi>>}`;
@@ -30,17 +31,10 @@ export function _generateHelpers<TAbi extends Abi>(
     }
 
     const helperName = `is${capitalize(item.name)}` as Helper<TAbi>;
+    const functionSelector = toFunctionSelector(item);
 
     helpers[helperName] = (data: Hex): boolean => {
-      try {
-        const { functionName } = _decodeFunctionData({
-          data,
-          abi,
-        });
-        return functionName === item.name;
-      } catch {
-        return false;
-      }
+      return data.startsWith(functionSelector);
     };
   }
 

--- a/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
+++ b/src/domain/swaps/contracts/decoders/set-pre-signature-decoder.helper.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Module } from '@nestjs/common';
 import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
-import { parseAbi, toFunctionSelector } from 'viem';
+import { parseAbi } from 'viem';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 
 export const abi = parseAbi([
@@ -9,21 +9,10 @@ export const abi = parseAbi([
 
 @Injectable()
 export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
-  private readonly setPreSignatureFunctionSelector: `0x${string}`;
-
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
     super(abi);
-    this.setPreSignatureFunctionSelector = toFunctionSelector(abi[0]);
-  }
-
-  /**
-   * Checks if the provided transaction data is a setPreSignature call.
-   * @param data - the transaction data
-   */
-  isSetPreSignature(data: string): boolean {
-    return data.startsWith(this.setPreSignatureFunctionSelector);
   }
 
   /**
@@ -34,7 +23,7 @@ export class SetPreSignatureDecoder extends AbiDecoder<typeof abi> {
    */
   getOrderUid(data: `0x${string}`): `0x${string}` | null {
     try {
-      if (!this.isSetPreSignature(data)) return null;
+      if (!this.helpers.isSetPreSignature(data)) return null;
       const { args } = this.decodeFunctionData({ data });
       return args[0];
     } catch (e) {

--- a/src/routes/transactions/helpers/swap-order.helper.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.ts
@@ -149,7 +149,9 @@ export class SwapOrderHelper {
 
   private isSwapOrder(transaction: { data?: `0x${string}` }): boolean {
     if (!transaction.data) return false;
-    return this.setPreSignatureDecoder.isSetPreSignature(transaction.data);
+    return this.setPreSignatureDecoder.helpers.isSetPreSignature(
+      transaction.data,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

We were generating `AbiDecoder['helpers']` by decoding function data and returning `true`/`false` according to what it decodes. A more efficient method is comparing the beginning of the data against the function selector.

This adjusts the logic of `AbiDecoder['helpers']` to instead compare the beginning of the function data against the relevant selector.

## Changes

- Optimise `AbiDecoder['helpers']` generation
- Remove `SetPreSignatureDecoder['isSetPreSignature']` and replace all usage with `this.helpers.isSetPreSignature`