### PR TITLE
Ensure RPC URL formatting for Infura PublicClients

### DIFF
--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -1,6 +1,8 @@
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { BlockchainApiManager } from '@/datasources/blockchain/blockchain-api.manager';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { rpcUriBuilder } from '@/domain/chains/entities/__tests__/rpc-uri.builder';
+import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { faker } from '@faker-js/faker';
 
@@ -10,15 +12,13 @@ const configApiMock = jest.mocked({
 
 describe('BlockchainApiManager', () => {
   let target: BlockchainApiManager;
+  const infuraApiKey = faker.string.hexadecimal({ length: 32 });
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     const fakeConfigurationService = new FakeConfigurationService();
-    fakeConfigurationService.set(
-      'blockchain.infura.apiKey',
-      faker.string.hexadecimal({ length: 32 }),
-    );
+    fakeConfigurationService.set('blockchain.infura.apiKey', infuraApiKey);
     target = new BlockchainApiManager(fakeConfigurationService, configApiMock);
   });
 
@@ -31,6 +31,45 @@ describe('BlockchainApiManager', () => {
       const cachedApi = await target.getBlockchainApi(chain.chainId);
 
       expect(api).toBe(cachedApi);
+    });
+
+    it('should include the INFURA_API_KEY in the RPC URI for an Infura URI with API_KEY_PATH authentication', async () => {
+      const rpcUriValue = `${faker.internet.url()}infura${faker.string.sample()}`;
+      const chain = chainBuilder()
+        .with(
+          'rpcUri',
+          rpcUriBuilder()
+            .with('value', rpcUriValue)
+            .with('authentication', RpcUriAuthentication.ApiKeyPath)
+            .build(),
+        )
+        .build();
+      configApiMock.getChain.mockResolvedValue(chain);
+
+      const api = await target.getBlockchainApi(chain.chainId);
+
+      expect(api.chain?.rpcUrls.default.http[0]).toContain(infuraApiKey);
+    });
+
+    it('should not include the INFURA_API_KEY in the RPC URI for an Infura URI without API_KEY_PATH authentication', async () => {
+      const rpcUriValue = `${faker.internet.url()}infura${faker.string.sample()}`;
+      const chain = chainBuilder()
+        .with('rpcUri', rpcUriBuilder().with('value', rpcUriValue).build())
+        .build();
+      configApiMock.getChain.mockResolvedValue(chain);
+
+      const api = await target.getBlockchainApi(chain.chainId);
+
+      expect(api.chain?.rpcUrls.default.http[0]).not.toContain(infuraApiKey);
+    });
+
+    it('should not include the INFURA_API_KEY in the RPC URI for a RPC provider different from Infura', async () => {
+      const chain = chainBuilder().build();
+      configApiMock.getChain.mockResolvedValue(chain);
+
+      const api = await target.getBlockchainApi(chain.chainId);
+
+      expect(api.chain?.rpcUrls.default.http[0]).not.toContain(infuraApiKey);
     });
   });
 

--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -34,7 +34,7 @@ describe('BlockchainApiManager', () => {
     });
 
     it('should include the INFURA_API_KEY in the RPC URI for an Infura URI with API_KEY_PATH authentication', async () => {
-      const rpcUriValue = `${faker.internet.url()}infura${faker.string.sample()}`;
+      const rpcUriValue = `https://${faker.string.sample()}.infura.io/v3/`;
       const chain = chainBuilder()
         .with(
           'rpcUri',
@@ -52,7 +52,7 @@ describe('BlockchainApiManager', () => {
     });
 
     it('should not include the INFURA_API_KEY in the RPC URI for an Infura URI without API_KEY_PATH authentication', async () => {
-      const rpcUriValue = `${faker.internet.url()}infura${faker.string.sample()}`;
+      const rpcUriValue = `https://${faker.string.sample()}.infura.io/v3/`;
       const chain = chainBuilder()
         .with('rpcUri', rpcUriBuilder().with('value', rpcUriValue).build())
         .build();

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -8,6 +8,7 @@ import { Chain, PublicClient, createPublicClient, http } from 'viem';
 
 @Injectable()
 export class BlockchainApiManager implements IBlockchainApiManager {
+  private static readonly INFURA_URL_PATTERN = 'infura';
   private readonly blockchainApiMap: Record<string, PublicClient> = {};
   private readonly infuraApiKey: string;
 
@@ -59,9 +60,15 @@ export class BlockchainApiManager implements IBlockchainApiManager {
     };
   }
 
-  // Note: this assumes Infura as provider when using an API key as authentication method.
+  /**
+   * Formats rpcUri to include the Infura API key if the rpcUri is an Infura URL
+   * and the authentication method is {@link RpcUriAuthentication.ApiKeyPath}.
+   * @param rpcUri rpcUri to format
+   * @returns Formatted rpcUri
+   */
   private formatRpcUri(rpcUri: DomainChain['rpcUri']): string {
-    return rpcUri.authentication === RpcUriAuthentication.ApiKeyPath
+    return rpcUri.authentication === RpcUriAuthentication.ApiKeyPath &&
+      rpcUri.value.includes(BlockchainApiManager.INFURA_URL_PATTERN)
       ? rpcUri.value + this.infuraApiKey
       : rpcUri.value;
   }


### PR DESCRIPTION
## Changes
- Adds a check to `BlockchainApiManager.formatRpcUri` to verify the URL is an Infura one before adding the configured API key to the path.
- Adds related unit tests.
