### PR TITLE
Removes unnecessary TODO comment

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -199,8 +199,6 @@ export class MultisigTransactionInfoMapper {
     );
   }
 
-  // TODO: Refactor mapSwapOrder, mapTwapOrder and mapTwapSwapOrder as they follow the same pattern
-
   /**
    * Maps a swap order transaction.
    * If the transaction is not a swap order, it returns null.


### PR DESCRIPTION
## Summary

When implementing TWAP mapping, a TODO was added to refactor mappers for SWAP/TWAP transactions as they follow a similar pattern.

Due to intricacies of `mapSwapOrder`, `mapTwapOrder` and `mapTwapSwapOrder` (`mapSwapTransfer`), there is seemingly no "blanket" refactor possible, e.g. some check addresses and others execution details. This therefore removes the TODO  note.

## Changes

- Remove TODO comment