### PR TITLE
Use `AuthDecorator` for instantiation of account-related `AuthPayload`s

### DIFF
--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -2,24 +2,24 @@ import { AccountsDatasourceModule } from '@/datasources/accounts/accounts.dataso
 import { AccountsRepository } from '@/domain/accounts/accounts.repository';
 import { AccountDataType } from '@/domain/accounts/entities/account-data-type.entity';
 import { Account } from '@/domain/accounts/entities/account.entity';
-import { AuthPayloadDto } from '@/domain/auth/entities/auth-payload.entity';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { Module } from '@nestjs/common';
 
 export const IAccountsRepository = Symbol('IAccountsRepository');
 
 export interface IAccountsRepository {
   createAccount(args: {
-    auth: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<Account>;
 
   getAccount(args: {
-    auth: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<Account>;
 
   deleteAccount(args: {
-    auth: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<void>;
 

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -4,10 +4,7 @@ import {
   Account,
   AccountSchema,
 } from '@/domain/accounts/entities/account.entity';
-import {
-  AuthPayload,
-  AuthPayloadDto,
-} from '@/domain/auth/entities/auth-payload.entity';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 
@@ -19,44 +16,40 @@ export class AccountsRepository implements IAccountsRepository {
   ) {}
 
   async createAccount(args: {
-    auth: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<Account> {
-    const { auth, address } = args;
-    this.checkAuth(auth, address);
-    const account = await this.datasource.createAccount(address);
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+    const account = await this.datasource.createAccount(args.address);
     return AccountSchema.parse(account);
   }
 
   async getAccount(args: {
-    auth: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<Account> {
-    const { auth, address } = args;
-    this.checkAuth(auth, address);
-    const account = await this.datasource.getAccount(address);
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+    const account = await this.datasource.getAccount(args.address);
     return AccountSchema.parse(account);
   }
 
   async deleteAccount(args: {
-    auth: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<void> {
-    const { auth, address } = args;
-    this.checkAuth(auth, address);
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
     // TODO: trigger a cascade deletion of the account-associated data.
-    return this.datasource.deleteAccount(address);
+    return this.datasource.deleteAccount(args.address);
   }
 
   async getDataTypes(): Promise<AccountDataType[]> {
     // TODO: add caching with clearing mechanism.
     return this.datasource.getDataTypes();
-  }
-
-  private checkAuth(auth: AuthPayloadDto, address: `0x${string}`): void {
-    const authPayload = new AuthPayload(auth);
-    if (!authPayload.isForSigner(address)) {
-      throw new UnauthorizedException();
-    }
   }
 }

--- a/src/routes/accounts/accounts.controller.ts
+++ b/src/routes/accounts/accounts.controller.ts
@@ -1,3 +1,4 @@
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { AccountsService } from '@/routes/accounts/accounts.service';
 import { AccountDataType } from '@/routes/accounts/entities/account-data-type.entity';
 import { Account } from '@/routes/accounts/entities/account.entity';
@@ -15,11 +16,10 @@ import {
   HttpStatus,
   Param,
   Post,
-  Req,
   UseGuards,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { Request } from 'express';
+import { Auth } from '@/routes/auth/decorators/auth.decorator';
 
 @ApiTags('accounts')
 @Controller({ path: 'accounts', version: '1' })
@@ -33,10 +33,12 @@ export class AccountsController {
   async createAccount(
     @Body(new ValidationPipe(CreateAccountDtoSchema))
     createAccountDto: CreateAccountDto,
-    @Req() request: Request,
+    @Auth() authPayload: AuthPayload,
   ): Promise<Account> {
-    const auth = request.accessToken;
-    return this.accountsService.createAccount({ auth, createAccountDto });
+    return this.accountsService.createAccount({
+      authPayload,
+      createAccountDto,
+    });
   }
 
   @ApiOkResponse({ type: AccountDataType, isArray: true })
@@ -50,10 +52,9 @@ export class AccountsController {
   @UseGuards(AuthGuard)
   async getAccount(
     @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
-    @Req() request: Request,
+    @Auth() authPayload: AuthPayload,
   ): Promise<Account> {
-    const auth = request.accessToken;
-    return this.accountsService.getAccount({ auth, address });
+    return this.accountsService.getAccount({ authPayload, address });
   }
 
   @Delete(':address')
@@ -61,9 +62,8 @@ export class AccountsController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteAccount(
     @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
-    @Req() request: Request,
+    @Auth() authPayload: AuthPayload,
   ): Promise<void> {
-    const auth = request.accessToken;
-    return this.accountsService.deleteAccount({ auth, address });
+    return this.accountsService.deleteAccount({ authPayload, address });
   }
 }

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -1,11 +1,11 @@
 import { IAccountsRepository } from '@/domain/accounts/accounts.repository.interface';
 import { Account as DomainAccount } from '@/domain/accounts/entities/account.entity';
 import { AccountDataType as DomainAccountDataType } from '@/domain/accounts/entities/account-data-type.entity';
-import { AuthPayloadDto } from '@/domain/auth/entities/auth-payload.entity';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { AccountDataType } from '@/routes/accounts/entities/account-data-type.entity';
 import { Account } from '@/routes/accounts/entities/account.entity';
 import { CreateAccountDto } from '@/routes/accounts/entities/create-account.dto.entity';
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
 export class AccountsService {
@@ -15,42 +15,33 @@ export class AccountsService {
   ) {}
 
   async createAccount(args: {
-    auth?: AuthPayloadDto;
+    authPayload: AuthPayload;
     createAccountDto: CreateAccountDto;
   }): Promise<Account> {
-    if (!args.auth) {
-      throw new UnauthorizedException();
-    }
     const domainAccount = await this.accountsRepository.createAccount({
-      auth: args.auth,
+      authPayload: args.authPayload,
       address: args.createAccountDto.address,
     });
     return this.mapAccount(domainAccount);
   }
 
   async getAccount(args: {
-    auth?: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<Account> {
-    if (!args.auth) {
-      throw new UnauthorizedException();
-    }
     const domainAccount = await this.accountsRepository.getAccount({
-      auth: args.auth,
+      authPayload: args.authPayload,
       address: args.address,
     });
     return this.mapAccount(domainAccount);
   }
 
   async deleteAccount(args: {
-    auth?: AuthPayloadDto;
+    authPayload: AuthPayload;
     address: `0x${string}`;
   }): Promise<void> {
-    if (!args.auth) {
-      throw new UnauthorizedException();
-    }
     await this.accountsRepository.deleteAccount({
-      auth: args.auth,
+      authPayload: args.authPayload,
       address: args.address,
     });
   }


### PR DESCRIPTION
## Summary

When using the `AuthGuard`, we can be sure that the `accessToken` is present in the `request`. Currently, our account-related methods instantiate the relative `AuthPayload` individually. There is, however, a specific (`Auth`) decorator that handles instantiation.

This replaces the aforementioned for the creation, retrieval and deletion of accounts.

## Changes

- Expect an `AuthPayload` instead of `AuthPayloadDto` in `AccountsController`, `AccountsService` and `AccountsRepository`.
- Use `AuthPayload` directly for authorisation in `AccountsRepository`,