### PR TITLE
Fix mock `kind` of `Order` builder

### DIFF
--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -31,7 +31,7 @@ export function orderBuilder(): IBuilder<Order> {
       }),
     )
     .with('feeAmount', faker.number.bigInt({ min: 1 }))
-    .with('kind', faker.helpers.arrayElement([OrderKind.Buy, OrderKind.Buy]))
+    .with('kind', faker.helpers.arrayElement([OrderKind.Buy, OrderKind.Sell]))
     .with('partiallyFillable', faker.datatype.boolean())
     .with(
       'sellTokenBalance',


### PR DESCRIPTION
## Summary

The `kind` of an `Order` can be any form of `OrderKind`. Currently the builder for the entity only returns `OrderKind.Buy`. This changes it to also return `OrderKind.Sell`.