### PR TITLE
Initialize AccountsModule behind FF_ACCOUNTS

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -44,6 +44,7 @@ import { CacheControlInterceptor } from '@/routes/common/interceptors/cache-cont
 import { AuthModule } from '@/routes/auth/auth.module';
 import { TransactionsViewControllerModule } from '@/routes/transactions/transactions-view.controller';
 import { DelegatesV2Module } from '@/routes/delegates/v2/delegates.v2.module';
+import { AccountsModule } from '@/routes/accounts/accounts.module';
 
 @Module({})
 export class AppModule implements NestModule {
@@ -53,6 +54,7 @@ export class AppModule implements NestModule {
   static register(configFactory = configuration): DynamicModule {
     const {
       auth: isAuthFeatureEnabled,
+      accounts: isAccountsFeatureEnabled,
       email: isEmailFeatureEnabled,
       confirmationView: isConfirmationViewEnabled,
       delegatesV2: isDelegatesV2Enabled,
@@ -63,6 +65,7 @@ export class AppModule implements NestModule {
       imports: [
         // features
         AboutModule,
+        ...(isAccountsFeatureEnabled ? [AccountsModule] : []),
         ...(isAuthFeatureEnabled ? [AuthModule] : []),
         BalancesModule,
         CacheHooksModule,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -116,6 +116,7 @@ export default (): ReturnType<typeof configuration> => ({
     eventsQueue: false,
     delegatesV2: false,
     counterfactualBalances: false,
+    accounts: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -174,6 +174,7 @@ export default () => ({
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
+    accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -1,0 +1,19 @@
+import { AccountsDatasourceModule } from '@/datasources/accounts/accounts.datasource.module';
+import { AccountsRepository } from '@/domain/accounts/accounts.repository';
+import { Module } from '@nestjs/common';
+
+export const IAccountsRepository = Symbol('IAccountsRepository');
+
+export interface IAccountsRepository {}
+
+@Module({
+  imports: [AccountsDatasourceModule],
+  providers: [
+    {
+      provide: IAccountsRepository,
+      useClass: AccountsRepository,
+    },
+  ],
+  exports: [IAccountsRepository],
+})
+export class AccountsRepositoryModule {}

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -1,0 +1,5 @@
+import { IAccountsRepository } from '@/domain/accounts/accounts.repository.interface';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AccountsRepository implements IAccountsRepository {}

--- a/src/routes/accounts/accounts.module.ts
+++ b/src/routes/accounts/accounts.module.ts
@@ -1,0 +1,9 @@
+import { AccountsRepositoryModule } from '@/domain/accounts/accounts.repository.interface';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [AccountsRepositoryModule],
+  controllers: [],
+  providers: [],
+})
+export class AccountsModule {}


### PR DESCRIPTION
## Summary
`AccountsDatasource` was added in https://github.com/safe-global/safe-client-gateway/pull/1654

This PR initializes the class dependency chain (`AccountsModule -> AccountsRepository -> AccountsDatasource`) in `AppModule`, when `FF_ACCOUNTS` is enabled in the configuration.

**Note**: as a side effect of this change, `/migrations/00001_accounts/index.sql` will be applied if `FF_ACCOUNTS` is enabled.

## Changes
- Adds `AccountsModule` and `AccountsRepository` (along with its interface).
- Imports `AccountsDatasourceModule` into `AccountsRepositoryModule`.

