### PR TITLE
Add missing properties to `balanceBuilder`

### DIFF
--- a/src/domain/balances/entities/__tests__/balance.builder.ts
+++ b/src/domain/balances/entities/__tests__/balance.builder.ts
@@ -8,5 +8,7 @@ export function balanceBuilder(): IBuilder<Balance> {
   return new Builder<Balance>()
     .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
     .with('token', balanceTokenBuilder().build())
-    .with('balance', faker.string.numeric());
+    .with('balance', faker.string.numeric())
+    .with('fiatBalance', null)
+    .with('fiatConversion', null);
 }


### PR DESCRIPTION
## Summary

The `balanceBuilder` is missing `fiatBalance` and `fiatConversion` properties/mock values. This adds them with a default value of `null`.

## Changes

- Add `fiatBalance` and `fiatConversion` to `balanceBuilder`.