### PR TITLE
Assign default value for `confirmationsRequired`

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -1442,7 +1442,7 @@ describe('TransactionApi', () => {
         offset,
       });
 
-      expect(actual).toBe(multisigTransactionsPage);
+      expect(actual).toStrictEqual(multisigTransactionsPage);
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
       expect(mockDataSource.get).toHaveBeenCalledWith({
         cacheDir,
@@ -1826,7 +1826,6 @@ describe('TransactionApi', () => {
             },
           ],
         });
-        // Doesn't need to fetch the Safe for it's threshold
         expect(mockDataSource.get).toHaveBeenCalledTimes(3);
         expect(mockDataSource.get).toHaveBeenNthCalledWith(1, {
           cacheDir: multisigTransactionsCacheDir,

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -160,7 +160,10 @@ describe('Transactions History Controller (Unit)', () => {
   it('Failure: data page validation fails', async () => {
     const safeAddress = faker.finance.ethereumAddress();
     const chain = chainBuilder().build();
-    const page = pageBuilder().build();
+    const multisigTransaction = multisigTransactionBuilder().build();
+    // @ts-expect-error - Safe must be defined
+    multisigTransaction.safe = null;
+    const page = pageBuilder().with('results', [multisigTransaction]).build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       // Param ValidationPipe checksums address
@@ -170,7 +173,7 @@ describe('Transactions History Controller (Unit)', () => {
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: { ...page, results: faker.word.words() },
+          data: page,
           status: 200,
         });
       }


### PR DESCRIPTION
## Summary

We are occasionally seeing `confirmationsRequired` of multisig transactions returned as `null` by the Transaction Service. As we [expect it to be an integer](https://github.com/safe-global/safe-client-gateway/blob/default-confirmations-required/src/domain/safe/entities/multisig-transaction.entity.ts#L49), this therefore fails validation.

As this causes transactions not to be returned, this implements fallback values should the value be `null`:

- Safe threshold for queued transactions
- Confirmations required (if present) or Safe threshold for historical transactions

Note: the above is a [known bug](https://github.com/safe-global/safe-transaction-service/issues/2170) that should eventually be tackled on the Transaction Service, after which we intend to revert the above.

## Changes

- Fallback to the default values when fetching singular/a list of multisig transactions, or all transactions
- Add appropriate test coverage