### PR TITLE
Counterfactual Safes retrieval by account address endpoint

### DIFF
--- a/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.interface.ts
+++ b/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.interface.ts
@@ -18,6 +18,11 @@ export interface ICounterfactualSafesRepository {
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe>;
 
+  getCounterfactualSafes(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<CounterfactualSafe[]>;
+
   createCounterfactualSafe(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;

--- a/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.ts
+++ b/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.ts
@@ -58,6 +58,28 @@ export class CounterfactualSafesRepository
   }
 
   /**
+   * Gets all the Counterfactual Safes associated with an account address.
+   * Checks that the account has the CounterfactualSafes data setting enabled.
+   */
+  async getCounterfactualSafes(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<CounterfactualSafe[]> {
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+    await this.checkCounterfactualSafesIsEnabled({
+      authPayload: args.authPayload,
+      address: args.address,
+    });
+    const account = await this.accountsRepository.getAccount({
+      authPayload: args.authPayload,
+      address: args.address,
+    });
+    return this.datasource.getCounterfactualSafesForAccount(account);
+  }
+
+  /**
    * Gets or creates a Counterfactual Safe.
    * Checks that the account has the CounterfactualSafes data setting enabled.
    *

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.ts
@@ -42,6 +42,19 @@ export class CounterfactualSafesController {
     });
   }
 
+  @ApiOkResponse({ type: CounterfactualSafe, isArray: true })
+  @Get(':address/counterfactual-safes')
+  @UseGuards(AuthGuard)
+  async getCounterfactualSafes(
+    @Auth() authPayload: AuthPayload,
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
+  ): Promise<CounterfactualSafe[]> {
+    return this.service.getCounterfactualSafes({
+      authPayload,
+      address,
+    });
+  }
+
   @ApiOkResponse({ type: CounterfactualSafe })
   @Put(':address/counterfactual-safes')
   @UseGuards(AuthGuard)

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.service.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.service.ts
@@ -23,6 +23,17 @@ export class CounterfactualSafesService {
     return this.mapCounterfactualSafe(domainCounterfactualSafe);
   }
 
+  async getCounterfactualSafes(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<CounterfactualSafe[]> {
+    const domainCounterfactualSafes =
+      await this.repository.getCounterfactualSafes(args);
+    return domainCounterfactualSafes.map((counterfactualSafe) =>
+      this.mapCounterfactualSafe(counterfactualSafe),
+    );
+  }
+
   async createCounterfactualSafe(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;


### PR DESCRIPTION
## Depends on #1795 

## Summary
This PR adds a route to the Counterfactual Safes storage controller endpoints:
```
GET /v1/accounts/:address/storage/counterfactual-safes
```

The endpoint gets all Counterfactual Safes by the creator's account address.

## Changes
- Add `GET /v1/accounts/:address/storage/counterfactual-safes`
