### PR TITLE
Add FF_RUN_MIGRATIONS 

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -107,6 +107,7 @@ export default (): ReturnType<typeof configuration> => ({
   },
   express: { jsonLimit: '1mb' },
   features: {
+    runMigrations: true,
     richFragments: true,
     email: false,
     zerionBalancesChainIds: ['137'],

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -160,6 +160,7 @@ export default () => ({
     jsonLimit: process.env.EXPRESS_JSON_LIMIT ?? '1mb',
   },
   features: {
+    runMigrations: process.env.FF_RUN_MIGRATIONS?.toLowerCase() === 'true',
     richFragments: process.env.FF_RICH_FRAGMENTS?.toLowerCase() === 'true',
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
     zerionBalancesChainIds:

--- a/src/datasources/db/postgres-database.migration.hook.spec.ts
+++ b/src/datasources/db/postgres-database.migration.hook.spec.ts
@@ -1,0 +1,76 @@
+import { TestDbFactory } from '@/__tests__/db.factory';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { PostgresDatabaseMigrationHook } from '@/datasources/db/postgres-database.migration.hook';
+import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker';
+import postgres from 'postgres';
+
+const migrator = jest.mocked({
+  migrate: jest.fn(),
+} as jest.MockedObjectDeep<PostgresDatabaseMigrator>);
+
+const loggingService = jest.mocked({
+  error: jest.fn(),
+  info: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
+const configurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+describe('PostgresDatabaseMigrationHook tests', () => {
+  let sql: postgres.Sql;
+  let target: PostgresDatabaseMigrationHook;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+  });
+
+  afterAll(async () => {
+    await testDbFactory.destroyTestDatabase(sql);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not run migrations', async () => {
+    configurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'features.runMigrations') return false;
+    });
+    target = new PostgresDatabaseMigrationHook(
+      sql,
+      migrator,
+      loggingService,
+      configurationService,
+    );
+
+    await target.onModuleInit();
+
+    expect(loggingService.info).toHaveBeenCalledWith(
+      'Database migrations are disabled',
+    );
+  });
+
+  it('should run migrations', async () => {
+    configurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'features.runMigrations') return true;
+    });
+    target = new PostgresDatabaseMigrationHook(
+      sql,
+      migrator,
+      loggingService,
+      configurationService,
+    );
+
+    await target.onModuleInit();
+
+    expect(loggingService.info).toHaveBeenCalledTimes(2);
+    expect(loggingService.info).toHaveBeenCalledWith('Checking migrations');
+    expect(loggingService.info).toHaveBeenCalledWith(
+      'Pending migrations executed',
+    );
+  });
+});

--- a/src/datasources/db/postgres-database.migration.hook.ts
+++ b/src/datasources/db/postgres-database.migration.hook.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import postgres from 'postgres';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 
 /**
  * The {@link PostgresDatabaseMigrationHook} is a Module Init hook meaning
@@ -13,15 +14,26 @@ import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.mig
 @Injectable({})
 export class PostgresDatabaseMigrationHook implements OnModuleInit {
   private static LOCK_MAGIC_NUMBER = 132;
+  private readonly runMigrations: boolean;
 
   constructor(
     @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
     @Inject(PostgresDatabaseMigrator)
     private readonly migrator: PostgresDatabaseMigrator,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
-  ) {}
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.runMigrations = this.configurationService.getOrThrow<boolean>(
+      'features.runMigrations',
+    );
+  }
 
   async onModuleInit(): Promise<void> {
+    if (!this.runMigrations) {
+      return this.loggingService.info('Database migrations are disabled');
+    }
+
     this.loggingService.info('Checking migrations');
     try {
       // Acquire lock to perform a migration.


### PR DESCRIPTION
## Summary
This PR adds a feature flag to (de-)activate the database migrations execution at the service startup.

## Changes
- Adds `FF_RUN_MIGRATIONS` to control the execution of database migrations at the application bootstrap.
- Adds a test suite for `PostgresDatabaseMigrationHook`.
