### PR TITLE
Add test for `getOrderUidFromSetPreSignature`

### DIFF
--- a/src/domain/swaps/contracts/decoders/gp-v2-decoder.helper.spec.ts
+++ b/src/domain/swaps/contracts/decoders/gp-v2-decoder.helper.spec.ts
@@ -34,8 +34,16 @@ describe('GPv2Decoder', () => {
     expect(() => target.decodeFunctionData({ data })).toThrow();
   });
 
-  // TODO: Add test - should've been added in first swaps integration
-  it.todo('gets orderUid from setPreSignature function call');
+  it('gets orderUid from setPreSignature function call', () => {
+    const setPreSignature = setPreSignatureEncoder();
+    const args = setPreSignature.build();
+
+    const orderUid = target.getOrderUidFromSetPreSignature(
+      setPreSignature.encode(),
+    );
+
+    expect(orderUid).toBe(args.orderUid);
+  });
 
   it('should decode an order from a settle function call', () => {
     /**


### PR DESCRIPTION
## Summary

The method for retrieving the `orderUid` was without test and therefore marked with `it.todo`. This adds the relative test coverage.

## Changes

- Add test coverage for `GPv2Decoder['getOrderUidFromSetPreSignature']`