### PR TITLE
Set MAX_TTL as TTL when caching SAFE_EXISTS_KEY

### DIFF
--- a/src/datasources/cache/constants.ts
+++ b/src/datasources/cache/constants.ts
@@ -8,3 +8,12 @@
  * that a cache instance might be shared between the tests.
  */
 export const CacheKeyPrefix = Symbol('CacheKeyPrefix');
+
+/**
+ * This number is used to set the maximum TTL for a key in Redis.
+ * A safe JS value is used to prevent overflow errors. This value in milliseconds equals to 285420 years.
+ *
+ * Note: The maximum value allowed by Redis is higher: LLONG_MAX (C's long long int, 2**63-1) minus the unix epoch in milliseconds.
+ * Ref: https://github.com/redis/redis/blob/cc244370a2d622d5d2fec5573ae87de6c59ed3b9/src/expire.c#L573
+ */
+export const MAX_TTL = Number.MAX_SAFE_INTEGER - 1;

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -59,7 +59,7 @@ describe('TransactionApi', () => {
   const baseUrl = faker.internet.url({ appendSlash: false });
   let httpErrorFactory: HttpErrorFactory;
   let service: TransactionApi;
-  const indefiniteExpirationTime = -1;
+  const maxTtl = 2147483647;
   let defaultExpirationTimeInSeconds: number;
   let notFoundExpireTimeSeconds: number;
   let ownersTtlSeconds: number;
@@ -353,11 +353,7 @@ describe('TransactionApi', () => {
         url: `${baseUrl}/api/v1/safes/${safe.address}`,
       });
       expect(cacheService.set).toHaveBeenCalledTimes(1);
-      expect(cacheService.set).toHaveBeenCalledWith(
-        cacheDir,
-        'true',
-        indefiniteExpirationTime,
-      );
+      expect(cacheService.set).toHaveBeenCalledWith(cacheDir, 'true', maxTtl);
     });
 
     it('should return the cached value', async () => {

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -59,7 +59,6 @@ describe('TransactionApi', () => {
   const baseUrl = faker.internet.url({ appendSlash: false });
   let httpErrorFactory: HttpErrorFactory;
   let service: TransactionApi;
-  const maxTtl = 2147483647;
   let defaultExpirationTimeInSeconds: number;
   let notFoundExpireTimeSeconds: number;
   let ownersTtlSeconds: number;
@@ -353,7 +352,11 @@ describe('TransactionApi', () => {
         url: `${baseUrl}/api/v1/safes/${safe.address}`,
       });
       expect(cacheService.set).toHaveBeenCalledTimes(1);
-      expect(cacheService.set).toHaveBeenCalledWith(cacheDir, 'true', maxTtl);
+      expect(cacheService.set).toHaveBeenCalledWith(
+        cacheDir,
+        'true',
+        Number.MAX_SAFE_INTEGER - 1,
+      );
     });
 
     it('should return the cached value', async () => {

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -31,7 +31,7 @@ import { get } from 'lodash';
 
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
-  private static readonly INDEFINITE_EXPIRATION_TIME = -1;
+  private static readonly MAX_TTL = 2147483647;
 
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
@@ -199,7 +199,7 @@ export class TransactionApi implements ITransactionApi {
       JSON.stringify(isSafe),
       isSafe
         ? // We can indefinitely cache this as an address cannot "un-Safe" itself
-          TransactionApi.INDEFINITE_EXPIRATION_TIME
+          TransactionApi.MAX_TTL
         : this.defaultExpirationTimeInSeconds,
     );
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -2,6 +2,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
+import { MAX_TTL } from '@/datasources/cache/constants';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { INetworkService } from '@/datasources/network/network.service.interface';
@@ -31,7 +32,6 @@ import { get } from 'lodash';
 
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
-  private static readonly MAX_TTL = 2147483647;
 
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
@@ -197,10 +197,8 @@ export class TransactionApi implements ITransactionApi {
     await this.cacheService.set(
       cacheDir,
       JSON.stringify(isSafe),
-      isSafe
-        ? // We can indefinitely cache this as an address cannot "un-Safe" itself
-          TransactionApi.MAX_TTL
-        : this.defaultExpirationTimeInSeconds,
+      // We can indefinitely cache this as an address cannot "un-Safe" itself
+      isSafe ? MAX_TTL : this.defaultExpirationTimeInSeconds,
     );
 
     return isSafe;


### PR DESCRIPTION
## Summary
This PR fixes the TTL value when storing the `SAFE_EXISTS_KEY`. It was previously set to `-1`, but `RedisCacheService` explicitly avoids storing values when the TTL is less than zero. (See [this reference](https://github.com/safe-global/safe-client-gateway/blob/5a66c242d50fc32868b0bfb5c8a4467163053801/src/datasources/cache/redis.cache.service.ts#L39)) 

## Changes
- Changes `INDEFINITE_EXPIRATION_TIME` for `MAX_TTL`, with a value of `2^31 - 1` (maximum value allowed by Redis, maximum positive value of a 32-bit signed integer)