### PR TITLE
Fix getNumberString utils function

### DIFF
--- a/src/domain/common/utils/utils.ts
+++ b/src/domain/common/utils/utils.ts
@@ -1,6 +1,7 @@
 export function getNumberString(value: number): string {
   // Prevent scientific notation
-  return value.toLocaleString('fullwide', {
+  return value.toLocaleString('en-US', {
+    notation: 'standard',
     useGrouping: false,
   });
 }


### PR DESCRIPTION
Closes #1701 

## Changes
- Changes `getNumberString` implementation to use a fixed locale, standard notation, and no grouping.