### PR TITLE
Fix bad types on TwapOrderMapper

### DIFF
--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -319,8 +319,8 @@ describe('TwapOrderMapper', () => {
       durationOfPart: {
         durationType: 'AUTO',
       },
-      executedBuyAmount: '1379444631694674400',
-      executedSellAmount: '427173750967724300000',
+      executedBuyAmount: '1379444631694674612',
+      executedSellAmount: '427173750967724283500',
       executedSurplusFee: '222222222',
       fullAppData,
       humanDescription: null,

--- a/src/routes/transactions/mappers/common/twap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.ts
@@ -204,22 +204,22 @@ export class TwapOrderMapper {
     return OrderStatus.Unknown;
   }
 
-  private getExecutedSellAmount(orders: Array<KnownOrder>): number {
+  private getExecutedSellAmount(orders: Array<KnownOrder>): bigint {
     return orders.reduce((acc, order) => {
-      return acc + Number(order.executedSellAmount);
-    }, 0);
+      return acc + BigInt(order.executedSellAmount);
+    }, BigInt(0));
   }
 
-  private getExecutedBuyAmount(orders: Array<KnownOrder>): number {
+  private getExecutedBuyAmount(orders: Array<KnownOrder>): bigint {
     return orders.reduce((acc, order) => {
-      return acc + Number(order.executedBuyAmount);
-    }, 0);
+      return acc + BigInt(order.executedBuyAmount);
+    }, BigInt(0));
   }
 
-  private getExecutedSurplusFee(orders: Array<KnownOrder>): number {
+  private getExecutedSurplusFee(orders: Array<KnownOrder>): bigint {
     return orders.reduce((acc, order) => {
-      return acc + Number(order.executedSurplusFee);
-    }, 0);
+      return acc + BigInt(order.executedSurplusFee ?? BigInt(0));
+    }, BigInt(0));
   }
 }
 


### PR DESCRIPTION
## Summary
This PR changes intra-function `Number` instantiation to `BigInt` while adding TWAP-related quantities.

Thanks to @compojoom for detecting this.

## Changes
- Changes `Number` as an intermediate type on `getExecutedSellAmount` execution.
- Changes `Number` as an intermediate type on `getExecutedBuyAmount` execution.
- Changes `Number` as an intermediate type on `getExecutedSurplusFee` execution.
