### PR TITLE
Add automatic row timestamps for Accounts and Groups tables

### DIFF
--- a/migrations/00001_accounts/index.sql
+++ b/migrations/00001_accounts/index.sql
@@ -11,7 +11,7 @@ CREATE TABLE
 CREATE TABLE
     accounts (
         id SERIAL PRIMARY KEY,
-        group_id INTEGER REFERENCES groups (id),
+        group_id INTEGER REFERENCES groups (id) ON DELETE SET NULL,
         address CHARACTER VARYING(42) NOT NULL,
         created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),

--- a/migrations/00001_accounts/index.sql
+++ b/migrations/00001_accounts/index.sql
@@ -2,12 +2,31 @@ DROP TABLE IF EXISTS groups,
 accounts CASCADE;
 
 CREATE TABLE
-    groups (id SERIAL PRIMARY KEY);
+    groups (
+        id SERIAL PRIMARY KEY,
+        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    );
 
 CREATE TABLE
     accounts (
         id SERIAL PRIMARY KEY,
         group_id INTEGER REFERENCES groups (id),
         address CHARACTER VARYING(42) NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
         UNIQUE (address)
     );
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER update_accounts_updated_at
+BEFORE UPDATE ON accounts
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();

--- a/migrations/__tests__/00001_accounts.spec.ts
+++ b/migrations/__tests__/00001_accounts.spec.ts
@@ -7,7 +7,7 @@ interface AccountRow {
   group_id: number;
   created_at: Date;
   updated_at: Date;
-  address: string;
+  address: `0x${string};
 }
 
 describe('Migration 00001_accounts', () => {

--- a/migrations/__tests__/00001_accounts.spec.ts
+++ b/migrations/__tests__/00001_accounts.spec.ts
@@ -2,9 +2,21 @@ import { dbFactory } from '@/__tests__/db.factory';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
 import { Sql } from 'postgres';
 
+interface AccountRow {
+  id: number;
+  group_id: number;
+  created_at: Date;
+  updated_at: Date;
+  address: string;
+}
+
 describe('Migration 00001_accounts', () => {
   const sql = dbFactory();
   const migrator = new PostgresDatabaseMigrator(sql);
+
+  afterAll(async () => {
+    await sql.end();
+  });
 
   it('runs successfully', async () => {
     await sql`DROP TABLE IF EXISTS groups, accounts CASCADE;`;
@@ -32,20 +44,51 @@ describe('Migration 00001_accounts', () => {
         columns: [
           { column_name: 'id' },
           { column_name: 'group_id' },
+          { column_name: 'created_at' },
+          { column_name: 'updated_at' },
           { column_name: 'address' },
         ],
         rows: [],
       },
       groups: {
         columns: [
-          {
-            column_name: 'id',
-          },
+          { column_name: 'id' },
+          { column_name: 'created_at' },
+          { column_name: 'updated_at' },
         ],
         rows: [],
       },
     });
+  });
 
-    await sql.end();
+  it('should add and update row timestamps', async () => {
+    await sql`DROP TABLE IF EXISTS groups, accounts CASCADE;`;
+
+    const result: {
+      before: unknown;
+      after: AccountRow[];
+    } = await migrator.test({
+      migration: '00001_accounts',
+      after: async (sql: Sql): Promise<AccountRow[]> => {
+        await sql`INSERT INTO groups (id) VALUES (1);`;
+        await sql`INSERT INTO accounts (id, group_id, address) VALUES (1, 1, '0x0000');`;
+        await sql`UPDATE accounts set address = '0x0001' WHERE id = 1;`;
+        return await sql<AccountRow[]>`SELECT * FROM accounts`;
+      },
+    });
+
+    const createdAt = new Date(result.after[0].created_at);
+    const updatedAt = new Date(result.after[0].updated_at);
+
+    expect(result.after).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          created_at: createdAt,
+          updated_at: updatedAt,
+        }),
+      ]),
+    );
+
+    expect(updatedAt.getTime()).toBeGreaterThan(createdAt.getTime());
   });
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -175,7 +175,7 @@ export default () => ({
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
-    accounts: true,
+    accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -175,7 +175,7 @@ export default () => ({
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
-    accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
+    accounts: true,
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -43,6 +43,8 @@ describe('AccountsDatasource tests', () => {
         id: expect.any(Number),
         group_id: null,
         address,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
       });
     });
 
@@ -67,6 +69,8 @@ describe('AccountsDatasource tests', () => {
         id: expect.any(Number),
         group_id: null,
         address,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
       });
     });
 

--- a/src/datasources/accounts/entities/__tests__/account.builder.ts
+++ b/src/datasources/accounts/entities/__tests__/account.builder.ts
@@ -7,5 +7,7 @@ export function accountBuilder(): IBuilder<Account> {
   return new Builder<Account>()
     .with('id', faker.number.int())
     .with('group_id', faker.number.int())
-    .with('address', getAddress(faker.finance.ethereumAddress()));
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('created_at', faker.date.recent())
+    .with('updated_at', faker.date.recent());
 }

--- a/src/datasources/accounts/entities/__tests__/group.builder.ts
+++ b/src/datasources/accounts/entities/__tests__/group.builder.ts
@@ -3,5 +3,8 @@ import { Group } from '@/datasources/accounts/entities/group.entity';
 import { faker } from '@faker-js/faker';
 
 export function groupBuilder(): IBuilder<Group> {
-  return new Builder<Group>().with('id', faker.number.int());
+  return new Builder<Group>()
+    .with('id', faker.number.int())
+    .with('created_at', faker.date.recent())
+    .with('updated_at', faker.date.recent());
 }

--- a/src/datasources/accounts/entities/account.entity.spec.ts
+++ b/src/datasources/accounts/entities/account.entity.spec.ts
@@ -97,6 +97,20 @@ describe('AccountSchema', () => {
       },
       {
         code: 'invalid_type',
+        expected: 'date',
+        message: 'Required',
+        path: ['created_at'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'date',
+        message: 'Required',
+        path: ['updated_at'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
         expected: 'number',
         message: 'Required',
         path: ['group_id'],

--- a/src/datasources/accounts/entities/account.entity.ts
+++ b/src/datasources/accounts/entities/account.entity.ts
@@ -1,11 +1,11 @@
 import { GroupSchema } from '@/datasources/accounts/entities/group.entity';
+import { RowSchema } from '@/datasources/db/entities/row.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
 
 export type Account = z.infer<typeof AccountSchema>;
 
-export const AccountSchema = z.object({
-  id: z.number().int(),
+export const AccountSchema = RowSchema.extend({
   group_id: GroupSchema.shape.id,
   address: AddressSchema,
 });

--- a/src/datasources/accounts/entities/group.entity.spec.ts
+++ b/src/datasources/accounts/entities/group.entity.spec.ts
@@ -60,6 +60,20 @@ describe('GroupSchema', () => {
         path: ['id'],
         received: 'undefined',
       },
+      {
+        code: 'invalid_type',
+        expected: 'date',
+        message: 'Required',
+        path: ['created_at'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'date',
+        message: 'Required',
+        path: ['updated_at'],
+        received: 'undefined',
+      },
     ]);
   });
 });

--- a/src/datasources/accounts/entities/group.entity.ts
+++ b/src/datasources/accounts/entities/group.entity.ts
@@ -3,4 +3,4 @@ import { z } from 'zod';
 
 export type Group = z.infer<typeof GroupSchema>;
 
-export const GroupSchema = RowSchema
+export const GroupSchema = RowSchema;

--- a/src/datasources/accounts/entities/group.entity.ts
+++ b/src/datasources/accounts/entities/group.entity.ts
@@ -3,4 +3,4 @@ import { z } from 'zod';
 
 export type Group = z.infer<typeof GroupSchema>;
 
-export const GroupSchema = RowSchema.extend({});
+export const GroupSchema = RowSchema

--- a/src/datasources/accounts/entities/group.entity.ts
+++ b/src/datasources/accounts/entities/group.entity.ts
@@ -1,7 +1,6 @@
+import { RowSchema } from '@/datasources/db/entities/row.entity';
 import { z } from 'zod';
 
 export type Group = z.infer<typeof GroupSchema>;
 
-export const GroupSchema = z.object({
-  id: z.number().int(),
-});
+export const GroupSchema = RowSchema.extend({});

--- a/src/datasources/db/entities/row.entity.ts
+++ b/src/datasources/db/entities/row.entity.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export type Row = z.infer<typeof RowSchema>;
+
+export const RowSchema = z.object({
+  id: z.number().int(),
+  created_at: z.date(),
+  updated_at: z.date(),
+});

--- a/src/datasources/db/entities/row.entity.ts
+++ b/src/datasources/db/entities/row.entity.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 
 export type Row = z.infer<typeof RowSchema>;
 
+/**
+ * Note: this is a base schema for all entities that are meant to be persisted to the database.
+ * The 'id' field is a primary key, and the 'created_at' and 'updated_at' fields are timestamps.
+ * These fields shouldn't be modified by the application, and should be managed by the database.
+ */
 export const RowSchema = z.object({
   id: z.number().int(),
   created_at: z.date(),

--- a/src/datasources/db/postgres-database.migrator.spec.ts
+++ b/src/datasources/db/postgres-database.migrator.spec.ts
@@ -196,7 +196,7 @@ describe('PostgresDatabaseMigrator tests', () => {
       await expect(
         target.test({
           migration: migration1.name,
-          before: (sql) => sql`SELECT * FROM test`,
+          before: (sql) => sql`SELECT * FROM test`.catch(() => undefined),
           after: (sql) => sql`SELECT * FROM test`,
           folder,
         }),
@@ -265,7 +265,7 @@ describe('PostgresDatabaseMigrator tests', () => {
         target.test({
           migration: migration3.name,
           before: (sql) => sql`SELECT * FROM test`,
-          after: (sql) => sql`SELECT * FROM test`,
+          after: (sql) => sql`SELECT * FROM test`.catch(() => undefined),
           folder,
         }),
       ).resolves.toStrictEqual({

--- a/src/datasources/db/postgres-database.migrator.spec.ts
+++ b/src/datasources/db/postgres-database.migrator.spec.ts
@@ -45,6 +45,8 @@ const migrations: Array<{
     },
   },
 ];
+type TestRow = { a: string; b: number };
+type ExtendedTestRow = { a: string; b: number; c: Date };
 
 describe('PostgresDatabaseMigrator tests', () => {
   let sql: postgres.Sql;
@@ -197,7 +199,8 @@ describe('PostgresDatabaseMigrator tests', () => {
         target.test({
           migration: migration1.name,
           before: (sql) => sql`SELECT * FROM test`.catch(() => undefined),
-          after: (sql) => sql`SELECT * FROM test`,
+          after: (sql): Promise<TestRow[]> =>
+            sql<TestRow[]>`SELECT * FROM test`,
           folder,
         }),
       ).resolves.toStrictEqual({
@@ -227,8 +230,10 @@ describe('PostgresDatabaseMigrator tests', () => {
       await expect(
         target.test({
           migration: migration2.name,
-          before: (sql) => sql`SELECT * FROM test`,
-          after: (sql) => sql`SELECT * FROM test`,
+          before: (sql): Promise<TestRow[]> =>
+            sql<TestRow[]>`SELECT * FROM test`,
+          after: (sql): Promise<ExtendedTestRow[]> =>
+            sql<ExtendedTestRow[]>`SELECT * FROM test`,
           folder,
         }),
       ).resolves.toStrictEqual({


### PR DESCRIPTION
## Summary
This PR adds `createdAt` and `updatedAt` timestamps to `Accounts` and `Groups` tables.
- `createdAt` is set to the current timestamp when a new row is created and it's not meant to be modified.
- `updatedAt` is set to the current timestamp when a new row is created and the idea is to modify it automatically using a trigger.

The goal is to enhance these database tables' maintainability and auditing while improving debugging.

## Changes
- Add `Row` as an entity meant to be extended by any persistence entity (`id`, `created_at`, `updated_at` are enforced).
- Add `createdAt` and `updatedAt` timestamps to `Accounts` and `Groups` tables.
- Add a Postgres function/trigger to automatically set `updatedAt` on each row modification.
- Modifies `PostgresDatabaseMigrator.test` to make it generic, as the caller may need to specify the types returned to access their properties in the tests.
- Add a test to check the behavior.
