### PR TITLE
Don't coerce numerical strings of `CampaignActivities`

### DIFF
--- a/src/domain/community/entities/__tests__/campaign-activity.builder.ts
+++ b/src/domain/community/entities/__tests__/campaign-activity.builder.ts
@@ -8,9 +8,9 @@ export function campaignActivityBuilder(): IBuilder<CampaignActivity> {
     .with('holder', getAddress(faker.finance.ethereumAddress()))
     .with('startDate', faker.date.recent())
     .with('endDate', faker.date.future())
-    .with('boost', faker.number.float())
-    .with('totalPoints', faker.number.float())
-    .with('totalBoostedPoints', faker.number.float());
+    .with('boost', faker.string.numeric())
+    .with('totalPoints', faker.string.numeric())
+    .with('totalBoostedPoints', faker.string.numeric());
 }
 
 export function toJson(campaignActivity: CampaignActivity): unknown {

--- a/src/domain/community/entities/campaign-activity.entity.ts
+++ b/src/domain/community/entities/campaign-activity.entity.ts
@@ -1,14 +1,15 @@
 import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
 export const CampaignActivitySchema = z.object({
   startDate: z.coerce.date(),
   endDate: z.coerce.date(),
   holder: AddressSchema,
-  boost: z.coerce.number(),
-  totalPoints: z.coerce.number(),
-  totalBoostedPoints: z.coerce.number(),
+  boost: NumericStringSchema,
+  totalPoints: NumericStringSchema,
+  totalBoostedPoints: NumericStringSchema,
 });
 
 export const CampaignActivityPageSchema = buildPageSchema(

--- a/src/domain/community/entities/schemas/__tests__/campaign-activity.schema.spec.ts
+++ b/src/domain/community/entities/schemas/__tests__/campaign-activity.schema.spec.ts
@@ -44,7 +44,7 @@ describe('CampaignActivitySchema', () => {
     'totalBoostedPoints' as const,
   ])(`should validate a decimal %s`, (field) => {
     const campaignActivity = campaignActivityBuilder()
-      .with(field, faker.number.float())
+      .with(field, faker.number.int().toString())
       .build();
 
     const result = CampaignActivitySchema.safeParse(campaignActivity);
@@ -58,7 +58,7 @@ describe('CampaignActivitySchema', () => {
     'totalBoostedPoints' as const,
   ])(`should validate a float %s`, (field) => {
     const campaignActivity = campaignActivityBuilder()
-      .with(field, faker.number.float())
+      .with(field, faker.number.float().toString())
       .build();
 
     const result = CampaignActivitySchema.safeParse(campaignActivity);
@@ -92,24 +92,24 @@ describe('CampaignActivitySchema', () => {
         },
         {
           code: 'invalid_type',
-          expected: 'number',
-          received: 'nan',
+          expected: 'string',
+          received: 'undefined',
           path: ['boost'],
-          message: 'Expected number, received nan',
+          message: 'Required',
         },
         {
           code: 'invalid_type',
-          expected: 'number',
-          received: 'nan',
+          expected: 'string',
+          received: 'undefined',
           path: ['totalPoints'],
-          message: 'Expected number, received nan',
+          message: 'Required',
         },
         {
           code: 'invalid_type',
-          expected: 'number',
-          received: 'nan',
+          expected: 'string',
+          received: 'undefined',
           path: ['totalBoostedPoints'],
-          message: 'Expected number, received nan',
+          message: 'Required',
         },
       ]),
     );

--- a/src/routes/community/entities/campaign-activity.entity.ts
+++ b/src/routes/community/entities/campaign-activity.entity.ts
@@ -9,9 +9,9 @@ export class CampaignActivity implements DomainCampaignActivity {
   @ApiProperty({ type: String })
   endDate!: Date;
   @ApiProperty()
-  boost!: number;
+  boost!: string;
   @ApiProperty()
-  totalPoints!: number;
+  totalPoints!: string;
   @ApiProperty()
-  totalBoostedPoints!: number;
+  totalBoostedPoints!: string;
 }


### PR DESCRIPTION
## Summary

After discussion, due to large numbers the coercion of `boost`, `totalPoints` and `totalBoostedPoints` (#1657) may cause issues. This reverts the change, validating that the values are numerical string.

## Changes

- Ensure `boost`, `totalPoints` and `totalBoostedPoints` of `CampaignActivites` are numerical string
- Propagate the type
- Update tests