### PR TITLE
Fix Counterfactual Safes cache keys

### DIFF
--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
@@ -273,7 +273,7 @@ describe('CounterfactualSafesDatasource tests', () => {
 
       expect(actual).toStrictEqual(counterfactualSafe);
       const cacheDir = new CacheDir(
-        `${counterfactualSafe.chain_id}_counterfactual_safe_${counterfactualSafe.predicted_address}`,
+        `${counterfactualSafe.chain_id}_counterfactual_safe_${account.id}_${counterfactualSafe.predicted_address}`,
         '',
       );
       const cacheContent = await fakeCacheService.get(cacheDir);
@@ -281,12 +281,12 @@ describe('CounterfactualSafesDatasource tests', () => {
       expect(mockLoggingService.debug).toHaveBeenCalledTimes(2);
       expect(mockLoggingService.debug).toHaveBeenNthCalledWith(1, {
         type: 'cache_miss',
-        key: `${counterfactualSafe.chain_id}_counterfactual_safe_${counterfactualSafe.predicted_address}`,
+        key: `${counterfactualSafe.chain_id}_counterfactual_safe_${account.id}_${counterfactualSafe.predicted_address}`,
         field: '',
       });
       expect(mockLoggingService.debug).toHaveBeenNthCalledWith(2, {
         type: 'cache_hit',
-        key: `${counterfactualSafe.chain_id}_counterfactual_safe_${counterfactualSafe.predicted_address}`,
+        key: `${counterfactualSafe.chain_id}_counterfactual_safe_${account.id}_${counterfactualSafe.predicted_address}`,
         field: '',
       });
     });
@@ -315,19 +315,19 @@ describe('CounterfactualSafesDatasource tests', () => {
       ).rejects.toThrow('Error getting Counterfactual Safe.');
 
       const cacheDir = new CacheDir(
-        `${counterfactualSafe.chainId}_counterfactual_safe_${counterfactualSafe.predictedAddress}`,
+        `${counterfactualSafe.chainId}_counterfactual_safe_${account.id}_${counterfactualSafe.predictedAddress}`,
         '',
       );
       expect(await fakeCacheService.get(cacheDir)).toBeUndefined();
       expect(mockLoggingService.debug).toHaveBeenCalledTimes(2);
       expect(mockLoggingService.debug).toHaveBeenNthCalledWith(1, {
         type: 'cache_miss',
-        key: `${counterfactualSafe.chainId}_counterfactual_safe_${counterfactualSafe.predictedAddress}`,
+        key: `${counterfactualSafe.chainId}_counterfactual_safe_${account.id}_${counterfactualSafe.predictedAddress}`,
         field: '',
       });
       expect(mockLoggingService.debug).toHaveBeenNthCalledWith(2, {
         type: 'cache_miss',
-        key: `${counterfactualSafe.chainId}_counterfactual_safe_${counterfactualSafe.predictedAddress}`,
+        key: `${counterfactualSafe.chainId}_counterfactual_safe_${account.id}_${counterfactualSafe.predictedAddress}`,
         field: '',
       });
     });
@@ -453,7 +453,7 @@ describe('CounterfactualSafesDatasource tests', () => {
         predictedAddress: counterfactualSafe.predicted_address,
       });
       const cacheDir = new CacheDir(
-        `${counterfactualSafe.chain_id}_counterfactual_safe_${counterfactualSafe.predicted_address}`,
+        `${counterfactualSafe.chain_id}_counterfactual_safe_${account.id}_${counterfactualSafe.predicted_address}`,
         '',
       );
       const beforeDeletion = await fakeCacheService.get(cacheDir);

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
@@ -71,10 +71,11 @@ export class CounterfactualSafesDatasource
     chainId: string;
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe> {
-    const cacheDir = CacheRouter.getCounterfactualSafeCacheDir(
-      args.chainId,
-      args.predictedAddress,
-    );
+    const cacheDir = CacheRouter.getCounterfactualSafeCacheDir({
+      accountId: args.account.id,
+      chainId: args.chainId,
+      predictedAddress: args.predictedAddress,
+    });
     const [counterfactualSafe] = await this.cachedQueryResolver.get<
       CounterfactualSafe[]
     >({
@@ -124,10 +125,11 @@ export class CounterfactualSafesDatasource
     } finally {
       await Promise.all([
         this.cacheService.deleteByKey(
-          CacheRouter.getCounterfactualSafeCacheDir(
-            args.chainId,
-            args.predictedAddress,
-          ).key,
+          CacheRouter.getCounterfactualSafeCacheDir({
+            accountId: args.account.id,
+            chainId: args.chainId,
+            predictedAddress: args.predictedAddress,
+          }).key,
         ),
         this.cacheService.deleteByKey(
           CacheRouter.getCounterfactualSafesCacheDir(args.account.address).key,
@@ -150,10 +152,11 @@ export class CounterfactualSafesDatasource
       await Promise.all(
         deleted.map((row) => {
           return this.cacheService.deleteByKey(
-            CacheRouter.getCounterfactualSafeCacheDir(
-              row.chain_id,
-              row.predicted_address,
-            ).key,
+            CacheRouter.getCounterfactualSafeCacheDir({
+              accountId: account.id,
+              chainId: row.chain_id,
+              predictedAddress: row.predicted_address,
+            }).key,
           );
         }),
       );

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -516,12 +516,13 @@ export class CacheRouter {
     );
   }
 
-  static getCounterfactualSafeCacheDir(
-    chainId: string,
-    predictedAddress: `0x${string}`,
-  ): CacheDir {
+  static getCounterfactualSafeCacheDir(args: {
+    accountId: number;
+    chainId: string;
+    predictedAddress: `0x${string}`;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.COUNTERFACTUAL_SAFE_KEY}_${predictedAddress}`,
+      `${args.chainId}_${CacheRouter.COUNTERFACTUAL_SAFE_KEY}_${args.accountId}_${args.predictedAddress}`,
       '',
     );
   }


### PR DESCRIPTION
## Summary
This PR adds the `accountId` as part of a given Counterfactual Safe cache key. It wasn't included in the original implementation by mistake. The `accountId` is part of [the unique constraint](https://github.com/safe-global/safe-client-gateway/blob/a1e6a99704bb700f3a7852416e9af31c73f803b1/migrations/00004_counterfactual-safes/index.sql#L17) for Counterfactual Safes.

## Changes
- Adds `accountId` to the arguments list for `CacheRouter.getCounterfactualSafeCacheDir`.
