### PR TITLE
Add `IPushNotificationsApi` datasource

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -146,6 +146,14 @@ export default (): ReturnType<typeof configuration> => ({
   owners: {
     ownersTtlSeconds: faker.number.int(),
   },
+  pushNotifications: {
+    baseUri: faker.internet.url({ appendSlash: false }),
+    project: faker.word.noun(),
+    serviceAccount: {
+      clientEmail: faker.internet.email(),
+      privateKey: faker.string.alphanumeric(),
+    },
+  },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -216,6 +216,18 @@ export default () => ({
       maxOverviews: parseInt(process.env.MAX_SAFE_OVERVIEWS ?? `${10}`),
     },
   },
+  pushNotifications: {
+    baseUri:
+      process.env.PUSH_NOTIFICATIONS_API_BASE_URI ||
+      'https://fcm.googleapis.com/v1/projects',
+    project: process.env.PUSH_NOTIFICATIONS_API_PROJECT,
+    serviceAccount: {
+      clientEmail:
+        process.env.PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL,
+      privateKey:
+        process.env.PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY,
+    },
+  },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -9,6 +9,7 @@ export class CacheRouter {
   private static readonly CONTRACT_KEY = 'contract';
   private static readonly CREATION_TRANSACTION_KEY = 'creation_transaction';
   private static readonly DELEGATES_KEY = 'delegates';
+  private static readonly FIREBASE_OAUTH2_TOKEN_KEY = 'firebase_oauth2_token';
   private static readonly INCOMING_TRANSFERS_KEY = 'incoming_transfers';
   private static readonly MESSAGE_KEY = 'message';
   private static readonly MESSAGES_KEY = 'messages';
@@ -183,6 +184,10 @@ export class CacheRouter {
       `${args.chainId}_${CacheRouter.DELEGATES_KEY}_${args.safeAddress}`,
       `${args.delegate}_${args.delegator}_${args.label}_${args.limit}_${args.offset}`,
     );
+  }
+
+  static getFirebaseOAuth2TokenCacheDir(): CacheDir {
+    return new CacheDir(CacheRouter.FIREBASE_OAUTH2_TOKEN_KEY, '');
   }
 
   static getTransferCacheDir(args: {

--- a/src/datasources/push-notifications-api/entities/firebase-notification.entity.ts
+++ b/src/datasources/push-notifications-api/entities/firebase-notification.entity.ts
@@ -1,0 +1,5 @@
+export type FirebaseNotification<T extends Record<string, unknown>> = {
+  title: string;
+  body: string;
+  data: T;
+};

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -1,0 +1,141 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import {
+  NetworkService,
+  INetworkService,
+} from '@/datasources/network/network.service.interface';
+import { IPushNotificationsApi } from '@/domain/interfaces/push-notifications-api.interface';
+import { Inject, Injectable } from '@nestjs/common';
+import { FirebaseNotification } from '@/datasources/push-notifications-api/entities/firebase-notification.entity';
+
+// TODO: Refactor to use JwtService
+import jwt from 'jsonwebtoken';
+
+@Injectable()
+export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
+  private static readonly OAuth2TokenUrl =
+    'https://oauth2.googleapis.com/token';
+  private static readonly Scope =
+    'https://www.googleapis.com/auth/firebase.messaging';
+
+  private readonly baseUrl: string;
+  private readonly project: string;
+  private readonly clientEmail: string;
+  private readonly privateKey: string;
+
+  constructor(
+    @Inject(NetworkService)
+    private readonly networkService: INetworkService,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
+    private readonly httpErrorFactory: HttpErrorFactory,
+  ) {
+    this.baseUrl = this.configurationService.getOrThrow<string>(
+      'pushNotifications.baseUri',
+    );
+    this.project = this.configurationService.getOrThrow<string>(
+      'pushNotifications.project',
+    );
+    // Service account credentials are used for OAuth2 assertion
+    this.clientEmail = this.configurationService.getOrThrow<string>(
+      'pushNotifications.serviceAccount.clientEmail',
+    );
+    this.privateKey = this.configurationService.getOrThrow<string>(
+      'pushNotifications.serviceAccount.privateKey',
+    );
+  }
+
+  /**
+   * Enqueues a notification to be sent to a device with given FCM token.
+   *
+   * @param fcmToken - device's FCM token
+   * @param notification - notification payload
+   */
+  async enqueueNotification<T extends Record<string, unknown>>(
+    fcmToken: string,
+    notification: FirebaseNotification<T>,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/${this.project}/messages:send`;
+    try {
+      const accessToken = await this.getOauth2Token();
+      await this.networkService.post({
+        url,
+        data: {
+          message: {
+            token: fcmToken,
+            notification,
+          },
+        },
+        networkRequest: {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      });
+    } catch (error) {
+      /**
+       * TODO: Error handling based on `error.details[i].reason`, e.g.
+       * - expired OAuth2 token
+       * - stale FCM token
+       */
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  /**
+   * Retrieves and caches OAuth2 token for Firebase Cloud Messaging API.
+   *
+   * @returns - OAuth2 token
+   */
+  private async getOauth2Token(): Promise<string> {
+    const cacheDir = CacheRouter.getFirebaseOAuth2TokenCacheDir();
+    const cachedToken = await this.cacheService.get(cacheDir);
+
+    if (cachedToken) {
+      return cachedToken;
+    }
+
+    const { data } = await this.networkService.post<{
+      access_token: string;
+      expires_in: number;
+      token_type: string;
+    }>({
+      url: FirebaseCloudMessagingApiService.OAuth2TokenUrl,
+      data: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: this.getAssertion(),
+      },
+    });
+
+    // Token cached according to issuance
+    await this.cacheService.set(cacheDir, data.access_token, data.expires_in);
+
+    return data.access_token;
+  }
+
+  /**
+   * Generates a signed JWT assertion for OAuth2 token request.
+   *
+   * @returns - signed JWT assertion
+   */
+  private getAssertion(): string {
+    const issuedAt = Math.floor(Date.now() / 1_000);
+    const payload = {
+      iss: this.clientEmail,
+      scope: FirebaseCloudMessagingApiService.Scope,
+      aud: FirebaseCloudMessagingApiService.OAuth2TokenUrl,
+      iat: issuedAt,
+      // Maximum expiration time is 1 hour
+      exp: issuedAt + 60 * 60,
+    };
+
+    return jwt.sign(payload, this.privateKey, { algorithm: 'RS256' });
+  }
+}

--- a/src/datasources/push-notifications-api/push-notifications-api.module.ts
+++ b/src/datasources/push-notifications-api/push-notifications-api.module.ts
@@ -1,0 +1,18 @@
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { FirebaseCloudMessagingApiService } from '@/datasources/push-notifications-api/firebase-cloud-messaging-api.service';
+import { IPushNotificationsApi } from '@/domain/interfaces/push-notifications-api.interface';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [CacheModule],
+  providers: [
+    HttpErrorFactory,
+    {
+      provide: IPushNotificationsApi,
+      useClass: FirebaseCloudMessagingApiService,
+    },
+  ],
+  exports: [IPushNotificationsApi],
+})
+export class PushNotificationsApiModule {}

--- a/src/domain/interfaces/push-notifications-api.interface.ts
+++ b/src/domain/interfaces/push-notifications-api.interface.ts
@@ -1,0 +1,5 @@
+export const IPushNotificationsApi = Symbol('IPushNotificationsApi');
+
+export interface IPushNotificationsApi {
+  enqueueNotification(token: string, notification: unknown): Promise<void>;
+}


### PR DESCRIPTION
## Summary

In preparation for migration of the notification service to the project, this adds a new `IPushNotificationsApi` datasource, initially implemented by FIrebase (Cloud Messaging).

## Changes

tbd