### PR TITLE
Handle all swap transfer mapping errors

### DIFF
--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
@@ -18,6 +18,7 @@ import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/tran
 import { getAddress } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
+import { ILoggingService } from '@/logging/logging.interface';
 
 const configurationService = jest.mocked({
   getOrThrow: jest.fn(),
@@ -36,6 +37,10 @@ const tokenRepository = jest.mocked({
   getToken: jest.fn(),
 } as jest.MockedObjectDeep<TokenRepository>);
 
+const mockLoggingService = jest.mocked({
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
 describe('Transfer Info mapper (Unit)', () => {
   let mapper: TransferInfoMapper;
 
@@ -46,6 +51,7 @@ describe('Transfer Info mapper (Unit)', () => {
       tokenRepository,
       swapTransferInfoMapper,
       addressInfoHelper,
+      mockLoggingService,
     );
   });
 
@@ -63,6 +69,9 @@ describe('Transfer Info mapper (Unit)', () => {
     const actual = await mapper.mapTransferInfo(chainId, transfer, safe);
 
     expect(actual).toBeInstanceOf(TransferTransactionInfo);
+    if (!(actual instanceof TransferTransactionInfo)) {
+      throw new Error('Not a TransferTransactionInfo instance');
+    }
     expect(actual.transferInfo).toBeInstanceOf(Erc20Transfer);
     expect(actual).toEqual(
       expect.objectContaining({
@@ -96,6 +105,9 @@ describe('Transfer Info mapper (Unit)', () => {
     const actual = await mapper.mapTransferInfo(chainId, transfer, safe);
 
     expect(actual).toBeInstanceOf(TransferTransactionInfo);
+    if (!(actual instanceof TransferTransactionInfo)) {
+      throw new Error('Not a TransferTransactionInfo instance');
+    }
     expect(actual.transferInfo).toBeInstanceOf(Erc721Transfer);
     expect(actual).toEqual(
       expect.objectContaining({
@@ -126,6 +138,9 @@ describe('Transfer Info mapper (Unit)', () => {
     const actual = await mapper.mapTransferInfo(chainId, transfer, safe);
 
     expect(actual).toBeInstanceOf(TransferTransactionInfo);
+    if (!(actual instanceof TransferTransactionInfo)) {
+      throw new Error('Not a TransferTransactionInfo instance');
+    }
     expect(actual.transferInfo).toBeInstanceOf(NativeCoinTransfer);
     expect(actual).toEqual(
       expect.objectContaining({

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -5,7 +5,10 @@ import { Token } from '@/domain/tokens/entities/token.entity';
 import { TokenRepository } from '@/domain/tokens/token.repository';
 import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
-import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import {
+  TransferDirection,
+  TransferTransactionInfo,
+} from '@/routes/transactions/entities/transfer-transaction-info.entity';
 import { Erc20Transfer } from '@/routes/transactions/entities/transfers/erc20-transfer.entity';
 import { Erc721Transfer } from '@/routes/transactions/entities/transfers/erc721-transfer.entity';
 import { NativeCoinTransfer } from '@/routes/transactions/entities/transfers/native-coin-transfer.entity';
@@ -13,6 +16,9 @@ import { getTransferDirection } from '@/routes/transactions/mappers/common/trans
 import { Transfer } from '@/routes/transactions/entities/transfers/transfer.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
 @Injectable()
 export class TransferInfoMapper {
@@ -25,6 +31,7 @@ export class TransferInfoMapper {
     @Inject(ITokenRepository) private readonly tokenRepository: TokenRepository,
     private readonly swapTransferInfoMapper: SwapTransferInfoMapper,
     private readonly addressInfoHelper: AddressInfoHelper,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
     this.isSwapsDecodingEnabled = this.configurationService.getOrThrow(
       'features.swapsDecoding',
@@ -38,7 +45,7 @@ export class TransferInfoMapper {
     chainId: string,
     domainTransfer: DomainTransfer,
     safe: Safe,
-  ): Promise<TransferTransactionInfo> {
+  ): Promise<SwapOrderTransactionInfo | TransferTransactionInfo> {
     const { from, to } = domainTransfer;
 
     const [sender, recipient, transferInfo] = await Promise.all([
@@ -51,16 +58,15 @@ export class TransferInfoMapper {
 
     if (this.isSwapsDecodingEnabled && this.isTwapsDecodingEnabled) {
       // If the transaction is a swap-based transfer, we return it immediately
-      const swapTransfer =
-        await this.swapTransferInfoMapper.mapSwapTransferInfo({
-          sender,
-          recipient,
-          direction,
-          transferInfo,
-          chainId,
-          safeAddress: safe.address,
-          domainTransfer,
-        });
+      const swapTransfer = await this.mapSwapTransfer({
+        sender,
+        recipient,
+        direction,
+        transferInfo,
+        chainId,
+        safeAddress: safe.address,
+        domainTransfer,
+      });
 
       if (swapTransfer) {
         return swapTransfer;
@@ -75,6 +81,36 @@ export class TransferInfoMapper {
       null,
       null,
     );
+  }
+
+  /**
+   * Maps a swap transfer transaction.
+   * If the transaction is not a swap transfer, it returns null.
+   *
+   * @param args.sender - {@link AddressInfo} sender of the transfer
+   * @param args.recipient - {@link AddressInfo} recipient of the transfer
+   * @param args.direction - {@link TransferDirection} of the transfer
+   * @param args.chainId - chain id of the transfer
+   * @param args.safeAddress - safe address of the transfer
+   * @param args.transferInfo - {@link Transfer} info
+   * @param args.domainTransfer - {@link DomainTransfer} domain transfer
+   */
+  private async mapSwapTransfer(args: {
+    sender: AddressInfo;
+    recipient: AddressInfo;
+    direction: TransferDirection;
+    chainId: string;
+    safeAddress: `0x${string}`;
+    transferInfo: Transfer;
+    domainTransfer: DomainTransfer;
+  }): Promise<SwapOrderTransactionInfo | null> {
+    try {
+      return await this.swapTransferInfoMapper.mapSwapTransferInfo(args);
+    } catch (error) {
+      // There were either issues mapping the swap transfer or it is a "normal" transfer
+      this.loggingService.warn(error);
+      return null;
+    }
   }
 
   private async getTransferByType(

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -16,7 +16,7 @@ import { getTransferDirection } from '@/routes/transactions/mappers/common/trans
 import { Transfer } from '@/routes/transactions/entities/transfers/transfer.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
-import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
+import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 
@@ -45,7 +45,7 @@ export class TransferInfoMapper {
     chainId: string,
     domainTransfer: DomainTransfer,
     safe: Safe,
-  ): Promise<SwapOrderTransactionInfo | TransferTransactionInfo> {
+  ): Promise<SwapTransferTransactionInfo | TransferTransactionInfo> {
     const { from, to } = domainTransfer;
 
     const [sender, recipient, transferInfo] = await Promise.all([
@@ -103,7 +103,7 @@ export class TransferInfoMapper {
     safeAddress: `0x${string}`;
     transferInfo: Transfer;
     domainTransfer: DomainTransfer;
-  }): Promise<SwapOrderTransactionInfo | null> {
+  }): Promise<SwapTransferTransactionInfo | null> {
     try {
       return await this.swapTransferInfoMapper.mapSwapTransferInfo(args);
     } catch (error) {

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.spec.ts
@@ -11,6 +11,7 @@ import {
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TokenRepository } from '@/domain/tokens/token.repository';
+import { ILoggingService } from '@/logging/logging.interface';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
@@ -44,6 +45,10 @@ const swapTransferInfoMapper = jest.mocked({
   mapSwapTransferInfo: jest.fn(),
 } as jest.MockedObjectDeep<SwapTransferInfoMapper>);
 
+const mockLoggingService = jest.mocked({
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
 describe('Transfer mapper (Unit)', () => {
   let mapper: TransferMapper;
 
@@ -55,6 +60,7 @@ describe('Transfer mapper (Unit)', () => {
       tokenRepository,
       swapTransferInfoMapper,
       addressInfoHelper,
+      mockLoggingService,
     );
     mapper = new TransferMapper(transferInfoMapper);
   });
@@ -111,7 +117,9 @@ describe('Transfer mapper (Unit)', () => {
         const token = tokenBuilder()
           .with('address', getAddress(transfer.tokenAddress))
           .build();
-        swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue(null);
+        swapTransferInfoMapper.mapSwapTransferInfo.mockRejectedValue(
+          'Not settlement',
+        );
         addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
         tokenRepository.getToken.mockResolvedValue(token);
 
@@ -153,7 +161,9 @@ describe('Transfer mapper (Unit)', () => {
             .with('address', getAddress(transfer.tokenAddress))
             .with('trusted', true)
             .build();
-          swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue(null);
+          swapTransferInfoMapper.mapSwapTransferInfo.mockRejectedValue(
+            'Not settlement',
+          );
           addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
           tokenRepository.getToken.mockResolvedValue(token);
 
@@ -646,7 +656,9 @@ describe('Transfer mapper (Unit)', () => {
       const untrustedErc20TransferWithoutValue = erc20TransferBuilder()
         .with('value', '0')
         .build();
-      swapTransferInfoMapper.mapSwapTransferInfo.mockResolvedValue(null);
+      swapTransferInfoMapper.mapSwapTransferInfo.mockRejectedValue(
+        'Not settlement',
+      );
       addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
       tokenRepository.getToken
         .mockResolvedValueOnce(erc721Token)


### PR DESCRIPTION
## Summary

Expanding upon https://github.com/safe-global/safe-client-gateway/pull/1732#discussion_r1666642902, when mapping a swap transfer, any failed requests to CoW will cause an error and break the mapping of "normal" transfers.

This wraps the call to the specified mapper, logging every error accordingly and meaning that the "normal" mapping of transfers will be used as a fallback.

## Changes
- _Always_ return a mapped transaction from `SwapTransferInfoMapper['mapSwapTransferInfo']`
- Add error handling wrapper that calls the above in to `TransferInfoMapper['mapSwapTransfer']`
- Update tests accordingly