### PR TITLE
Refactor test dbFactory to avoid race conditions

### DIFF
--- a/migrations/__tests__/00001_accounts.spec.ts
+++ b/migrations/__tests__/00001_accounts.spec.ts
@@ -22,8 +22,7 @@ describe('Migration 00001_accounts', () => {
   });
 
   afterAll(async () => {
-    await testDbFactory.dropTestDatabase(sql);
-    await testDbFactory.close();
+    await testDbFactory.destroyTestDatabase(sql);
   });
 
   it('runs successfully', async () => {

--- a/migrations/__tests__/00001_accounts.spec.ts
+++ b/migrations/__tests__/00001_accounts.spec.ts
@@ -1,6 +1,7 @@
-import { dbFactory } from '@/__tests__/db.factory';
+import { TestDbFactory } from '@/__tests__/db.factory';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
-import { Sql } from 'postgres';
+import { faker } from '@faker-js/faker';
+import postgres, { Sql } from 'postgres';
 
 interface AccountRow {
   id: number;
@@ -11,11 +12,18 @@ interface AccountRow {
 }
 
 describe('Migration 00001_accounts', () => {
-  const sql = dbFactory();
-  const migrator = new PostgresDatabaseMigrator(sql);
+  let sql: postgres.Sql;
+  let migrator: PostgresDatabaseMigrator;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
+  });
 
   afterAll(async () => {
-    await sql.end();
+    await testDbFactory.dropTestDatabase(sql);
+    await testDbFactory.close();
   });
 
   it('runs successfully', async () => {

--- a/migrations/__tests__/00002_account-data-types.spec.ts
+++ b/migrations/__tests__/00002_account-data-types.spec.ts
@@ -1,6 +1,7 @@
-import { dbFactory } from '@/__tests__/db.factory';
+import { TestDbFactory } from '@/__tests__/db.factory';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
-import { Sql } from 'postgres';
+import { faker } from '@faker-js/faker';
+import postgres, { Sql } from 'postgres';
 
 interface AccountDataTypeRow {
   id: number;
@@ -12,11 +13,18 @@ interface AccountDataTypeRow {
 }
 
 describe('Migration 00002_account-data-types', () => {
-  const sql = dbFactory();
-  const migrator = new PostgresDatabaseMigrator(sql);
+  let sql: postgres.Sql;
+  let migrator: PostgresDatabaseMigrator;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
+  });
 
   afterAll(async () => {
-    await sql.end();
+    await testDbFactory.dropTestDatabase(sql);
+    await testDbFactory.close();
   });
 
   it('runs successfully', async () => {

--- a/migrations/__tests__/00002_account-data-types.spec.ts
+++ b/migrations/__tests__/00002_account-data-types.spec.ts
@@ -23,8 +23,7 @@ describe('Migration 00002_account-data-types', () => {
   });
 
   afterAll(async () => {
-    await testDbFactory.dropTestDatabase(sql);
-    await testDbFactory.close();
+    await testDbFactory.destroyTestDatabase(sql);
   });
 
   it('runs successfully', async () => {

--- a/migrations/__tests__/_all.spec.ts
+++ b/migrations/__tests__/_all.spec.ts
@@ -14,8 +14,7 @@ describe('Migrations', () => {
   });
 
   afterAll(async () => {
-    await testDbFactory.dropTestDatabase(sql);
-    await testDbFactory.close();
+    await testDbFactory.destroyTestDatabase(sql);
   });
 
   it('run successfully', async () => {

--- a/migrations/__tests__/_all.spec.ts
+++ b/migrations/__tests__/_all.spec.ts
@@ -1,9 +1,22 @@
-import { dbFactory } from '@/__tests__/db.factory';
+import { TestDbFactory } from '@/__tests__/db.factory';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { faker } from '@faker-js/faker';
+import postgres from 'postgres';
 
 describe('Migrations', () => {
-  const sql = dbFactory();
-  const migrator = new PostgresDatabaseMigrator(sql);
+  let sql: postgres.Sql;
+  let migrator: PostgresDatabaseMigrator;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
+  });
+
+  afterAll(async () => {
+    await testDbFactory.dropTestDatabase(sql);
+    await testDbFactory.close();
+  });
 
   it('run successfully', async () => {
     await expect(migrator.migrate()).resolves.not.toThrow();

--- a/src/__tests__/db.factory.ts
+++ b/src/__tests__/db.factory.ts
@@ -3,28 +3,57 @@ import fs from 'node:fs';
 import path from 'node:path';
 import configuration from '@/config/entities/__tests__/configuration';
 
-export function dbFactory(): postgres.Sql {
-  const config = configuration();
-  const isCIContext = process.env.CI?.toLowerCase() === 'true';
+export class TestDbFactory {
+  private readonly config = configuration();
+  private readonly isCIContext = process.env.CI?.toLowerCase() === 'true';
+  private readonly mainConnection: postgres.Sql;
+  private static readonly TEST_CERTIFICATE_PATH = path.join(
+    process.cwd(),
+    'db_config/test/server.crt',
+  );
 
-  return postgres({
-    host: config.db.postgres.host,
-    port: parseInt(config.db.postgres.port),
-    db: config.db.postgres.database,
-    user: config.db.postgres.username,
-    password: config.db.postgres.password,
-    // If running on a CI context (e.g.: GitHub Actions),
-    // disable certificate pinning for the test execution
-    ssl:
-      isCIContext || !config.db.postgres.ssl.enabled
-        ? false
-        : {
-            requestCert: config.db.postgres.ssl.requestCert,
-            rejectUnauthorized: config.db.postgres.ssl.rejectUnauthorized,
-            ca: fs.readFileSync(
-              path.join(process.cwd(), 'db_config/test/server.crt'),
-              'utf8',
-            ),
-          },
-  });
+  constructor() {
+    this.mainConnection = this.connect(this.config.db.postgres.database);
+  }
+
+  async createTestDatabase(dbName: string): Promise<postgres.Sql> {
+    await this.mainConnection`create database ${this.mainConnection(dbName)}`;
+    return this.connect(dbName);
+  }
+
+  async dropTestDatabase(database: postgres.Sql): Promise<void> {
+    await database.end();
+    await this
+      .mainConnection`drop database ${this.mainConnection(database.options.database)} with (force)`;
+  }
+
+  async close(): Promise<void> {
+    await this.mainConnection.end();
+  }
+
+  /**
+   * Connect to the database pointed by the `dbName` parameter.
+   *
+   * If running on a CI context (e.g.: GitHub Actions),
+   * certificate pinning is disabled for the test execution.
+   *
+   * @param dbName - database name
+   * @returns {@link postgres.Sql} pointing to the database
+   */
+  private connect(dbName: string): postgres.Sql {
+    const { host, port, username, password, ssl } = this.config.db.postgres;
+    const sslEnabled = !this.isCIContext && ssl.enabled;
+    return postgres({
+      host,
+      port: parseInt(port),
+      db: dbName,
+      user: username,
+      password,
+      ssl: sslEnabled && {
+        requestCert: ssl.requestCert,
+        rejectUnauthorized: ssl.rejectUnauthorized,
+        ca: fs.readFileSync(TestDbFactory.TEST_CERTIFICATE_PATH, 'utf8'),
+      },
+    });
+  }
 }

--- a/src/__tests__/db.factory.ts
+++ b/src/__tests__/db.factory.ts
@@ -46,11 +46,13 @@ export class TestDbFactory {
       db: dbName,
       user: username,
       password,
-      ssl: sslEnabled ? {
-        requestCert: ssl.requestCert,
-        rejectUnauthorized: ssl.rejectUnauthorized,
-        ca: fs.readFileSync(TestDbFactory.TEST_CERTIFICATE_PATH, 'utf8'),
-      } : false,
+      ssl: sslEnabled
+        ? {
+            requestCert: ssl.requestCert,
+            rejectUnauthorized: ssl.rejectUnauthorized,
+            ca: fs.readFileSync(TestDbFactory.TEST_CERTIFICATE_PATH, 'utf8'),
+          }
+        : false,
     });
   }
 }

--- a/src/__tests__/db.factory.ts
+++ b/src/__tests__/db.factory.ts
@@ -4,13 +4,13 @@ import path from 'node:path';
 import configuration from '@/config/entities/__tests__/configuration';
 
 export class TestDbFactory {
-  private readonly config = configuration();
-  private readonly isCIContext = process.env.CI?.toLowerCase() === 'true';
-  private readonly mainConnection: postgres.Sql;
   private static readonly TEST_CERTIFICATE_PATH = path.join(
     process.cwd(),
     'db_config/test/server.crt',
   );
+  private readonly config = configuration();
+  private readonly isCIContext = process.env.CI?.toLowerCase() === 'true';
+  private readonly mainConnection: postgres.Sql;
 
   constructor() {
     this.mainConnection = this.connect(this.config.db.postgres.database);
@@ -21,13 +21,10 @@ export class TestDbFactory {
     return this.connect(dbName);
   }
 
-  async dropTestDatabase(database: postgres.Sql): Promise<void> {
+  async destroyTestDatabase(database: postgres.Sql): Promise<void> {
     await database.end();
     await this
       .mainConnection`drop database ${this.mainConnection(database.options.database)} with (force)`;
-  }
-
-  async close(): Promise<void> {
     await this.mainConnection.end();
   }
 

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -1,12 +1,10 @@
-import { dbFactory } from '@/__tests__/db.factory';
+import { TestDbFactory } from '@/__tests__/db.factory';
 import { AccountsDatasource } from '@/datasources/accounts/accounts.datasource';
+import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
 import { ILoggingService } from '@/logging/logging.interface';
 import { faker } from '@faker-js/faker';
-import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import postgres from 'postgres';
 import { getAddress } from 'viem';
-
-const sql = dbFactory();
-const migrator = new PostgresDatabaseMigrator(sql);
 
 const mockLoggingService = {
   debug: jest.fn(),
@@ -16,13 +14,14 @@ const mockLoggingService = {
 
 describe('AccountsDatasource tests', () => {
   let target: AccountsDatasource;
+  let migrator: PostgresDatabaseMigrator;
+  let sql: postgres.Sql;
+  const testDbFactory = new TestDbFactory();
 
-  // Run pending migrations before tests
   beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
     await migrator.migrate();
-  });
-
-  beforeEach(() => {
     target = new AccountsDatasource(sql, mockLoggingService);
   });
 
@@ -31,7 +30,8 @@ describe('AccountsDatasource tests', () => {
   });
 
   afterAll(async () => {
-    await sql.end();
+    await testDbFactory.dropTestDatabase(sql);
+    await testDbFactory.close();
   });
 
   describe('createAccount', () => {

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -30,8 +30,7 @@ describe('AccountsDatasource tests', () => {
   });
 
   afterAll(async () => {
-    await testDbFactory.dropTestDatabase(sql);
-    await testDbFactory.close();
+    await testDbFactory.destroyTestDatabase(sql);
   });
 
   describe('createAccount', () => {

--- a/src/datasources/db/postgres-database.migrator.spec.ts
+++ b/src/datasources/db/postgres-database.migrator.spec.ts
@@ -1,8 +1,9 @@
-import { dbFactory } from '@/__tests__/db.factory';
-import postgres from 'postgres';
-import path from 'node:path';
-import fs from 'node:fs';
+import { TestDbFactory } from '@/__tests__/db.factory';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { faker } from '@faker-js/faker';
+import fs from 'node:fs';
+import path from 'node:path';
+import postgres from 'postgres';
 
 const folder = path.join(__dirname, 'migrations');
 const migrations: Array<{
@@ -51,19 +52,19 @@ type ExtendedTestRow = { a: string; b: number; c: Date };
 describe('PostgresDatabaseMigrator tests', () => {
   let sql: postgres.Sql;
   let target: PostgresDatabaseMigrator;
+  const testDbFactory = new TestDbFactory();
 
-  beforeEach(() => {
-    sql = dbFactory();
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
     target = new PostgresDatabaseMigrator(sql);
   });
 
-  afterEach(async () => {
-    // Drop example table after each test
-    await sql`drop table if exists test`;
+  afterAll(async () => {
+    await testDbFactory.dropTestDatabase(sql);
+    await testDbFactory.close();
+  });
 
-    // Close connection after each test
-    await sql.end();
-
+  afterEach(() => {
     // Remove migrations folder after each test
     fs.rmSync(folder, { recursive: true, force: true });
   });

--- a/src/datasources/db/postgres-database.migrator.spec.ts
+++ b/src/datasources/db/postgres-database.migrator.spec.ts
@@ -60,8 +60,7 @@ describe('PostgresDatabaseMigrator tests', () => {
   });
 
   afterAll(async () => {
-    await testDbFactory.dropTestDatabase(sql);
-    await testDbFactory.close();
+    await testDbFactory.destroyTestDatabase(sql);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
This PR provisions a transient database namespace for each persistence-related test suite.

## Changes
- Changes the `dbFactory` for `TestDbFactory`, which spins off a main test database, and exposes functions to create and drop transient databases.
- Calls the create/drop test database `TestDbFactory` functions on the `beforeAll/afterAll` hooks of the existent persistence-related test classes.