### PR TITLE
Implement GET /v1/accounts/:address/data-settings

### DIFF
--- a/src/datasources/accounts/__tests__/test.accounts.datasource.module.ts
+++ b/src/datasources/accounts/__tests__/test.accounts.datasource.module.ts
@@ -6,6 +6,7 @@ const accountsDatasource = {
   deleteAccount: jest.fn(),
   getAccount: jest.fn(),
   getDataTypes: jest.fn(),
+  getAccountDataSettings: jest.fn(),
   upsertAccountDataSettings: jest.fn(),
 } as jest.MockedObjectDeep<IAccountsDatasource>;
 

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -73,7 +73,9 @@ export class AccountsDatasource implements IAccountsDatasource {
   ): Promise<AccountDataSetting[]> {
     const account = await this.getAccount(address);
     return this.sql<[AccountDataSetting]>`
-      SELECT * FROM account_data_settings WHERE account_id = ${account.id}
+      SELECT ads.* FROM account_data_settings ads INNER JOIN account_data_types adt
+        ON ads.account_data_type_id = adt.id
+      WHERE ads.account_id = ${account.id} AND adt.is_active IS TRUE;
     `;
   }
 
@@ -117,7 +119,7 @@ export class AccountsDatasource implements IAccountsDatasource {
   private getActiveDataTypes(): Promise<AccountDataType[]> {
     // TODO: add caching with clearing mechanism.
     return this.sql<[AccountDataType]>`
-      SELECT * FROM account_data_types WHERE is_active = true
+      SELECT * FROM account_data_types WHERE is_active IS TRUE;
     `;
   }
 

--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -27,6 +27,11 @@ export interface IAccountsRepository {
 
   getDataTypes(): Promise<AccountDataType[]>;
 
+  getAccountDataSettings(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<AccountDataSetting[]>;
+
   upsertAccountDataSettings(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -54,6 +54,17 @@ export class AccountsRepository implements IAccountsRepository {
     return this.datasource.getDataTypes();
   }
 
+  async getAccountDataSettings(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<AccountDataSetting[]> {
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+
+    return this.datasource.getAccountDataSettings(args.address);
+  }
+
   async upsertAccountDataSettings(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;

--- a/src/domain/interfaces/accounts.datasource.interface.ts
+++ b/src/domain/interfaces/accounts.datasource.interface.ts
@@ -14,6 +14,8 @@ export interface IAccountsDatasource {
 
   getDataTypes(): Promise<AccountDataType[]>;
 
+  getAccountDataSettings(address: `0x${string}`): Promise<AccountDataSetting[]>;
+
   upsertAccountDataSettings(
     address: `0x${string}`,
     upsertAccountDataSettings: UpsertAccountDataSettingsDto,

--- a/src/routes/accounts/accounts.controller.ts
+++ b/src/routes/accounts/accounts.controller.ts
@@ -52,6 +52,19 @@ export class AccountsController {
   }
 
   @ApiOkResponse({ type: AccountDataSetting, isArray: true })
+  @Get(':address/data-settings')
+  @UseGuards(AuthGuard)
+  async getAccountDataSettings(
+    @Auth() authPayload: AuthPayload,
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
+  ): Promise<AccountDataSetting[]> {
+    return this.accountsService.getAccountDataSettings({
+      authPayload,
+      address,
+    });
+  }
+
+  @ApiOkResponse({ type: AccountDataSetting, isArray: true })
   @Put(':address/data-settings')
   @UseGuards(AuthGuard)
   async upsertAccountDataSettings(

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -56,6 +56,23 @@ export class AccountsService {
     );
   }
 
+  async getAccountDataSettings(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<AccountDataSetting[]> {
+    const [domainAccountDataSettings, dataTypes] = await Promise.all([
+      this.accountsRepository.getAccountDataSettings({
+        authPayload: args.authPayload,
+        address: args.address,
+      }),
+      this.accountsRepository.getDataTypes(),
+    ]);
+
+    return domainAccountDataSettings.map((domainAccountDataSetting) =>
+      this.mapDataSetting(dataTypes, domainAccountDataSetting),
+    );
+  }
+
   async upsertAccountDataSettings(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;


### PR DESCRIPTION
## Summary
This PR adds the endpoint:
```
GET /v1/accounts/:address/data-settings
```

- The endpoint is authenticated using SIWE, so an `accessToken` associated with the address included in the URL needs to be provided. Otherwise, a `403` status will be returned.

## Changes
- The endpoint `GET /v1/accounts/:address/data-settings` was added to `AccountsController`, protected by `AuthGuard`.
- Associated tests and domain classes were added.
