### PR TITLE
Make Chain.pricesProvider nullable

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -116,8 +116,11 @@ export class CoingeckoApi implements IPricesApi {
     fiatCode: string;
   }): Promise<number | null> {
     try {
-      const lowerCaseFiatCode = args.fiatCode.toLowerCase();
       const nativeCoinId = args.chain.pricesProvider.nativeCoin;
+      if (nativeCoinId == null) {
+        throw new DataSourceError('pricesProvider.nativeCoinId is not defined');
+      }
+      const lowerCaseFiatCode = args.fiatCode.toLowerCase();
       const cacheDir = CacheRouter.getNativeCoinPriceCacheDir({
         nativeCoinId,
         fiatCode: lowerCaseFiatCode,
@@ -145,7 +148,7 @@ export class CoingeckoApi implements IPricesApi {
       // Error at this level are logged out, but not thrown to the upper layers.
       // The service won't throw an error if a single coin price retrieval fails.
       this.loggingService.error(
-        `Error while getting native coin price: ${asError(error)} `,
+        `Error getting native coin price: ${asError(error)} `,
       );
       return null;
     }
@@ -166,11 +169,14 @@ export class CoingeckoApi implements IPricesApi {
     fiatCode: string;
   }): Promise<AssetPrice[]> {
     try {
+      const chainName = args.chain.pricesProvider.chainName;
+      if (chainName == null) {
+        throw new DataSourceError('pricesProvider.chainName is not defined');
+      }
       const lowerCaseFiatCode = args.fiatCode.toLowerCase();
       const lowerCaseTokenAddresses = args.tokenAddresses.map((address) =>
         address.toLowerCase(),
       );
-      const chainName = args.chain.pricesProvider.chainName;
       const pricesFromCache = await this._getTokenPricesFromCache({
         chainName,
         tokenAddresses: lowerCaseTokenAddresses,
@@ -193,7 +199,7 @@ export class CoingeckoApi implements IPricesApi {
       // Error at this level are logged out, but not thrown to the upper layers.
       // The service won't throw an error if a single token price retrieval fails.
       this.loggingService.error(
-        `Error while getting token prices: ${asError(error)} `,
+        `Error getting token prices: ${asError(error)} `,
       );
       return [];
     }
@@ -219,7 +225,7 @@ export class CoingeckoApi implements IPricesApi {
       return result.map((item) => item.toUpperCase());
     } catch (error) {
       this.loggingService.error(
-        `CoinGecko error while getting fiat codes: ${asError(error)} `,
+        `CoinGecko error getting fiat codes: ${asError(error)} `,
       );
       return [];
     }

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -55,8 +55,8 @@ export const GasPriceSchema = z.array(
 );
 
 export const PricesProviderSchema = z.object({
-  chainName: z.string(),
-  nativeCoin: z.string(),
+  chainName: z.string().nullish().default(null),
+  nativeCoin: z.string().nullish().default(null),
 });
 
 export const BalancesProviderSchema = z.object({

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -114,7 +114,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProvider.nativeCoin]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -274,7 +274,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProvider.nativeCoin]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -486,10 +486,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProvider.nativeCoin]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProvider.nativeCoin]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -710,10 +710,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProvider.nativeCoin]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProvider.nativeCoin]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -891,7 +891,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProvider.nativeCoin]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1041,7 +1041,7 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain.pricesProvider.nativeCoin]: {
+        [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1234,10 +1234,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProvider.nativeCoin]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProvider.nativeCoin]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1428,10 +1428,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProvider.nativeCoin]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProvider.nativeCoin]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1628,10 +1628,10 @@ describe('Safes Controller Overview (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [chain1.pricesProvider.nativeCoin]: {
+        [chain1.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
-        [chain2.pricesProvider.nativeCoin]: {
+        [chain2.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
         },
       };
@@ -1784,7 +1784,7 @@ describe('Safes Controller Overview (Unit)', () => {
       const chainName = chain.pricesProvider.chainName;
       const currency = faker.finance.currencyCode();
       const nativeCoinPriceProviderResponse = {
-        [nativeCoinId]: { [currency.toLowerCase()]: 1536.75 },
+        [nativeCoinId!]: { [currency.toLowerCase()]: 1536.75 },
       };
       const walletAddress = faker.finance.ethereumAddress();
       const multisigTransactions = [


### PR DESCRIPTION
## Summary
`Chain.pricesProvider` was defined as a non-nullable attribute in `ChainSchema`. But this attribute is optional in the Safe Config Service `Chain` model (ref: https://github.com/safe-global/safe-config-service/blob/ff74e49ab2e2846ff3d3479fb18eda0f5a1c7c6d/src/chains/models.py#L139)

Having this as optional makes sense as there might be use cases where token pricing is optional for a given blockchain or the Safe Infrastructure is not being deployed with fiat pricing enabled. So this PR makes that `pricesProvider` configuration also optional, targeting the alignment of the services.

## Changes
- Makes `Chain.pricesProvider` optional. 
- Modifies unit/controller tests accordingly.
