### PR TITLE
Add application.isProduction configuration flag

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -14,7 +14,7 @@ export default (): ReturnType<typeof configuration> => ({
     prefetch: faker.number.int(),
   },
   application: {
-    env: faker.string.sample(),
+    isProduction: faker.datatype.boolean(),
     port: faker.internet.port().toString(),
   },
   auth: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -24,7 +24,7 @@ export default () => ({
         : 100,
   },
   application: {
-    env: process.env.CGW_ENV || 'production',
+    isProduction: process.env.CGW_ENV === 'production',
     port: process.env.APPLICATION_PORT || '3000',
   },
   auth: {

--- a/src/routes/auth/auth.controller.spec.ts
+++ b/src/routes/auth/auth.controller.spec.ts
@@ -90,7 +90,7 @@ describe('AuthController', () => {
       ...defaultConfiguration,
       application: {
         ...defaultConfiguration.application,
-        env: 'production',
+        isProduction: true,
       },
       features: {
         ...defaultConfiguration.features,
@@ -232,7 +232,7 @@ describe('AuthController', () => {
         ...defaultConfiguration,
         application: {
           ...defaultConfiguration.application,
-          env: 'staging',
+          isProduction: false,
         },
         features: {
           ...defaultConfiguration.features,

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -31,15 +31,16 @@ export class AuthController {
   static readonly ACCESS_TOKEN_COOKIE_SAME_SITE_LAX = 'lax';
   static readonly ACCESS_TOKEN_COOKIE_SAME_SITE_NONE = 'none';
   static readonly CGW_ENV_PRODUCTION = 'production';
-  private readonly cgwEnv: string;
+  private readonly isProduction: boolean;
 
   constructor(
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     private readonly authService: AuthService,
   ) {
-    this.cgwEnv =
-      this.configurationService.getOrThrow<string>('application.env');
+    this.isProduction = this.configurationService.getOrThrow<boolean>(
+      'application.isProduction',
+    );
   }
 
   @Get('nonce')
@@ -58,12 +59,11 @@ export class AuthController {
     siweDto: SiweDto,
   ): Promise<void> {
     const { accessToken } = await this.authService.getAccessToken(siweDto);
-    const isProduction = this.cgwEnv === AuthController.CGW_ENV_PRODUCTION;
 
     res.cookie(AuthController.ACCESS_TOKEN_COOKIE_NAME, accessToken, {
       httpOnly: true,
       secure: true,
-      sameSite: isProduction
+      sameSite: this.isProduction
         ? AuthController.ACCESS_TOKEN_COOKIE_SAME_SITE_LAX
         : AuthController.ACCESS_TOKEN_COOKIE_SAME_SITE_NONE,
       path: '/',


### PR DESCRIPTION
## Summary
This PR changes the way the CGW checks the runtime environment. Instead of checking a `cgwEnv` configuration variable, an `isProduction` flag is exposed via the configuration, so the logic gets simplified.

## Changes
- Exposes and uses the `application.isProduction` configuration field, instead of `application.cgwEnv`.
