### PR TITLE
Add Holesky cache expiration time tests

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -54,6 +54,7 @@ export class TransactionApi implements ITransactionApi {
     private readonly networkService: INetworkService,
     private readonly loggingService: ILoggingService,
   ) {
+    // TODO: Remove temporary cache times for Holesky chain.
     if (chainId === TransactionApi.HOLESKY_CHAIN_ID) {
       const holeskyExpirationTime =
         this.configurationService.getOrThrow<number>(


### PR DESCRIPTION
## Summary
This PR adds unit tests for the custom cache expiration time for Holesky (`chainId: 17000`) network, which was added in the PR: #1810 

## Changes
- Adds cache expiration time tests for the Holesky network.