### PR TITLE
Adjust access token cookie configuration

### DIFF
--- a/src/routes/auth/auth.controller.spec.ts
+++ b/src/routes/auth/auth.controller.spec.ts
@@ -44,25 +44,9 @@ describe('AuthController', () => {
   let blockchainApiManager: FakeBlockchainApiManager;
   let maxValidityPeriodInMs: number;
 
-  beforeEach(async () => {
-    jest.useFakeTimers();
-    jest.resetAllMocks();
-
-    const defaultConfiguration = configuration();
-    const testConfiguration = (): typeof defaultConfiguration => ({
-      ...defaultConfiguration,
-      application: {
-        ...defaultConfiguration.application,
-        env: 'production',
-      },
-      features: {
-        ...defaultConfiguration.features,
-        auth: true,
-      },
-    });
-
+  async function initApp(config: typeof configuration): Promise<void> {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(testConfiguration)],
+      imports: [AppModule.register(config)],
     })
       .overrideModule(JWT_CONFIGURATION_MODULE)
       .useModule(JwtConfigurationModule.register(jwtConfiguration))
@@ -95,6 +79,26 @@ describe('AuthController', () => {
     app = await new TestAppProvider().provide(moduleFixture);
 
     await app.init();
+  }
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.resetAllMocks();
+
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      application: {
+        ...defaultConfiguration.application,
+        env: 'production',
+      },
+      features: {
+        ...defaultConfiguration.features,
+        auth: true,
+      },
+    });
+
+    await initApp(testConfiguration);
   });
 
   afterAll(async () => {
@@ -218,6 +222,74 @@ describe('AuthController', () => {
         });
       // Verified on-chain as could not verify EOA
       expect(verifySiweMessageMock).toHaveBeenCalledTimes(1);
+      // Nonce deleted
+      await expect(cacheService.get(cacheDir)).resolves.toBe(undefined);
+    });
+
+    it('should set SameSite=none if application.env is not production', async () => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): typeof defaultConfiguration => ({
+        ...defaultConfiguration,
+        application: {
+          ...defaultConfiguration.application,
+          env: 'staging',
+        },
+        features: {
+          ...defaultConfiguration.features,
+          auth: true,
+        },
+      });
+
+      await initApp(testConfiguration);
+
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const nonceResponse = await request(app.getHttpServer()).get(
+        '/v1/auth/nonce',
+      );
+      const nonce: string = nonceResponse.body.nonce;
+      const cacheDir = new CacheDir(`auth_nonce_${nonce}`, '');
+      const expirationTime = faker.date.between({
+        from: new Date(),
+        to: new Date(Date.now() + maxValidityPeriodInMs),
+      });
+      const message = createSiweMessage(
+        siweMessageBuilder()
+          .with('address', signer.address)
+          .with('nonce', nonce)
+          .with('expirationTime', expirationTime)
+          .build(),
+      );
+      const signature = await signer.signMessage({
+        message,
+      });
+      const maxAge = getSecondsUntil(expirationTime);
+      // jsonwebtoken sets expiration based on timespans, not exact dates
+      // meaning we cannot use expirationTime directly
+      const expires = new Date(Date.now() + maxAge * 1_000);
+
+      await expect(cacheService.get(cacheDir)).resolves.toBe(
+        nonceResponse.body.nonce,
+      );
+
+      await request(app.getHttpServer())
+        .post('/v1/auth/verify')
+        .send({
+          message,
+          signature,
+        })
+        .expect(200)
+        .expect(({ headers }) => {
+          const setCookie = headers['set-cookie'];
+          const setCookieRegExp = new RegExp(
+            `access_token=([^;]*); Max-Age=${maxAge}; Path=/; Expires=${expires.toUTCString()}; HttpOnly; Secure; SameSite=None`,
+          );
+
+          expect(setCookie).toHaveLength;
+          expect(setCookie[0]).toMatch(setCookieRegExp);
+        });
+      // Verified off-chain as EOA
+      expect(verifySiweMessageMock).not.toHaveBeenCalled();
       // Nonce deleted
       await expect(cacheService.get(cacheDir)).resolves.toBe(undefined);
     });

--- a/src/routes/auth/auth.controller.spec.ts
+++ b/src/routes/auth/auth.controller.spec.ts
@@ -51,6 +51,10 @@ describe('AuthController', () => {
     const defaultConfiguration = configuration();
     const testConfiguration = (): typeof defaultConfiguration => ({
       ...defaultConfiguration,
+      application: {
+        ...defaultConfiguration.application,
+        env: 'production',
+      },
       features: {
         ...defaultConfiguration.features,
         auth: true,

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -28,6 +28,9 @@ import { Response } from 'express';
 @ApiExcludeController()
 export class AuthController {
   static readonly ACCESS_TOKEN_COOKIE_NAME = 'access_token';
+  static readonly ACCESS_TOKEN_COOKIE_SAME_SITE_LAX = 'lax';
+  static readonly ACCESS_TOKEN_COOKIE_SAME_SITE_NONE = 'none';
+  static readonly CGW_ENV_PRODUCTION = 'production';
   private readonly cgwEnv: string;
 
   constructor(
@@ -55,11 +58,14 @@ export class AuthController {
     siweDto: SiweDto,
   ): Promise<void> {
     const { accessToken } = await this.authService.getAccessToken(siweDto);
+    const isProduction = this.cgwEnv === AuthController.CGW_ENV_PRODUCTION;
 
     res.cookie(AuthController.ACCESS_TOKEN_COOKIE_NAME, accessToken, {
       httpOnly: true,
       secure: true,
-      sameSite: this.cgwEnv === 'production' ? 'lax' : 'none',
+      sameSite: isProduction
+        ? AuthController.ACCESS_TOKEN_COOKIE_SAME_SITE_LAX
+        : AuthController.ACCESS_TOKEN_COOKIE_SAME_SITE_NONE,
       path: '/',
       // Extract maxAge from token as it may slightly differ to SiWe message
       maxAge: this.getMaxAge(accessToken),


### PR DESCRIPTION
## Summary
This change changes the configuration of the `accessToken` cookie, by setting `SameSite=Lax` when `CGW_ENV=production`, and `SameSite=None` otherwise.

## Changes
- Changes `AuthController.verify` function to set an authentication cookie with `SameSite=Lax` or `SameSite=None` depending on `CGW_ENV`.