### PR TITLE
Extract getFromCacheOrExecuteAndCache utility function

### DIFF
--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -4,6 +4,7 @@ import { AccountsDatasource } from '@/datasources/accounts/accounts.datasource';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { MAX_TTL } from '@/datasources/cache/constants';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
 import { accountDataTypeBuilder } from '@/domain/accounts/entities/__tests__/account-data-type.builder';
 import { upsertAccountDataSettingsDtoBuilder } from '@/domain/accounts/entities/__tests__/upsert-account-data-settings.dto.entity.builder';
@@ -43,6 +44,7 @@ describe('AccountsDatasource tests', () => {
     target = new AccountsDatasource(
       fakeCacheService,
       sql,
+      new CachedQueryResolver(mockLoggingService, fakeCacheService),
       mockLoggingService,
       mockConfigurationService,
     );

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -75,9 +75,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
     const cacheDir = CacheRouter.getAccountCacheDir(address);
     const [account] = await this.cachedQueryResolver.get<Account[]>({
       cacheDir,
-      query: this.sql<
-        Account[]
-      >`SELECT * FROM accounts WHERE address = ${address}`,
+      query: this.sql`SELECT * FROM accounts WHERE address = ${address}`,
       ttl: this.defaultExpirationTimeInSeconds,
     });
 
@@ -111,7 +109,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
     const cacheDir = CacheRouter.getAccountDataTypesCacheDir();
     return this.cachedQueryResolver.get<AccountDataType[]>({
       cacheDir,
-      query: this.sql<AccountDataType[]>`SELECT * FROM account_data_types`,
+      query: this.sql`SELECT * FROM account_data_types`,
       ttl: MAX_TTL,
     });
   }
@@ -123,9 +121,9 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
     const cacheDir = CacheRouter.getAccountDataSettingsCacheDir(address);
     return this.cachedQueryResolver.get<AccountDataSetting[]>({
       cacheDir,
-      query: this.sql<AccountDataSetting[]>`
-        SELECT ads.* FROM account_data_settings ads INNER JOIN account_data_types adt
-          ON ads.account_data_type_id = adt.id
+      query: this.sql`
+        SELECT ads.* FROM account_data_settings ads
+          INNER JOIN account_data_types adt ON ads.account_data_type_id = adt.id
         WHERE ads.account_id = ${account.id} AND adt.is_active IS TRUE;`,
       ttl: this.defaultExpirationTimeInSeconds,
     });

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -6,6 +6,7 @@ import {
 } from '@/datasources/cache/cache.service.interface';
 import { MAX_TTL } from '@/datasources/cache/constants';
 import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
+import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
 import { AccountDataSetting } from '@/domain/accounts/entities/account-data-setting.entity';
 import { AccountDataType } from '@/domain/accounts/entities/account-data-type.entity';
 import { Account } from '@/domain/accounts/entities/account.entity';
@@ -29,6 +30,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
   constructor(
     @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
+    @Inject(ICachedQueryResolver)
     private readonly cachedQueryResolver: CachedQueryResolver,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
     @Inject(IConfigurationService)

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -5,7 +5,7 @@ import {
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import { MAX_TTL } from '@/datasources/cache/constants';
-import { getFromCacheOrExecuteAndCache } from '@/datasources/db/utils';
+import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 import { AccountDataSetting } from '@/domain/accounts/entities/account-data-setting.entity';
 import { AccountDataType } from '@/domain/accounts/entities/account-data-type.entity';
 import { Account } from '@/domain/accounts/entities/account.entity';
@@ -29,6 +29,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
   constructor(
     @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
+    private readonly cachedQueryResolver: CachedQueryResolver,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
@@ -70,13 +71,13 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
 
   async getAccount(address: `0x${string}`): Promise<Account> {
     const cacheDir = CacheRouter.getAccountCacheDir(address);
-    const [account] = await getFromCacheOrExecuteAndCache<Account[]>(
-      this.loggingService,
-      this.cacheService,
+    const [account] = await this.cachedQueryResolver.get<Account[]>({
       cacheDir,
-      this.sql<Account[]>`SELECT * FROM accounts WHERE address = ${address}`,
-      this.defaultExpirationTimeInSeconds,
-    );
+      query: this.sql<
+        Account[]
+      >`SELECT * FROM accounts WHERE address = ${address}`,
+      ttl: this.defaultExpirationTimeInSeconds,
+    });
 
     if (!account) {
       throw new NotFoundException('Error getting account.');
@@ -106,13 +107,11 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
 
   async getDataTypes(): Promise<AccountDataType[]> {
     const cacheDir = CacheRouter.getAccountDataTypesCacheDir();
-    return getFromCacheOrExecuteAndCache<AccountDataType[]>(
-      this.loggingService,
-      this.cacheService,
+    return this.cachedQueryResolver.get<AccountDataType[]>({
       cacheDir,
-      this.sql<AccountDataType[]>`SELECT * FROM account_data_types`,
-      MAX_TTL,
-    );
+      query: this.sql<AccountDataType[]>`SELECT * FROM account_data_types`,
+      ttl: MAX_TTL,
+    });
   }
 
   async getAccountDataSettings(
@@ -120,16 +119,14 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
   ): Promise<AccountDataSetting[]> {
     const account = await this.getAccount(address);
     const cacheDir = CacheRouter.getAccountDataSettingsCacheDir(address);
-    return getFromCacheOrExecuteAndCache<AccountDataSetting[]>(
-      this.loggingService,
-      this.cacheService,
+    return this.cachedQueryResolver.get<AccountDataSetting[]>({
       cacheDir,
-      this.sql<AccountDataSetting[]>`
+      query: this.sql<AccountDataSetting[]>`
         SELECT ads.* FROM account_data_settings ads INNER JOIN account_data_types adt
           ON ads.account_data_type_id = adt.id
         WHERE ads.account_id = ${account.id} AND adt.is_active IS TRUE;`,
-      this.defaultExpirationTimeInSeconds,
-    );
+      ttl: this.defaultExpirationTimeInSeconds,
+    });
   }
 
   /**

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
@@ -3,6 +3,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { CounterfactualSafesDatasource } from '@/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
 import { createCounterfactualSafeDtoBuilder } from '@/domain/accounts/counterfactual-safes/entities/__tests__/create-counterfactual-safe.dto.entity.builder';
 import { accountBuilder } from '@/domain/accounts/entities/__tests__/account.builder';
@@ -42,6 +43,7 @@ describe('CounterfactualSafesDatasource tests', () => {
     target = new CounterfactualSafesDatasource(
       fakeCacheService,
       sql,
+      new CachedQueryResolver(mockLoggingService, fakeCacheService),
       mockLoggingService,
       mockConfigurationService,
     );

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
@@ -5,6 +5,7 @@ import {
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
+import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
 import { CounterfactualSafe } from '@/domain/accounts/counterfactual-safes/entities/counterfactual-safe.entity';
 import { CreateCounterfactualSafeDto } from '@/domain/accounts/counterfactual-safes/entities/create-counterfactual-safe.dto.entity';
 import { Account } from '@/domain/accounts/entities/account.entity';
@@ -22,6 +23,7 @@ export class CounterfactualSafesDatasource
   constructor(
     @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
+    @Inject(ICachedQueryResolver)
     private readonly cachedQueryResolver: CachedQueryResolver,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
     @Inject(IConfigurationService)

--- a/src/datasources/db/cached-query-resolver.interface.ts
+++ b/src/datasources/db/cached-query-resolver.interface.ts
@@ -1,0 +1,12 @@
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import postgres from 'postgres';
+
+export const ICachedQueryResolver = Symbol('ICachedQueryResolver');
+
+export interface ICachedQueryResolver {
+  get<T extends postgres.MaybeRow[]>(args: {
+    cacheDir: CacheDir;
+    query: postgres.PendingQuery<T>;
+    ttl: number;
+  }): Promise<T>;
+}

--- a/src/datasources/db/cached-query-resolver.spec.ts
+++ b/src/datasources/db/cached-query-resolver.spec.ts
@@ -48,8 +48,6 @@ describe('CachedQueryResolver', () => {
         key: 'key',
         field: 'field',
       });
-      const cacheContent = await fakeCacheService.get(cacheDir);
-      expect(cacheContent).toBe(JSON.stringify(value));
     });
 
     it('should execute the query and cache the result if the cache is empty', async () => {

--- a/src/datasources/db/cached-query-resolver.spec.ts
+++ b/src/datasources/db/cached-query-resolver.spec.ts
@@ -1,0 +1,74 @@
+import { fakeJson } from '@/__tests__/faker';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker';
+import postgres, { MaybeRow } from 'postgres';
+
+const mockLoggingService = jest.mocked({
+  debug: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
+const mockQuery = jest.mocked({ catch: jest.fn() } as jest.MockedObjectDeep<
+  postgres.PendingQuery<MaybeRow[]>
+>);
+
+describe('CachedQueryResolver', () => {
+  let fakeCacheService: FakeCacheService;
+  let target: CachedQueryResolver;
+
+  beforeAll(() => {
+    fakeCacheService = new FakeCacheService();
+    target = new CachedQueryResolver(mockLoggingService, fakeCacheService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+  });
+
+  describe('get', () => {
+    it('should return the content from cache if it exists', async () => {
+      const cacheDir = { key: 'key', field: 'field' };
+      const ttl = faker.number.int({ min: 1, max: 1000 });
+      const value = fakeJson();
+      await fakeCacheService.set(cacheDir, JSON.stringify(value), ttl);
+
+      const actual = await target.get({
+        cacheDir,
+        query: mockQuery,
+        ttl,
+      });
+
+      expect(actual).toBe(value);
+      expect(mockLoggingService.debug).toHaveBeenCalledWith({
+        type: 'cache_hit',
+        key: 'key',
+        field: 'field',
+      });
+      expect(mockQuery.catch).not.toHaveBeenCalled();
+    });
+
+    it('should execute the query and cache the result if the cache is empty', async () => {
+      const cacheDir = { key: 'key', field: 'field' };
+      const ttl = faker.number.int({ min: 1, max: 1000 });
+      const dbResult = { ...JSON.parse(fakeJson()), count: 1 };
+      mockQuery.catch.mockResolvedValue(dbResult);
+
+      const actual = await target.get({
+        cacheDir,
+        query: mockQuery,
+        ttl,
+      });
+
+      expect(actual).toBe(dbResult);
+      expect(mockLoggingService.debug).toHaveBeenCalledWith({
+        type: 'cache_miss',
+        key: 'key',
+        field: 'field',
+      });
+      const cacheContent = await fakeCacheService.get(cacheDir);
+      expect(cacheContent).toBe(JSON.stringify(dbResult));
+    });
+  });
+});

--- a/src/datasources/db/cached-query-resolver.ts
+++ b/src/datasources/db/cached-query-resolver.ts
@@ -1,0 +1,61 @@
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import postgres from 'postgres';
+
+@Injectable()
+// TODO: add/implement interface
+export class CachedQueryResolver {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    @Inject(CacheService) private readonly cacheService: ICacheService,
+  ) {}
+
+  /**
+   * Returns the content from cache or executes the query and caches the result.
+   * If the specified {@link CacheDir} is empty, the query is executed and the result is cached.
+   * If the specified {@link CacheDir} is not empty, the pointed content is returned.
+   *
+   * @param cacheDir {@link CacheDir} to use for caching
+   * @param query query to execute
+   * @param ttl time to live for the cache
+   * @returns content from cache or query result
+   */
+  async get<T extends postgres.MaybeRow[]>(args: {
+    cacheDir: CacheDir;
+    query: postgres.PendingQuery<T>;
+    ttl: number;
+  }): Promise<T> {
+    const { key, field } = args.cacheDir;
+    const cached = await this.cacheService.get(args.cacheDir);
+    if (cached != null) {
+      this.loggingService.debug({ type: 'cache_hit', key, field });
+      return JSON.parse(cached);
+    }
+    this.loggingService.debug({ type: 'cache_miss', key, field });
+
+    // log & hide database errors
+    const result = await args.query.catch((e) => {
+      this.loggingService.error(asError(e).message);
+      throw new InternalServerErrorException();
+    });
+
+    if (result.count > 0) {
+      await this.cacheService.set(
+        args.cacheDir,
+        JSON.stringify(result),
+        args.ttl,
+      );
+    }
+    return result;
+  }
+}

--- a/src/datasources/db/cached-query-resolver.ts
+++ b/src/datasources/db/cached-query-resolver.ts
@@ -21,7 +21,7 @@ export class CachedQueryResolver implements ICachedQueryResolver {
   ) {}
 
   /**
-   * Returns the content from cache or executes the query and caches the result.
+   * Returns the content from cache or executes the query, caches the result and returns it.
    * If the specified {@link CacheDir} is empty, the query is executed and the result is cached.
    * If the specified {@link CacheDir} is not empty, the pointed content is returned.
    *

--- a/src/datasources/db/cached-query-resolver.ts
+++ b/src/datasources/db/cached-query-resolver.ts
@@ -3,6 +3,7 @@ import {
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
 import {
@@ -13,8 +14,7 @@ import {
 import postgres from 'postgres';
 
 @Injectable()
-// TODO: add/implement interface
-export class CachedQueryResolver {
+export class CachedQueryResolver implements ICachedQueryResolver {
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
     @Inject(CacheService) private readonly cacheService: ICacheService,

--- a/src/datasources/db/postgres-database.module.spec.ts
+++ b/src/datasources/db/postgres-database.module.spec.ts
@@ -1,10 +1,11 @@
-import { Test } from '@nestjs/testing';
-import { PostgresDatabaseModule } from '@/datasources/db/postgres-database.module';
 import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { PostgresDatabaseModule } from '@/datasources/db/postgres-database.module';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import postgres from 'postgres';
+import { Test } from '@nestjs/testing';
 import { join } from 'path';
+import postgres from 'postgres';
 
 describe('PostgresDatabaseModule tests', () => {
   let sql: postgres.Sql;
@@ -34,6 +35,7 @@ describe('PostgresDatabaseModule tests', () => {
         PostgresDatabaseModule,
         ConfigurationModule.register(testConfiguration),
         TestLoggingModule,
+        TestCacheModule,
       ],
     }).compile();
 

--- a/src/datasources/db/postgres-database.module.ts
+++ b/src/datasources/db/postgres-database.module.ts
@@ -5,6 +5,8 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { PostgresDatabaseMigrationHook } from '@/datasources/db/postgres-database.migration.hook';
 import fs from 'fs';
 import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
+import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 
 function dbFactory(configurationService: IConfigurationService): postgres.Sql {
   const caPath = configurationService.get<string>('db.postgres.ssl.caPath');
@@ -48,9 +50,13 @@ function migratorFactory(sql: postgres.Sql): PostgresDatabaseMigrator {
       useFactory: migratorFactory,
       inject: ['DB_INSTANCE'],
     },
+    {
+      provide: ICachedQueryResolver,
+      useClass: CachedQueryResolver,
+    },
     PostgresDatabaseShutdownHook,
     PostgresDatabaseMigrationHook,
   ],
-  exports: ['DB_INSTANCE'],
+  exports: ['DB_INSTANCE', ICachedQueryResolver],
 })
 export class PostgresDatabaseModule {}


### PR DESCRIPTION
## Summary
This PR extracts the utility function used to retrieve data from the service cache before executing a query to its own class.

A new `CachedQueryResolver` was created, which exposes a `get` function that:
- Receives a `CacheDir`, a `query`, and `ttl` value.
- Tries to get the data from the cache, using the record pointed by `CacheDir`. If the data is found, it's returned, if it's not found, then it tries to get it from the database. If successful, caches the data under `CacheDir` with `ttl` TTL.

(More context in: https://github.com/safe-global/safe-client-gateway/pull/1773#discussion_r1683049155)

## Changes
- Adds `CachedQueryResolver` class, to be used to retrieve data from the service cache before executing a query.