### PR TITLE
Add Holesky custom cache expiration time

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -100,6 +100,7 @@ export default (): ReturnType<typeof configuration> => ({
   },
   expirationTimeInSeconds: {
     default: faker.number.int(),
+    holesky: faker.number.int(),
     notFound: {
       default: faker.number.int(),
       contract: faker.number.int(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -143,6 +143,7 @@ export default () => ({
   },
   expirationTimeInSeconds: {
     default: parseInt(process.env.EXPIRATION_TIME_DEFAULT_SECONDS ?? `${60}`),
+    holesky: parseInt(process.env.HOLESKY_EXPIRATION_TIME_SECONDS ?? `${60}`),
     notFound: {
       default: parseInt(
         process.env.DEFAULT_NOT_FOUND_EXPIRE_TIME_SECONDS ?? `${30}`,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -32,6 +32,7 @@ import { get } from 'lodash';
 
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
+  private static readonly HOLESKY_CHAIN_ID = '17000';
 
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
@@ -49,24 +50,36 @@ export class TransactionApi implements ITransactionApi {
     private readonly networkService: INetworkService,
     private readonly loggingService: ILoggingService,
   ) {
-    this.defaultExpirationTimeInSeconds =
-      this.configurationService.getOrThrow<number>(
-        'expirationTimeInSeconds.default',
-      );
-    this.defaultNotFoundExpirationTimeSeconds =
-      this.configurationService.getOrThrow<number>(
-        'expirationTimeInSeconds.notFound.default',
-      );
-    this.tokenNotFoundExpirationTimeSeconds =
-      this.configurationService.getOrThrow<number>(
-        'expirationTimeInSeconds.notFound.token',
-      );
-    this.contractNotFoundExpirationTimeSeconds =
-      this.configurationService.getOrThrow<number>(
-        'expirationTimeInSeconds.notFound.contract',
-      );
-    this.ownersExpirationTimeSeconds =
-      this.configurationService.getOrThrow<number>('owners.ownersTtlSeconds');
+    if (chainId === TransactionApi.HOLESKY_CHAIN_ID) {
+      const holeskyExpirationTime =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.holesky',
+        );
+      this.defaultExpirationTimeInSeconds = holeskyExpirationTime;
+      this.defaultNotFoundExpirationTimeSeconds = holeskyExpirationTime;
+      this.tokenNotFoundExpirationTimeSeconds = holeskyExpirationTime;
+      this.contractNotFoundExpirationTimeSeconds = holeskyExpirationTime;
+      this.ownersExpirationTimeSeconds = holeskyExpirationTime;
+    } else {
+      this.defaultExpirationTimeInSeconds =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.default',
+        );
+      this.defaultNotFoundExpirationTimeSeconds =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.notFound.default',
+        );
+      this.tokenNotFoundExpirationTimeSeconds =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.notFound.token',
+        );
+      this.contractNotFoundExpirationTimeSeconds =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.notFound.contract',
+        );
+      this.ownersExpirationTimeSeconds =
+        this.configurationService.getOrThrow<number>('owners.ownersTtlSeconds');
+    }
   }
 
   async getDataDecoded(args: {


### PR DESCRIPTION
## Summary
This PR adds a special custom cache expiration time for Holesky (`chainId: 17000`) network. The initial value is set to `60 seconds` but it's configurable via the `HOLESKY_EXPIRATION_TIME_SECONDS` environment variable.

## Changes
- Adds a custom cache expiration time for the Holesky network.