### PR TITLE
Add tests for `FirebaseCloudMessagingApiService`

### DIFF
--- a/src/datasources/push-notifications-api/__tests__/firebase-notification.builder.ts
+++ b/src/datasources/push-notifications-api/__tests__/firebase-notification.builder.ts
@@ -1,0 +1,13 @@
+import { IBuilder, Builder } from '@/__tests__/builder';
+import { fakeJson } from '@/__tests__/faker';
+import { FirebaseNotification } from '@/datasources/push-notifications-api/entities/firebase-notification.entity';
+import { faker } from '@faker-js/faker';
+
+export function firebaseNotificationBuilder(): IBuilder<FirebaseNotification> {
+  return new Builder<FirebaseNotification>()
+    .with('notification', {
+      title: faker.lorem.sentence(),
+      body: faker.lorem.sentence(),
+    })
+    .with('data', JSON.parse(fakeJson()) as Record<string, string>);
+}

--- a/src/datasources/push-notifications-api/entities/firebase-notification.entity.ts
+++ b/src/datasources/push-notifications-api/entities/firebase-notification.entity.ts
@@ -1,5 +1,7 @@
-export type FirebaseNotification<T extends Record<string, unknown>> = {
-  title: string;
-  body: string;
-  data: T;
+export type FirebaseNotification = {
+  notification?: {
+    title?: string;
+    body?: string;
+  };
+  data?: Record<string, string>;
 };

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -1,10 +1,10 @@
-import { fakeJson } from '@/__tests__/faker';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import { INetworkService } from '@/datasources/network/network.service.interface';
+import { firebaseNotificationBuilder } from '@/datasources/push-notifications-api/__tests__/firebase-notification.builder';
 import { FirebaseCloudMessagingApiService } from '@/datasources/push-notifications-api/firebase-cloud-messaging-api.service';
 import { faker } from '@faker-js/faker';
 
@@ -71,11 +71,7 @@ describe('FirebaseCloudMessagingApiService', () => {
     const oauth2Token = faker.string.alphanumeric();
     const oauth2TokenExpiresIn = faker.number.int();
     const fcmToken = faker.string.alphanumeric();
-    const notification = {
-      title: faker.lorem.sentence(),
-      body: faker.lorem.sentence(),
-      data: JSON.parse(fakeJson()),
-    };
+    const notification = firebaseNotificationBuilder().build();
     mockJwtService.sign.mockReturnValue(oauth2AssertionJwt);
     mockNetworkService.post.mockResolvedValueOnce({
       status: 200,
@@ -129,11 +125,7 @@ describe('FirebaseCloudMessagingApiService', () => {
       oauth2TokenExpiresIn,
     );
     const fcmToken = faker.string.alphanumeric();
-    const notification = {
-      title: faker.lorem.sentence(),
-      body: faker.lorem.sentence(),
-      data: JSON.parse(fakeJson()),
-    };
+    const notification = firebaseNotificationBuilder().build();
 
     await expect(
       target.enqueueNotification(fcmToken, notification),

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -1,0 +1,159 @@
+import { fakeJson } from '@/__tests__/faker';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { INetworkService } from '@/datasources/network/network.service.interface';
+import { FirebaseCloudMessagingApiService } from '@/datasources/push-notifications-api/firebase-cloud-messaging-api.service';
+import { faker } from '@faker-js/faker';
+
+const mockNetworkService = jest.mocked({
+  get: jest.fn(),
+  post: jest.fn(),
+} as jest.MockedObjectDeep<INetworkService>);
+
+const mockJwtService = jest.mocked({
+  sign: jest.fn(),
+} as jest.MockedObjectDeep<IJwtService>);
+
+const mockHttpErrorFactory = jest.mocked({
+  from: jest.fn(),
+} as jest.MockedObjectDeep<HttpErrorFactory>);
+
+describe('FirebaseCloudMessagingApiService', () => {
+  let target: FirebaseCloudMessagingApiService;
+  let fakeCacheService: FakeCacheService;
+
+  let pushNotificationsBaseUri: string;
+  let pushNotificationsProject: string;
+  let pushNotificationsServiceAccountClientEmail: string;
+  let pushNotificationsServiceAccountPrivateKey: string;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    pushNotificationsBaseUri = faker.internet.url({ appendSlash: false });
+    pushNotificationsProject = faker.word.noun();
+    pushNotificationsServiceAccountClientEmail = faker.internet.email();
+    pushNotificationsServiceAccountPrivateKey = faker.string.alphanumeric();
+
+    const fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'pushNotifications.baseUri',
+      pushNotificationsBaseUri,
+    );
+    fakeConfigurationService.set(
+      'pushNotifications.project',
+      pushNotificationsProject,
+    );
+    fakeConfigurationService.set(
+      'pushNotifications.serviceAccount.clientEmail',
+      pushNotificationsServiceAccountClientEmail,
+    );
+    fakeConfigurationService.set(
+      'pushNotifications.serviceAccount.privateKey',
+      pushNotificationsServiceAccountPrivateKey,
+    );
+
+    fakeCacheService = new FakeCacheService();
+    target = new FirebaseCloudMessagingApiService(
+      mockNetworkService,
+      fakeConfigurationService,
+      fakeCacheService,
+      mockJwtService,
+      mockHttpErrorFactory,
+    );
+  });
+
+  it('it should get an OAuth2 token if not cached, cache it and enqueue a notification', async () => {
+    const oauth2AssertionJwt = faker.string.alphanumeric();
+    const oauth2Token = faker.string.alphanumeric();
+    const oauth2TokenExpiresIn = faker.number.int();
+    const fcmToken = faker.string.alphanumeric();
+    const notification = {
+      title: faker.lorem.sentence(),
+      body: faker.lorem.sentence(),
+      data: JSON.parse(fakeJson()),
+    };
+    mockJwtService.sign.mockReturnValue(oauth2AssertionJwt);
+    mockNetworkService.post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        access_token: oauth2Token,
+        expires_in: oauth2TokenExpiresIn,
+      },
+    });
+
+    await expect(
+      target.enqueueNotification(fcmToken, notification),
+    ).resolves.toBeUndefined();
+
+    expect(mockNetworkService.post).toHaveBeenCalledTimes(2);
+    // Get OAuth2 token
+    expect(mockNetworkService.post).toHaveBeenNthCalledWith(1, {
+      url: 'https://oauth2.googleapis.com/token',
+      data: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: oauth2AssertionJwt,
+      },
+    });
+    // Send notification
+    expect(mockNetworkService.post).toHaveBeenNthCalledWith(2, {
+      url: `${pushNotificationsBaseUri}/${pushNotificationsProject}/messages:send`,
+      data: {
+        message: {
+          token: fcmToken,
+          notification,
+        },
+      },
+      networkRequest: {
+        headers: {
+          Authorization: `Bearer ${oauth2Token}`,
+        },
+      },
+    });
+    // Cached OAuth2 token
+    expect(fakeCacheService.keyCount()).toBe(1);
+    await expect(
+      fakeCacheService.get(new CacheDir('firebase_oauth2_token', '')),
+    ).resolves.toBe(oauth2Token);
+  });
+
+  it('should use an OAuth2 token from cache if available', async () => {
+    const oauth2Token = faker.string.alphanumeric();
+    const oauth2TokenExpiresIn = faker.number.int();
+    await fakeCacheService.set(
+      new CacheDir('firebase_oauth2_token', ''),
+      oauth2Token,
+      oauth2TokenExpiresIn,
+    );
+    const fcmToken = faker.string.alphanumeric();
+    const notification = {
+      title: faker.lorem.sentence(),
+      body: faker.lorem.sentence(),
+      data: JSON.parse(fakeJson()),
+    };
+
+    await expect(
+      target.enqueueNotification(fcmToken, notification),
+    ).resolves.toBeUndefined();
+
+    expect(mockNetworkService.post).toHaveBeenCalledTimes(1);
+    // Send notification
+    expect(mockNetworkService.post).toHaveBeenNthCalledWith(1, {
+      url: `${pushNotificationsBaseUri}/${pushNotificationsProject}/messages:send`,
+      data: {
+        message: {
+          token: fcmToken,
+          notification,
+        },
+      },
+      networkRequest: {
+        headers: {
+          Authorization: `Bearer ${oauth2Token}`,
+        },
+      },
+    });
+  });
+});

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -59,9 +59,9 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
    * @param fcmToken - device's FCM token
    * @param notification - notification payload
    */
-  async enqueueNotification<T extends Record<string, unknown>>(
+  async enqueueNotification(
     fcmToken: string,
-    notification: FirebaseNotification<T>,
+    notification: FirebaseNotification,
   ): Promise<void> {
     const url = `${this.baseUrl}/${this.project}/messages:send`;
     try {


### PR DESCRIPTION
## Summary

The `FirebaseCloudMessagingApiService` datasource requires us to authenticate with Google before dispatching a push notification. This adds test coverage of for it.

## Changes

- Add according test coverage for `FirebaseCloudMessagingApiService`