### PR TITLE
Map TWAP orders in the queue

### DIFF
--- a/src/routes/transactions/helpers/swap-order.helper.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.ts
@@ -103,19 +103,15 @@ export class SwapOrderHelper {
    * @param {string} args.orderUid - The unique identifier of the order, prefixed with '0x'.
    * @returns {Promise} A promise that resolves to an object containing the order and token details.
    *
-   * The returned object includes:
-   * - `order`: An object representing the order.
-   * - `sellToken`: The Token object with a mandatory `decimals` property
-   * - `buyToken`: Similar to `sellToken`, for the token being purchased in the order.
+   * The returned object represents the order.
    *
    * @throws {Error} Throws an error if the order `kind` is 'unknown'.
    * @throws {Error} Throws an error if either the sellToken or buyToken object has null decimals.
    */
-  async getOrder(args: { chainId: string; orderUid: `0x${string}` }): Promise<{
-    order: Order & { kind: Exclude<Order['kind'], 'unknown'> };
-    sellToken: Token & { decimals: number };
-    buyToken: Token & { decimals: number };
-  }> {
+  async getOrder(args: {
+    chainId: string;
+    orderUid: `0x${string}`;
+  }): Promise<Order & { kind: Exclude<Order['kind'], 'unknown'> }> {
     const order = await this.swapsRepository.getOrder(
       args.chainId,
       args.orderUid,
@@ -123,21 +119,9 @@ export class SwapOrderHelper {
 
     if (order.kind === OrderKind.Unknown) throw new Error('Unknown order kind');
 
-    const [buyToken, sellToken] = await Promise.all([
-      this.getToken({
-        chainId: args.chainId,
-        address: order.buyToken,
-      }),
-      this.getToken({
-        chainId: args.chainId,
-        address: order.sellToken,
-      }),
-    ]);
-
     return {
-      order: { ...order, kind: order.kind },
-      buyToken,
-      sellToken,
+      ...order,
+      kind: order.kind,
     };
   }
 

--- a/src/routes/transactions/mappers/common/swap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.ts
@@ -53,12 +53,22 @@ export class SwapOrderMapper {
     chainId: string;
     orderUid: `0x${string}`;
   }): Promise<SwapOrderTransactionInfo> {
-    const { order, sellToken, buyToken } =
-      await this.swapOrderHelper.getOrder(args);
+    const order = await this.swapOrderHelper.getOrder(args);
 
     if (!this.swapOrderHelper.isAppAllowed(order)) {
       throw new Error(`Unsupported App: ${order.fullAppData?.appCode}`);
     }
+
+    const [sellToken, buyToken] = await Promise.all([
+      this.swapOrderHelper.getToken({
+        address: order.sellToken,
+        chainId: args.chainId,
+      }),
+      this.swapOrderHelper.getToken({
+        address: order.buyToken,
+        chainId: args.chainId,
+      }),
+    ]);
 
     return new SwapOrderTransactionInfo({
       uid: order.uid,

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -254,7 +254,7 @@ export class MultisigTransactionInfoMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
   ): Promise<TwapOrderTransactionInfo | null> {
-    if (!transaction?.data || !transaction?.executionDate) {
+    if (!transaction?.data) {
       return null;
     }
 

--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -14,6 +14,7 @@ import { SwapOrderHelper } from '@/routes/transactions/helpers/swap-order.helper
 import { TwapOrderHelper } from '@/routes/transactions/helpers/twap-order.helper';
 import { TwapOrderMapper } from '@/routes/transactions/mappers/common/twap-order.mapper';
 import { ILoggingService } from '@/logging/logging.interface';
+import { getAddress } from 'viem';
 
 const loggingService = {
   debug: jest.fn(),
@@ -58,7 +59,115 @@ describe('TwapOrderMapper', () => {
     composableCowDecoder,
   );
 
-  it('should map a TWAP order', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should map a queued TWAP order', async () => {
+    const now = new Date();
+    jest.setSystemTime(now);
+
+    configurationService.set('swaps.maxNumberOfParts', 2);
+
+    // We instantiate in tests to be able to set maxNumberOfParts
+    const mapper = new TwapOrderMapper(
+      configurationService,
+      swapOrderHelper,
+      mockSwapsRepository,
+      composableCowDecoder,
+      gpv2OrderHelper,
+      twapOrderHelper,
+    );
+
+    // Taken from queued transaction of specified owner before execution
+    const chainId = '11155111';
+    const owner = '0x31eaC7F0141837B266De30f4dc9aF15629Bd5381';
+    const data =
+      '0x0d0d9800000000000000000000000000000000000000000000000000000000000000008000000000000000000000000052ed56da04309aca4c3fecc595298d80c2f16bac000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000000010000000000000000000000006cf1e9ca41f7611def408122793c358a3d11e5a50000000000000000000000000000000000000000000000000000001903c57a7700000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000140000000000000000000000000fff9976782d46cc05630d1f6ebab18b2324d6b140000000000000000000000000625afb445c3b6b7b929342a04a22599fd5dbb5900000000000000000000000031eac7f0141837b266de30f4dc9af15629bd538100000000000000000000000000000000000000000000000006f05b59d3b2000000000000000000000000000000000000000000000000000165e249251c2365980000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000023280000000000000000000000000000000000000000000000000000000000000000f7be7261f56698c258bf75f888d68a00c85b22fb21958b9009c719eb88aebda00000000000000000000000000000000000000000000000000000000000000000';
+
+    const buyToken = tokenBuilder()
+      .with('address', '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59')
+      .build();
+    const sellToken = tokenBuilder()
+      .with('address', '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14')
+      .build();
+    const fullAppData = JSON.parse(fakeJson());
+
+    // Orders throw as they don't exist
+    mockSwapsRepository.getOrder.mockRejectedValue(
+      new Error('Order not found'),
+    );
+    mockTokenRepository.getToken.mockImplementation(async ({ address }) => {
+      // We only need mock part1 addresses as all parts use the same tokens
+      switch (address) {
+        case buyToken.address: {
+          return Promise.resolve(buyToken);
+        }
+        case sellToken.address: {
+          return Promise.resolve(sellToken);
+        }
+        default: {
+          return Promise.reject(new Error(`Token not found: ${address}`));
+        }
+      }
+    });
+    mockSwapsRepository.getFullAppData.mockResolvedValue({ fullAppData });
+
+    const result = await mapper.mapTwapOrder(chainId, owner, {
+      data,
+      executionDate: null,
+    });
+
+    expect(result).toEqual({
+      buyAmount: '51576509680023161648',
+      buyToken: {
+        address: buyToken.address,
+        decimals: buyToken.decimals,
+        logoUri: buyToken.logoUri,
+        name: buyToken.name,
+        symbol: buyToken.symbol,
+        trusted: buyToken.trusted,
+      },
+      class: 'limit',
+      durationOfPart: {
+        durationType: 'AUTO',
+      },
+      executedBuyAmount: '0',
+      executedSellAmount: '0',
+      fullAppData,
+      humanDescription: null,
+      kind: 'sell',
+      minPartLimit: '25788254840011580824',
+      numberOfParts: '2',
+      status: 'presignaturePending',
+      owner: '0x31eaC7F0141837B266De30f4dc9aF15629Bd5381',
+      partSellAmount: '500000000000000000',
+      receiver: '0x31eaC7F0141837B266De30f4dc9aF15629Bd5381',
+      richDecodedInfo: null,
+      sellAmount: '1000000000000000000',
+      sellToken: {
+        address: sellToken.address,
+        decimals: sellToken.decimals,
+        logoUri: sellToken.logoUri,
+        name: sellToken.name,
+        symbol: sellToken.symbol,
+        trusted: sellToken.trusted,
+      },
+      startTime: {
+        startType: 'AT_MINING_TIME',
+      },
+      timeBetweenParts: 9000,
+      type: 'TwapOrder',
+      validUntil: Math.ceil(now.getTime() / 1_000) + 17999,
+    });
+  });
+
+  it('should map an executed TWAP order', async () => {
     configurationService.set('swaps.maxNumberOfParts', 2);
 
     // We instantiate in tests to be able to set maxNumberOfParts
@@ -161,8 +270,12 @@ describe('TwapOrderMapper', () => {
       interactions: { pre: [], post: [] },
     } as unknown as Order;
 
-    const buyToken = tokenBuilder().with('address', part1.buyToken).build();
-    const sellToken = tokenBuilder().with('address', part1.sellToken).build();
+    const buyToken = tokenBuilder()
+      .with('address', getAddress(part1.buyToken))
+      .build();
+    const sellToken = tokenBuilder()
+      .with('address', getAddress(part1.sellToken))
+      .build();
     const fullAppData = JSON.parse(fakeJson());
 
     mockSwapsRepository.getOrder
@@ -171,10 +284,10 @@ describe('TwapOrderMapper', () => {
     mockTokenRepository.getToken.mockImplementation(async ({ address }) => {
       // We only need mock part1 addresses as all parts use the same tokens
       switch (address) {
-        case part1.buyToken: {
+        case buyToken.address: {
           return Promise.resolve(buyToken);
         }
-        case part1.sellToken: {
+        case sellToken.address: {
           return Promise.resolve(sellToken);
         }
         default: {
@@ -293,18 +406,22 @@ describe('TwapOrderMapper', () => {
       interactions: { pre: [], post: [] },
     } as unknown as Order;
 
-    const buyToken = tokenBuilder().with('address', part2.buyToken).build();
-    const sellToken = tokenBuilder().with('address', part2.sellToken).build();
+    const buyToken = tokenBuilder()
+      .with('address', getAddress(part2.buyToken))
+      .build();
+    const sellToken = tokenBuilder()
+      .with('address', getAddress(part2.sellToken))
+      .build();
     const fullAppData = JSON.parse(fakeJson());
 
     mockSwapsRepository.getOrder.mockResolvedValueOnce(part2);
     mockTokenRepository.getToken.mockImplementation(async ({ address }) => {
       // We only need mock part1 addresses as all parts use the same tokens
       switch (address) {
-        case part2.buyToken: {
+        case buyToken.address: {
           return Promise.resolve(buyToken);
         }
-        case part2.sellToken: {
+        case sellToken.address: {
           return Promise.resolve(sellToken);
         }
         default: {
@@ -333,8 +450,8 @@ describe('TwapOrderMapper', () => {
       durationOfPart: {
         durationType: 'AUTO',
       },
-      executedBuyAmount: null,
-      executedSellAmount: null,
+      executedBuyAmount: '687772850053823700',
+      executedSellAmount: '213586875483862140000',
       fullAppData,
       humanDescription: null,
       kind: 'sell',

--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -450,8 +450,8 @@ describe('TwapOrderMapper', () => {
       durationOfPart: {
         durationType: 'AUTO',
       },
-      executedBuyAmount: '687772850053823700',
-      executedSellAmount: '213586875483862140000',
+      executedBuyAmount: null,
+      executedSellAmount: null,
       fullAppData,
       humanDescription: null,
       kind: 'sell',

--- a/src/routes/transactions/mappers/common/twap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.ts
@@ -50,7 +50,7 @@ export class TwapOrderMapper {
   async mapTwapOrder(
     chainId: string,
     safeAddress: `0x${string}`,
-    transaction: { data: `0x${string}`; executionDate: Date },
+    transaction: { data: `0x${string}`; executionDate: Date | null },
   ): Promise<TwapOrderTransactionInfo> {
     // Decode `staticInput` of `createWithContextCall`
     const twapStruct = this.composableCowDecoder.decodeTwapStruct(
@@ -62,7 +62,7 @@ export class TwapOrderMapper {
     // Generate parts of the TWAP order
     const twapParts = this.twapOrderHelper.generateTwapOrderParts({
       twapStruct,
-      executionDate: transaction.executionDate,
+      executionDate: transaction.executionDate ?? new Date(),
       chainId,
     });
 
@@ -70,16 +70,18 @@ export class TwapOrderMapper {
     // to avoid requesting too many orders
     const hasAbundantParts = twapParts.length > this.maxNumberOfParts;
 
-    const partsToFetch = hasAbundantParts
-      ? // We use the last part (and only one) to get the status of the entire
-        // order and we only need one to get the token info
-        twapParts.slice(-1)
-      : twapParts;
+    // Fetch all order parts if the transaction has been executed, otherwise none
+    const partsToFetch = transaction.executionDate
+      ? hasAbundantParts
+        ? // We use the last part (and only one) to get the status of the entire
+          // order and we only need one to get the token info
+          twapParts.slice(-1)
+        : twapParts
+      : [];
 
     const [{ fullAppData }, ...orders] = await Promise.all([
       // Decode hash of `appData`
       this.swapsRepository.getFullAppData(chainId, twapStruct.appData),
-      // Fetch all order parts
       ...partsToFetch.map((order) => {
         const orderUid = this.gpv2OrderHelper.computeOrderUid({
           chainId,
@@ -93,19 +95,27 @@ export class TwapOrderMapper {
     // TODO: Handling of restricted Apps, calling `getToken` directly instead of multiple times in `getOrder` for sellToken and buyToken
 
     const executedSellAmount: TwapOrderInfo['executedSellAmount'] =
-      hasAbundantParts ? null : this.getExecutedSellAmount(orders).toString();
+      this.getExecutedSellAmount(orders).toString();
 
     const executedBuyAmount: TwapOrderInfo['executedBuyAmount'] =
-      hasAbundantParts ? null : this.getExecutedBuyAmount(orders).toString();
+      this.getExecutedBuyAmount(orders).toString();
 
-    // All orders have the same sellToken and buyToken
-    const { sellToken, buyToken } = orders[0];
+    const [sellToken, buyToken] = await Promise.all([
+      this.swapOrderHelper.getToken({
+        chainId,
+        address: twapStruct.sellToken,
+      }),
+      this.swapOrderHelper.getToken({
+        chainId,
+        address: twapStruct.buyToken,
+      }),
+    ]);
 
     return new TwapOrderTransactionInfo({
       status: this.getOrderStatus(orders),
       kind: twapOrderData.kind,
       class: twapOrderData.class,
-      validUntil: Math.max(...partsToFetch.map((order) => order.validTo)),
+      validUntil: Math.max(...twapParts.map((order) => order.validTo)),
       sellAmount: twapOrderData.sellAmount,
       buyAmount: twapOrderData.buyAmount,
       executedSellAmount,
@@ -141,6 +151,10 @@ export class TwapOrderMapper {
   private getOrderStatus(
     orders: Array<Awaited<ReturnType<typeof this.swapOrderHelper.getOrder>>>,
   ): OrderStatus {
+    if (orders.length === 0) {
+      return OrderStatus.PreSignaturePending;
+    }
+
     // If an order is fulfilled, cancelled or expired, the part is "complete"
     const completeStatuses = [
       OrderStatus.Fulfilled,
@@ -149,7 +163,7 @@ export class TwapOrderMapper {
     ];
 
     for (let i = 0; i < orders.length; i++) {
-      const { order } = orders[i];
+      const order = orders[i];
 
       // Return the status of the last part
       if (i === orders.length - 1) {
@@ -170,7 +184,7 @@ export class TwapOrderMapper {
   private getExecutedSellAmount(
     orders: Array<Awaited<ReturnType<typeof this.swapOrderHelper.getOrder>>>,
   ): number {
-    return orders.reduce((acc, { order }) => {
+    return orders.reduce((acc, order) => {
       return acc + Number(order.executedSellAmount);
     }, 0);
   }
@@ -178,7 +192,7 @@ export class TwapOrderMapper {
   private getExecutedBuyAmount(
     orders: Array<Awaited<ReturnType<typeof this.swapOrderHelper.getOrder>>>,
   ): number {
-    return orders.reduce((acc, { order }) => {
+    return orders.reduce((acc, order) => {
       return acc + Number(order.executedBuyAmount);
     }, 0);
   }

--- a/src/routes/transactions/mappers/common/twap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.ts
@@ -95,10 +95,10 @@ export class TwapOrderMapper {
     // TODO: Handling of restricted Apps, calling `getToken` directly instead of multiple times in `getOrder` for sellToken and buyToken
 
     const executedSellAmount: TwapOrderInfo['executedSellAmount'] =
-      this.getExecutedSellAmount(orders).toString();
+      hasAbundantParts ? null : this.getExecutedSellAmount(orders).toString();
 
     const executedBuyAmount: TwapOrderInfo['executedBuyAmount'] =
-      this.getExecutedBuyAmount(orders).toString();
+      hasAbundantParts ? null : this.getExecutedBuyAmount(orders).toString();
 
     const [sellToken, buyToken] = await Promise.all([
       this.swapOrderHelper.getToken({

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -98,7 +98,7 @@ export class TransactionsViewService {
       throw new Error('Order UID not found in transaction data');
     }
 
-    const { order, sellToken, buyToken } = await this.swapOrderHelper.getOrder({
+    const order = await this.swapOrderHelper.getOrder({
       chainId: args.chainId,
       orderUid,
     });
@@ -106,6 +106,17 @@ export class TransactionsViewService {
     if (!this.swapOrderHelper.isAppAllowed(order)) {
       throw new Error(`Unsupported App: ${order.fullAppData?.appCode}`);
     }
+
+    const [sellToken, buyToken] = await Promise.all([
+      this.swapOrderHelper.getToken({
+        chainId: args.chainId,
+        address: order.sellToken,
+      }),
+      this.swapOrderHelper.getToken({
+        chainId: args.chainId,
+        address: order.buyToken,
+      }),
+    ]);
 
     return new CowSwapConfirmationView({
       method: args.dataDecoded.method,


### PR DESCRIPTION
## Summary

We currently check that an `executionDate` is present within a transaction in order to map the TWAP order. However, queued transactions aren't executed yet.

This removes the above check, adjusting the logic accordingly so that TWAP orders inthe queue can be mapped.

## Changes

- Decouple fetching of buy/sell token with order, fetching the later separately
- Don't fetch orders if the transaction is not executed, mapping "empty" values if no orders were fetched
- Add/update the test coverage accordingly