### PR TITLE
Santioned addresses indexer

### DIFF
--- a/src/domain/blockchain/__tests__/log.builder.ts
+++ b/src/domain/blockchain/__tests__/log.builder.ts
@@ -1,0 +1,16 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { faker } from '@faker-js/faker';
+import { getAddress, Log } from 'viem';
+
+export function logBuilder(): IBuilder<Log> {
+  return new Builder<Log>()
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('blockHash', faker.string.hexadecimal() as `0x${string}`)
+    .with('blockNumber', faker.number.bigInt())
+    .with('logIndex', faker.number.int())
+    .with('removed', false)
+    .with('transactionHash', faker.string.hexadecimal() as `0x${string}`)
+    .with('transactionIndex', faker.number.int())
+    .with('data', faker.string.hexadecimal() as `0x${string}`)
+    .with('topics', []);
+}

--- a/src/domain/blockchain/__tests__/sanctioned-addresses-encoder.builder.ts
+++ b/src/domain/blockchain/__tests__/sanctioned-addresses-encoder.builder.ts
@@ -1,0 +1,122 @@
+import { Builder } from '@/__tests__/builder';
+import { IEncoder } from '@/__tests__/encoder-builder';
+import { faker } from '@faker-js/faker';
+import {
+  parseAbi,
+  encodeEventTopics,
+  encodeAbiParameters,
+  parseAbiParameters,
+  getAddress,
+} from 'viem';
+
+// SanctionedAddressesAdded
+
+type SanctionedAddressesAddedEventArgs = {
+  addrs: Array<`0x${string}`>;
+};
+
+type SanctionedAddressesAddedEvent = {
+  data: `0x${string}`;
+  topics: [signature: `0x${string}`, ...args: Array<`0x${string}`>];
+};
+
+class SanctionedAddressesAddedEventBuilder<
+    T extends SanctionedAddressesAddedEventArgs,
+  >
+  extends Builder<T>
+  implements IEncoder<SanctionedAddressesAddedEvent>
+{
+  static readonly NON_INDEXED_PARAMS = 'address[] addrs' as const;
+  static readonly EVENT_SIGNATURE =
+    `event SanctionedAddressesAdded(${SanctionedAddressesAddedEventBuilder.NON_INDEXED_PARAMS})` as const;
+
+  encode(): SanctionedAddressesAddedEvent {
+    const abi = parseAbi([
+      SanctionedAddressesAddedEventBuilder.EVENT_SIGNATURE,
+    ]);
+
+    const args = this.build();
+
+    const data = encodeAbiParameters(
+      parseAbiParameters(
+        SanctionedAddressesAddedEventBuilder.NON_INDEXED_PARAMS,
+      ),
+      [args.addrs],
+    );
+
+    const topics = encodeEventTopics({
+      abi,
+      eventName: 'SanctionedAddressesAdded',
+      args: {
+        addrs: args.addrs,
+      },
+    }) as SanctionedAddressesAddedEvent['topics'];
+
+    return {
+      data,
+      topics,
+    };
+  }
+}
+
+export function sanctionedAddressesAddedEventBuilder(): SanctionedAddressesAddedEventBuilder<SanctionedAddressesAddedEventArgs> {
+  return new SanctionedAddressesAddedEventBuilder().with('addrs', [
+    getAddress(faker.finance.ethereumAddress()),
+  ]);
+}
+
+// SanctionedAddressesRemoved
+
+type SanctionedAddressesRemovedEventArgs = {
+  addrs: Array<`0x${string}`>;
+};
+
+type SanctionedAddressesRemovedEvent = {
+  data: `0x${string}`;
+  topics: [signature: `0x${string}`, ...args: Array<`0x${string}`>];
+};
+
+class SanctionedAddressesRemovedEventBuilder<
+    T extends SanctionedAddressesRemovedEventArgs,
+  >
+  extends Builder<T>
+  implements IEncoder<SanctionedAddressesRemovedEvent>
+{
+  static readonly NON_INDEXED_PARAMS = 'address[] addrs' as const;
+  static readonly EVENT_SIGNATURE =
+    `event SanctionedAddressesRemoved(${SanctionedAddressesRemovedEventBuilder.NON_INDEXED_PARAMS})` as const;
+
+  encode(): SanctionedAddressesRemovedEvent {
+    const abi = parseAbi([
+      SanctionedAddressesRemovedEventBuilder.EVENT_SIGNATURE,
+    ]);
+
+    const args = this.build();
+
+    const data = encodeAbiParameters(
+      parseAbiParameters(
+        SanctionedAddressesRemovedEventBuilder.NON_INDEXED_PARAMS,
+      ),
+      [args.addrs],
+    );
+
+    const topics = encodeEventTopics({
+      abi,
+      eventName: 'SanctionedAddressesRemoved',
+      args: {
+        addrs: args.addrs,
+      },
+    }) as SanctionedAddressesRemovedEvent['topics'];
+
+    return {
+      data,
+      topics,
+    };
+  }
+}
+
+export function sanctionedAddressesRemovedEventBuilder(): SanctionedAddressesRemovedEventBuilder<SanctionedAddressesRemovedEventArgs> {
+  return new SanctionedAddressesRemovedEventBuilder().with('addrs', [
+    getAddress(faker.finance.ethereumAddress()),
+  ]);
+}

--- a/src/domain/blockchain/__tests__/transaction-receipt.builder.ts
+++ b/src/domain/blockchain/__tests__/transaction-receipt.builder.ts
@@ -1,0 +1,21 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { faker } from '@faker-js/faker';
+import { getAddress, TransactionReceipt } from 'viem';
+
+export function transactionReceiptBuilder(): IBuilder<TransactionReceipt> {
+  return new Builder<TransactionReceipt>()
+    .with('blockHash', faker.string.hexadecimal() as `0x${string}`)
+    .with('blockNumber', faker.number.bigInt())
+    .with('cumulativeGasUsed', faker.number.bigInt())
+    .with('contractAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('effectiveGasPrice', faker.number.bigInt())
+    .with('from', getAddress(faker.finance.ethereumAddress()))
+    .with('gasUsed', faker.number.bigInt())
+    .with('logs', [])
+    .with('logsBloom', faker.string.hexadecimal() as `0x${string}`)
+    .with('status', 'success')
+    .with('to', getAddress(faker.finance.ethereumAddress()))
+    .with('transactionHash', faker.string.hexadecimal() as `0x${string}`)
+    .with('transactionIndex', faker.number.int())
+    .with('type', faker.string.alpha());
+}

--- a/src/domain/blockchain/sanctioned-addresses.indexer.spec.ts
+++ b/src/domain/blockchain/sanctioned-addresses.indexer.spec.ts
@@ -1,0 +1,147 @@
+import { logBuilder } from '@/domain/blockchain/__tests__/log.builder';
+import {
+  sanctionedAddressesAddedEventBuilder,
+  sanctionedAddressesRemovedEventBuilder,
+} from '@/domain/blockchain/__tests__/sanctioned-addresses-encoder.builder';
+import { transactionReceiptBuilder } from '@/domain/blockchain/__tests__/transaction-receipt.builder';
+import { SanctionedAddressesIndexer } from '@/domain/blockchain/sanctioned-addresses.indexer';
+import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker';
+import { PublicClient } from 'viem';
+
+const mockPublicClient = jest.mocked({
+  getTransactionReceipt: jest.fn(),
+  getBlockNumber: jest.fn(),
+  getContractEvents: jest.fn(),
+} as jest.MockedObjectDeep<PublicClient>);
+
+const mockBlockchainApiManager = jest.mocked({
+  getApi: jest.fn(),
+} as jest.MockedObjectDeep<IBlockchainApiManager>);
+
+const mockLoggingService = jest.mocked({
+  debug: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
+describe('SanctionedAddressesIndexer', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns sanctioned addresses since contract creation', async () => {
+    const receipt = transactionReceiptBuilder().build();
+    const blockNumber = faker.number.bigInt({ min: receipt.blockNumber });
+    const sanctionedAddressesAddedEvent =
+      sanctionedAddressesAddedEventBuilder();
+    const { data, topics } = sanctionedAddressesAddedEvent.encode();
+    const eventLog = {
+      ...logBuilder().with('data', data).with('topics', topics).build(),
+      args: sanctionedAddressesAddedEvent.build(),
+      eventName: 'SanctionedAddressesAdded',
+    };
+    mockPublicClient.getTransactionReceipt.mockResolvedValue(receipt);
+    mockPublicClient.getBlockNumber.mockResolvedValue(blockNumber);
+    mockPublicClient.getContractEvents.mockResolvedValue([eventLog]);
+    mockBlockchainApiManager.getApi.mockResolvedValue(mockPublicClient);
+    const target = new SanctionedAddressesIndexer(
+      mockBlockchainApiManager,
+      mockLoggingService,
+    );
+
+    const result = await target.getSanctionedAddresses('1');
+
+    expect(result).toStrictEqual(sanctionedAddressesAddedEvent.build().addrs);
+  });
+
+  it('does not return duplicate addresses', async () => {
+    const receipt = transactionReceiptBuilder().build();
+    const blockNumber = faker.number.bigInt({ min: receipt.blockNumber });
+    const sanctionedAddressesAddedEvent =
+      sanctionedAddressesAddedEventBuilder();
+    const { data, topics } = sanctionedAddressesAddedEvent.encode();
+    const eventLog = {
+      ...logBuilder().with('data', data).with('topics', topics).build(),
+      args: sanctionedAddressesAddedEvent.build(),
+      eventName: 'SanctionedAddressesAdded',
+    };
+    mockPublicClient.getTransactionReceipt.mockResolvedValue(receipt);
+    mockPublicClient.getBlockNumber.mockResolvedValue(blockNumber);
+    // Multiple events
+    mockPublicClient.getContractEvents.mockResolvedValue([
+      eventLog,
+      eventLog,
+      eventLog,
+    ]);
+    mockBlockchainApiManager.getApi.mockResolvedValue(mockPublicClient);
+    const target = new SanctionedAddressesIndexer(
+      mockBlockchainApiManager,
+      mockLoggingService,
+    );
+
+    const result = await target.getSanctionedAddresses('1');
+
+    expect(result).toStrictEqual(sanctionedAddressesAddedEvent.build().addrs);
+    expect(result.length).toBe(1);
+  });
+
+  it('does not include sanctioned addresses that were later removed', async () => {
+    const receipt = transactionReceiptBuilder().build();
+    const blockNumber = faker.number.bigInt({ min: receipt.blockNumber });
+    const sanctionedAddressesAddedEvent =
+      sanctionedAddressesAddedEventBuilder();
+    const sanctionedAddressAddedEventArgs =
+      sanctionedAddressesAddedEvent.build();
+    const encodedSactionedAddressesAddedEvent =
+      sanctionedAddressesAddedEvent.encode();
+    const addEventLog = {
+      ...logBuilder()
+        .with('data', encodedSactionedAddressesAddedEvent.data)
+        .with('topics', encodedSactionedAddressesAddedEvent.topics)
+        .build(),
+      args: sanctionedAddressAddedEventArgs,
+      eventName: 'SanctionedAddressesAdded',
+    };
+    const sanctionedAddressesRemovedEvent =
+      sanctionedAddressesRemovedEventBuilder().with(
+        'addrs',
+        sanctionedAddressAddedEventArgs.addrs,
+      );
+    const encodedSactionedAddressesRemovedEvent =
+      sanctionedAddressesAddedEvent.encode();
+    const removeEventLog = {
+      ...logBuilder()
+        .with('data', encodedSactionedAddressesRemovedEvent.data)
+        .with('topics', encodedSactionedAddressesRemovedEvent.topics)
+        .build(),
+      args: sanctionedAddressesRemovedEvent.build(),
+      eventName: 'SanctionedAddressesRemoved',
+    };
+
+    mockPublicClient.getTransactionReceipt.mockResolvedValue(receipt);
+    mockPublicClient.getBlockNumber.mockResolvedValue(blockNumber);
+    // Added then removed
+    mockPublicClient.getContractEvents.mockResolvedValue([
+      addEventLog,
+      removeEventLog,
+    ]);
+    mockBlockchainApiManager.getApi.mockResolvedValue(mockPublicClient);
+    const target = new SanctionedAddressesIndexer(
+      mockBlockchainApiManager,
+      mockLoggingService,
+    );
+
+    const result = await target.getSanctionedAddresses('1');
+
+    expect(result).toStrictEqual([]);
+  });
+
+  // TODO: Write tests for the following once implemented
+  it.todo('caches and returns cached sanctioned addresses');
+
+  it.todo('indexes sanctioned addresses since last indexed block');
+
+  it.todo('runs a job to index sanctioned addresses');
+
+  it.todo("does't index sanctioned addresses if already indexed");
+});

--- a/src/domain/blockchain/sanctioned-addresses.indexer.ts
+++ b/src/domain/blockchain/sanctioned-addresses.indexer.ts
@@ -163,15 +163,6 @@ export class SanctionedAddressesIndexer {
           return [];
         });
 
-      const isInsufficientLogs = BigInt(pageEvents.length) < pageSize;
-      const isLastPage = block + pageSize > latestBlock;
-
-      if (isInsufficientLogs && !isLastPage) {
-        throw new Error(
-          `RPC returned insufficient logs (${pageEvents.length}/${pageSize.toString()})! There is likely an \`eth_Logs\` restriction on chain ${chainId}`,
-        );
-      }
-
       events.push(...pageEvents);
     }
 

--- a/src/domain/blockchain/sanctioned-addresses.indexer.ts
+++ b/src/domain/blockchain/sanctioned-addresses.indexer.ts
@@ -84,26 +84,26 @@ export class SanctionedAddressesIndexer {
 
   // TODO: Store addresses with block indexed until (for continuation) - concatenated across all chains?
   async getSanctionedAddresses(chainId: string): Promise<Array<`0x${string}`>> {
-    const events = await this.getAllSanctionEvents(chainId);
+    const events = await this.getAllSanctionedEvents(chainId);
 
     // Parse events, accordingly populating a sanctioned addresses Set
-    const blockedAddresses = events.reduce((acc, event) => {
+    const sanctionedAddresses = events.reduce((acc, event) => {
       for (const address of event.args.addrs) {
         if (event.eventName === 'SanctionedAddressesAdded') {
           acc.add(address);
         } else if (event.eventName === 'SanctionedAddressesRemoved') {
           acc.delete(address);
         } else {
-          throw new Error('Unexpected log when fetching blocked addresses');
+          throw new Error('Unexpected log when fetching sanctioned addresses');
         }
       }
       return acc;
     }, new Set<`0x${string}`>());
 
-    return Array.from(blockedAddresses);
+    return Array.from(sanctionedAddresses);
   }
 
-  private async getAllSanctionEvents(
+  private async getAllSanctionedEvents(
     chainId: string,
   ): Promise<
     GetContractEventsReturnType<

--- a/src/domain/blockchain/sanctioned-addresses.indexer.ts
+++ b/src/domain/blockchain/sanctioned-addresses.indexer.ts
@@ -1,0 +1,180 @@
+import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { Inject, Injectable } from '@nestjs/common';
+import { GetContractEventsReturnType, parseAbi } from 'viem';
+
+@Injectable()
+export class SanctionedAddressesIndexer {
+  // TODO: Include some form of E2E test to ensure pageSize is correctly set and doesn't error
+  private static readonly OracleByChainId: {
+    [chainId: string]: {
+      address: `0x${string}`;
+      creationTxHash: `0x${string}`;
+      pageSize: bigint | null;
+    };
+  } = {
+    // Mainnet
+    '1': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x06b69d22afb6fd1399d2ee15bf51ed53d55212ccf8a2bfd5d427ecc06d5c519f',
+      pageSize: null,
+    },
+    // BSC
+    '56': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x4383f79125e4912a454a2b340e1307a45fbae424e4c434a50c96c1b8ab839f3a',
+      pageSize: BigInt(2_000),
+    },
+    // Polygon
+    '137': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x2402805df99b3ce3a92ae073ef2221b73a711867d1ded529a51f21e91e9a7dae',
+      pageSize: null,
+    },
+    // Base
+    '8453': {
+      address: '0x3A91A31cB3dC49b4db9Ce721F50a9D076c8D739B',
+      creationTxHash:
+        '0x4a7273ae2cbec2c80e7a72640101dbe0c765d39fe06b557a8f29898d9fe6131a',
+      pageSize: null,
+    },
+    // Arbitrum
+    '42161': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x85d27fb186607a904c8e8dd8dcfb54c7217a7e1564cdb438fa7bde982f3ab062',
+      pageSize: null,
+    },
+    // Celo
+    '42220': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x1d1e60302407e6409989e01ca6c5ef5b70dd2e8f78c05c5fa04eebe5c0e36cc1',
+      pageSize: null,
+    },
+    // Avalanche
+    '43114': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x272a3311131feacc7b32138896c05f580cc8b5dfece2256c0848b323c1503f0d',
+      pageSize: null,
+    },
+    // Optimism
+    '11155420': {
+      address: '0x40C57923924B5c5c5455c48D93317139ADDaC8fb',
+      creationTxHash:
+        '0x141d187d2a1cde323896752ebd9d4b843b0c040865c82ec8b1db92fcf134c7eb',
+      pageSize: null,
+    },
+  };
+
+  private static readonly OracleAbi = parseAbi([
+    'event SanctionedAddressesAdded(address[] addrs)',
+    'event SanctionedAddressesRemoved(address[] addrs)',
+  ]);
+
+  constructor(
+    @Inject(IBlockchainApiManager)
+    private readonly blockchainApiManager: IBlockchainApiManager,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  // TODO: Store addresses with block indexed until, for continuation purposes
+  async getSanctionedAddresses(chainId: string): Promise<Array<`0x${string}`>> {
+    const events = await this.getAllSanctionEvents(chainId);
+
+    // Parse events, accordingly populating a sanctioned addresses Set
+    const blockedAddresses = events.reduce((acc, event) => {
+      for (const address of event.args.addrs) {
+        if (event.eventName === 'SanctionedAddressesAdded') {
+          acc.add(address);
+        } else if (event.eventName === 'SanctionedAddressesRemoved') {
+          acc.delete(address);
+        } else {
+          throw new Error('Unexpected log when fetching blocked addresses');
+        }
+      }
+      return acc;
+    }, new Set<`0x${string}`>());
+
+    return Array.from(blockedAddresses);
+  }
+
+  private async getAllSanctionEvents(
+    chainId: string,
+  ): Promise<
+    GetContractEventsReturnType<
+      typeof SanctionedAddressesIndexer.OracleAbi,
+      undefined,
+      true,
+      bigint,
+      bigint
+    >
+  > {
+    const contract = SanctionedAddressesIndexer.OracleByChainId[chainId];
+
+    if (!contract) {
+      this.loggingService.warn(
+        `Sanctioned addresses contract not found for chain ${chainId}`,
+      );
+      return [];
+    }
+
+    const blockchainApi = await this.blockchainApiManager.getApi(chainId);
+    const [creationTx, latestBlock] = await Promise.all([
+      blockchainApi.getTransactionReceipt({
+        hash: contract.creationTxHash,
+      }),
+      blockchainApi.getBlockNumber(),
+    ]);
+
+    // Index by page to avoid log limitations
+    const pageSize = contract.pageSize ?? creationTx.blockNumber;
+
+    const events: GetContractEventsReturnType<
+      typeof SanctionedAddressesIndexer.OracleAbi,
+      undefined,
+      true,
+      bigint,
+      bigint
+    > = [];
+
+    for (
+      let block = creationTx.blockNumber;
+      block < latestBlock;
+      block += pageSize
+    ) {
+      const pageEvents = await blockchainApi
+        .getContractEvents({
+          address: contract.address,
+          abi: SanctionedAddressesIndexer.OracleAbi,
+          fromBlock: block,
+          toBlock: block + pageSize - BigInt(1),
+          strict: true,
+        })
+        // Errors are likely due to RPC restrictions
+        .catch((e) => {
+          this.loggingService.warn(
+            `Error fetching sanctioned addresses events for chain ${chainId} with a page size of ${pageSize}: ${e.message}`,
+          );
+          return [];
+        });
+
+      const isInsufficientLogs = BigInt(pageEvents.length) < pageSize;
+      const isLastPage = block + pageSize > latestBlock;
+
+      if (isInsufficientLogs && !isLastPage) {
+        throw new Error(
+          `RPC returned insufficient logs (${pageEvents.length}/${pageSize.toString()})! There is likely an \`eth_Logs\` restriction on chain ${chainId}`,
+        );
+      }
+
+      events.push(...pageEvents);
+    }
+
+    return events;
+  }
+}

--- a/src/domain/blockchain/sanctioned-addresses.indexer.ts
+++ b/src/domain/blockchain/sanctioned-addresses.indexer.ts
@@ -82,7 +82,7 @@ export class SanctionedAddressesIndexer {
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
-  // TODO: Store addresses with block indexed until, for continuation purposes
+  // TODO: Store addresses with block indexed until (for continuation) - concatenated across all chains?
   async getSanctionedAddresses(chainId: string): Promise<Array<`0x${string}`>> {
     const events = await this.getAllSanctionEvents(chainId);
 


### PR DESCRIPTION
⚠️ This is demonstative, showcasing a basic indexer (with caveats) for https://github.com/safe-global/safe-client-gateway/issues/1750

## Summary

As clients restrict swap features based on address sactioning, a [hardcoded list of addresses](https://github.com/safe-global/safe-wallet-web/blob/84050cc88bf353d06f5b794bf49ffa81e85fed9a/src/services/ofac/blockedAddressList.json) is currently referenced. Whilst this works, it requires manual updating and release.

This lays the foundations for indexing of the [Chainalysis oracle for sanctioned addresses](https://go.chainalysis.com/chainalysis-oracle-docs.html). Indexing has its caveats as chains often restrict `eth_getLogs` calls meaning we would need to index in chucks (or pages). These limits vary by chain and, depending on the limit, could mean indexing takes a long time.

Note: whether we opt for this and cache/store the addresses, or instead rely on an API is to be decided.

## Changes

- Add `SanctionedAddressesIndexer`
- Add appropriate test coverage with respective builders