### PR TITLE
Improve `postgres-shift` types

### DIFF
--- a/src/types/postgres-shift.d.ts
+++ b/src/types/postgres-shift.d.ts
@@ -1,12 +1,22 @@
 declare module 'postgres-shift' {
   import { Sql } from 'postgres';
 
-  // https://github.com/porsager/postgres-shift/blob/master/index.js
+  /**
+   * Shift the database to the latest migration.
+   *
+   * @param options.sql - The SQL instance to use.
+   * @param options.path - The path of the migrations directory.
+   * @param options.before - A callback to run before each migration.
+   * @param options.after - A callback to run after each migration.
+   *
+   * Note: this definition is for postgres-shit@0.1.0.
+   * @see https://github.com/porsager/postgres-shift/blob/e7a4cb16d66c33c73f4f730b7d1de33b7757fea9/index.js
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export default async (options: {
     sql: Sql;
     path?: string;
-    before?: boolean | null;
-    after?: boolean | null;
-  }): Promise<unknown> => {};
+    before?: (args: { migration_id: string; name: string }) => void;
+    after?: (args: { migration_id: string; name: string }) => void;
+  }): Promise<void> => {};
 }


### PR DESCRIPTION
## Summary

The package we use for migrations (`postgres-shift`) has no types. As such, we have a custom defintion file for it that is not "complete". This improves the definition to match [the integration](https://github.com/porsager/postgres-shift/blob/e7a4cb16d66c33c73f4f730b7d1de33b7757fea9/index.js).

## Changes

- Add documentation to definition
- Add types for `before`/`after` callbacks