### PR TITLE
Don't copy patches to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV NODE_ENV production
 ENV YARN_CACHE_FOLDER /root/.yarn
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
-COPY --chown=node:node .yarn/patches ./.yarn/patches
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
 COPY --chown=node:node scripts/generate-abis.js ./scripts/generate-abis.js
 RUN --mount=type=cache,target=/root/.yarn yarn


### PR DESCRIPTION
## Summary

As we are no longer patching packers after #1655, there is no `.yarn/patches` folder. Docker therefore fails when trying to copy it.

This removes the `COPY` from the `Dockerfile` to fix the issue.

## Changes

- Don't copy `.yarn/patches` into the build