### PR TITLE
Type datasources arguments

### DIFF
--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -62,7 +62,7 @@ describe('AccountsDatasource tests', () => {
     it('creates an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
-      const result = await target.createAccount({ address });
+      const result = await target.createAccount(address);
 
       expect(result).toStrictEqual({
         id: expect.any(Number),
@@ -88,9 +88,9 @@ describe('AccountsDatasource tests', () => {
 
     it('throws when an account with the same address already exists', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
 
-      await expect(target.createAccount({ address })).rejects.toThrow(
+      await expect(target.createAccount(address)).rejects.toThrow(
         'Error creating account.',
       );
     });
@@ -99,9 +99,9 @@ describe('AccountsDatasource tests', () => {
   describe('getAccount', () => {
     it('returns an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
 
-      const result = await target.getAccount({ address });
+      const result = await target.getAccount(address);
 
       expect(result).toStrictEqual(
         expect.objectContaining({
@@ -114,9 +114,9 @@ describe('AccountsDatasource tests', () => {
 
     it('returns an account from cache', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
 
-      const result = await target.getAccount({ address });
+      const result = await target.getAccount(address);
 
       expect(result).toStrictEqual(
         expect.objectContaining({
@@ -148,10 +148,10 @@ describe('AccountsDatasource tests', () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
       // should not cache the account
-      await expect(target.getAccount({ address })).rejects.toThrow(
+      await expect(target.getAccount(address)).rejects.toThrow(
         'Error getting account.',
       );
-      await expect(target.getAccount({ address })).rejects.toThrow(
+      await expect(target.getAccount(address)).rejects.toThrow(
         'Error getting account.',
       );
 
@@ -172,9 +172,9 @@ describe('AccountsDatasource tests', () => {
   describe('deleteAccount', () => {
     it('deletes an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
 
-      await expect(target.deleteAccount({ address })).resolves.not.toThrow();
+      await expect(target.deleteAccount(address)).resolves.not.toThrow();
 
       expect(mockLoggingService.debug).not.toHaveBeenCalled();
     });
@@ -182,17 +182,17 @@ describe('AccountsDatasource tests', () => {
     it('does not throws if no account is found', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
-      await expect(target.deleteAccount({ address })).resolves.not.toThrow();
+      await expect(target.deleteAccount(address)).resolves.not.toThrow();
 
       expect(mockLoggingService.debug).toHaveBeenCalledTimes(1);
     });
 
     it('should clear the cache on account deletion', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
 
       // get the account from the cache
-      const beforeDeletion = await target.getAccount({ address });
+      const beforeDeletion = await target.getAccount(address);
       expect(beforeDeletion).toStrictEqual(
         expect.objectContaining({
           id: expect.any(Number),
@@ -222,8 +222,8 @@ describe('AccountsDatasource tests', () => {
       );
 
       // the account is deleted from the database and the cache
-      await expect(target.deleteAccount({ address })).resolves.not.toThrow();
-      await expect(target.getAccount({ address })).rejects.toThrow();
+      await expect(target.deleteAccount(address)).resolves.not.toThrow();
+      await expect(target.getAccount(address)).rejects.toThrow();
       const accountCacheDir = new CacheDir(`account_${address}`, '');
       const cached = await fakeCacheService.get(accountCacheDir);
       expect(cached).toBeUndefined();
@@ -333,7 +333,7 @@ describe('AccountsDatasource tests', () => {
   describe('getAccountDataSettings', () => {
     it('should get the account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount({ address });
+      const account = await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -349,7 +349,7 @@ describe('AccountsDatasource tests', () => {
         INSERT INTO account_data_settings 
         ${sql(accountDataSettingRows, 'account_id', 'account_data_type_id', 'enabled')} returning *`;
 
-      const actual = await target.getAccountDataSettings({ address });
+      const actual = await target.getAccountDataSettings(address);
 
       const expected = accountDataSettingRows.map((accountDataSettingRow) => ({
         account_id: account.id,
@@ -364,7 +364,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should get the account data settings from cache', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount({ address });
+      const account = await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -379,10 +379,10 @@ describe('AccountsDatasource tests', () => {
       await sql`
         INSERT INTO account_data_settings
         ${sql(accountDataSettingRows, 'account_id', 'account_data_type_id', 'enabled')} returning *`;
-      await target.getAccountDataSettings({ address });
+      await target.getAccountDataSettings(address);
 
       // check the account data settings are in the cache
-      const actual = await target.getAccountDataSettings({ address });
+      const actual = await target.getAccountDataSettings(address);
 
       const expected = accountDataSettingRows.map((accountDataSettingRow) =>
         expect.objectContaining({
@@ -424,7 +424,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should omit account data settings which data type is not active', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount({ address });
+      const account = await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -446,7 +446,7 @@ describe('AccountsDatasource tests', () => {
         INSERT INTO account_data_settings 
         ${sql(accountDataSettingRows, 'account_id', 'account_data_type_id', 'enabled')} returning *`;
 
-      const actual = await target.getAccountDataSettings({ address });
+      const actual = await target.getAccountDataSettings(address);
 
       const expected = accountDataSettingRows
         .map((accountDataSettingRow) => ({
@@ -465,7 +465,7 @@ describe('AccountsDatasource tests', () => {
   describe('upsertAccountDataSettings', () => {
     it('adds account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount({ address });
+      const account = await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -498,7 +498,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should write the associated cache on upsert', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount({ address });
+      const account = await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -536,7 +536,7 @@ describe('AccountsDatasource tests', () => {
 
     it('updates existing account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount({ address });
+      const account = await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -621,7 +621,7 @@ describe('AccountsDatasource tests', () => {
 
     it('throws an error if a non-existent data type is provided', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -650,7 +650,7 @@ describe('AccountsDatasource tests', () => {
 
     it('throws an error if an inactive data type is provided', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount({ address });
+      await target.createAccount(address);
       const accountDataTypes = [
         accountDataTypeBuilder().with('is_active', false).build(),
         accountDataTypeBuilder().build(),

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -62,7 +62,7 @@ describe('AccountsDatasource tests', () => {
     it('creates an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
-      const result = await target.createAccount(address);
+      const result = await target.createAccount({ address });
 
       expect(result).toStrictEqual({
         id: expect.any(Number),
@@ -88,9 +88,9 @@ describe('AccountsDatasource tests', () => {
 
     it('throws when an account with the same address already exists', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
 
-      await expect(target.createAccount(address)).rejects.toThrow(
+      await expect(target.createAccount({ address })).rejects.toThrow(
         'Error creating account.',
       );
     });
@@ -99,9 +99,9 @@ describe('AccountsDatasource tests', () => {
   describe('getAccount', () => {
     it('returns an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
 
-      const result = await target.getAccount(address);
+      const result = await target.getAccount({ address });
 
       expect(result).toStrictEqual(
         expect.objectContaining({
@@ -114,9 +114,9 @@ describe('AccountsDatasource tests', () => {
 
     it('returns an account from cache', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
 
-      const result = await target.getAccount(address);
+      const result = await target.getAccount({ address });
 
       expect(result).toStrictEqual(
         expect.objectContaining({
@@ -148,10 +148,10 @@ describe('AccountsDatasource tests', () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
       // should not cache the account
-      await expect(target.getAccount(address)).rejects.toThrow(
+      await expect(target.getAccount({ address })).rejects.toThrow(
         'Error getting account.',
       );
-      await expect(target.getAccount(address)).rejects.toThrow(
+      await expect(target.getAccount({ address })).rejects.toThrow(
         'Error getting account.',
       );
 
@@ -172,9 +172,9 @@ describe('AccountsDatasource tests', () => {
   describe('deleteAccount', () => {
     it('deletes an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
 
-      await expect(target.deleteAccount(address)).resolves.not.toThrow();
+      await expect(target.deleteAccount({ address })).resolves.not.toThrow();
 
       expect(mockLoggingService.debug).not.toHaveBeenCalled();
     });
@@ -182,17 +182,17 @@ describe('AccountsDatasource tests', () => {
     it('does not throws if no account is found', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
-      await expect(target.deleteAccount(address)).resolves.not.toThrow();
+      await expect(target.deleteAccount({ address })).resolves.not.toThrow();
 
       expect(mockLoggingService.debug).toHaveBeenCalledTimes(1);
     });
 
     it('should clear the cache on account deletion', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
 
       // get the account from the cache
-      const beforeDeletion = await target.getAccount(address);
+      const beforeDeletion = await target.getAccount({ address });
       expect(beforeDeletion).toStrictEqual(
         expect.objectContaining({
           id: expect.any(Number),
@@ -222,8 +222,8 @@ describe('AccountsDatasource tests', () => {
       );
 
       // the account is deleted from the database and the cache
-      await expect(target.deleteAccount(address)).resolves.not.toThrow();
-      await expect(target.getAccount(address)).rejects.toThrow();
+      await expect(target.deleteAccount({ address })).resolves.not.toThrow();
+      await expect(target.getAccount({ address })).rejects.toThrow();
       const accountCacheDir = new CacheDir(`account_${address}`, '');
       const cached = await fakeCacheService.get(accountCacheDir);
       expect(cached).toBeUndefined();
@@ -333,7 +333,7 @@ describe('AccountsDatasource tests', () => {
   describe('getAccountDataSettings', () => {
     it('should get the account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -349,7 +349,7 @@ describe('AccountsDatasource tests', () => {
         INSERT INTO account_data_settings 
         ${sql(accountDataSettingRows, 'account_id', 'account_data_type_id', 'enabled')} returning *`;
 
-      const actual = await target.getAccountDataSettings(address);
+      const actual = await target.getAccountDataSettings({ address });
 
       const expected = accountDataSettingRows.map((accountDataSettingRow) => ({
         account_id: account.id,
@@ -364,7 +364,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should get the account data settings from cache', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -379,10 +379,10 @@ describe('AccountsDatasource tests', () => {
       await sql`
         INSERT INTO account_data_settings
         ${sql(accountDataSettingRows, 'account_id', 'account_data_type_id', 'enabled')} returning *`;
-      await target.getAccountDataSettings(address);
+      await target.getAccountDataSettings({ address });
 
       // check the account data settings are in the cache
-      const actual = await target.getAccountDataSettings(address);
+      const actual = await target.getAccountDataSettings({ address });
 
       const expected = accountDataSettingRows.map((accountDataSettingRow) =>
         expect.objectContaining({
@@ -424,7 +424,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should omit account data settings which data type is not active', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -446,7 +446,7 @@ describe('AccountsDatasource tests', () => {
         INSERT INTO account_data_settings 
         ${sql(accountDataSettingRows, 'account_id', 'account_data_type_id', 'enabled')} returning *`;
 
-      const actual = await target.getAccountDataSettings(address);
+      const actual = await target.getAccountDataSettings({ address });
 
       const expected = accountDataSettingRows
         .map((accountDataSettingRow) => ({
@@ -465,7 +465,7 @@ describe('AccountsDatasource tests', () => {
   describe('upsertAccountDataSettings', () => {
     it('adds account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -480,10 +480,10 @@ describe('AccountsDatasource tests', () => {
         .with('accountDataSettings', accountDataSettings)
         .build();
 
-      const actual = await target.upsertAccountDataSettings(
+      const actual = await target.upsertAccountDataSettings({
         address,
         upsertAccountDataSettingsDto,
-      );
+      });
 
       const expected = accountDataSettings.map((accountDataSetting) => ({
         account_id: account.id,
@@ -498,7 +498,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should write the associated cache on upsert', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -513,10 +513,10 @@ describe('AccountsDatasource tests', () => {
         .with('accountDataSettings', accountDataSettings)
         .build();
 
-      await target.upsertAccountDataSettings(
+      await target.upsertAccountDataSettings({
         address,
         upsertAccountDataSettingsDto,
-      );
+      });
 
       // check the account data settings are stored in the cache
       const cacheDir = new CacheDir(`account_data_settings_${address}`, '');
@@ -536,7 +536,7 @@ describe('AccountsDatasource tests', () => {
 
     it('updates existing account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -551,10 +551,10 @@ describe('AccountsDatasource tests', () => {
         .with('accountDataSettings', accountDataSettings)
         .build();
 
-      const beforeUpdate = await target.upsertAccountDataSettings(
+      const beforeUpdate = await target.upsertAccountDataSettings({
         address,
         upsertAccountDataSettingsDto,
-      );
+      });
 
       expect(beforeUpdate).toStrictEqual(
         expect.arrayContaining(
@@ -577,10 +577,10 @@ describe('AccountsDatasource tests', () => {
           .with('accountDataSettings', accountDataSettings2)
           .build();
 
-      const afterUpdate = await target.upsertAccountDataSettings(
+      const afterUpdate = await target.upsertAccountDataSettings({
         address,
-        upsertAccountDataSettingsDto2,
-      );
+        upsertAccountDataSettingsDto: upsertAccountDataSettingsDto2,
+      });
 
       expect(afterUpdate).toStrictEqual(
         expect.arrayContaining(
@@ -612,13 +612,16 @@ describe('AccountsDatasource tests', () => {
         .build();
 
       await expect(
-        target.upsertAccountDataSettings(address, upsertAccountDataSettingsDto),
+        target.upsertAccountDataSettings({
+          address,
+          upsertAccountDataSettingsDto,
+        }),
       ).rejects.toThrow('Error getting account.');
     });
 
     it('throws an error if a non-existent data type is provided', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -638,13 +641,16 @@ describe('AccountsDatasource tests', () => {
       });
 
       await expect(
-        target.upsertAccountDataSettings(address, upsertAccountDataSettingsDto),
+        target.upsertAccountDataSettings({
+          address,
+          upsertAccountDataSettingsDto,
+        }),
       ).rejects.toThrow('Data types not found or not active.');
     });
 
     it('throws an error if an inactive data type is provided', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address });
       const accountDataTypes = [
         accountDataTypeBuilder().with('is_active', false).build(),
         accountDataTypeBuilder().build(),
@@ -660,7 +666,10 @@ describe('AccountsDatasource tests', () => {
         .build();
 
       await expect(
-        target.upsertAccountDataSettings(address, upsertAccountDataSettingsDto),
+        target.upsertAccountDataSettings({
+          address,
+          upsertAccountDataSettingsDto,
+        }),
       ).rejects.toThrow(`Data types not found or not active.`);
     });
   });

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
@@ -97,7 +97,7 @@ describe('CounterfactualSafesDatasource tests', () => {
         createCounterfactualSafeDto:
           createCounterfactualSafeDtoBuilder().build(),
       });
-      await target.getCounterfactualSafesForAccount({ account });
+      await target.getCounterfactualSafesForAccount(account);
       const cacheDir = new CacheDir(`counterfactual_safes_${address}`, '');
       await fakeCacheService.set(
         cacheDir,
@@ -260,7 +260,7 @@ describe('CounterfactualSafesDatasource tests', () => {
         }),
       ]);
 
-      const actual = await target.getCounterfactualSafesForAccount({ account });
+      const actual = await target.getCounterfactualSafesForAccount(account);
       expect(actual).toStrictEqual(expect.arrayContaining(counterfactualSafes));
     });
 
@@ -285,8 +285,8 @@ describe('CounterfactualSafesDatasource tests', () => {
       ]);
 
       // first call is not cached
-      const actual = await target.getCounterfactualSafesForAccount({ account });
-      await target.getCounterfactualSafesForAccount({ account });
+      const actual = await target.getCounterfactualSafesForAccount(account);
+      await target.getCounterfactualSafesForAccount(account);
 
       expect(actual).toStrictEqual(expect.arrayContaining(counterfactualSafes));
       const cacheDir = new CacheDir(`counterfactual_safes_${address}`, '');
@@ -428,11 +428,11 @@ describe('CounterfactualSafesDatasource tests', () => {
       ];
 
       await expect(
-        target.deleteCounterfactualSafesForAccount({ account }),
+        target.deleteCounterfactualSafesForAccount(account),
       ).resolves.not.toThrow();
 
       // database is cleared
-      const actual = await target.getCounterfactualSafesForAccount({ account });
+      const actual = await target.getCounterfactualSafesForAccount(account);
       expect(actual).toHaveLength(0);
       // cache is cleared
       expect(

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
@@ -76,18 +76,18 @@ export class CounterfactualSafesDatasource
     return counterfactualSafe;
   }
 
-  getCounterfactualSafesForAccount(args: {
-    account: Account;
-  }): Promise<CounterfactualSafe[]> {
+  getCounterfactualSafesForAccount(
+    account: Account,
+  ): Promise<CounterfactualSafe[]> {
     const cacheDir = CacheRouter.getCounterfactualSafesCacheDir(
-      args.account.address,
+      account.address,
     );
     return getFromCacheOrExecuteAndCache<CounterfactualSafe[]>(
       this.loggingService,
       this.cacheService,
       cacheDir,
       this.sql<CounterfactualSafe[]>`
-        SELECT * FROM counterfactual_safes WHERE account_id = ${args.account.id}`,
+        SELECT * FROM counterfactual_safes WHERE account_id = ${account.id}`,
       this.defaultExpirationTimeInSeconds,
     );
   }
@@ -120,18 +120,16 @@ export class CounterfactualSafesDatasource
     }
   }
 
-  async deleteCounterfactualSafesForAccount(args: {
-    account: Account;
-  }): Promise<void> {
+  async deleteCounterfactualSafesForAccount(account: Account): Promise<void> {
     let deleted: CounterfactualSafe[] = [];
     try {
       const rows = await this.sql<
         CounterfactualSafe[]
-      >`DELETE FROM counterfactual_safes WHERE account_id = ${args.account.id} RETURNING *`;
+      >`DELETE FROM counterfactual_safes WHERE account_id = ${account.id} RETURNING *`;
       deleted = rows;
     } finally {
       await this.cacheService.deleteByKey(
-        CacheRouter.getCounterfactualSafesCacheDir(args.account.address).key,
+        CacheRouter.getCounterfactualSafesCacheDir(account.address).key,
       );
       await Promise.all(
         deleted.map((row) => {

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
@@ -35,26 +35,28 @@ export class CounterfactualSafesDatasource
   // TODO: the repository calling this function should:
   // - check the AccountDataSettings to see if counterfactual-safes is enabled.
   // - check the AccountDataType to see if it's active.
-  async createCounterfactualSafe(
-    account: Account,
-    createCounterfactualSafeDto: CreateCounterfactualSafeDto,
-  ): Promise<CounterfactualSafe> {
+  async createCounterfactualSafe(args: {
+    account: Account;
+    createCounterfactualSafeDto: CreateCounterfactualSafeDto;
+  }): Promise<CounterfactualSafe> {
     const [counterfactualSafe] = await this.sql<CounterfactualSafe[]>`
       INSERT INTO counterfactual_safes 
-      ${this.sql([this.mapCreationDtoToRow(account, createCounterfactualSafeDto)])}
+      ${this.sql([this.mapCreationDtoToRow(args.account, args.createCounterfactualSafeDto)])}
       RETURNING *`;
-    const { key } = CacheRouter.getCounterfactualSafesCacheDir(account.address);
+    const { key } = CacheRouter.getCounterfactualSafesCacheDir(
+      args.account.address,
+    );
     await this.cacheService.deleteByKey(key);
     return counterfactualSafe;
   }
 
-  async getCounterfactualSafe(
-    chainId: string,
-    predictedAddress: `0x${string}`,
-  ): Promise<CounterfactualSafe> {
+  async getCounterfactualSafe(args: {
+    chainId: string;
+    predictedAddress: `0x${string}`;
+  }): Promise<CounterfactualSafe> {
     const cacheDir = CacheRouter.getCounterfactualSafeCacheDir(
-      chainId,
-      predictedAddress,
+      args.chainId,
+      args.predictedAddress,
     );
     const [counterfactualSafe] = await getFromCacheOrExecuteAndCache<
       CounterfactualSafe[]
@@ -63,7 +65,7 @@ export class CounterfactualSafesDatasource
       this.cacheService,
       cacheDir,
       this.sql<CounterfactualSafe[]>`
-        SELECT * FROM counterfactual_safes WHERE chain_id = ${chainId} AND predicted_address = ${predictedAddress}`,
+        SELECT * FROM counterfactual_safes WHERE chain_id = ${args.chainId} AND predicted_address = ${args.predictedAddress}`,
       this.defaultExpirationTimeInSeconds,
     );
 
@@ -74,58 +76,62 @@ export class CounterfactualSafesDatasource
     return counterfactualSafe;
   }
 
-  getCounterfactualSafesForAccount(
-    account: Account,
-  ): Promise<CounterfactualSafe[]> {
+  getCounterfactualSafesForAccount(args: {
+    account: Account;
+  }): Promise<CounterfactualSafe[]> {
     const cacheDir = CacheRouter.getCounterfactualSafesCacheDir(
-      account.address,
+      args.account.address,
     );
     return getFromCacheOrExecuteAndCache<CounterfactualSafe[]>(
       this.loggingService,
       this.cacheService,
       cacheDir,
       this.sql<CounterfactualSafe[]>`
-        SELECT * FROM counterfactual_safes WHERE account_id = ${account.id}`,
+        SELECT * FROM counterfactual_safes WHERE account_id = ${args.account.id}`,
       this.defaultExpirationTimeInSeconds,
     );
   }
 
-  async deleteCounterfactualSafe(
-    account: Account,
-    chainId: string,
-    predictedAddress: `0x${string}`,
-  ): Promise<void> {
+  async deleteCounterfactualSafe(args: {
+    account: Account;
+    chainId: string;
+    predictedAddress: `0x${string}`;
+  }): Promise<void> {
     try {
       const { count } = await this
-        .sql`DELETE FROM counterfactual_safes WHERE chain_id = ${chainId} AND predicted_address = ${predictedAddress} AND account_id = ${account.id}`;
+        .sql`DELETE FROM counterfactual_safes WHERE chain_id = ${args.chainId} AND predicted_address = ${args.predictedAddress} AND account_id = ${args.account.id}`;
       if (count === 0) {
         this.loggingService.debug(
-          `Error deleting Counterfactual Safe (${chainId}, ${predictedAddress}): not found`,
+          `Error deleting Counterfactual Safe (${args.chainId}, ${args.predictedAddress}): not found`,
         );
       }
     } finally {
       await Promise.all([
         this.cacheService.deleteByKey(
-          CacheRouter.getCounterfactualSafeCacheDir(chainId, predictedAddress)
-            .key,
+          CacheRouter.getCounterfactualSafeCacheDir(
+            args.chainId,
+            args.predictedAddress,
+          ).key,
         ),
         this.cacheService.deleteByKey(
-          CacheRouter.getCounterfactualSafesCacheDir(account.address).key,
+          CacheRouter.getCounterfactualSafesCacheDir(args.account.address).key,
         ),
       ]);
     }
   }
 
-  async deleteCounterfactualSafesForAccount(account: Account): Promise<void> {
+  async deleteCounterfactualSafesForAccount(args: {
+    account: Account;
+  }): Promise<void> {
     let deleted: CounterfactualSafe[] = [];
     try {
       const rows = await this.sql<
         CounterfactualSafe[]
-      >`DELETE FROM counterfactual_safes WHERE account_id = ${account.id} RETURNING *`;
+      >`DELETE FROM counterfactual_safes WHERE account_id = ${args.account.id} RETURNING *`;
       deleted = rows;
     } finally {
       await this.cacheService.deleteByKey(
-        CacheRouter.getCounterfactualSafesCacheDir(account.address).key,
+        CacheRouter.getCounterfactualSafesCacheDir(args.account.address).key,
       );
       await Promise.all(
         deleted.map((row) => {

--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -35,7 +35,7 @@ export interface IAccountsRepository {
   upsertAccountDataSettings(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;
-    upsertAccountDataSettings: UpsertAccountDataSettingsDto;
+    upsertAccountDataSettingsDto: UpsertAccountDataSettingsDto;
   }): Promise<AccountDataSetting[]>;
 }
 

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -24,9 +24,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    const account = await this.datasource.createAccount({
-      address: args.address,
-    });
+    const account = await this.datasource.createAccount(args.address);
     return AccountSchema.parse(account);
   }
 
@@ -37,7 +35,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    const account = await this.datasource.getAccount({ address: args.address });
+    const account = await this.datasource.getAccount(args.address);
     return AccountSchema.parse(account);
   }
 
@@ -48,7 +46,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    return this.datasource.deleteAccount({ address: args.address });
+    return this.datasource.deleteAccount(args.address);
   }
 
   async getDataTypes(): Promise<AccountDataType[]> {
@@ -63,7 +61,7 @@ export class AccountsRepository implements IAccountsRepository {
       throw new UnauthorizedException();
     }
 
-    return this.datasource.getAccountDataSettings({ address: args.address });
+    return this.datasource.getAccountDataSettings(args.address);
   }
 
   async upsertAccountDataSettings(args: {

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -24,7 +24,9 @@ export class AccountsRepository implements IAccountsRepository {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    const account = await this.datasource.createAccount(args.address);
+    const account = await this.datasource.createAccount({
+      address: args.address,
+    });
     return AccountSchema.parse(account);
   }
 
@@ -35,7 +37,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    const account = await this.datasource.getAccount(args.address);
+    const account = await this.datasource.getAccount({ address: args.address });
     return AccountSchema.parse(account);
   }
 
@@ -46,8 +48,7 @@ export class AccountsRepository implements IAccountsRepository {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    // TODO: trigger a cascade deletion of the account-associated data.
-    return this.datasource.deleteAccount(args.address);
+    return this.datasource.deleteAccount({ address: args.address });
   }
 
   async getDataTypes(): Promise<AccountDataType[]> {
@@ -62,25 +63,25 @@ export class AccountsRepository implements IAccountsRepository {
       throw new UnauthorizedException();
     }
 
-    return this.datasource.getAccountDataSettings(args.address);
+    return this.datasource.getAccountDataSettings({ address: args.address });
   }
 
   async upsertAccountDataSettings(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;
-    upsertAccountDataSettings: UpsertAccountDataSettingsDto;
+    upsertAccountDataSettingsDto: UpsertAccountDataSettingsDto;
   }): Promise<AccountDataSetting[]> {
-    const { address, upsertAccountDataSettings } = args;
+    const { address, upsertAccountDataSettingsDto } = args;
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    if (upsertAccountDataSettings.accountDataSettings.length === 0) {
+    if (upsertAccountDataSettingsDto.accountDataSettings.length === 0) {
       return [];
     }
 
-    return this.datasource.upsertAccountDataSettings(
+    return this.datasource.upsertAccountDataSettings({
       address,
-      upsertAccountDataSettings,
-    );
+      upsertAccountDataSettingsDto,
+    });
   }
 }

--- a/src/domain/interfaces/accounts.datasource.interface.ts
+++ b/src/domain/interfaces/accounts.datasource.interface.ts
@@ -6,17 +6,15 @@ import { UpsertAccountDataSettingsDto } from '@/domain/accounts/entities/upsert-
 export const IAccountsDatasource = Symbol('IAccountsDatasource');
 
 export interface IAccountsDatasource {
-  createAccount(args: { address: `0x${string}` }): Promise<Account>;
+  createAccount(address: `0x${string}`): Promise<Account>;
 
-  getAccount(args: { address: `0x${string}` }): Promise<Account>;
+  getAccount(address: `0x${string}`): Promise<Account>;
 
-  deleteAccount(args: { address: `0x${string}` }): Promise<void>;
+  deleteAccount(address: `0x${string}`): Promise<void>;
 
   getDataTypes(): Promise<AccountDataType[]>;
 
-  getAccountDataSettings(args: {
-    address: `0x${string}`;
-  }): Promise<AccountDataSetting[]>;
+  getAccountDataSettings(address: `0x${string}`): Promise<AccountDataSetting[]>;
 
   upsertAccountDataSettings(args: {
     address: `0x${string}`;

--- a/src/domain/interfaces/accounts.datasource.interface.ts
+++ b/src/domain/interfaces/accounts.datasource.interface.ts
@@ -6,18 +6,20 @@ import { UpsertAccountDataSettingsDto } from '@/domain/accounts/entities/upsert-
 export const IAccountsDatasource = Symbol('IAccountsDatasource');
 
 export interface IAccountsDatasource {
-  createAccount(address: `0x${string}`): Promise<Account>;
+  createAccount(args: { address: `0x${string}` }): Promise<Account>;
 
-  getAccount(address: `0x${string}`): Promise<Account>;
+  getAccount(args: { address: `0x${string}` }): Promise<Account>;
 
-  deleteAccount(address: `0x${string}`): Promise<void>;
+  deleteAccount(args: { address: `0x${string}` }): Promise<void>;
 
   getDataTypes(): Promise<AccountDataType[]>;
 
-  getAccountDataSettings(address: `0x${string}`): Promise<AccountDataSetting[]>;
+  getAccountDataSettings(args: {
+    address: `0x${string}`;
+  }): Promise<AccountDataSetting[]>;
 
-  upsertAccountDataSettings(
-    address: `0x${string}`,
-    upsertAccountDataSettings: UpsertAccountDataSettingsDto,
-  ): Promise<AccountDataSetting[]>;
+  upsertAccountDataSettings(args: {
+    address: `0x${string}`;
+    upsertAccountDataSettingsDto: UpsertAccountDataSettingsDto;
+  }): Promise<AccountDataSetting[]>;
 }

--- a/src/domain/interfaces/counterfactual-safes.datasource.interface.ts
+++ b/src/domain/interfaces/counterfactual-safes.datasource.interface.ts
@@ -7,25 +7,27 @@ export const ICounterfactualSafesDatasource = Symbol(
 );
 
 export interface ICounterfactualSafesDatasource {
-  createCounterfactualSafe(
-    account: Account,
-    createCounterfactualSafeDto: CreateCounterfactualSafeDto,
-  ): Promise<CounterfactualSafe>;
+  createCounterfactualSafe(args: {
+    account: Account;
+    createCounterfactualSafeDto: CreateCounterfactualSafeDto;
+  }): Promise<CounterfactualSafe>;
 
-  getCounterfactualSafe(
-    chainId: string,
-    predictedAddress: `0x${string}`,
-  ): Promise<CounterfactualSafe>;
+  getCounterfactualSafe(args: {
+    chainId: string;
+    predictedAddress: `0x${string}`;
+  }): Promise<CounterfactualSafe>;
 
-  getCounterfactualSafesForAccount(
-    account: Account,
-  ): Promise<CounterfactualSafe[]>;
+  getCounterfactualSafesForAccount(args: {
+    account: Account;
+  }): Promise<CounterfactualSafe[]>;
 
-  deleteCounterfactualSafe(
-    account: Account,
-    chainId: string,
-    predictedAddress: `0x${string}`,
-  ): Promise<void>;
+  deleteCounterfactualSafe(args: {
+    account: Account;
+    chainId: string;
+    predictedAddress: `0x${string}`;
+  }): Promise<void>;
 
-  deleteCounterfactualSafesForAccount(account: Account): Promise<void>;
+  deleteCounterfactualSafesForAccount(args: {
+    account: Account;
+  }): Promise<void>;
 }

--- a/src/domain/interfaces/counterfactual-safes.datasource.interface.ts
+++ b/src/domain/interfaces/counterfactual-safes.datasource.interface.ts
@@ -17,9 +17,9 @@ export interface ICounterfactualSafesDatasource {
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe>;
 
-  getCounterfactualSafesForAccount(args: {
-    account: Account;
-  }): Promise<CounterfactualSafe[]>;
+  getCounterfactualSafesForAccount(
+    account: Account,
+  ): Promise<CounterfactualSafe[]>;
 
   deleteCounterfactualSafe(args: {
     account: Account;
@@ -27,7 +27,5 @@ export interface ICounterfactualSafesDatasource {
     predictedAddress: `0x${string}`;
   }): Promise<void>;
 
-  deleteCounterfactualSafesForAccount(args: {
-    account: Account;
-  }): Promise<void>;
+  deleteCounterfactualSafesForAccount(account: Account): Promise<void>;
 }

--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -109,7 +109,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.createAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.createAccount).toHaveBeenCalledWith({ address });
+      expect(accountDataSource.createAccount).toHaveBeenCalledWith(address);
     });
 
     it('Returns 403 if no token is present', async () => {
@@ -272,7 +272,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.getAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.getAccount).toHaveBeenCalledWith({ address });
+      expect(accountDataSource.getAccount).toHaveBeenCalledWith(address);
     });
 
     it('should get a group account', async () => {
@@ -300,7 +300,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.getAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.getAccount).toHaveBeenCalledWith({ address });
+      expect(accountDataSource.getAccount).toHaveBeenCalledWith(address);
     });
 
     it('Returns 403 if no token is present', async () => {
@@ -447,7 +447,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.deleteAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.deleteAccount).toHaveBeenCalledWith({ address });
+      expect(accountDataSource.deleteAccount).toHaveBeenCalledWith(address);
     });
 
     it('Returns 403 if no token is present', async () => {
@@ -819,9 +819,9 @@ describe('AccountsController', () => {
         .expect(200);
 
       expect(accountDataSource.getAccountDataSettings).toHaveBeenCalledTimes(1);
-      expect(accountDataSource.getAccountDataSettings).toHaveBeenCalledWith({
+      expect(accountDataSource.getAccountDataSettings).toHaveBeenCalledWith(
         address,
-      });
+      );
     });
 
     it('Returns 403 if no token is present', async () => {

--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -109,7 +109,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.createAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.createAccount).toHaveBeenCalledWith(address);
+      expect(accountDataSource.createAccount).toHaveBeenCalledWith({ address });
     });
 
     it('Returns 403 if no token is present', async () => {
@@ -272,7 +272,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.getAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.getAccount).toHaveBeenCalledWith(address);
+      expect(accountDataSource.getAccount).toHaveBeenCalledWith({ address });
     });
 
     it('should get a group account', async () => {
@@ -300,7 +300,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.getAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.getAccount).toHaveBeenCalledWith(address);
+      expect(accountDataSource.getAccount).toHaveBeenCalledWith({ address });
     });
 
     it('Returns 403 if no token is present', async () => {
@@ -447,7 +447,7 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.deleteAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.deleteAccount).toHaveBeenCalledWith(address);
+      expect(accountDataSource.deleteAccount).toHaveBeenCalledWith({ address });
     });
 
     it('Returns 403 if no token is present', async () => {
@@ -638,10 +638,10 @@ describe('AccountsController', () => {
       expect(accountDataSource.upsertAccountDataSettings).toHaveBeenCalledTimes(
         1,
       );
-      expect(accountDataSource.upsertAccountDataSettings).toHaveBeenCalledWith(
+      expect(accountDataSource.upsertAccountDataSettings).toHaveBeenCalledWith({
         address,
         upsertAccountDataSettingsDto,
-      );
+      });
     });
 
     it('should accept a empty array of data settings', async () => {
@@ -819,9 +819,9 @@ describe('AccountsController', () => {
         .expect(200);
 
       expect(accountDataSource.getAccountDataSettings).toHaveBeenCalledTimes(1);
-      expect(accountDataSource.getAccountDataSettings).toHaveBeenCalledWith(
+      expect(accountDataSource.getAccountDataSettings).toHaveBeenCalledWith({
         address,
-      );
+      });
     });
 
     it('Returns 403 if no token is present', async () => {

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -82,7 +82,7 @@ export class AccountsService {
       this.accountsRepository.upsertAccountDataSettings({
         authPayload: args.authPayload,
         address: args.address,
-        upsertAccountDataSettings: {
+        upsertAccountDataSettingsDto: {
           accountDataSettings:
             args.upsertAccountDataSettingsDto.accountDataSettings,
         },


### PR DESCRIPTION
## Summary
This PR changes the Accounts and CounterfactualSafes datasource function from using an enumeration of arguments to a fixed typed object as an argument, in alignment with the rest of the classes in the service.

## Changes
- Adds `args: {...}` as an argument to all non-singular argument functions on both `AccountsDatasource` and `CounterfactualSafesDatasource`.