### PR TITLE
Remove unused balances.balancesTtlSeconds configuration key

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -20,7 +20,6 @@ export default (): ReturnType<typeof configuration> => ({
     maxValidityPeriodSeconds: faker.number.int({ min: 1, max: 60 * 1_000 }),
   },
   balances: {
-    balancesTtlSeconds: faker.number.int(),
     providers: {
       safe: {
         prices: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -34,7 +34,6 @@ export default () => ({
     ),
   },
   balances: {
-    balancesTtlSeconds: parseInt(process.env.BALANCES_TTL_SECONDS ?? `${300}`),
     providers: {
       safe: {
         prices: {


### PR DESCRIPTION
## Changes
- Removes `balances.balancesTtlSeconds` configuration key, as it wasn't used in the service code.
