### PR TITLE
Include `SwapTransfer` when checking whether `TransactionInfo['type']` is a transfer

### DIFF
--- a/src/routes/transactions/mappers/transfers/transfer-imitation.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-imitation.mapper.ts
@@ -6,6 +6,7 @@ import {
   TransferTransactionInfo,
 } from '@/routes/transactions/entities/transfer-transaction-info.entity';
 import { isErc20Transfer } from '@/routes/transactions/entities/transfers/erc20-transfer.entity';
+import { isSwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
 import { Inject } from '@nestjs/common';
 import { formatUnits } from 'viem';
 
@@ -65,7 +66,10 @@ export class TransferImitationMapper {
       const txInfo = item.transaction.txInfo;
       // Only transfers can be imitated, of which we are only interested in ERC20s
       if (
-        !isTransferTransactionInfo(txInfo) ||
+        !(
+          isTransferTransactionInfo(txInfo) ||
+          isSwapTransferTransactionInfo(txInfo)
+        ) ||
         !isErc20Transfer(txInfo.transferInfo)
       ) {
         mappedTransactions.unshift(item);
@@ -103,7 +107,10 @@ export class TransferImitationMapper {
       const isImitation = prevItems.some((prevItem) => {
         const prevTxInfo = prevItem.transaction.txInfo;
         if (
-          !isTransferTransactionInfo(prevTxInfo) ||
+          !(
+            isTransferTransactionInfo(prevTxInfo) ||
+            isSwapTransferTransactionInfo(prevTxInfo)
+          ) ||
           !isErc20Transfer(prevTxInfo.transferInfo) ||
           // Do not compare against previously identified imitations
           prevTxInfo.transferInfo.imitation

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.spec.ts
@@ -3,13 +3,25 @@ import { erc20TransferBuilder } from '@/domain/safe/entities/__tests__/erc20-tra
 import { erc721TransferBuilder } from '@/domain/safe/entities/__tests__/erc721-transfer.builder';
 import { nativeTokenTransferBuilder } from '@/domain/safe/entities/__tests__/native-token-transfer.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import {
+  OrderClass,
+  OrderKind,
+  OrderStatus,
+} from '@/domain/swaps/entities/order.entity';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TokenRepository } from '@/domain/tokens/token.repository';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
+import { TransactionInfoType } from '@/routes/transactions/entities/transaction-info.entity';
 import { TransactionStatus } from '@/routes/transactions/entities/transaction-status.entity';
 import { Transaction } from '@/routes/transactions/entities/transaction.entity';
-import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import {
+  TransferDirection,
+  TransferTransactionInfo,
+} from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import { TransferType } from '@/routes/transactions/entities/transfers/transfer.entity';
 import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
 import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/transfer-info.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
@@ -99,6 +111,7 @@ describe('Transfer mapper (Unit)', () => {
         const token = tokenBuilder()
           .with('address', getAddress(transfer.tokenAddress))
           .build();
+        swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue(null);
         addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
         tokenRepository.getToken.mockResolvedValue(token);
 
@@ -140,6 +153,7 @@ describe('Transfer mapper (Unit)', () => {
             .with('address', getAddress(transfer.tokenAddress))
             .with('trusted', true)
             .build();
+          swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue(null);
           addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
           tokenRepository.getToken.mockResolvedValue(token);
 
@@ -271,6 +285,331 @@ describe('Transfer mapper (Unit)', () => {
       });
     });
 
+    describe('ERC20 swap transfers', () => {
+      // Note: swap transfers can never have a value of 0
+
+      describe('without onlyTrusted flag', () => {
+        it('should map swap transfers of trusted tokens with value', async () => {
+          const chainId = faker.string.numeric();
+          const safe = safeBuilder().build();
+          /**
+           * TODO: Mock the following
+           * @see https://sepolia.etherscan.io/tx/0x5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148
+           */
+          const transfer = {
+            type: 'ERC20_TRANSFER',
+            executionDate: new Date('2024-07-04T09:22:48Z'),
+            blockNumber: 6243548,
+            transactionHash:
+              '0x5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148',
+            to: safe.address,
+            value: '1625650639290905524',
+            tokenId: null,
+            tokenAddress: '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
+            transferId:
+              'e5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148120',
+            tokenInfo: {
+              type: 'ERC20',
+              address: '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
+              name: 'GNO (test)',
+              symbol: 'GNO',
+              decimals: 18,
+              logoUri:
+                'https://safe-transaction-assets.safe.global/tokens/logos/0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De.png',
+              trusted: true,
+            },
+            from: safe.address,
+          } as const;
+          const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
+          swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue({
+            type: TransactionInfoType.SwapTransfer,
+            humanDescription: null,
+            richDecodedInfo: null,
+            sender: {
+              value: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
+              name: 'GPv2Settlement',
+              logoUri:
+                'https://safe-transaction-assets.safe.global/contracts/logos/0x9008D19f58AAbD9eD0D60971565AA8510560ab41.png',
+            },
+            recipient: {
+              value: safe.address,
+              name: 'GnosisSafeProxy',
+              logoUri: null,
+            },
+            direction: TransferDirection.Incoming,
+            transferInfo: { ...transfer.tokenInfo, type: TransferType.Erc20 },
+            uid: '0xf48010ff178567a04cb9e82341325d2bdcbf646b4ed54ef0305163368819f4bd2a73e61bd15b25b6958b4da3bfc759ca4db249b96686709e',
+            status: OrderStatus.Fulfilled,
+            kind: OrderKind.Sell,
+            orderClass: OrderClass.Limit,
+            validUntil: 1720086686,
+            sellAmount: '10000000000000000000',
+            buyAmount: '1608062657377840160',
+            executedSellAmount: '10000000000000000000',
+            executedBuyAmount: '1625650639290905524',
+            sellToken: tokenBuilder().build() as TokenInfo & {
+              decimals: number;
+            },
+            buyToken: transfer.tokenInfo,
+            explorerUrl:
+              'https://explorer.cow.fi/orders/0xf48010ff178567a04cb9e82341325d2bdcbf646b4ed54ef0305163368819f4bd2a73e61bd15b25b6958b4da3bfc759ca4db249b96686709e',
+            executedSurplusFee: '1400734851526479789',
+            receiver: safe.address,
+            owner: safe.address,
+            fullAppData: {
+              appCode: 'CoW Swap-SafeApp',
+              environment: 'production',
+              metadata: {
+                orderClass: {
+                  orderClass: 'market',
+                },
+                quote: {
+                  slippageBips: 40,
+                },
+              },
+              version: '1.1.0',
+            },
+          } as const);
+          addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+          tokenRepository.getToken.mockResolvedValue({
+            ...transfer.tokenInfo,
+            type: TokenType.Erc20,
+          });
+
+          const actual = await mapper.mapTransfers({
+            chainId,
+            transfers: [transfer],
+            safe,
+            onlyTrusted: false,
+          });
+
+          expect(
+            actual.every((transaction) => transaction instanceof Transaction),
+          ).toBe(true);
+          expect(actual).toEqual([
+            {
+              id: `transfer_${safe.address}_${transfer.transferId}`,
+              timestamp: transfer.executionDate.getTime(),
+              txStatus: TransactionStatus.Success,
+              txInfo: expect.any(TransferTransactionInfo),
+              executionInfo: null,
+              safeAppInfo: null,
+              txHash: transfer.transactionHash,
+            },
+          ]);
+        });
+      });
+
+      describe('with onlyTrusted flag', () => {
+        it('should map swap transfers of trusted tokens', async () => {
+          const chainId = faker.string.numeric();
+          const safe = safeBuilder().build();
+          /**
+           * TODO: Mock the following
+           * @see https://sepolia.etherscan.io/tx/0x5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148
+           */
+          const transfer = {
+            type: 'ERC20_TRANSFER',
+            executionDate: new Date('2024-07-04T09:22:48Z'),
+            blockNumber: 6243548,
+            transactionHash:
+              '0x5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148',
+            to: safe.address,
+            value: '1625650639290905524',
+            tokenId: null,
+            tokenAddress: '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
+            transferId:
+              'e5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148120',
+            tokenInfo: {
+              type: 'ERC20',
+              address: '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
+              name: 'GNO (test)',
+              symbol: 'GNO',
+              decimals: 18,
+              logoUri:
+                'https://safe-transaction-assets.safe.global/tokens/logos/0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De.png',
+              trusted: true,
+            },
+            from: safe.address,
+          } as const;
+          const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
+          swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue({
+            type: TransactionInfoType.SwapTransfer,
+            humanDescription: null,
+            richDecodedInfo: null,
+            sender: {
+              value: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
+              name: 'GPv2Settlement',
+              logoUri:
+                'https://safe-transaction-assets.safe.global/contracts/logos/0x9008D19f58AAbD9eD0D60971565AA8510560ab41.png',
+            },
+            recipient: {
+              value: safe.address,
+              name: 'GnosisSafeProxy',
+              logoUri: null,
+            },
+            direction: TransferDirection.Incoming,
+            transferInfo: { ...transfer.tokenInfo, type: TransferType.Erc20 },
+            uid: '0xf48010ff178567a04cb9e82341325d2bdcbf646b4ed54ef0305163368819f4bd2a73e61bd15b25b6958b4da3bfc759ca4db249b96686709e',
+            status: OrderStatus.Fulfilled,
+            kind: OrderKind.Sell,
+            orderClass: OrderClass.Limit,
+            validUntil: 1720086686,
+            sellAmount: '10000000000000000000',
+            buyAmount: '1608062657377840160',
+            executedSellAmount: '10000000000000000000',
+            executedBuyAmount: '1625650639290905524',
+            sellToken: tokenBuilder().build() as TokenInfo & {
+              decimals: number;
+            },
+            buyToken: transfer.tokenInfo,
+            explorerUrl:
+              'https://explorer.cow.fi/orders/0xf48010ff178567a04cb9e82341325d2bdcbf646b4ed54ef0305163368819f4bd2a73e61bd15b25b6958b4da3bfc759ca4db249b96686709e',
+            executedSurplusFee: '1400734851526479789',
+            receiver: safe.address,
+            owner: safe.address,
+            fullAppData: {
+              appCode: 'CoW Swap-SafeApp',
+              environment: 'production',
+              metadata: {
+                orderClass: {
+                  orderClass: 'market',
+                },
+                quote: {
+                  slippageBips: 40,
+                },
+              },
+              version: '1.1.0',
+            },
+          } as const);
+          addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+          tokenRepository.getToken.mockResolvedValue({
+            ...transfer.tokenInfo,
+            type: TokenType.Erc20,
+          });
+
+          const actual = await mapper.mapTransfers({
+            chainId,
+            transfers: [transfer],
+            safe,
+            onlyTrusted: true,
+          });
+
+          expect(
+            actual.every((transaction) => transaction instanceof Transaction),
+          ).toBe(true);
+          expect(actual).toEqual([
+            {
+              id: `transfer_${safe.address}_${transfer.transferId}`,
+              timestamp: transfer.executionDate.getTime(),
+              txStatus: TransactionStatus.Success,
+              txInfo: expect.any(TransferTransactionInfo),
+              executionInfo: null,
+              safeAppInfo: null,
+              txHash: transfer.transactionHash,
+            },
+          ]);
+        });
+
+        it('should not map transfers of untrusted tokens', async () => {
+          const chainId = faker.string.numeric();
+          const safe = safeBuilder().build();
+          /**
+           * TODO: Mock the following
+           * @see https://sepolia.etherscan.io/tx/0x5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148
+           */
+          const transfer = {
+            type: 'ERC20_TRANSFER',
+            executionDate: new Date('2024-07-04T09:22:48Z'),
+            blockNumber: 6243548,
+            transactionHash:
+              '0x5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148',
+            to: safe.address,
+            value: '1625650639290905524',
+            tokenId: null,
+            tokenAddress: '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
+            transferId:
+              'e5779dc3891a4693a4c6f44eb86abd4c553e3d3d36cacfc2c791b87b6c136f148120',
+            tokenInfo: {
+              type: 'ERC20',
+              address: '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
+              name: 'GNO (test)',
+              symbol: 'GNO',
+              decimals: 18,
+              logoUri:
+                'https://safe-transaction-assets.safe.global/tokens/logos/0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De.png',
+              trusted: false,
+            },
+            from: safe.address,
+          } as const;
+          const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
+          swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue({
+            type: TransactionInfoType.SwapTransfer,
+            humanDescription: null,
+            richDecodedInfo: null,
+            sender: {
+              value: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
+              name: 'GPv2Settlement',
+              logoUri:
+                'https://safe-transaction-assets.safe.global/contracts/logos/0x9008D19f58AAbD9eD0D60971565AA8510560ab41.png',
+            },
+            recipient: {
+              value: safe.address,
+              name: 'GnosisSafeProxy',
+              logoUri: null,
+            },
+            direction: TransferDirection.Incoming,
+            transferInfo: { ...transfer.tokenInfo, type: TransferType.Erc20 },
+            uid: '0xf48010ff178567a04cb9e82341325d2bdcbf646b4ed54ef0305163368819f4bd2a73e61bd15b25b6958b4da3bfc759ca4db249b96686709e',
+            status: OrderStatus.Fulfilled,
+            kind: OrderKind.Sell,
+            orderClass: OrderClass.Limit,
+            validUntil: 1720086686,
+            sellAmount: '10000000000000000000',
+            buyAmount: '1608062657377840160',
+            executedSellAmount: '10000000000000000000',
+            executedBuyAmount: '1625650639290905524',
+            sellToken: tokenBuilder().build() as TokenInfo & {
+              decimals: number;
+            },
+            buyToken: transfer.tokenInfo,
+            explorerUrl:
+              'https://explorer.cow.fi/orders/0xf48010ff178567a04cb9e82341325d2bdcbf646b4ed54ef0305163368819f4bd2a73e61bd15b25b6958b4da3bfc759ca4db249b96686709e',
+            executedSurplusFee: '1400734851526479789',
+            receiver: safe.address,
+            owner: safe.address,
+            fullAppData: {
+              appCode: 'CoW Swap-SafeApp',
+              environment: 'production',
+              metadata: {
+                orderClass: {
+                  orderClass: 'market',
+                },
+                quote: {
+                  slippageBips: 40,
+                },
+              },
+              version: '1.1.0',
+            },
+          } as const);
+          addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+          tokenRepository.getToken.mockResolvedValue({
+            ...transfer.tokenInfo,
+            type: TokenType.Erc20,
+          });
+
+          const actual = await mapper.mapTransfers({
+            chainId,
+            transfers: [transfer],
+            safe,
+            onlyTrusted: true,
+          });
+
+          expect(actual).toEqual([]);
+        });
+      });
+    });
+
     it('should map and filter a mixture of transfers', async () => {
       const chainId = faker.string.numeric();
       const safe = safeBuilder().build();
@@ -307,6 +646,7 @@ describe('Transfer mapper (Unit)', () => {
       const untrustedErc20TransferWithoutValue = erc20TransferBuilder()
         .with('value', '0')
         .build();
+      swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue(null);
       addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
       tokenRepository.getToken
         .mockResolvedValueOnce(erc721Token)
@@ -317,6 +657,7 @@ describe('Transfer mapper (Unit)', () => {
 
       const actual = await mapper.mapTransfers({
         chainId,
+        // TODO: Add swap transfers
         transfers: [
           nativeTransfer,
           erc721Transfer,

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.ts
@@ -10,6 +10,7 @@ import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/tran
 import { Transaction } from '@/routes/transactions/entities/transaction.entity';
 import { isTransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
 import { isErc20Transfer } from '@/routes/transactions/entities/transfers/erc20-transfer.entity';
+import { isSwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
 
 @Injectable()
 export class TransferMapper {
@@ -62,14 +63,22 @@ export class TransferMapper {
    * @private
    */
   private isTransferWithValue(transaction: Transaction): boolean {
-    if (!isTransferTransactionInfo(transaction.txInfo)) return true;
+    if (
+      !isTransferTransactionInfo(transaction.txInfo) &&
+      !isSwapTransferTransactionInfo(transaction.txInfo)
+    )
+      return true;
     if (!isErc20Transfer(transaction.txInfo.transferInfo)) return true;
 
     return Number(transaction.txInfo.transferInfo.value) > 0;
   }
 
   private isTrustedTransfer(transaction: Transaction): boolean {
-    if (!isTransferTransactionInfo(transaction.txInfo)) return true;
+    if (
+      !isTransferTransactionInfo(transaction.txInfo) &&
+      !isSwapTransferTransactionInfo(transaction.txInfo)
+    )
+      return true;
     if (!isErc20Transfer(transaction.txInfo.transferInfo)) return true;
 
     return !!transaction.txInfo.transferInfo.trusted;

--- a/src/routes/transactions/swap-transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/swap-transfer-transaction-info.entity.ts
@@ -168,3 +168,9 @@ export class SwapTransferTransactionInfo
     this.fullAppData = args.fullAppData;
   }
 }
+
+export function isSwapTransferTransactionInfo(
+  txInfo: TransactionInfo,
+): txInfo is TransferTransactionInfo {
+  return txInfo.type === TransactionInfoType.SwapTransfer;
+}


### PR DESCRIPTION
## Summary

When mapping swap transfers, the `type` is no longer `Transfer` but `SwapTransfer`. This means that any comparisons happening according to what was previously `Transfer` no longer happen: trust filtering and imitation flagging early returns.

This adds the relative checks for `SwapTransfer`-typed transfers, as well as adding relative test coverage.

## Changes

Note: the following can be assumed as we check the address of the settlement contract:

- Add early return for imitation flagging
- Assume `trust` when filtering transfers
- Add test coverage accordingly