### PR TITLE
Adjust random TTL for not-found token prices calculation

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -634,9 +634,9 @@ describe('CoingeckoAPI', () => {
       JSON.stringify({ [thirdTokenAddress]: { [lowerCaseFiatCode]: null } }),
     );
     expect(mockCacheService.set.mock.calls[0][2]).toBeGreaterThanOrEqual(
-      (fakeConfigurationService.get(
+      fakeConfigurationService.get(
         'balances.providers.safe.prices.notFoundPriceTtlSeconds',
-      ) as number) - CoingeckoApi.NOT_FOUND_TTL_RANGE_SECONDS,
+      ) as number,
     );
     expect(mockCacheService.set.mock.calls[0][2]).toBeLessThanOrEqual(
       (fakeConfigurationService.get(


### PR DESCRIPTION
## Changes
- Changes the implementation of `CoingeckoApi._getRandomNotFoundTokenPriceTtl` to avoid get negative TTLs if `notFoundPriceTtlSeconds < NOT_FOUND_TTL_RANGE_SECONDS`.
