### PR TITLE
Rename Account.accountId to Account.id on the route-level entity

### DIFF
--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -256,7 +256,7 @@ describe('AccountsController', () => {
       const account = accountBuilder().with('group_id', null).build();
       accountDataSource.getAccount.mockResolvedValue(account);
       const expected: Account = {
-        accountId: account.id.toString(),
+        id: account.id.toString(),
         groupId: null,
         address: account.address,
       };
@@ -284,7 +284,7 @@ describe('AccountsController', () => {
       const account = accountBuilder().with('group_id', groupId).build();
       accountDataSource.getAccount.mockResolvedValue(account);
       const expected: Account = {
-        accountId: account.id.toString(),
+        id: account.id.toString(),
         groupId: groupId.toString(),
         address: account.address,
       };

--- a/src/routes/accounts/entities/account.entity.ts
+++ b/src/routes/accounts/entities/account.entity.ts
@@ -2,18 +2,14 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class Account {
   @ApiProperty()
-  accountId: string;
+  id: string;
   @ApiPropertyOptional({ type: String, nullable: true })
   groupId: string | null;
   @ApiProperty()
   address: `0x${string}`;
 
-  constructor(
-    accountId: string,
-    groupId: string | null,
-    address: `0x${string}`,
-  ) {
-    this.accountId = accountId;
+  constructor(id: string, groupId: string | null, address: `0x${string}`) {
+    this.id = id;
     this.groupId = groupId;
     this.address = address;
   }


### PR DESCRIPTION
## Summary
In addition to the changes introduced in https://github.com/safe-global/safe-client-gateway/pull/1771, the `Account` type also has an ID as the primary key, but it was referenced by `accountId` instead of simply `id`. This PR changes the name of that property and it's more aligned with the `AccountDataType` type definition.

## Changes
- Rename `Account.accountId` to `Account.id` on the route-level `Account` entity.
