### PR TITLE
Remove unnecessary test of `SwapOrderMapper`

### DIFF
--- a/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/swap-order.mapper.spec.ts
@@ -1,4 +1,0 @@
-describe('SwapOrderMapper', () => {
-  // TODO: Add test - should've been added in first swaps integration
-  it.todo('should map a swap order');
-});


### PR DESCRIPTION
## Summary

When adding TWAP-mapping, a TODO test was included for the `SwapOrderMapper`. We've since confirmed that the component is tested [in the helper class](https://github.com/safe-global/safe-client-gateway/commit/8f93ef19e54e1849eff9d25cbdb4aeb10916c01b#diff-405aa2404e9a727e959580191869a0512770fa079e6869dc815fa692f764b3ac).

## Changes

- Removes unnecessary `swap-order.mapper.spec.ts` suite