### PR TITLE
Add Holesky balances custom cache expiration time

### DIFF
--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -17,6 +17,7 @@ export class SafeBalancesApi implements IBalancesApi {
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
   private static readonly DEFAULT_DECIMALS = 18;
+  private static readonly HOLESKY_CHAIN_ID = '17000';
 
   constructor(
     private readonly chainId: string,
@@ -27,14 +28,24 @@ export class SafeBalancesApi implements IBalancesApi {
     private readonly httpErrorFactory: HttpErrorFactory,
     private readonly coingeckoApi: IPricesApi,
   ) {
-    this.defaultExpirationTimeInSeconds =
-      this.configurationService.getOrThrow<number>(
-        'expirationTimeInSeconds.default',
-      );
-    this.defaultNotFoundExpirationTimeSeconds =
-      this.configurationService.getOrThrow<number>(
-        'expirationTimeInSeconds.notFound.default',
-      );
+    // TODO: Remove temporary cache times for Holesky chain.
+    if (chainId === SafeBalancesApi.HOLESKY_CHAIN_ID) {
+      const holeskyExpirationTime =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.holesky',
+        );
+      this.defaultExpirationTimeInSeconds = holeskyExpirationTime;
+      this.defaultNotFoundExpirationTimeSeconds = holeskyExpirationTime;
+    } else {
+      this.defaultExpirationTimeInSeconds =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.default',
+        );
+      this.defaultNotFoundExpirationTimeSeconds =
+        this.configurationService.getOrThrow<number>(
+          'expirationTimeInSeconds.notFound.default',
+        );
+    }
   }
 
   async getBalances(args: {


### PR DESCRIPTION
## Summary
This PR adds a special custom cache expiration time for Holesky balances (`chainId: 17000`) network. The initial value is set to `60 seconds` but it's configurable via the `HOLESKY_EXPIRATION_TIME_SECONDS` environment variable.

## Changes
- A custom cache expiration time for the Holesky network balances is added.