### PR TITLE
Add `AccountsDatasource`

### DIFF
--- a/migrations/00001_accounts/index.sql
+++ b/migrations/00001_accounts/index.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS groups,
+accounts CASCADE;
+
+CREATE TABLE
+    groups (id SERIAL PRIMARY KEY);
+
+CREATE TABLE
+    accounts (
+        id SERIAL PRIMARY KEY,
+        group_id INTEGER REFERENCES groups (id),
+        address CHARACTER VARYING(42) NOT NULL,
+        UNIQUE (address)
+    );

--- a/src/datasources/accounts/__tests__/test.accounts.datasource.modulte.ts
+++ b/src/datasources/accounts/__tests__/test.accounts.datasource.modulte.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
+
+const accountsDatasource = {
+  getAccount: jest.fn(),
+  createAccount: jest.fn(),
+} as jest.MockedObjectDeep<IAccountsDatasource>;
+
+@Module({
+  providers: [
+    {
+      provide: IAccountsDatasource,
+      useFactory: (): jest.MockedObjectDeep<IAccountsDatasource> => {
+        return jest.mocked(accountsDatasource);
+      },
+    },
+  ],
+  exports: [IAccountsDatasource],
+})
+export class TestAccountsDataSourceModule {}

--- a/src/datasources/accounts/accounts.datasource.module.ts
+++ b/src/datasources/accounts/accounts.datasource.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PostgresDatabaseModule } from '@/datasources/db/postgres-database.module';
+import { AccountsDatasource } from '@/datasources/accounts/accounts.datasource';
+import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
+
+@Module({
+  imports: [PostgresDatabaseModule],
+  providers: [{ provide: IAccountsDatasource, useClass: AccountsDatasource }],
+  exports: [IAccountsDatasource],
+})
+export class AccountsDatasourceModule {}

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -1,0 +1,106 @@
+import configuration from '@/config/entities/__tests__/configuration';
+import { AccountsDatasource } from '@/datasources/accounts/accounts.datasource';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker';
+import fs from 'node:fs';
+import path from 'node:path';
+import postgres from 'postgres';
+import shift from 'postgres-shift';
+import { getAddress } from 'viem';
+
+const config = configuration();
+
+const isCIContext = process.env.CI?.toLowerCase() === 'true';
+
+const sql = postgres({
+  host: config.db.postgres.host,
+  port: parseInt(config.db.postgres.port),
+  db: config.db.postgres.database,
+  user: config.db.postgres.username,
+  password: config.db.postgres.password,
+  // If running on a CI context (e.g.: GitHub Actions),
+  // disable certificate pinning for the test execution
+  ssl:
+    isCIContext || !config.db.postgres.ssl.enabled
+      ? false
+      : {
+          requestCert: config.db.postgres.ssl.requestCert,
+          rejectUnauthorized: config.db.postgres.ssl.rejectUnauthorized,
+          ca: fs.readFileSync(
+            path.join(process.cwd(), 'db_config/test/server.crt'),
+            'utf8',
+          ),
+        },
+});
+
+const mockLoggingService = {
+  info: jest.fn(),
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+describe('AccountsDatasource tests', () => {
+  let target: AccountsDatasource;
+
+  // Run pending migrations before tests
+  beforeAll(async () => {
+    await shift({ sql });
+  });
+
+  beforeEach(() => {
+    target = new AccountsDatasource(sql, mockLoggingService);
+  });
+
+  afterEach(async () => {
+    await sql`TRUNCATE TABLE groups, accounts CASCADE`;
+  });
+
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  describe('createAccount', () => {
+    it('creates an account successfully', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      const result = await target.createAccount(address);
+
+      expect(result).toStrictEqual({
+        id: expect.any(Number),
+        group_id: null,
+        address,
+      });
+    });
+
+    it('throws when an account with the same address already exists', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      await target.createAccount(address);
+
+      await expect(target.createAccount(address)).rejects.toThrow(
+        'Error creating account.',
+      );
+    });
+  });
+
+  describe('getAccount', () => {
+    it('returns an account successfully', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      await target.createAccount(address);
+
+      const result = await target.getAccount(address);
+
+      expect(result).toStrictEqual({
+        id: expect.any(Number),
+        group_id: null,
+        address,
+      });
+    });
+
+    it('throws if no account is found', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      await expect(target.getAccount(address)).rejects.toThrow(
+        'Error getting account.',
+      );
+    });
+  });
+});

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -1,0 +1,61 @@
+import { Account } from '@/datasources/accounts/entities/account.entity';
+import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
+import {
+  Inject,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import postgres from 'postgres';
+
+@Injectable()
+export class AccountsDatasource implements IAccountsDatasource {
+  constructor(
+    @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async createAccount(address: `0x${string}`): Promise<Account> {
+    const [account] = await this.sql<[Account]>`INSERT INTO
+                                                    accounts (address)
+                                                VALUES
+                                                    (${address}) RETURNING *`.catch(
+      (e) => {
+        this.loggingService.warn(
+          `Error creating account: ${asError(e).message}`,
+        );
+        return [];
+      },
+    );
+
+    if (!account) {
+      throw new UnprocessableEntityException('Error creating account.');
+    }
+
+    return account;
+  }
+
+  async getAccount(address: `0x${string}`): Promise<Account> {
+    const [account] = await this.sql<[Account]>`SELECT
+                                                    *
+                                                FROM
+                                                    accounts
+                                                WHERE
+                                                    address = ${address}`.catch(
+      (e) => {
+        this.loggingService.info(
+          `Error getting account: ${asError(e).message}`,
+        );
+        return [];
+      },
+    );
+
+    if (!account) {
+      throw new NotFoundException('Error getting account.');
+    }
+
+    return account;
+  }
+}

--- a/src/datasources/accounts/entities/__tests__/account.builder.ts
+++ b/src/datasources/accounts/entities/__tests__/account.builder.ts
@@ -1,0 +1,11 @@
+import { IBuilder, Builder } from '@/__tests__/builder';
+import { Account } from '@/datasources/accounts/entities/account.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+export function accountBuilder(): IBuilder<Account> {
+  return new Builder<Account>()
+    .with('id', faker.number.int())
+    .with('group_id', faker.number.int())
+    .with('address', getAddress(faker.finance.ethereumAddress()));
+}

--- a/src/datasources/accounts/entities/__tests__/group.builder.ts
+++ b/src/datasources/accounts/entities/__tests__/group.builder.ts
@@ -1,0 +1,7 @@
+import { IBuilder, Builder } from '@/__tests__/builder';
+import { Group } from '@/datasources/accounts/entities/group.entity';
+import { faker } from '@faker-js/faker';
+
+export function groupBuilder(): IBuilder<Group> {
+  return new Builder<Group>().with('id', faker.number.int());
+}

--- a/src/datasources/accounts/entities/account.entity.spec.ts
+++ b/src/datasources/accounts/entities/account.entity.spec.ts
@@ -37,7 +37,7 @@ describe('AccountSchema', () => {
     'should not verify an Account with a string %s',
     (field) => {
       const account = accountBuilder().build();
-      // @ts-expect-error
+      // @ts-expect-error - should be integers
       account[field] = account[field].toString();
 
       const result = AccountSchema.safeParse(account);
@@ -70,7 +70,7 @@ describe('AccountSchema', () => {
 
   it('should checksum the address of an Account', () => {
     const account = accountBuilder().build();
-    // @ts-expect-error
+    // @ts-expect-error - address should be `0x${string}`
     account.address = account.address.toLowerCase();
 
     const result = AccountSchema.safeParse(account);

--- a/src/datasources/accounts/entities/account.entity.spec.ts
+++ b/src/datasources/accounts/entities/account.entity.spec.ts
@@ -1,0 +1,114 @@
+import { accountBuilder } from '@/datasources/accounts/entities/__tests__/account.builder';
+import { AccountSchema } from '@/datasources/accounts/entities/account.entity';
+import { getAddress } from 'viem';
+import { faker } from '@faker-js/faker';
+
+describe('AccountSchema', () => {
+  it('should verify an Account', () => {
+    const account = accountBuilder().build();
+
+    const result = AccountSchema.safeParse(account);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['id' as const, 'group_id' as const])(
+    'should not verify an Account with a float %s',
+    (field) => {
+      const account = accountBuilder()
+        .with(field, faker.number.float())
+        .build();
+
+      const result = AccountSchema.safeParse(account);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'integer',
+          message: 'Expected integer, received float',
+          path: [field],
+          received: 'float',
+        },
+      ]);
+    },
+  );
+
+  it.each(['id' as const, 'group_id' as const])(
+    'should not verify an Account with a string %s',
+    (field) => {
+      const account = accountBuilder().build();
+      // @ts-expect-error
+      account[field] = account[field].toString();
+
+      const result = AccountSchema.safeParse(account);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Expected number, received string',
+          path: [field],
+          received: 'string',
+        },
+      ]);
+    },
+  );
+
+  it('should not verify an Account with a non-Ethereum address', () => {
+    const account = accountBuilder().with('address', '0x123').build();
+
+    const result = AccountSchema.safeParse(account);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid address',
+        path: ['address'],
+      },
+    ]);
+  });
+
+  it('should checksum the address of an Account', () => {
+    const account = accountBuilder().build();
+    // @ts-expect-error
+    account.address = account.address.toLowerCase();
+
+    const result = AccountSchema.safeParse(account);
+
+    expect(result.success && result.data.address).toBe(
+      getAddress(account.address),
+    );
+  });
+
+  it('should not verify an invalid Account', () => {
+    const account = {
+      invalid: 'account',
+    };
+
+    const result = AccountSchema.safeParse(account);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Required',
+        path: ['id'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Required',
+        path: ['group_id'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['address'],
+        received: 'undefined',
+      },
+    ]);
+  });
+});

--- a/src/datasources/accounts/entities/account.entity.ts
+++ b/src/datasources/accounts/entities/account.entity.ts
@@ -1,0 +1,11 @@
+import { GroupSchema } from '@/datasources/accounts/entities/group.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { z } from 'zod';
+
+export type Account = z.infer<typeof AccountSchema>;
+
+export const AccountSchema = z.object({
+  id: z.number().int(),
+  group_id: GroupSchema.shape.id,
+  address: AddressSchema,
+});

--- a/src/datasources/accounts/entities/group.entity.spec.ts
+++ b/src/datasources/accounts/entities/group.entity.spec.ts
@@ -1,0 +1,65 @@
+import { groupBuilder } from '@/datasources/accounts/entities/__tests__/group.builder';
+import { GroupSchema } from '@/datasources/accounts/entities/group.entity';
+import { faker } from '@faker-js/faker';
+
+describe('GroupSchema', () => {
+  it('should verify a Group', () => {
+    const group = groupBuilder().build();
+
+    const result = GroupSchema.safeParse(group);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not verify a Group with a float id', () => {
+    const group = groupBuilder().with('id', faker.number.float()).build();
+
+    const result = GroupSchema.safeParse(group);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'integer',
+        message: 'Expected integer, received float',
+        path: ['id'],
+        received: 'float',
+      },
+    ]);
+  });
+
+  it('should not verify a Group with a string id', () => {
+    const group = groupBuilder().build();
+    // @ts-expect-error
+    group.id = group.id.toString();
+
+    const result = GroupSchema.safeParse(group);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Expected number, received string',
+        path: ['id'],
+        received: 'string',
+      },
+    ]);
+  });
+
+  it('should not verify an invalid Group', () => {
+    const group = {
+      invalid: 'group',
+    };
+
+    const result = GroupSchema.safeParse(group);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Required',
+        path: ['id'],
+        received: 'undefined',
+      },
+    ]);
+  });
+});

--- a/src/datasources/accounts/entities/group.entity.spec.ts
+++ b/src/datasources/accounts/entities/group.entity.spec.ts
@@ -29,7 +29,7 @@ describe('GroupSchema', () => {
 
   it('should not verify a Group with a string id', () => {
     const group = groupBuilder().build();
-    // @ts-expect-error
+    // @ts-expect-error - id should be an integer
     group.id = group.id.toString();
 
     const result = GroupSchema.safeParse(group);

--- a/src/datasources/accounts/entities/group.entity.ts
+++ b/src/datasources/accounts/entities/group.entity.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export type Group = z.infer<typeof GroupSchema>;
+
+export const GroupSchema = z.object({
+  id: z.number().int(),
+});

--- a/src/domain/interfaces/accounts.datasource.interface.ts
+++ b/src/domain/interfaces/accounts.datasource.interface.ts
@@ -1,0 +1,9 @@
+import { Account } from '@/datasources/accounts/entities/account.entity';
+
+export const IAccountsDatasource = Symbol('IAccountsDatasource');
+
+export interface IAccountsDatasource {
+  createAccount(address: `0x${string}`): Promise<Account>;
+
+  getAccount(address: `0x${string}`): Promise<Account>;
+}


### PR DESCRIPTION
## Summary

This adds a new datasource for accounts, implementing a basic database with tables for `accounts` and `groups:

- `accounts` are address specific and containt an `id`, `group_id` and `address` column
- `groups` are will be for defining "shared" accounts, currently only having an `id`

Leveraging the database is the `IAccountsDatasource`, containing two methods: `createAccount` and `getAccount`.

## Changes

- Create `00001_accounts` migration to create database
- Create `Account` entity with test coverage
- Create `Group` entity with test coverage
- Create `IAccountsDatasource` with implementation and test override