### PR TITLE
Add optional CGW_ENV attribute to the configuration

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -13,7 +13,10 @@ export default (): ReturnType<typeof configuration> => ({
     queue: faker.string.sample(),
     prefetch: faker.number.int(),
   },
-  applicationPort: faker.internet.port().toString(),
+  application: {
+    env: faker.string.sample(),
+    port: faker.internet.port().toString(),
+  },
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),
     nonceTtlSeconds: faker.number.int(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -23,7 +23,10 @@ export default () => ({
         ? parseInt(process.env.AMQP_PREFETCH)
         : 100,
   },
-  applicationPort: process.env.APPLICATION_PORT || '3000',
+  application: {
+    env: process.env.CGW_ENV || 'production',
+    port: process.env.APPLICATION_PORT || '3000',
+  },
   auth: {
     token: process.env.AUTH_TOKEN,
     nonceTtlSeconds: parseInt(

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap(): Promise<void> {
   const configurationService: IConfigurationService =
     app.get<IConfigurationService>(IConfigurationService);
   const applicationPort: string =
-    configurationService.getOrThrow('applicationPort');
+    configurationService.getOrThrow('application.port');
 
   await app.listen(applicationPort);
 }


### PR DESCRIPTION
## Summary
This is motivated by the necessity of having different auth cookie configurations per environment, so the CGW needs a configuration value specifying the current environment at runtime.

## Changes
- Add optional `CGW_ENV` attribute to the configuration.
- Moves the `applicationPort` attribute along with the new one to an `application` node in the configuration schema.
