### PR TITLE
Implement GET /v1/accounts/:address

### DIFF
--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -12,6 +12,11 @@ export interface IAccountsRepository {
     address: `0x${string}`;
   }): Promise<Account>;
 
+  getAccount(args: {
+    auth: AuthPayloadDto;
+    address: `0x${string}`;
+  }): Promise<Account>;
+
   deleteAccount(args: {
     auth: AuthPayloadDto;
     address: `0x${string}`;

--- a/src/domain/accounts/entities/account.entity.spec.ts
+++ b/src/domain/accounts/entities/account.entity.spec.ts
@@ -111,13 +111,6 @@ describe('AccountSchema', () => {
       },
       {
         code: 'invalid_type',
-        expected: 'number',
-        message: 'Required',
-        path: ['group_id'],
-        received: 'undefined',
-      },
-      {
-        code: 'invalid_type',
         expected: 'string',
         message: 'Required',
         path: ['address'],

--- a/src/domain/accounts/entities/account.entity.ts
+++ b/src/domain/accounts/entities/account.entity.ts
@@ -6,6 +6,6 @@ import { z } from 'zod';
 export type Account = z.infer<typeof AccountSchema>;
 
 export const AccountSchema = RowSchema.extend({
-  group_id: GroupSchema.shape.id.nullable(),
+  group_id: GroupSchema.shape.id.nullish().default(null),
   address: AddressSchema,
 });

--- a/src/routes/accounts/accounts.controller.ts
+++ b/src/routes/accounts/accounts.controller.ts
@@ -9,6 +9,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   HttpCode,
   HttpStatus,
   Param,
@@ -35,6 +36,17 @@ export class AccountsController {
   ): Promise<Account> {
     const auth = request.accessToken;
     return this.accountsService.createAccount({ auth, createAccountDto });
+  }
+
+  @ApiOkResponse({ type: Account })
+  @Get(':address')
+  @UseGuards(AuthGuard)
+  async getAccount(
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
+    @Req() request: Request,
+  ): Promise<Account> {
+    const auth = request.accessToken;
+    return this.accountsService.getAccount({ auth, address });
   }
 
   @Delete(':address')

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -26,6 +26,20 @@ export class AccountsService {
     return this.mapAccount(domainAccount);
   }
 
+  async getAccount(args: {
+    auth?: AuthPayloadDto;
+    address: `0x${string}`;
+  }): Promise<Account> {
+    if (!args.auth) {
+      throw new UnauthorizedException();
+    }
+    const domainAccount = await this.accountsRepository.getAccount({
+      auth: args.auth,
+      address: args.address,
+    });
+    return this.mapAccount(domainAccount);
+  }
+
   async deleteAccount(args: {
     auth?: AuthPayloadDto;
     address: `0x${string}`;


### PR DESCRIPTION
## Summary
This PR adds the endpoint:
```
GET /v1/accounts/:address
```

- The endpoint expects an `address` in the request path, targeting the Ethereum address associated with the account.
- The endpoint is authenticated using SIWE, so an `accessToken` associated with the address needs to be provided. Otherwise, a `403` status will be returned.

## Changes
- The endpoint `GET /v1/accounts/:address` was added to `AccountsController`, protected by `AuthGuard`.
- Associated tests and domain classes were added.
