### PR TITLE
Implement DELETE /v1/accounts/:address

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -176,7 +176,7 @@ export default () => ({
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
-    accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
+    accounts: true,
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -176,7 +176,7 @@ export default () => ({
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
-    accounts: true,
+    accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/datasources/accounts/__tests__/test.accounts.datasource.module.ts
+++ b/src/datasources/accounts/__tests__/test.accounts.datasource.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
 
 const accountsDatasource = {
-  getAccount: jest.fn(),
   createAccount: jest.fn(),
+  deleteAccount: jest.fn(),
+  getAccount: jest.fn(),
 } as jest.MockedObjectDeep<IAccountsDatasource>;
 
 @Module({

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -9,6 +9,7 @@ const sql = dbFactory();
 const migrator = new PostgresDatabaseMigrator(sql);
 
 const mockLoggingService = {
+  debug: jest.fn(),
   info: jest.fn(),
   warn: jest.fn(),
 } as jest.MockedObjectDeep<ILoggingService>;
@@ -80,6 +81,25 @@ describe('AccountsDatasource tests', () => {
       await expect(target.getAccount(address)).rejects.toThrow(
         'Error getting account.',
       );
+    });
+  });
+
+  describe('deleteAccount', () => {
+    it('deletes an account successfully', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      await target.createAccount(address);
+
+      await expect(target.deleteAccount(address)).resolves.not.toThrow();
+
+      expect(mockLoggingService.debug).not.toHaveBeenCalled();
+    });
+
+    it('does not throws if no account is found', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      await expect(target.deleteAccount(address)).resolves.not.toThrow();
+
+      expect(mockLoggingService.debug).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -58,4 +58,15 @@ export class AccountsDatasource implements IAccountsDatasource {
 
     return account;
   }
+
+  async deleteAccount(address: `0x${string}`): Promise<void> {
+    const { count } = await this
+      .sql`DELETE FROM accounts WHERE address = ${address}`;
+
+    if (count === 0) {
+      this.loggingService.debug(
+        `No account found for address ${address} on deletion.`,
+      );
+    }
+  }
 }

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -18,10 +18,9 @@ export class AccountsDatasource implements IAccountsDatasource {
   ) {}
 
   async createAccount(address: `0x${string}`): Promise<Account> {
-    const [account] = await this.sql<[Account]>`INSERT INTO
-                                                    accounts (address)
-                                                VALUES
-                                                    (${address}) RETURNING *`.catch(
+    const [account] = await this.sql<
+      [Account]
+    >`INSERT INTO accounts (address) VALUES (${address}) RETURNING *`.catch(
       (e) => {
         this.loggingService.warn(
           `Error creating account: ${asError(e).message}`,
@@ -38,19 +37,12 @@ export class AccountsDatasource implements IAccountsDatasource {
   }
 
   async getAccount(address: `0x${string}`): Promise<Account> {
-    const [account] = await this.sql<[Account]>`SELECT
-                                                    *
-                                                FROM
-                                                    accounts
-                                                WHERE
-                                                    address = ${address}`.catch(
-      (e) => {
-        this.loggingService.info(
-          `Error getting account: ${asError(e).message}`,
-        );
-        return [];
-      },
-    );
+    const [account] = await this.sql<
+      [Account]
+    >`SELECT * FROM accounts WHERE address = ${address}`.catch((e) => {
+      this.loggingService.info(`Error getting account: ${asError(e).message}`);
+      return [];
+    });
 
     if (!account) {
       throw new NotFoundException('Error getting account.');

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -56,9 +56,7 @@ export class AccountsDatasource implements IAccountsDatasource {
       .sql`DELETE FROM accounts WHERE address = ${address}`;
 
     if (count === 0) {
-      this.loggingService.debug(
-        `No account found for address ${address} on deletion.`,
-      );
+      this.loggingService.debug(`Error deleting account ${address}: not found`);
     }
   }
 }

--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -11,6 +11,11 @@ export interface IAccountsRepository {
     auth: AuthPayloadDto;
     address: `0x${string}`;
   }): Promise<Account>;
+
+  deleteAccount(args: {
+    auth: AuthPayloadDto;
+    address: `0x${string}`;
+  }): Promise<void>;
 }
 
 @Module({

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -38,7 +38,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    // TODO: trigger cascade deletion (keepData parameter)
+    // TODO: trigger a cascade deletion of the account-associated data.
     return this.datasource.deleteAccount(args.address);
   }
 }

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -38,7 +38,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-
+    // TODO: trigger cascade deletion (keepData parameter)
     return this.datasource.deleteAccount(args.address);
   }
 }

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -29,4 +29,16 @@ export class AccountsRepository implements IAccountsRepository {
     const account = await this.datasource.createAccount(args.address);
     return AccountSchema.parse(account);
   }
+
+  async deleteAccount(args: {
+    auth: AuthPayloadDto;
+    address: `0x${string}`;
+  }): Promise<void> {
+    const authPayload = new AuthPayload(args.auth);
+    if (!authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+
+    return this.datasource.deleteAccount(args.address);
+  }
 }

--- a/src/domain/interfaces/accounts.datasource.interface.ts
+++ b/src/domain/interfaces/accounts.datasource.interface.ts
@@ -6,4 +6,6 @@ export interface IAccountsDatasource {
   createAccount(address: `0x${string}`): Promise<Account>;
 
   getAccount(address: `0x${string}`): Promise<Account>;
+
+  deleteAccount(address: `0x${string}`): Promise<void>;
 }

--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -235,4 +235,142 @@ describe('AccountsController', () => {
       expect(accountDataSource.createAccount).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('Delete accounts', () => {
+    it('should delete an account', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const account = accountBuilder().build();
+      accountDataSource.createAccount.mockResolvedValue(account);
+      accountDataSource.deleteAccount.mockResolvedValue();
+
+      await request(app.getHttpServer())
+        .post(`/v1/accounts`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address: address.toLowerCase() })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(204);
+
+      expect(accountDataSource.deleteAccount).toHaveBeenCalledTimes(1);
+      // Check the address was checksummed
+      expect(accountDataSource.deleteAccount).toHaveBeenCalledWith(address);
+    });
+
+    it('Returns 403 if no token is present', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .send({ address })
+        .expect(403);
+    });
+
+    it('returns 403 if token is not a valid JWT', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const accessToken = faker.string.sample();
+
+      expect(() => jwtService.verify(accessToken)).toThrow('jwt malformed');
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address })
+        .expect(403);
+    });
+
+    it('returns 403 is token it not yet valid', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto, {
+        notBefore: getSecondsUntil(faker.date.future()),
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address })
+        .expect(403);
+    });
+
+    it('returns 403 if token has expired', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto, { expiresIn: 0 });
+      jest.advanceTimersByTime(1_000);
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address })
+        .expect(403);
+    });
+
+    it('returns 403 if signer_address is not a valid Ethereum address', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', faker.string.hexadecimal() as `0x${string}`)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address })
+        .expect(403);
+    });
+
+    it('returns 403 if chain_id is not a valid chain ID', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', faker.lorem.sentence())
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address })
+        .expect(403);
+    });
+
+    it('should propagate errors', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chain.chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      accountDataSource.deleteAccount.mockImplementation(() => {
+        throw new Error('test error');
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/v1/accounts/${address}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ address: address.toLowerCase() })
+        .expect(500);
+
+      expect(accountDataSource.deleteAccount).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/routes/accounts/accounts.controller.ts
+++ b/src/routes/accounts/accounts.controller.ts
@@ -3,12 +3,15 @@ import { Account } from '@/routes/accounts/entities/account.entity';
 import { CreateAccountDto } from '@/routes/accounts/entities/create-account.dto.entity';
 import { CreateAccountDtoSchema } from '@/routes/accounts/entities/schemas/create-account.dto.schema';
 import { AuthGuard } from '@/routes/auth/guards/auth.guard';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import {
   Body,
   Controller,
+  Delete,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   Req,
   UseGuards,
@@ -32,5 +35,15 @@ export class AccountsController {
   ): Promise<Account> {
     const auth = request.accessToken;
     return this.accountsService.createAccount({ auth, createAccountDto });
+  }
+
+  @Delete(':address')
+  @UseGuards(AuthGuard)
+  async deleteAccount(
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
+    @Req() request: Request,
+  ): Promise<void> {
+    const auth = request.accessToken;
+    return this.accountsService.deleteAccount({ auth, address });
   }
 }

--- a/src/routes/accounts/accounts.controller.ts
+++ b/src/routes/accounts/accounts.controller.ts
@@ -39,6 +39,7 @@ export class AccountsController {
 
   @Delete(':address')
   @UseGuards(AuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
   async deleteAccount(
     @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
     @Req() request: Request,

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -27,10 +27,10 @@ export class AccountsService {
   }
 
   async deleteAccount(args: {
-    auth: AuthPayloadDto | undefined;
+    auth?: AuthPayloadDto;
     address: `0x${string}`;
   }): Promise<void> {
-    if (args.auth === undefined) {
+    if (!args.auth) {
       throw new UnauthorizedException();
     }
     await this.accountsRepository.deleteAccount({

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -26,6 +26,19 @@ export class AccountsService {
     return this.mapAccount(domainAccount);
   }
 
+  async deleteAccount(args: {
+    auth: AuthPayloadDto | undefined;
+    address: `0x${string}`;
+  }): Promise<void> {
+    if (args.auth === undefined) {
+      throw new UnauthorizedException();
+    }
+    await this.accountsRepository.deleteAccount({
+      auth: args.auth,
+      address: args.address,
+    });
+  }
+
   private mapAccount(domainAccount: DomainAccount): Account {
     return new Account(
       domainAccount.id.toString(),


### PR DESCRIPTION
## Summary
This PR adds the endpoint:
```
DELETE /v1/accounts/:address
```

- The endpoint expects an `address` in the request path, targeting the Ethereum address associated with the account.
- The endpoint is authenticated using SIWE, so an `accessToken` associated with the address needs to be provided. Otherwise, a `403` status will be returned.

## Changes
- The endpoint `DELETE /v1/accounts/:address` was added to `AccountsController`, protected by `AuthGuard`.
- Associated tests and domain classes were added.
