### PR TITLE
Map `contractAddresses` to `Chain` entity

### DIFF
--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -483,6 +483,47 @@ describe('Chain schemas', () => {
         expect(result.success && result.data[field]).toBe(null);
       });
     });
+
+    // TODO: Remove after deployed and all chain caches include the `contractAddresses` field
+    describe('should default all contract addresses to null if the chain cache does not contain contractAddresses', () => {
+      it('on a ContractAddresses level', () => {
+        const contractAddresses = undefined;
+
+        const result = ContractAddressesSchema.safeParse(contractAddresses);
+
+        expect(result.success && result.data).toStrictEqual({
+          safeSingletonAddress: null,
+          safeProxyFactoryAddress: null,
+          multiSendAddress: null,
+          multiSendCallOnlyAddress: null,
+          fallbackHandlerAddress: null,
+          signMessageLibAddress: null,
+          createCallAddress: null,
+          simulateTxAccessorAddress: null,
+          safeWebAuthnSignerFactoryAddress: null,
+        });
+      });
+
+      it('on a Chain level', () => {
+        const chain = chainBuilder().build();
+        // @ts-expect-error - pre-inclusion of `contractAddresses` field
+        delete chain.contractAddresses;
+
+        const result = ChainSchema.safeParse(chain);
+
+        expect(result.success && result.data.contractAddresses).toStrictEqual({
+          safeSingletonAddress: null,
+          safeProxyFactoryAddress: null,
+          multiSendAddress: null,
+          multiSendCallOnlyAddress: null,
+          fallbackHandlerAddress: null,
+          signMessageLibAddress: null,
+          createCallAddress: null,
+          simulateTxAccessorAddress: null,
+          safeWebAuthnSignerFactoryAddress: null,
+        });
+      });
+    });
   });
 
   describe('ChainSchema', () => {

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -64,17 +64,30 @@ export const BalancesProviderSchema = z.object({
   enabled: z.boolean(),
 });
 
-export const ContractAddressesSchema = z.object({
-  safeSingletonAddress: AddressSchema.nullish().default(null),
-  safeProxyFactoryAddress: AddressSchema.nullish().default(null),
-  multiSendAddress: AddressSchema.nullish().default(null),
-  multiSendCallOnlyAddress: AddressSchema.nullish().default(null),
-  fallbackHandlerAddress: AddressSchema.nullish().default(null),
-  signMessageLibAddress: AddressSchema.nullish().default(null),
-  createCallAddress: AddressSchema.nullish().default(null),
-  simulateTxAccessorAddress: AddressSchema.nullish().default(null),
-  safeWebAuthnSignerFactoryAddress: AddressSchema.nullish().default(null),
-});
+export const ContractAddressesSchema = z
+  .object({
+    safeSingletonAddress: AddressSchema.nullish().default(null),
+    safeProxyFactoryAddress: AddressSchema.nullish().default(null),
+    multiSendAddress: AddressSchema.nullish().default(null),
+    multiSendCallOnlyAddress: AddressSchema.nullish().default(null),
+    fallbackHandlerAddress: AddressSchema.nullish().default(null),
+    signMessageLibAddress: AddressSchema.nullish().default(null),
+    createCallAddress: AddressSchema.nullish().default(null),
+    simulateTxAccessorAddress: AddressSchema.nullish().default(null),
+    safeWebAuthnSignerFactoryAddress: AddressSchema.nullish().default(null),
+  })
+  // TODO: Remove catch after deployed and all chain caches include the `contractAddresses` field
+  .catch({
+    safeSingletonAddress: null,
+    safeProxyFactoryAddress: null,
+    multiSendAddress: null,
+    multiSendCallOnlyAddress: null,
+    fallbackHandlerAddress: null,
+    signMessageLibAddress: null,
+    createCallAddress: null,
+    simulateTxAccessorAddress: null,
+    safeWebAuthnSignerFactoryAddress: null,
+  });
 
 export const ChainSchema = z.object({
   chainId: z.string(),

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -117,6 +117,7 @@ describe('Chains Controller (Unit)', () => {
               disabledWallets: chainsResponse.results[0].disabledWallets,
               features: chainsResponse.results[0].features,
               balancesProvider: chainsResponse.results[0].balancesProvider,
+              contractAddresses: chainsResponse.results[0].contractAddresses,
             },
             {
               chainId: chainsResponse.results[1].chainId,
@@ -141,6 +142,7 @@ describe('Chains Controller (Unit)', () => {
               disabledWallets: chainsResponse.results[1].disabledWallets,
               features: chainsResponse.results[1].features,
               balancesProvider: chainsResponse.results[1].balancesProvider,
+              contractAddresses: chainsResponse.results[1].contractAddresses,
             },
           ],
         });
@@ -237,6 +239,7 @@ describe('Chains Controller (Unit)', () => {
           ? getAddress(chainDomain.ensRegistryAddress)
           : chainDomain.ensRegistryAddress,
         balancesProvider: chainDomain.balancesProvider,
+        contractAddresses: chainDomain.contractAddresses,
       };
       networkService.get.mockResolvedValueOnce({
         data: chainDomain,

--- a/src/routes/chains/chains.service.ts
+++ b/src/routes/chains/chains.service.ts
@@ -35,30 +35,30 @@ export class ChainsService {
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, result.next);
     const previousURL = cursorUrlFromLimitAndOffset(routeUrl, result.previous);
 
-    const chains = result.results.map(
-      (chain) =>
-        new Chain(
-          chain.chainId,
-          chain.chainName,
-          chain.description,
-          chain.l2,
-          chain.nativeCurrency,
-          chain.transactionService,
-          chain.blockExplorerUriTemplate,
-          chain.disabledWallets,
-          chain.features,
-          chain.gasPrice,
-          chain.publicRpcUri,
-          chain.rpcUri,
-          chain.safeAppsRpcUri,
-          chain.shortName,
-          chain.theme,
-          chain.ensRegistryAddress,
-          chain.isTestnet,
-          chain.chainLogoUri,
-          chain.balancesProvider,
-        ),
-    );
+    const chains = result.results.map((chain) => {
+      return new Chain({
+        chainId: chain.chainId,
+        chainName: chain.chainName,
+        description: chain.description,
+        l2: chain.l2,
+        nativeCurrency: chain.nativeCurrency,
+        transactionService: chain.transactionService,
+        blockExplorerUriTemplate: chain.blockExplorerUriTemplate,
+        disabledWallets: chain.disabledWallets,
+        features: chain.features,
+        gasPrice: chain.gasPrice,
+        publicRpcUri: chain.publicRpcUri,
+        rpcUri: chain.rpcUri,
+        safeAppsRpcUri: chain.safeAppsRpcUri,
+        shortName: chain.shortName,
+        theme: chain.theme,
+        ensRegistryAddress: chain.ensRegistryAddress,
+        isTestnet: chain.isTestnet,
+        chainLogoUri: chain.chainLogoUri,
+        balancesProvider: chain.balancesProvider,
+        contractAddresses: chain.contractAddresses,
+      });
+    });
 
     return {
       count: result.count,
@@ -70,27 +70,28 @@ export class ChainsService {
 
   async getChain(chainId: string): Promise<Chain> {
     const result = await this.chainsRepository.getChain(chainId);
-    return new Chain(
-      result.chainId,
-      result.chainName,
-      result.description,
-      result.l2,
-      result.nativeCurrency,
-      result.transactionService,
-      result.blockExplorerUriTemplate,
-      result.disabledWallets,
-      result.features,
-      result.gasPrice,
-      result.publicRpcUri,
-      result.rpcUri,
-      result.safeAppsRpcUri,
-      result.shortName,
-      result.theme,
-      result.ensRegistryAddress,
-      result.isTestnet,
-      result.chainLogoUri,
-      result.balancesProvider,
-    );
+    return new Chain({
+      chainId: result.chainId,
+      chainName: result.chainName,
+      description: result.description,
+      l2: result.l2,
+      nativeCurrency: result.nativeCurrency,
+      transactionService: result.transactionService,
+      blockExplorerUriTemplate: result.blockExplorerUriTemplate,
+      disabledWallets: result.disabledWallets,
+      features: result.features,
+      gasPrice: result.gasPrice,
+      publicRpcUri: result.publicRpcUri,
+      rpcUri: result.rpcUri,
+      safeAppsRpcUri: result.safeAppsRpcUri,
+      shortName: result.shortName,
+      theme: result.theme,
+      ensRegistryAddress: result.ensRegistryAddress,
+      isTestnet: result.isTestnet,
+      chainLogoUri: result.chainLogoUri,
+      balancesProvider: result.balancesProvider,
+      contractAddresses: result.contractAddresses,
+    });
   }
 
   async getAboutChain(chainId: string): Promise<AboutChain> {

--- a/src/routes/chains/entities/chain.entity.ts
+++ b/src/routes/chains/entities/chain.entity.ts
@@ -33,6 +33,7 @@ import {
   Theme as ApiTheme,
 } from '@/routes/chains/entities/theme.entity';
 import { BalancesProvider } from '@/routes/chains/entities/balances-provider.entity';
+import { ContractAddresses } from '@/routes/chains/entities/contract-addresses.entity';
 
 @ApiExtraModels(ApiGasPriceOracle, ApiGasPriceFixed, ApiGasPriceFixedEIP1559)
 export class Chain {
@@ -57,9 +58,11 @@ export class Chain {
   @ApiProperty()
   disabledWallets: string[];
   @ApiPropertyOptional({ type: String, nullable: true })
-  ensRegistryAddress: string | null;
+  ensRegistryAddress: `0x${string}` | null;
   @ApiProperty()
   balancesProvider: BalancesProvider;
+  @ApiProperty()
+  contractAddresses: ContractAddresses;
   @ApiProperty()
   features: string[];
   @ApiProperty({
@@ -86,45 +89,47 @@ export class Chain {
   @ApiProperty()
   theme: ApiTheme;
 
-  constructor(
-    chainId: string,
-    chainName: string,
-    description: string,
-    l2: boolean,
-    nativeCurrency: NativeCurrency,
-    transactionService: string,
-    blockExplorerUriTemplate: BlockExplorerUriTemplate,
-    disabledWallets: string[],
-    features: string[],
-    gasPrice: Array<GasPriceOracle | GasPriceFixed | GasPriceFixedEIP1559>,
-    publicRpcUri: RpcUri,
-    rpcUri: RpcUri,
-    safeAppsRpcUri: RpcUri,
-    shortName: string,
-    theme: Theme,
-    ensRegistryAddress: string | null,
-    isTestnet: boolean,
-    chainLogoUri: string | null,
-    balancesProvider: BalancesProvider,
-  ) {
-    this.chainId = chainId;
-    this.chainName = chainName;
-    this.description = description;
-    this.chainLogoUri = chainLogoUri;
-    this.l2 = l2;
-    this.isTestnet = isTestnet;
-    this.nativeCurrency = nativeCurrency;
-    this.transactionService = transactionService;
-    this.blockExplorerUriTemplate = blockExplorerUriTemplate;
-    this.disabledWallets = disabledWallets;
-    this.ensRegistryAddress = ensRegistryAddress;
-    this.features = features;
-    this.gasPrice = gasPrice;
-    this.publicRpcUri = publicRpcUri;
-    this.rpcUri = rpcUri;
-    this.safeAppsRpcUri = safeAppsRpcUri;
-    this.shortName = shortName;
-    this.theme = theme;
-    this.balancesProvider = balancesProvider;
+  constructor(args: {
+    chainId: string;
+    chainName: string;
+    description: string;
+    l2: boolean;
+    nativeCurrency: NativeCurrency;
+    transactionService: string;
+    blockExplorerUriTemplate: BlockExplorerUriTemplate;
+    disabledWallets: string[];
+    features: string[];
+    gasPrice: Array<GasPriceOracle | GasPriceFixed | GasPriceFixedEIP1559>;
+    publicRpcUri: RpcUri;
+    rpcUri: RpcUri;
+    safeAppsRpcUri: RpcUri;
+    shortName: string;
+    theme: Theme;
+    ensRegistryAddress: `0x${string}` | null;
+    isTestnet: boolean;
+    chainLogoUri: string | null;
+    balancesProvider: BalancesProvider;
+    contractAddresses: ContractAddresses;
+  }) {
+    this.chainId = args.chainId;
+    this.chainName = args.chainName;
+    this.description = args.description;
+    this.chainLogoUri = args.chainLogoUri;
+    this.l2 = args.l2;
+    this.isTestnet = args.isTestnet;
+    this.nativeCurrency = args.nativeCurrency;
+    this.transactionService = args.transactionService;
+    this.blockExplorerUriTemplate = args.blockExplorerUriTemplate;
+    this.disabledWallets = args.disabledWallets;
+    this.ensRegistryAddress = args.ensRegistryAddress;
+    this.features = args.features;
+    this.gasPrice = args.gasPrice;
+    this.publicRpcUri = args.publicRpcUri;
+    this.rpcUri = args.rpcUri;
+    this.safeAppsRpcUri = args.safeAppsRpcUri;
+    this.shortName = args.shortName;
+    this.theme = args.theme;
+    this.balancesProvider = args.balancesProvider;
+    this.contractAddresses = args.contractAddresses;
   }
 }

--- a/src/routes/chains/entities/contract-addresses.entity.ts
+++ b/src/routes/chains/entities/contract-addresses.entity.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ContractAddresses as DomainContractAddresses } from '@/domain/chains/entities/contract-addresses.entity';
+
+export class ContractAddresses implements DomainContractAddresses {
+  @ApiPropertyOptional({ type: String, nullable: true })
+  safeSingletonAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  safeProxyFactoryAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  multiSendAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  multiSendCallOnlyAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  fallbackHandlerAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  signMessageLibAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  createCallAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  simulateTxAccessorAddress!: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  safeWebAuthnSignerFactoryAddress!: `0x${string}` | null;
+}


### PR DESCRIPTION
## Summary

Although the `contractAddresses` was [added to the domain entity](https://github.com/safe-global/safe-client-gateway/pull/1752), it was not on a route level. This maps it accordingly, as well as adding a fallback value if not present on the Config Service (if a stale cache value is present after release).

## Changes

- Adjust route-level `Chain` entity to accept constructor arguments as an object for clarity
- Add `ContractAddresses` route-level entity and include it to `Chain`
- Map `contractAddresses` to `Chain` route-level entiy
- Add fallback value for `ContractAddresses`
- Add appropriate test coverage