### PR TITLE
Add method to `ISwapsApi` for fetching orders by transaction hash

### DIFF
--- a/src/datasources/swaps-api/cowswap-api.service.ts
+++ b/src/datasources/swaps-api/cowswap-api.service.ts
@@ -21,6 +21,16 @@ export class CowSwapApi implements ISwapsApi {
     }
   }
 
+  async getOrders(txHash: string): Promise<Array<Order>> {
+    try {
+      const url = `${this.baseUrl}/api/v1/transactions/${txHash}/orders`;
+      const { data } = await this.networkService.get<Array<Order>>({ url });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   async getFullAppData(appDataHash: `0x${string}`): Promise<FullAppData> {
     try {
       const url = `${this.baseUrl}/api/v1/app_data/${appDataHash}`;

--- a/src/domain/interfaces/swaps-api.interface.ts
+++ b/src/domain/interfaces/swaps-api.interface.ts
@@ -4,5 +4,7 @@ import { Order } from '@/domain/swaps/entities/order.entity';
 export interface ISwapsApi {
   getOrder(uid: string): Promise<Order>;
 
+  getOrders(txHash: string): Promise<Array<Order>>;
+
   getFullAppData(appDataHash: `0x${string}`): Promise<FullAppData>;
 }

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -101,3 +101,5 @@ export const OrderSchema = z.object({
   executedSurplusFee: z.coerce.bigint().nullish().default(null),
   fullAppData: FullAppDataSchema.shape.fullAppData,
 });
+
+export const OrdersSchema = z.array(OrderSchema);

--- a/src/domain/swaps/swaps.repository.ts
+++ b/src/domain/swaps/swaps.repository.ts
@@ -1,6 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ISwapsApiFactory } from '@/domain/interfaces/swaps-api.factory';
-import { Order, OrderSchema } from '@/domain/swaps/entities/order.entity';
+import {
+  Order,
+  OrderSchema,
+  OrdersSchema,
+} from '@/domain/swaps/entities/order.entity';
 import {
   FullAppData,
   FullAppDataSchema,
@@ -10,6 +14,8 @@ export const ISwapsRepository = Symbol('ISwapsRepository');
 
 export interface ISwapsRepository {
   getOrder(chainId: string, orderUid: `0x${string}`): Promise<Order>;
+
+  getOrders(chainId: string, txHash: string): Promise<Array<Order>>;
 
   getFullAppData(
     chainId: string,
@@ -28,6 +34,12 @@ export class SwapsRepository implements ISwapsRepository {
     const api = this.swapsApiFactory.get(chainId);
     const order = await api.getOrder(orderUid);
     return OrderSchema.parse(order);
+  }
+
+  async getOrders(chainId: string, txHash: string): Promise<Array<Order>> {
+    const api = this.swapsApiFactory.get(chainId);
+    const order = await api.getOrders(txHash);
+    return OrdersSchema.parse(order);
   }
 
   async getFullAppData(


### PR DESCRIPTION
## Summary

Transfers returned by the Transaction Service do not contain the data of the relative transaction. This means that the transaction cannot be decoded to detect the `settle` call. As such, we need to fetch the order of a transaction by transaction hash.

This adds a new `ISwapsApi['getOrders']` method that accepts the transaction hash, fetching the order book from CoW accodingly.

## Changes

- Add `ISwapsApi['getOrders']` and implementation
- Add `ISwapsRepository['getOrders']` and validated implementation