### PR TITLE
Add DB_MAX_SAFE_INTEGER constant

### DIFF
--- a/src/domain/accounts/entities/__tests__/account.builder.ts
+++ b/src/domain/accounts/entities/__tests__/account.builder.ts
@@ -1,12 +1,13 @@
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { Account } from '@/domain/accounts/entities/account.entity';
+import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 
 export function accountBuilder(): IBuilder<Account> {
   return new Builder<Account>()
-    .with('id', faker.number.int({ max: 1_000_000 }))
-    .with('group_id', faker.number.int({ max: 1_000_000 }))
+    .with('id', faker.number.int({ max: DB_MAX_SAFE_INTEGER }))
+    .with('group_id', faker.number.int({ max: DB_MAX_SAFE_INTEGER }))
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('created_at', faker.date.recent())
     .with('updated_at', faker.date.recent());

--- a/src/domain/common/constants.ts
+++ b/src/domain/common/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * The maximum safe integer for the database.
+ * This is the maximum value that can be stored in the database for an integer column.
+ */
+export const DB_MAX_SAFE_INTEGER = Math.pow(2, 31) - 1;

--- a/src/domain/common/constants.ts
+++ b/src/domain/common/constants.ts
@@ -1,5 +1,6 @@
 /**
  * The maximum safe integer for the database.
  * This is the maximum value that can be stored in the database for an integer column.
+ * Ref: https://www.postgresql.org/docs/16/datatype-numeric.html
  */
 export const DB_MAX_SAFE_INTEGER = Math.pow(2, 31) - 1;


### PR DESCRIPTION
## Summary

Context: https://github.com/safe-global/safe-client-gateway/pull/1773#discussion_r1684538079

## Changes
- Adds a `DB_MAX_SAFE_INTEGER` constant, with value `(2^31)-1` (max Postgres value for an `integer` column).
