### PR TITLE
Add method to get `fullAppData` from `appDataHash`

### DIFF
--- a/src/datasources/swaps-api/cowswap-api.service.ts
+++ b/src/datasources/swaps-api/cowswap-api.service.ts
@@ -2,6 +2,7 @@ import { INetworkService } from '@/datasources/network/network.service.interface
 import { Order } from '@/domain/swaps/entities/order.entity';
 import { ISwapsApi } from '@/domain/interfaces/swaps-api.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { FullAppData } from '@/domain/swaps/entities/full-app-data.entity';
 
 export class CowSwapApi implements ISwapsApi {
   constructor(
@@ -14,6 +15,16 @@ export class CowSwapApi implements ISwapsApi {
     try {
       const url = `${this.baseUrl}/api/v1/orders/${uid}`;
       const { data } = await this.networkService.get<Order>({ url });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getFullAppData(appDataHash: `0x${string}`): Promise<FullAppData> {
+    try {
+      const url = `${this.baseUrl}/api/v1/app_data/${appDataHash}`;
+      const { data } = await this.networkService.get<FullAppData>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/domain/interfaces/swaps-api.factory.ts
+++ b/src/domain/interfaces/swaps-api.factory.ts
@@ -2,6 +2,7 @@ import { ISwapsApi } from '@/domain/interfaces/swaps-api.interface';
 
 export const ISwapsApiFactory = Symbol('ISwapsApiFactory');
 
+// TODO: Extend IApiManager interface and clear on `CHAIN_UPDATE`
 export interface ISwapsApiFactory {
   get(chainId: string): ISwapsApi;
 }

--- a/src/domain/interfaces/swaps-api.interface.ts
+++ b/src/domain/interfaces/swaps-api.interface.ts
@@ -1,5 +1,8 @@
+import { FullAppData } from '@/domain/swaps/entities/full-app-data.entity';
 import { Order } from '@/domain/swaps/entities/order.entity';
 
 export interface ISwapsApi {
   getOrder(uid: string): Promise<Order>;
+
+  getFullAppData(appDataHash: `0x${string}`): Promise<FullAppData>;
 }

--- a/src/domain/swaps/entities/full-app-data.entity.spec.ts
+++ b/src/domain/swaps/entities/full-app-data.entity.spec.ts
@@ -1,0 +1,28 @@
+import { FullAppDataSchema } from '@/domain/swaps/entities/full-app-data.entity';
+
+describe('FullAppDataSchema', () => {
+  it.each([
+    '[]',
+    '{}',
+    'null',
+    '{\n  "version": "0.1.0",\n  "appCode": "Yearn",\n  "metadata": {\n    "referrer": {\n      "version": "0.1.0",\n      "address": "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"\n    }\n  }\n}\n',
+  ])('%s is valid', (fullAppData) => {
+    const data = {
+      fullAppData,
+    };
+
+    const result = FullAppDataSchema.safeParse(data);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['a', 'a : b', '{', '['])('%s is not valid', (fullAppData) => {
+    const data = {
+      fullAppData,
+    };
+
+    const result = FullAppDataSchema.safeParse(data);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/domain/swaps/entities/full-app-data.entity.ts
+++ b/src/domain/swaps/entities/full-app-data.entity.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export type FullAppData = z.infer<typeof FullAppDataSchema>;
+
+export const FullAppDataSchema = z.object({
+  fullAppData: z
+    .string()
+    .nullish()
+    .default(null)
+    .transform((jsonString, ctx) => {
+      try {
+        if (!jsonString) return null;
+        return JSON.parse(jsonString);
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Not a valid JSON payload',
+        });
+        return z.NEVER;
+      }
+    }),
+});

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { FullAppDataSchema } from '@/domain/swaps/entities/full-app-data.entity';
 
 export type Order = z.infer<typeof OrderSchema>;
 
@@ -79,20 +80,5 @@ export const OrderSchema = z.object({
     .nullish()
     .default(null),
   executedSurplusFee: z.coerce.bigint().nullish().default(null),
-  fullAppData: z
-    .string()
-    .nullish()
-    .default(null)
-    .transform((jsonString, ctx) => {
-      try {
-        if (!jsonString) return null;
-        return JSON.parse(jsonString);
-      } catch (error) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'Not a valid JSON payload',
-        });
-        return z.NEVER;
-      }
-    }),
+  fullAppData: FullAppDataSchema.shape.fullAppData,
 });

--- a/src/domain/swaps/swaps.repository.ts
+++ b/src/domain/swaps/swaps.repository.ts
@@ -1,11 +1,20 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ISwapsApiFactory } from '@/domain/interfaces/swaps-api.factory';
 import { Order, OrderSchema } from '@/domain/swaps/entities/order.entity';
+import {
+  FullAppData,
+  FullAppDataSchema,
+} from '@/domain/swaps/entities/full-app-data.entity';
 
 export const ISwapsRepository = Symbol('ISwapsRepository');
 
 export interface ISwapsRepository {
   getOrder(chainId: string, orderUid: `0x${string}`): Promise<Order>;
+
+  getFullAppData(
+    chainId: string,
+    appDataHash: `0x${string}`,
+  ): Promise<FullAppData>;
 }
 
 @Injectable()
@@ -19,5 +28,14 @@ export class SwapsRepository implements ISwapsRepository {
     const api = this.swapsApiFactory.get(chainId);
     const order = await api.getOrder(orderUid);
     return OrderSchema.parse(order);
+  }
+
+  async getFullAppData(
+    chainId: string,
+    appDataHash: `0x${string}`,
+  ): Promise<FullAppData> {
+    const api = this.swapsApiFactory.get(chainId);
+    const fullAppData = api.getFullAppData(appDataHash);
+    return FullAppDataSchema.parse(fullAppData);
   }
 }

--- a/src/domain/swaps/swaps.repository.ts
+++ b/src/domain/swaps/swaps.repository.ts
@@ -35,7 +35,7 @@ export class SwapsRepository implements ISwapsRepository {
     appDataHash: `0x${string}`,
   ): Promise<FullAppData> {
     const api = this.swapsApiFactory.get(chainId);
-    const fullAppData = api.getFullAppData(appDataHash);
+    const fullAppData = await api.getFullAppData(appDataHash);
     return FullAppDataSchema.parse(fullAppData);
   }
 }


### PR DESCRIPTION
## Summary

When decoding TWAP orders, the `appData` is returned as a hash. In order to decode this to the relevant JSON, we need to use the CoW API.

This adds a new `ISwapsApi['getFullAppData']` that accepts the aforementioned hash and returns the decoded value according to the [CoW API](https://docs.cow.fi/cow-protocol/reference/apis/orderbook).

## Changes

- Add `ISwapsApi['getFullAppData']` and implementation
- Add `FullAppDataSchema` (and use it within the `OrderSchema` as well) with test coverage
- Add `ISwapsRepository['getFullAppData']`, calling the API and validating the response