### PR TITLE
Change AccountDataSettings and UpsertAccountDataSettingsDto entities

### DIFF
--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -443,7 +443,7 @@ describe('AccountsDatasource tests', () => {
       const insertedDataTypes =
         await sql`INSERT INTO account_data_types ${sql(accountDataTypes, 'name', 'is_active')} returning *`;
       const accountDataSettings = insertedDataTypes.map((dataType) => ({
-        id: dataType.id,
+        dataTypeId: dataType.id,
         enabled: faker.datatype.boolean(),
       }));
       const upsertAccountDataSettingsDto = upsertAccountDataSettingsDtoBuilder()
@@ -457,7 +457,7 @@ describe('AccountsDatasource tests', () => {
 
       const expected = accountDataSettings.map((accountDataSetting) => ({
         account_id: account.id,
-        account_data_type_id: accountDataSetting.id,
+        account_data_type_id: accountDataSetting.dataTypeId,
         enabled: accountDataSetting.enabled,
         created_at: expect.any(Date),
         updated_at: expect.any(Date),
@@ -514,7 +514,7 @@ describe('AccountsDatasource tests', () => {
       const insertedDataTypes =
         await sql`INSERT INTO account_data_types ${sql(accountDataTypes, 'name', 'is_active')} returning *`;
       const accountDataSettings = insertedDataTypes.map((dataType) => ({
-        id: dataType.id,
+        dataTypeId: dataType.id,
         enabled: faker.datatype.boolean(),
       }));
       const upsertAccountDataSettingsDto = upsertAccountDataSettingsDtoBuilder()
@@ -530,7 +530,7 @@ describe('AccountsDatasource tests', () => {
         expect.arrayContaining(
           accountDataSettings.map((accountDataSetting) => ({
             account_id: account.id,
-            account_data_type_id: accountDataSetting.id,
+            account_data_type_id: accountDataSetting.dataTypeId,
             enabled: accountDataSetting.enabled,
             created_at: expect.any(Date),
             updated_at: expect.any(Date),
@@ -556,7 +556,7 @@ describe('AccountsDatasource tests', () => {
         expect.arrayContaining(
           accountDataSettings.map((accountDataSetting) => ({
             account_id: account.id,
-            account_data_type_id: accountDataSetting.id,
+            account_data_type_id: accountDataSetting.dataTypeId,
             enabled: !accountDataSetting.enabled, // 'enabled' row was updated
             created_at: expect.any(Date),
             updated_at: expect.any(Date),
@@ -574,7 +574,7 @@ describe('AccountsDatasource tests', () => {
       const insertedDataTypes =
         await sql`INSERT INTO account_data_types ${sql(accountDataTypes, 'name', 'is_active')} returning *`;
       const accountDataSettings = insertedDataTypes.map((dataType) => ({
-        id: dataType.id,
+        dataTypeId: dataType.id,
         enabled: faker.datatype.boolean(),
       }));
       const upsertAccountDataSettingsDto = upsertAccountDataSettingsDtoBuilder()
@@ -596,14 +596,14 @@ describe('AccountsDatasource tests', () => {
       const insertedDataTypes =
         await sql`INSERT INTO account_data_types ${sql(accountDataTypes, 'name', 'is_active')} returning *`;
       const accountDataSettings = insertedDataTypes.map((dataType) => ({
-        id: dataType.id,
+        dataTypeId: dataType.id,
         enabled: faker.datatype.boolean(),
       }));
       const upsertAccountDataSettingsDto = upsertAccountDataSettingsDtoBuilder()
         .with('accountDataSettings', accountDataSettings)
         .build();
       upsertAccountDataSettingsDto.accountDataSettings.push({
-        id: faker.string.numeric(5),
+        dataTypeId: faker.string.numeric(5),
         enabled: faker.datatype.boolean(),
       });
 
@@ -622,7 +622,7 @@ describe('AccountsDatasource tests', () => {
       const insertedDataTypes =
         await sql`INSERT INTO account_data_types ${sql(accountDataTypes, 'name', 'is_active')} returning *`;
       const accountDataSettings = insertedDataTypes.map((dataType) => ({
-        id: dataType.id,
+        dataTypeId: dataType.id,
         enabled: faker.datatype.boolean(),
       }));
       const upsertAccountDataSettingsDto = upsertAccountDataSettingsDtoBuilder()

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -476,7 +476,7 @@ describe('AccountsDatasource tests', () => {
       const insertedDataTypes =
         await sql`INSERT INTO account_data_types ${sql(accountDataTypes, 'name', 'is_active')} returning *`;
       const accountDataSettings = insertedDataTypes.map((dataType) => ({
-        id: dataType.id,
+        dataTypeId: dataType.id,
         enabled: faker.datatype.boolean(),
       }));
       const upsertAccountDataSettingsDto = upsertAccountDataSettingsDtoBuilder()
@@ -496,7 +496,7 @@ describe('AccountsDatasource tests', () => {
           accountDataSettings.map((accountDataSetting) =>
             expect.objectContaining({
               account_id: account.id,
-              account_data_type_id: accountDataSetting.id,
+              account_data_type_id: accountDataSetting.dataTypeId,
               enabled: accountDataSetting.enabled,
             }),
           ),

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -147,7 +147,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
         accountDataSettings.map(async (accountDataSetting) => {
           return sql`
             INSERT INTO account_data_settings (account_id, account_data_type_id, enabled)
-            VALUES (${account.id}, ${accountDataSetting.id}, ${accountDataSetting.enabled})
+            VALUES (${account.id}, ${accountDataSetting.dataTypeId}, ${accountDataSetting.enabled})
             ON CONFLICT (account_id, account_data_type_id) DO UPDATE SET enabled = EXCLUDED.enabled
           `.catch((e) => {
             throw new UnprocessableEntityException(
@@ -178,7 +178,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
       .map((ads) => ads.id);
     if (
       !accountDataSettings.every((ads) =>
-        activeDataTypeIds.includes(Number(ads.id)),
+        activeDataTypeIds.includes(Number(ads.dataTypeId)),
       )
     ) {
       throw new UnprocessableEntityException(

--- a/src/domain/accounts/entities/__tests__/upsert-account-data-settings.dto.entity.builder.ts
+++ b/src/domain/accounts/entities/__tests__/upsert-account-data-settings.dto.entity.builder.ts
@@ -6,7 +6,7 @@ export function upsertAccountDataSettingsDtoBuilder(): IBuilder<UpsertAccountDat
   return new Builder<UpsertAccountDataSettingsDto>().with(
     'accountDataSettings',
     Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () => ({
-      id: faker.string.numeric(),
+      dataTypeId: faker.string.numeric(),
       enabled: faker.datatype.boolean(),
     })),
   );

--- a/src/domain/accounts/entities/upsert-account-data-settings.dto.entity.ts
+++ b/src/domain/accounts/entities/upsert-account-data-settings.dto.entity.ts
@@ -5,7 +5,7 @@ export class UpsertAccountDataSettingsDto
   implements z.infer<typeof UpsertAccountDataSettingsDtoSchema>
 {
   accountDataSettings: {
-    id: string;
+    dataTypeId: string;
     enabled: boolean;
   }[];
 
@@ -15,7 +15,7 @@ export class UpsertAccountDataSettingsDto
 }
 
 export const UpsertAccountDataSettingDtoSchema = z.object({
-  id: NumericStringSchema,
+  dataTypeId: NumericStringSchema,
   enabled: z.boolean(),
 });
 

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -125,8 +125,7 @@ export class AccountsService {
     }
 
     return {
-      name: dataType.name,
-      description: dataType.description,
+      dataTypeId: dataType.id.toString(),
       enabled: domainAccountDataSetting.enabled,
     };
   }

--- a/src/routes/accounts/entities/account-data-setting.entity.ts
+++ b/src/routes/accounts/entities/account-data-setting.entity.ts
@@ -1,16 +1,13 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AccountDataSetting {
   @ApiProperty()
-  name: string;
-  @ApiPropertyOptional({ type: String, nullable: true })
-  description: string | null;
+  dataTypeId: string;
   @ApiProperty()
   enabled: boolean;
 
-  constructor(name: string, description: string | null, enabled: boolean) {
-    this.name = name;
-    this.description = description;
+  constructor(dataTypeId: string, enabled: boolean) {
+    this.dataTypeId = dataTypeId;
     this.enabled = enabled;
   }
 }

--- a/src/routes/accounts/entities/upsert-account-data-settings.dto.entity.ts
+++ b/src/routes/accounts/entities/upsert-account-data-settings.dto.entity.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 class UpsertAccountDataSettingDto {
   @ApiProperty()
-  id!: string; // A 'numeric string' type is used to align with other API endpoints
+  dataTypeId!: string; // A 'numeric string' type is used to align with other API endpoints
   @ApiProperty()
   enabled!: boolean;
 }


### PR DESCRIPTION
## Changes
- Adds `dataTypeId` to `AccountDataSetting`. Otherwise, the clients cannot know the `AccountDataType` referenced by the `AccountDataSetting`.
- Changes `UpsertAccountDataSettingDto.id` to `UpsertAccountDataSettingDto.dataTypeId`. The `id` property is referencing an `AccountDataType` instance, not an `AccountDataSetting` instance, so naming it just `id` could be confusing for clients.
- Both `AccountDataSetting.name` and `AccountDataSetting.description` were also removed as these point to an `AccountDataType` instance, so again they can confuse. The `name` and `description` properties are already available for clients on the `AccountDataType`, so there's no need to include them on the `AccountDataSetting`.