### PR TITLE
Rename AccountDataType.dataTypeId to AccountDataType.id

### DIFF
--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -560,7 +560,7 @@ describe('AccountsController', () => {
       ];
       accountDataSource.getDataTypes.mockResolvedValue(dataTypes);
       const expected = dataTypes.map((dataType) => ({
-        dataTypeId: dataType.id.toString(),
+        id: dataType.id.toString(),
         name: dataType.name,
         description: dataType.description,
         isActive: dataType.is_active,

--- a/src/routes/accounts/entities/account-data-type.entity.ts
+++ b/src/routes/accounts/entities/account-data-type.entity.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class AccountDataType {
   @ApiProperty()
-  dataTypeId: string;
+  id: string;
   @ApiProperty()
   name: string;
   @ApiPropertyOptional({ type: String, nullable: true })
@@ -11,12 +11,12 @@ export class AccountDataType {
   isActive: boolean;
 
   constructor(
-    dataTypeId: string,
+    id: string,
     name: string,
     description: string | null,
     isActive: boolean,
   ) {
-    this.dataTypeId = dataTypeId; // TODO: rename as 'id'
+    this.id = id;
     this.name = name;
     this.description = description;
     this.isActive = isActive;


### PR DESCRIPTION
## Summary
Aiming to be consistent with the decisions taken in this discussion https://github.com/safe-global/safe-client-gateway/pull/1715#discussion_r1668372234, this PR changes `dataTypeId` to `id` in the route layer entity `AccountDataType`.

## Changes
- Rename `AccountDataType.dataTypeId` to `AccountDataType.id`.
