### PR TITLE
Add Chains retrieval and cache deletion debug logs

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -114,6 +114,7 @@ export default (): ReturnType<typeof configuration> => ({
     swapsDecoding: true,
     twapsDecoding: true,
     debugLogs: false,
+    configHooksDebugLogs: false,
     imitationMapping: false,
     auth: false,
     confirmationView: false,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -170,6 +170,8 @@ export default () => ({
     swapsDecoding: process.env.FF_SWAPS_DECODING?.toLowerCase() === 'true',
     twapsDecoding: process.env.FF_TWAPS_DECODING?.toLowerCase() === 'true',
     debugLogs: process.env.FF_DEBUG_LOGS?.toLowerCase() === 'true',
+    configHooksDebugLogs:
+      process.env.FF_CONFIG_HOOKS_DEBUG_LOGS?.toLowerCase() === 'true',
     imitationMapping:
       process.env.FF_IMITATION_MAPPING?.toLowerCase() === 'true',
     auth: process.env.FF_AUTH?.toLowerCase() === 'true',

--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -33,6 +33,7 @@ describe('CacheFirstDataSource', () => {
     fakeCacheService = new FakeCacheService();
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('features.debugLogs', true);
+    fakeConfigurationService.set('features.configHooksDebugLogs', false);
     cacheFirstDataSource = new CacheFirstDataSource(
       fakeCacheService,
       mockNetworkService,

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -7,6 +7,7 @@ import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { safeAppBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app.builder';
+import { ILoggingService } from '@/logging/logging.interface';
 import { faker } from '@faker-js/faker';
 
 const dataSource = {
@@ -24,6 +25,10 @@ const httpErrorFactory = {
   from: jest.fn(),
 } as jest.MockedObjectDeep<HttpErrorFactory>;
 const mockHttpErrorFactory = jest.mocked(httpErrorFactory);
+
+const mockLoggingService = {
+  info: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
 
 describe('ConfigApi', () => {
   const baseUri = faker.internet.url({ appendSlash: false });
@@ -43,6 +48,7 @@ describe('ConfigApi', () => {
       'expirationTimeInSeconds.notFound.default',
       notFoundExpirationTimeInSeconds,
     );
+    fakeConfigurationService.set('features.configHooksDebugLogs', false);
   });
 
   beforeEach(() => {
@@ -52,6 +58,7 @@ describe('ConfigApi', () => {
       mockCacheService,
       fakeConfigurationService,
       mockHttpErrorFactory,
+      mockLoggingService,
     );
   });
 
@@ -65,6 +72,7 @@ describe('ConfigApi', () => {
           mockCacheService,
           fakeConfigurationService,
           mockHttpErrorFactory,
+          mockLoggingService,
         ),
     ).toThrow();
   });


### PR DESCRIPTION
## Summary
This PR adds optional logs to the retrieval/cache deletion of `Chain` objects from the Safe Config Service.

## Changes
- Adds a feature flag to control Chain-related debugging logs: `configHooksDebugLogs`.
- Adds optional logging to `ConfigApi` when the `clearChain` function is executed (after the reception of a `CHAIN_UPDATED` event).
- Adds optional logging to `CacheFirstDatasource` when the `chain/chains` cache key is written in the cache.
