### PR TITLE
Only log when trying to map restricted swap transfers

### DIFF
--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
@@ -26,6 +26,7 @@ const mockSwapsRepository = jest.mocked({
 const mockLoggingService = jest.mocked({
   debug: jest.fn(),
   error: jest.fn(),
+  warn: jest.fn(),
 } as jest.MockedObjectDeep<ILoggingService>);
 
 describe('SwapTransferInfoMapper', () => {

--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
@@ -3,6 +3,7 @@ import { orderBuilder } from '@/domain/swaps/entities/__tests__/order.builder';
 import { OrdersSchema } from '@/domain/swaps/entities/order.entity';
 import { ISwapsRepository } from '@/domain/swaps/swaps.repository';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import { ILoggingService } from '@/logging/logging.interface';
 import { addressInfoBuilder } from '@/routes/common/__tests__/entities/address-info.builder';
 import { TransferDirection } from '@/routes/transactions/entities/transfer-transaction-info.entity';
 import { Erc20Transfer } from '@/routes/transactions/entities/transfers/erc20-transfer.entity';
@@ -22,6 +23,11 @@ const mockSwapsRepository = jest.mocked({
   getOrders: jest.fn(),
 } as jest.MockedObjectDeep<ISwapsRepository>);
 
+const mockLoggingService = jest.mocked({
+  debug: jest.fn(),
+  error: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
 describe('SwapTransferInfoMapper', () => {
   let target: SwapTransferInfoMapper;
 
@@ -33,6 +39,7 @@ describe('SwapTransferInfoMapper', () => {
     target = new SwapTransferInfoMapper(
       mockSwapOrderHelper,
       mockSwapsRepository,
+      mockLoggingService,
     );
   });
 
@@ -401,7 +408,7 @@ describe('SwapTransferInfoMapper', () => {
     });
   });
 
-  it('should throw if the app is not allowed', async () => {
+  it('should return null if the app is not allowed', async () => {
     /**
      * https://api.cow.fi/mainnet/api/v1/transactions/0x22fe458f3a70aaf83d42af2040f3b98404526b4ca588624e158c4b1f287ced8c/orders
      */
@@ -521,16 +528,16 @@ describe('SwapTransferInfoMapper', () => {
     );
     mockSwapOrderHelper.isAppAllowed.mockReturnValue(false);
 
-    await expect(
-      target.mapSwapTransferInfo({
-        sender,
-        recipient,
-        direction,
-        chainId,
-        safeAddress,
-        transferInfo,
-        domainTransfer,
-      }),
-    ).rejects.toThrow('Unsupported App: CoW Swap');
+    const actual = await target.mapSwapTransferInfo({
+      sender,
+      recipient,
+      direction,
+      chainId,
+      safeAddress,
+      transferInfo,
+      domainTransfer,
+    });
+
+    expect(actual).toEqual(null);
   });
 });

--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.ts
@@ -9,6 +9,7 @@ import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer
 import { getAddress, isAddressEqual } from 'viem';
 import { ISwapsRepository } from '@/domain/swaps/swaps.repository';
 import { Order } from '@/domain/swaps/entities/order.entity';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 @Injectable()
 export class SwapTransferInfoMapper {
@@ -16,6 +17,7 @@ export class SwapTransferInfoMapper {
     private readonly swapOrderHelper: SwapOrderHelper,
     @Inject(ISwapsRepository)
     private readonly swapsRepository: ISwapsRepository,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   /**
@@ -61,7 +63,11 @@ export class SwapTransferInfoMapper {
 
     // TODO: Refactor with confirmation view, swaps and TWAPs
     if (!this.swapOrderHelper.isAppAllowed(order)) {
-      throw new Error(`Unsupported App: ${order.fullAppData?.appCode}`);
+      this.loggingService.error(
+        `Unsupported App: ${order.fullAppData?.appCode}`,
+      );
+      // Don't throw in order to fallback to "standard" transfer mapping
+      return null;
     }
 
     const [sellToken, buyToken] = await Promise.all([

--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.ts
@@ -63,7 +63,7 @@ export class SwapTransferInfoMapper {
 
     // TODO: Refactor with confirmation view, swaps and TWAPs
     if (!this.swapOrderHelper.isAppAllowed(order)) {
-      this.loggingService.error(
+      this.loggingService.warn(
         `Unsupported App: ${order.fullAppData?.appCode}`,
       );
       // Don't throw in order to fallback to "standard" transfer mapping


### PR DESCRIPTION
## Summary

When mapping a swap transfer, we are currently throwing if the transfer was created by a disallowed app. This means that the mapping breaks when we should be falling back to "standard" transfer mapping.

This switches from throwing to instead logging and returning `null` instead of a mapped swap transfer. This means that the "standard" mapping will be done instead.

## Changes

- Log/return `null` instead of throwing when mapping a disallowed swap transfer
- Update test accordingly