### PR TITLE
Add `Chain[contractAddresses]` property

### DIFF
--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -10,6 +10,7 @@ import { themeBuilder } from '@/domain/chains/entities/__tests__/theme.builder';
 import { Chain } from '@/domain/chains/entities/chain.entity';
 import { pricesProviderBuilder } from '@/domain/chains/entities/__tests__/prices-provider.builder';
 import { balancesProviderBuilder } from '@/domain/chains/entities/__tests__/balances-provider.builder';
+import { contractAddressesBuilder } from '@/domain/chains/entities/__tests__/contract-addresses.builder';
 
 export function chainBuilder(): IBuilder<Chain> {
   return new Builder<Chain>()
@@ -27,6 +28,7 @@ export function chainBuilder(): IBuilder<Chain> {
     .with('nativeCurrency', nativeCurrencyBuilder().build())
     .with('pricesProvider', pricesProviderBuilder().build())
     .with('balancesProvider', balancesProviderBuilder().build())
+    .with('contractAddresses', contractAddressesBuilder().build())
     .with('transactionService', faker.internet.url({ appendSlash: false }))
     .with('vpcTransactionService', faker.internet.url({ appendSlash: false }))
     .with('theme', themeBuilder().build())

--- a/src/domain/chains/entities/__tests__/contract-addresses.builder.ts
+++ b/src/domain/chains/entities/__tests__/contract-addresses.builder.ts
@@ -21,5 +21,9 @@ export function contractAddressesBuilder(): IBuilder<ContractAddresses> {
     .with(
       'simulateTxAccessorAddress',
       getAddress(faker.finance.ethereumAddress()),
+    )
+    .with(
+      'safeWebAuthnSignerFactoryAddress',
+      getAddress(faker.finance.ethereumAddress()),
     );
 }

--- a/src/domain/chains/entities/__tests__/contract-addresses.builder.ts
+++ b/src/domain/chains/entities/__tests__/contract-addresses.builder.ts
@@ -1,0 +1,25 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { ContractAddresses } from '@/domain/chains/entities/contract-addresses.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+export function contractAddressesBuilder(): IBuilder<ContractAddresses> {
+  return new Builder<ContractAddresses>()
+    .with('safeSingletonAddress', getAddress(faker.finance.ethereumAddress()))
+    .with(
+      'safeProxyFactoryAddress',
+      getAddress(faker.finance.ethereumAddress()),
+    )
+    .with('multiSendAddress', getAddress(faker.finance.ethereumAddress()))
+    .with(
+      'multiSendCallOnlyAddress',
+      getAddress(faker.finance.ethereumAddress()),
+    )
+    .with('fallbackHandlerAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('signMessageLibAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('createCallAddress', getAddress(faker.finance.ethereumAddress()))
+    .with(
+      'simulateTxAccessorAddress',
+      getAddress(faker.finance.ethereumAddress()),
+    );
+}

--- a/src/domain/chains/entities/contract-addresses.entity.ts
+++ b/src/domain/chains/entities/contract-addresses.entity.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { ContractAddressesSchema } from '@/domain/chains/entities/schemas/chain.schema';
+
+// Responsible for populating the `ContractNetworksConfig` of the `protocol-kit`
+// @see https://docs.safe.global/sdk/protocol-kit/reference/safe#init
+export type ContractAddresses = z.infer<typeof ContractAddressesSchema>;

--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -457,6 +457,7 @@ describe('Chain schemas', () => {
       'signMessageLibAddress' as const,
       'createCallAddress' as const,
       'simulateTxAccessorAddress' as const,
+      'safeWebAuthnSignerFactoryAddress' as const,
     ].forEach((field) => {
       it(`should checksum the ${field}`, () => {
         const contractAddresses = contractAddressesBuilder()

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -64,6 +64,17 @@ export const BalancesProviderSchema = z.object({
   enabled: z.boolean(),
 });
 
+export const ContractAddressesSchema = z.object({
+  safeSingletonAddress: AddressSchema.nullish().default(null),
+  safeProxyFactoryAddress: AddressSchema.nullish().default(null),
+  multiSendAddress: AddressSchema.nullish().default(null),
+  multiSendCallOnlyAddress: AddressSchema.nullish().default(null),
+  fallbackHandlerAddress: AddressSchema.nullish().default(null),
+  signMessageLibAddress: AddressSchema.nullish().default(null),
+  createCallAddress: AddressSchema.nullish().default(null),
+  simulateTxAccessorAddress: AddressSchema.nullish().default(null),
+});
+
 export const ChainSchema = z.object({
   chainId: z.string(),
   chainName: z.string(),
@@ -76,6 +87,7 @@ export const ChainSchema = z.object({
   safeAppsRpcUri: RpcUriSchema,
   publicRpcUri: RpcUriSchema,
   blockExplorerUriTemplate: BlockExplorerUriTemplateSchema,
+  contractAddresses: ContractAddressesSchema,
   nativeCurrency: NativeCurrencySchema,
   pricesProvider: PricesProviderSchema,
   balancesProvider: BalancesProviderSchema,

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -73,6 +73,7 @@ export const ContractAddressesSchema = z.object({
   signMessageLibAddress: AddressSchema.nullish().default(null),
   createCallAddress: AddressSchema.nullish().default(null),
   simulateTxAccessorAddress: AddressSchema.nullish().default(null),
+  safeWebAuthnSignerFactoryAddress: AddressSchema.nullish().default(null),
 });
 
 export const ChainSchema = z.object({


### PR DESCRIPTION
⚠️ Depends on https://github.com/safe-global/safe-config-service/pull/1175 from the Config Service.

## Summary

When deploying the Safe infrastructure, it is currently necessary for a desired network to be present in our `safe-deployments` repo. as that is the source of truth for contract addresses.

In order to remove this hurdle, new (optional) fields for contract addresses to populate the [`ContractNetworksConfig` of the `protocol-kit`](https://docs.safe.global/sdk/protocol-kit/reference/safe#init) for a given chain are [to be added to the Config Service](https://github.com/safe-global/safe-config-service/pull/1175). This propagates the fields and validates them accordingly.

## Changes

- Add new `ContractAddressesSchema`, include it in `ChainSchema` and infer a new `ContractAddresses` entity from it
- Add new `contractAddressesBuilder` and include it in `chainBuilder`
- Add appropriate test coverage