### PR TITLE
Allow non-eth addresses in ZerionBalanceSchema

### DIFF
--- a/src/datasources/balances-api/entities/zerion-balance.entity.spec.ts
+++ b/src/datasources/balances-api/entities/zerion-balance.entity.spec.ts
@@ -515,6 +515,16 @@ describe('Zerion Balance Entity schemas', () => {
       );
     });
 
+    // Note: this is needed as the implementation address field can contain non-eth addresses.
+    it('should allow any string as address value', () => {
+      const zerionImplementation = zerionImplementationBuilder().build();
+      zerionImplementation.address = faker.string.sample();
+
+      const result = ZerionImplementationSchema.safeParse(zerionImplementation);
+
+      expect(result.success).toBe(true);
+    });
+
     it('should not allow an invalid address value', () => {
       const zerionImplementation = zerionImplementationBuilder().build();
       // @ts-expect-error - address is expected to be a string
@@ -540,7 +550,6 @@ describe('Zerion Balance Entity schemas', () => {
       const nonChecksummedAddress = faker.finance
         .ethereumAddress()
         .toLowerCase();
-      // @ts-expect-error - address is expected to be a checksummed address
       zerionImplementation.address = nonChecksummedAddress;
 
       const result = ZerionImplementationSchema.safeParse(zerionImplementation);

--- a/src/datasources/balances-api/entities/zerion-balance.entity.ts
+++ b/src/datasources/balances-api/entities/zerion-balance.entity.ts
@@ -3,7 +3,7 @@
  * Reference documentation: https://developers.zerion.io/reference/listwalletpositions
  */
 
-import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { getAddress, isAddress } from 'viem';
 import { z } from 'zod';
 
 export type ZerionFungibleInfo = z.infer<typeof ZerionFungibleInfoSchema>;
@@ -22,7 +22,14 @@ export type ZerionBalances = z.infer<typeof ZerionBalancesSchema>;
 
 export const ZerionImplementationSchema = z.object({
   chain_id: z.string(),
-  address: AddressSchema.nullish().default(null),
+  // Note: AddressSchema can't be used here because this field can contain non-eth addresses.
+  address: z
+    .string()
+    .nullish()
+    .default(null)
+    .transform((value) =>
+      value !== null && isAddress(value) ? getAddress(value) : value,
+    ),
   decimals: z.number(),
 });
 


### PR DESCRIPTION
## Summary
The changes in https://github.com/safe-global/safe-client-gateway/pull/1637 assumed all the addresses coming from the Zerion API as Ethereum addresses, but the addresses included as contract implementations can point non-EVM compatible blockchains. Example:

```
{
  "chain_id": "solana",
  "address": "C7NNPWuZCNjZBfW5p6JvGsR8pUdsRpEdP1ZAhnoDwj7h",
  "decimals": 8
}
```

## Changes
- Changes `ZerionBalance.data[].attributes.fungible_info.implementations[].address` to allow non-eth addresses.
