### PR TITLE
Implement Accounts creation rate limit

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -7,6 +7,10 @@ export default (): ReturnType<typeof configuration> => ({
     version: faker.system.semver(),
     buildNumber: faker.string.numeric(),
   },
+  accounts: {
+    creationRateLimitPeriodSeconds: faker.number.int(),
+    creationRateLimitCalls: faker.number.int(),
+  },
   amqp: {
     url: faker.internet.url({ appendSlash: false }),
     exchange: { name: faker.string.sample(), mode: faker.string.sample() },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -6,6 +6,14 @@ export default () => ({
     version: process.env.APPLICATION_VERSION,
     buildNumber: process.env.APPLICATION_BUILD_NUMBER,
   },
+  accounts: {
+    creationRateLimitPeriodSeconds: parseInt(
+      process.env.ACCOUNT_CREATION_RATE_LIMIT_PERIOD_SECONDS ?? `${60}`,
+    ),
+    creationRateLimitCalls: parseInt(
+      process.env.ACCOUNT_CREATION_RATE_LIMIT_CALLS_BY_PERIOD ?? `${1}`,
+    ),
+  },
   amqp: {
     url: process.env.AMQP_URL || 'amqp://localhost:5672',
     exchange: {

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -157,7 +157,6 @@ describe('AccountsDatasource tests', () => {
         }),
       ).rejects.toThrow('Rate limit reached');
 
-      expect(mockLoggingService.warn).toHaveBeenCalledTimes(1);
       const { count } = await sql`SELECT id FROM accounts`;
       expect(count).toBe(accountCreationRateLimitCalls);
     });
@@ -192,7 +191,6 @@ describe('AccountsDatasource tests', () => {
         });
       }
 
-      expect(mockLoggingService.warn).not.toHaveBeenCalled();
       const { count } = await sql`SELECT id FROM accounts`;
       expect(count).toBe(accountsToCreate);
     });

--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -64,7 +64,10 @@ describe('AccountsDatasource tests', () => {
     it('creates an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
 
-      const result = await target.createAccount(address);
+      const result = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
 
       expect(result).toStrictEqual({
         id: expect.any(Number),
@@ -88,20 +91,126 @@ describe('AccountsDatasource tests', () => {
       );
     });
 
+    it('creates an account successfully if the clientIp is not a valid IP', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      const result = await target.createAccount({
+        address,
+        clientIp: faker.string.sample(),
+      });
+
+      expect(result).toStrictEqual({
+        id: expect.any(Number),
+        group_id: null,
+        address,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      });
+
+      // check the account is stored in the cache
+      const cacheDir = new CacheDir(`account_${address}`, '');
+      const cacheContent = await fakeCacheService.get(cacheDir);
+      expect(JSON.parse(cacheContent as string)).toStrictEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            group_id: null,
+            address,
+          }),
+        ]),
+      );
+    });
+
+    it('should fail if the IP hits the rate limit', async () => {
+      const clientIp = faker.internet.ipv4();
+      const accountCreationRateLimitCalls = faker.number.int({
+        min: 2,
+        max: 5,
+      });
+      mockConfigurationService.getOrThrow.mockImplementation((key) => {
+        if (key === 'expirationTimeInSeconds.default')
+          return faker.number.int();
+        if (key === 'accounts.creationRateLimitCalls')
+          return accountCreationRateLimitCalls;
+        if (key === 'accounts.creationRateLimitPeriodSeconds')
+          return faker.number.int({ min: 10 });
+      });
+      target = new AccountsDatasource(
+        fakeCacheService,
+        sql,
+        new CachedQueryResolver(mockLoggingService, fakeCacheService),
+        mockLoggingService,
+        mockConfigurationService,
+      );
+
+      for (let i = 0; i < accountCreationRateLimitCalls; i++) {
+        await target.createAccount({
+          address: getAddress(faker.finance.ethereumAddress()),
+          clientIp,
+        });
+      }
+
+      await expect(
+        target.createAccount({
+          address: getAddress(faker.finance.ethereumAddress()),
+          clientIp,
+        }),
+      ).rejects.toThrow('Rate limit reached');
+
+      expect(mockLoggingService.warn).toHaveBeenCalledTimes(1);
+      const { count } = await sql`SELECT id FROM accounts`;
+      expect(count).toBe(accountCreationRateLimitCalls);
+    });
+
+    it('should create accounts while the IP does not hit the rate limit', async () => {
+      const clientIp = faker.internet.ipv4();
+      const accountsToCreate = faker.number.int({ min: 1, max: 5 });
+      const accountCreationRateLimitCalls = faker.number.int({
+        min: 5,
+        max: 10,
+      });
+      mockConfigurationService.getOrThrow.mockImplementation((key) => {
+        if (key === 'expirationTimeInSeconds.default')
+          return faker.number.int();
+        if (key === 'accounts.creationRateLimitCalls')
+          return accountCreationRateLimitCalls;
+        if (key === 'accounts.creationRateLimitPeriodSeconds')
+          return faker.number.int({ min: 10 });
+      });
+      target = new AccountsDatasource(
+        fakeCacheService,
+        sql,
+        new CachedQueryResolver(mockLoggingService, fakeCacheService),
+        mockLoggingService,
+        mockConfigurationService,
+      );
+
+      for (let i = 0; i < accountsToCreate; i++) {
+        await target.createAccount({
+          address: getAddress(faker.finance.ethereumAddress()),
+          clientIp,
+        });
+      }
+
+      expect(mockLoggingService.warn).not.toHaveBeenCalled();
+      const { count } = await sql`SELECT id FROM accounts`;
+      expect(count).toBe(accountsToCreate);
+    });
+
     it('throws when an account with the same address already exists', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
 
-      await expect(target.createAccount(address)).rejects.toThrow(
-        'Error creating account.',
-      );
+      await expect(
+        target.createAccount({ address, clientIp: faker.internet.ipv4() }),
+      ).rejects.toThrow('Error creating account.');
     });
   });
 
   describe('getAccount', () => {
     it('returns an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
 
       const result = await target.getAccount(address);
 
@@ -116,7 +225,7 @@ describe('AccountsDatasource tests', () => {
 
     it('returns an account from cache', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
 
       const result = await target.getAccount(address);
 
@@ -174,7 +283,7 @@ describe('AccountsDatasource tests', () => {
   describe('deleteAccount', () => {
     it('deletes an account successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
 
       await expect(target.deleteAccount(address)).resolves.not.toThrow();
 
@@ -191,7 +300,7 @@ describe('AccountsDatasource tests', () => {
 
     it('should clear the cache on account deletion', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
 
       // get the account from the cache
       const beforeDeletion = await target.getAccount(address);
@@ -335,7 +444,10 @@ describe('AccountsDatasource tests', () => {
   describe('getAccountDataSettings', () => {
     it('should get the account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -366,7 +478,10 @@ describe('AccountsDatasource tests', () => {
 
     it('should get the account data settings from cache', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -426,7 +541,10 @@ describe('AccountsDatasource tests', () => {
 
     it('should omit account data settings which data type is not active', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -467,7 +585,10 @@ describe('AccountsDatasource tests', () => {
   describe('upsertAccountDataSettings', () => {
     it('adds account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -500,7 +621,10 @@ describe('AccountsDatasource tests', () => {
 
     it('should write the associated cache on upsert', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -538,7 +662,10 @@ describe('AccountsDatasource tests', () => {
 
     it('updates existing account data settings successfully', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const account = await target.createAccount(address);
+      const account = await target.createAccount({
+        address,
+        clientIp: faker.internet.ipv4(),
+      });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -623,7 +750,7 @@ describe('AccountsDatasource tests', () => {
 
     it('throws an error if a non-existent data type is provided', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
       const accountDataTypes = Array.from(
         { length: faker.number.int({ min: 1, max: 4 }) },
         () => accountDataTypeBuilder().with('is_active', true).build(),
@@ -652,7 +779,7 @@ describe('AccountsDatasource tests', () => {
 
     it('throws an error if an inactive data type is provided', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      await target.createAccount(address);
+      await target.createAccount({ address, clientIp: faker.internet.ipv4() });
       const accountDataTypes = [
         accountDataTypeBuilder().with('is_active', false).build(),
         accountDataTypeBuilder().build(),

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -214,6 +214,10 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
   /**
    * Checks if the client IP address has reached the account creation rate limit.
    *
+   * NOTE: the rate limit is implemented in the datasource layer for this use case
+   * because we need to restrict the actual creation of accounts, not merely
+   * the attempts to create them.
+   *
    * If the client IP address is invalid, a warning is logged.
    * If the client IP address is valid and rate limit is reached, a {@link LimitReachedError} is thrown.
    *

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -15,6 +15,7 @@ import { UpsertAccountDataSettingsDto } from '@/domain/accounts/entities/upsert-
 import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
+import { IpSchema } from '@/validation/entities/schemas/ip.schema';
 import {
   Inject,
   Injectable,
@@ -26,7 +27,6 @@ import postgres from 'postgres';
 
 @Injectable()
 export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
-  private static readonly SIMPLE_IPV4_REGEX = /^(\d{1,3}\.){3}\d{1,3}$/;
   private static readonly ACCOUNT_CREATION_CACHE_PREFIX = 'account_creation';
   private readonly defaultExpirationTimeInSeconds: number;
   // Number of seconds for each rate-limit cycle
@@ -220,7 +220,8 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
    * @param clientIp - client IP address.
    */
   private async checkCreationRateLimit(clientIp: string): Promise<void> {
-    if (!clientIp || !AccountsDatasource.SIMPLE_IPV4_REGEX.test(clientIp)) {
+    const { success: isValidIp } = IpSchema.safeParse(clientIp);
+    if (!clientIp || !isValidIp) {
       this.loggingService.warn(
         `Invalid client IP while creating account: ${clientIp}`,
       );

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -7,6 +7,7 @@ import {
 import { MAX_TTL } from '@/datasources/cache/constants';
 import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
+import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
 import { AccountDataSetting } from '@/domain/accounts/entities/account-data-setting.entity';
 import { AccountDataType } from '@/domain/accounts/entities/account-data-type.entity';
 import { Account } from '@/domain/accounts/entities/account.entity';
@@ -25,7 +26,13 @@ import postgres from 'postgres';
 
 @Injectable()
 export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
+  private static readonly SIMPLE_IPV4_REGEX = /^(\d{1,3}\.){3}\d{1,3}$/;
+  private static readonly ACCOUNT_CREATION_CACHE_PREFIX = 'account_creation';
   private readonly defaultExpirationTimeInSeconds: number;
+  // Number of seconds for each rate-limit cycle
+  private readonly accountCreationRateLimitPeriodSeconds: number;
+  // Number of allowed calls on each rate-limit cycle
+  private readonly accountCreationRateLimitCalls: number;
 
   constructor(
     @Inject(CacheService) private readonly cacheService: ICacheService,
@@ -40,6 +47,13 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
       this.configurationService.getOrThrow<number>(
         'expirationTimeInSeconds.default',
       );
+    this.accountCreationRateLimitPeriodSeconds =
+      configurationService.getOrThrow(
+        'accounts.creationRateLimitPeriodSeconds',
+      );
+    this.accountCreationRateLimitCalls = configurationService.getOrThrow(
+      'accounts.creationRateLimitCalls',
+    );
   }
 
   /**
@@ -52,9 +66,13 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
     );
   }
 
-  async createAccount(address: `0x${string}`): Promise<Account> {
+  async createAccount(args: {
+    address: `0x${string}`;
+    clientIp: string;
+  }): Promise<Account> {
+    await this.checkCreationRateLimit(args.clientIp);
     const [account] = await this.sql<[Account]>`
-      INSERT INTO accounts (address) VALUES (${address}) RETURNING *`.catch(
+      INSERT INTO accounts (address) VALUES (${args.address}) RETURNING *`.catch(
       (e) => {
         this.loggingService.warn(
           `Error creating account: ${asError(e).message}`,
@@ -62,7 +80,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
         throw new UnprocessableEntityException('Error creating account.');
       },
     );
-    const cacheDir = CacheRouter.getAccountCacheDir(address);
+    const cacheDir = CacheRouter.getAccountCacheDir(args.address);
     await this.cacheService.set(
       cacheDir,
       JSON.stringify([account]),
@@ -190,6 +208,35 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
       throw new UnprocessableEntityException(
         `Data types not found or not active.`,
       );
+    }
+  }
+
+  /**
+   * Checks if the client IP address has reached the account creation rate limit.
+   *
+   * If the client IP address is invalid, a warning is logged.
+   * If the client IP address is valid and rate limit is reached, a {@link LimitReachedError} is thrown.
+   *
+   * @param clientIp - client IP address.
+   */
+  private async checkCreationRateLimit(clientIp: string): Promise<void> {
+    if (!clientIp || !AccountsDatasource.SIMPLE_IPV4_REGEX.test(clientIp)) {
+      this.loggingService.warn(
+        `Invalid client IP while creating account: ${clientIp}`,
+      );
+    } else {
+      const current = await this.cacheService.increment(
+        CacheRouter.getRateLimitCacheKey(
+          `${AccountsDatasource.ACCOUNT_CREATION_CACHE_PREFIX}_${clientIp}`,
+        ),
+        this.accountCreationRateLimitPeriodSeconds,
+      );
+      if (current > this.accountCreationRateLimitCalls) {
+        this.loggingService.warn(
+          `Limit of ${this.accountCreationRateLimitCalls} reached for IP ${clientIp}`,
+        );
+        throw new LimitReachedError();
+      }
     }
   }
 }

--- a/src/domain/accounts/accounts.repository.interface.ts
+++ b/src/domain/accounts/accounts.repository.interface.ts
@@ -13,6 +13,7 @@ export interface IAccountsRepository {
   createAccount(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;
+    clientIp: string;
   }): Promise<Account>;
 
   getAccount(args: {

--- a/src/domain/accounts/accounts.repository.ts
+++ b/src/domain/accounts/accounts.repository.ts
@@ -20,11 +20,15 @@ export class AccountsRepository implements IAccountsRepository {
   async createAccount(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;
+    clientIp: string;
   }): Promise<Account> {
     if (!args.authPayload.isForSigner(args.address)) {
       throw new UnauthorizedException();
     }
-    const account = await this.datasource.createAccount(args.address);
+    const account = await this.datasource.createAccount({
+      address: args.address,
+      clientIp: args.clientIp,
+    });
     return AccountSchema.parse(account);
   }
 

--- a/src/domain/interfaces/accounts.datasource.interface.ts
+++ b/src/domain/interfaces/accounts.datasource.interface.ts
@@ -6,7 +6,10 @@ import { UpsertAccountDataSettingsDto } from '@/domain/accounts/entities/upsert-
 export const IAccountsDatasource = Symbol('IAccountsDatasource');
 
 export interface IAccountsDatasource {
-  createAccount(address: `0x${string}`): Promise<Account>;
+  createAccount(args: {
+    address: `0x${string}`;
+    clientIp: string;
+  }): Promise<Account>;
 
   getAccount(address: `0x${string}`): Promise<Account>;
 

--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -129,7 +129,10 @@ describe('AccountsController', () => {
 
       expect(accountDataSource.createAccount).toHaveBeenCalledTimes(1);
       // Check the address was checksummed
-      expect(accountDataSource.createAccount).toHaveBeenCalledWith(address);
+      expect(accountDataSource.createAccount).toHaveBeenCalledWith({
+        address,
+        clientIp: expect.any(String),
+      });
     });
 
     it('should propagate errors', async () => {

--- a/src/routes/accounts/accounts.controller.ts
+++ b/src/routes/accounts/accounts.controller.ts
@@ -21,9 +21,11 @@ import {
   Param,
   Post,
   Put,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 
 @ApiTags('accounts')
 @Controller({ path: 'accounts', version: '1' })
@@ -38,10 +40,12 @@ export class AccountsController {
     @Body(new ValidationPipe(CreateAccountDtoSchema))
     createAccountDto: CreateAccountDto,
     @Auth() authPayload: AuthPayload,
+    @Req() req: Request,
   ): Promise<Account> {
     return this.accountsService.createAccount({
       authPayload,
       createAccountDto,
+      clientIp: req.ip,
     });
   }
 

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -20,10 +20,12 @@ export class AccountsService {
   async createAccount(args: {
     authPayload: AuthPayload;
     createAccountDto: CreateAccountDto;
+    clientIp: string;
   }): Promise<Account> {
     const domainAccount = await this.accountsRepository.createAccount({
       authPayload: args.authPayload,
       address: args.createAccountDto.address,
+      clientIp: args.clientIp,
     });
     return this.mapAccount(domainAccount);
   }

--- a/src/validation/entities/schemas/__tests__/ip.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/ip.schema.spec.ts
@@ -1,0 +1,24 @@
+import { IpSchema } from '@/validation/entities/schemas/ip.schema';
+
+describe('IpSchema', () => {
+  it('should validate a valid IP address', () => {
+    const value = '192.168.0.1';
+    const result = IpSchema.safeParse(value);
+
+    expect(result.success && result.data).toBe(value);
+  });
+
+  it('should not validate a non-IP address', () => {
+    const value = 'not-an-ip';
+    const result = IpSchema.safeParse(value);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should not validate an invalid IP address', () => {
+    const value = '192.168.0.256';
+    const result = IpSchema.safeParse(value);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/validation/entities/schemas/ip.schema.ts
+++ b/src/validation/entities/schemas/ip.schema.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const IpSchema = z.string().ip();


### PR DESCRIPTION
## Summary
This PR introduces a rate limitation to creating User Accounts using the related `AccountsController` endpoint.

## Changes
- Adds a rate limitation controlled by a cache key before proceeding with account creation.