### PR TITLE
Catch swapOrderHelper.getOrder errors

### DIFF
--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -5,6 +5,8 @@ import { FullAppDataSchema } from '@/domain/swaps/entities/full-app-data.entity'
 
 export type Order = z.infer<typeof OrderSchema>;
 
+export type KnownOrder = Order & { kind: Exclude<Order['kind'], 'unknown'> };
+
 export enum OrderStatus {
   PreSignaturePending = 'presignaturePending',
   Open = 'open',

--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -77,6 +77,7 @@ describe('TwapOrderMapper', () => {
     // We instantiate in tests to be able to set maxNumberOfParts
     const mapper = new TwapOrderMapper(
       configurationService,
+      mockLoggingService,
       swapOrderHelper,
       mockSwapsRepository,
       composableCowDecoder,
@@ -173,6 +174,7 @@ describe('TwapOrderMapper', () => {
     // We instantiate in tests to be able to set maxNumberOfParts
     const mapper = new TwapOrderMapper(
       configurationService,
+      mockLoggingService,
       swapOrderHelper,
       mockSwapsRepository,
       composableCowDecoder,
@@ -352,6 +354,7 @@ describe('TwapOrderMapper', () => {
     // We instantiate in tests to be able to set maxNumberOfParts
     const mapper = new TwapOrderMapper(
       configurationService,
+      mockLoggingService,
       swapOrderHelper,
       mockSwapsRepository,
       composableCowDecoder,


### PR DESCRIPTION
## Changes
- Adds a `catch` block when calling `swapOrderHelper.getOrder` on `TwapOrderMapper`, so the transaction is mapped to a TWAP order even if some partial orders are not found on the CowSwap API.
