### PR TITLE
Add `GET` `/v1/sanction-addresses`, returning addresses from SDN list

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { OwnersModule } from '@/routes/owners/owners.module';
 import { AboutModule } from '@/routes/about/about.module';
 import { TransactionsModule } from '@/routes/transactions/transactions.module';
 import { SafesModule } from '@/routes/safes/safes.module';
+import { SanctionedAddressesModule } from '@/routes/sanctioned-addresses/sanctioned-addresses.modules';
 import { NotificationsModule } from '@/routes/notifications/notifications.module';
 import { EstimationsModule } from '@/routes/estimations/estimations.module';
 import { MessagesModule } from '@/routes/messages/messages.module';
@@ -90,6 +91,7 @@ export class AppModule implements NestModule {
         RootModule,
         SafeAppsModule,
         SafesModule,
+        SanctionedAddressesModule,
         TransactionsModule,
         ...(isConfirmationViewEnabled
           ? [TransactionsViewControllerModule]

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -25,6 +25,7 @@ export class CacheRouter {
   private static readonly SAFE_EXISTS_KEY = 'safe_exists';
   private static readonly SAFE_FIAT_CODES_KEY = 'safe_fiat_codes';
   private static readonly SAFE_KEY = 'safe';
+  private static readonly SANCTIONED_ADDRESSES_KEY = 'sanctioned_addresses';
   private static readonly SINGLETONS_KEY = 'singletons';
   private static readonly TOKEN_KEY = 'token';
   private static readonly TOKEN_PRICE_KEY = 'token_price';
@@ -489,5 +490,9 @@ export class CacheRouter {
 
   static getPriceFiatCodesCacheDir(): CacheDir {
     return new CacheDir(CacheRouter.SAFE_FIAT_CODES_KEY, '');
+  }
+
+  static getSanctionedAddressesCacheDir(): CacheDir {
+    return new CacheDir(CacheRouter.SANCTIONED_ADDRESSES_KEY, '');
   }
 }

--- a/src/domain/sanctioned-addresses/sanctioned-addresses.repository.interface.ts
+++ b/src/domain/sanctioned-addresses/sanctioned-addresses.repository.interface.ts
@@ -1,0 +1,27 @@
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { SanctionedAddressesRepository } from '@/domain/sanctioned-addresses/sanctioned-addresses.repository';
+import { Module } from '@nestjs/common';
+
+export const ISanctionedAddressesRepository = Symbol(
+  'ISanctionedAddressesRepository',
+);
+
+export interface ISanctionedAddressesRepository {
+  /**
+   * Gets the list of sanctioned addresses
+   * @returns an array of strings representing the sanctioned addresses
+   */
+  getSanctionedAddresses(): Promise<Array<`0x${string}`>>;
+}
+
+@Module({
+  imports: [CacheModule],
+  providers: [
+    {
+      provide: ISanctionedAddressesRepository,
+      useClass: SanctionedAddressesRepository,
+    },
+  ],
+  exports: [ISanctionedAddressesRepository],
+})
+export class SanctionedAddressesRepositoryModule {}

--- a/src/domain/sanctioned-addresses/sanctioned-addresses.repository.ts
+++ b/src/domain/sanctioned-addresses/sanctioned-addresses.repository.ts
@@ -1,0 +1,110 @@
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { MAX_TTL } from '@/datasources/cache/constants';
+import {
+  NetworkService,
+  INetworkService,
+} from '@/datasources/network/network.service.interface';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
+import { Inject } from '@nestjs/common';
+import { isAddress, getAddress } from 'viem';
+
+export class SanctionedAddressesRepository {
+  private static readonly SdnListUrl =
+    'https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/SDN.XML';
+
+  /**
+   * The above XML file contains a list of sanctioned addresses in the following format:
+   * <id>
+   *   <uid>69420</uid>
+   *   <idType>Digital Currency Address - ETH</idType>
+   *   <idNumber>0x...</idNumber>
+   * </id>
+   */
+  private static readonly AddressIdTypeTag = 'Digital Currency Address - ETH';
+
+  constructor(
+    @Inject(CacheService) private readonly cacheService: ICacheService,
+    @Inject(NetworkService)
+    private readonly networkService: INetworkService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async getSanctionedAddresses(): Promise<Array<`0x${string}`>> {
+    const cacheDir = CacheRouter.getSanctionedAddressesCacheDir();
+    const cachedAddresses = await this.cacheService.get(cacheDir);
+
+    if (cachedAddresses) {
+      return JSON.parse(cachedAddresses);
+    } else {
+      await this.updateSanctionedAddresses();
+
+      const newCachedAddresses = await this.cacheService.get(cacheDir);
+      if (!newCachedAddresses) {
+        throw new Error('Failed populate sanctioned addresses cache');
+      }
+
+      return JSON.parse(newCachedAddresses);
+    }
+  }
+
+  private async updateSanctionedAddresses(): Promise<void> {
+    const cacheDir = CacheRouter.getSanctionedAddressesCacheDir();
+
+    try {
+      const list = await this.networkService.get<string>({
+        url: SanctionedAddressesRepository.SdnListUrl,
+      });
+      const addresses = this.parseAddressesFromList(list.data);
+
+      await this.cacheService.set(cacheDir, JSON.stringify(addresses), MAX_TTL);
+    } catch (error) {
+      this.loggingService.debug(
+        `Failed to update sanction list: ${asError(error).message}`,
+      );
+      throw new Error('Unable to update sanctioned addresses');
+    }
+  }
+
+  private parseAddressesFromList(xml: string): Array<`0x${string}`> {
+    const addresses = new Set<`0x${string}`>();
+
+    const idTagMatches = xml.match(this.getXmlRegEx('id', true));
+
+    if (!idTagMatches) {
+      throw new Error('No sanctions found in SDN list');
+    }
+
+    for (const idTagMatch of idTagMatches) {
+      const idTypeTagMatch = idTagMatch.match(this.getXmlRegEx('idType'));
+      const idNumberTagMatch = idTagMatch.match(this.getXmlRegEx('idNumber'));
+
+      if (!idTypeTagMatch || !idNumberTagMatch) {
+        continue;
+      }
+
+      const idType = idTypeTagMatch[1].trim();
+      const idNumber = idNumberTagMatch[1].trim();
+
+      console.log(idType, idNumber);
+
+      if (
+        idType == SanctionedAddressesRepository.AddressIdTypeTag &&
+        isAddress(idNumber)
+      ) {
+        addresses.add(getAddress(idNumber));
+      }
+    }
+
+    return Array.from(addresses);
+  }
+
+  private getXmlRegEx(tagName: string, global: boolean = false): RegExp {
+    const pattern = `<${tagName}>([\\s\\S]*?)<\\/${tagName}>`;
+    return new RegExp(pattern, global ? 'g' : '');
+  }
+}

--- a/src/routes/sanctioned-addresses/sanctioned-addresses.controller.spec.ts
+++ b/src/routes/sanctioned-addresses/sanctioned-addresses.controller.spec.ts
@@ -1,0 +1,203 @@
+import { INestApplication } from '@nestjs/common';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import { Server } from 'net';
+import { faker } from '@faker-js/faker';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheService } from '@/datasources/cache/cache.service.interface';
+import { getAddress } from 'viem';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import request from 'supertest';
+
+describe('Sanctioned Addresses Controller (Unit)', () => {
+  let app: INestApplication<Server>;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+  let fakeCacheService: FakeCacheService;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration)],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
+      .compile();
+
+    networkService = moduleFixture.get(NetworkService);
+    fakeCacheService = moduleFixture.get(CacheService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /v1/sanctioned-addresses', () => {
+    it('should populate then return cached sanctioned addresses', async () => {
+      // Lowercase to check checksumming occurs on response
+      const address1 = faker.finance.ethereumAddress().toLowerCase();
+      const address2 = faker.finance.ethereumAddress().toLowerCase();
+      const xml = `<?xml version="1.0" standalone="yes"?>
+<sdnList
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/XML">
+	<publshInformation>
+		<Publish_Date>${faker.date.recent()}</Publish_Date>
+		<Record_Count>${faker.string.numeric()}</Record_Count>
+	</publshInformation>
+	<sdnEntry>
+		<uid>${faker.string.numeric()}</uid>
+		<firstName>${faker.person.firstName()}</firstName>
+		<lastName>${faker.person.lastName()}</lastName>
+		<sdnType>Individual</sdnType>
+		<remarks>(Linked To: ${faker.person.lastName()}, ${faker.person.firstName()}; Linked To: ${faker.company.name()})</remarks>
+		<programList>
+			<program>${faker.location.country()}-EO14024</program>
+		</programList>
+		<idList>
+			<id>
+				<uid>${faker.string.numeric()}</uid>
+				<idType>Passport</idType>
+				<idNumber>${faker.string.alphanumeric()}</idNumber>
+				<idCountry>${faker.location.country()}</idCountry>
+			</id>
+			<id>
+				<uid>${faker.string.numeric}</uid>
+				<idType>Tax ID No.</idType>
+				<idNumber>${faker.string.numeric}</idNumber>
+				<idCountry>${faker.location.country()}</idCountry>
+			</id>
+			<id>
+				<uid>${faker.string.numeric()}</uid>
+				<idType>Gender</idType>
+				<idNumber>Male</idNumber>
+			</id>
+			<id>
+				<uid>${faker.string.numeric()}</uid>
+				<idType>Digital Currency Address - XBT</idType>
+				<idNumber>${faker.string.alphanumeric({ length: 42 })}</idNumber>
+			</id>
+			<id>
+				<uid>${faker.string.numeric()}</uid>
+				<idType>Digital Currency Address - ETH</idType>
+				<idNumber>${address1}</idNumber>
+			</id>
+			<id>
+				<uid>${faker.string.numeric()}</uid>
+				<idType>Digital Currency Address - ETH</idType>
+				<idNumber>${address2}</idNumber>
+			</id>
+			<id>
+				<uid>${faker.string.numeric()}</uid>
+				<idType>Secondary sanctions risk:</idType>
+				<idNumber>See Section 11 of Executive Order 14024.</idNumber>
+			</id>
+		</idList>
+		<akaList>
+			<aka>
+				<uid>${faker.string.numeric()}</uid>
+				<type>a.k.a.</type>
+				<category>strong</category>
+				<lastName>${faker.person.lastName()}</lastName>
+				<firstName>${faker.person.firstName()}</firstName>
+			</aka>
+			<aka>
+				<uid>${faker.string.numeric()}</uid>
+				<type>a.k.a.</type>
+				<category>strong</category>
+				<lastName>${faker.person.lastName()}</lastName>
+				<firstName>${faker.person.firstName()}</firstName>
+			</aka>
+		</akaList>
+		<addressList>
+			<address>
+				<uid>${faker.string.numeric()}</uid>
+				<country>${faker.location.country()}</country>
+			</address>
+		</addressList>
+		<nationalityList>
+			<nationality>
+				<uid>${faker.string.numeric()}</uid>
+				<country>${faker.location.country()}</country>
+				<mainEntry>true</mainEntry>
+			</nationality>
+			<nationality>
+				<uid>${faker.string.numeric()}</uid>
+				<country>${faker.location.country()}</country>
+				<mainEntry>false</mainEntry>
+			</nationality>
+			<nationality>
+				<uid>${faker.string.numeric()}</uid>
+				<country>${faker.location.country()}</country>
+				<mainEntry>false</mainEntry>
+			</nationality>
+		</nationalityList>
+		<dateOfBirthList>
+			<dateOfBirthItem>
+				<uid>${faker.string.numeric()}</uid>
+				<dateOfBirth>${faker.date.past()}</dateOfBirth>
+				<mainEntry>true</mainEntry>
+			</dateOfBirthItem>
+		</dateOfBirthList>
+		<placeOfBirthList>
+			<placeOfBirthItem>
+				<uid>${faker.string.numeric()}</uid>
+				<placeOfBirth>${faker.location.city()}, ${faker.location.country()}</placeOfBirth>
+				<mainEntry>true</mainEntry>
+			</placeOfBirthItem>
+		</placeOfBirthList>
+	</sdnEntry>
+</sdnList>`;
+      networkService.get.mockResolvedValue({ status: 200, data: xml });
+      const expected = [getAddress(address1), getAddress(address2)];
+
+      await request(app.getHttpServer())
+        .get('/v1/sanctioned-addresses')
+        .expect(200)
+        .expect(expected);
+      expect(networkService.get).toHaveBeenCalled();
+      expect(fakeCacheService.keyCount()).toBe(1);
+      await expect(
+        fakeCacheService.get(new CacheDir('sanctioned_addresses', '')),
+      ).resolves.toEqual(JSON.stringify(expected));
+    });
+
+    it('should return sanctioned addresses from cache', async () => {
+      const addresses = [
+        getAddress(faker.finance.ethereumAddress()),
+        getAddress(faker.finance.ethereumAddress()),
+      ];
+      const cacheDir = new CacheDir('sanctioned_addresses', '');
+      await fakeCacheService.set(cacheDir, JSON.stringify(addresses), 1);
+
+      await request(app.getHttpServer())
+        .get('/v1/sanctioned-addresses')
+        .expect(200)
+        .expect(addresses);
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/routes/sanctioned-addresses/sanctioned-addresses.controller.ts
+++ b/src/routes/sanctioned-addresses/sanctioned-addresses.controller.ts
@@ -1,0 +1,18 @@
+import { SanctionedAddressesService } from '@/routes/sanctioned-addresses/sanctioned-addresses.service';
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('sanctioned-addresses')
+@Controller({
+  version: '1',
+})
+export class SanctionedAddressesController {
+  constructor(
+    private readonly sanctionedAddressesService: SanctionedAddressesService,
+  ) {}
+
+  @Get('sanctioned-addresses')
+  async getSanctionedAddresses(): Promise<Array<`0x${string}`>> {
+    return this.sanctionedAddressesService.getSanctionedAddresses();
+  }
+}

--- a/src/routes/sanctioned-addresses/sanctioned-addresses.modules.ts
+++ b/src/routes/sanctioned-addresses/sanctioned-addresses.modules.ts
@@ -1,0 +1,11 @@
+import { SanctionedAddressesRepositoryModule } from '@/domain/sanctioned-addresses/sanctioned-addresses.repository.interface';
+import { SanctionedAddressesController } from '@/routes/sanctioned-addresses/sanctioned-addresses.controller';
+import { SanctionedAddressesService } from '@/routes/sanctioned-addresses/sanctioned-addresses.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [SanctionedAddressesRepositoryModule],
+  controllers: [SanctionedAddressesController],
+  providers: [SanctionedAddressesService],
+})
+export class SanctionedAddressesModule {}

--- a/src/routes/sanctioned-addresses/sanctioned-addresses.service.ts
+++ b/src/routes/sanctioned-addresses/sanctioned-addresses.service.ts
@@ -1,0 +1,14 @@
+import { ISanctionedAddressesRepository } from '@/domain/sanctioned-addresses/sanctioned-addresses.repository.interface';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SanctionedAddressesService {
+  constructor(
+    @Inject(ISanctionedAddressesRepository)
+    private readonly sanctionedAddressesRepository: ISanctionedAddressesRepository,
+  ) {}
+
+  async getSanctionedAddresses(): Promise<Array<`0x${string}`>> {
+    return this.sanctionedAddressesRepository.getSanctionedAddresses();
+  }
+}


### PR DESCRIPTION
## Summary

Our clients restrict access to the swap feature is an associated address is present on the SDN sanctions list. Currently, this list is [hardcoded](https://github.com/safe-global/safe-wallet-web/blob/84050cc88bf353d06f5b794bf49ffa81e85fed9a/src/services/ofac/blockedAddressList.json) and therefore needs manually updating.

This adds a new `GET` `/v1/sanctioned-addresses` endpoint the returns a list of addresses that are parsed/cached from the aforementioned SDN list.

Note: a follow up with include a relative CRON job to update the above accordingly.

## Changes

- Modify `FetchClient` to accordingly return text/json relative to the `content-type` of a response
- Add `SanctionedAddressesRepository` with method to get/update (and parse SDN list) sanctioned addresses
- Add new controller, returning the sanctioned addresses under `GET` `/v1/sanctioned-addresses`