### PR TITLE
Adjust and unify rate limits granularity

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -8,10 +8,10 @@ export default () => ({
   },
   accounts: {
     creationRateLimitPeriodSeconds: parseInt(
-      process.env.ACCOUNT_CREATION_RATE_LIMIT_PERIOD_SECONDS ?? `${60}`,
+      process.env.ACCOUNT_CREATION_RATE_LIMIT_PERIOD_SECONDS ?? `${3600}`,
     ),
     creationRateLimitCalls: parseInt(
-      process.env.ACCOUNT_CREATION_RATE_LIMIT_CALLS_BY_PERIOD ?? `${1}`,
+      process.env.ACCOUNT_CREATION_RATE_LIMIT_CALLS_BY_PERIOD ?? `${25}`,
     ),
     counterfactualSafes: {
       creationRateLimitPeriodSeconds: parseInt(
@@ -20,7 +20,7 @@ export default () => ({
       ),
       creationRateLimitCalls: parseInt(
         process.env.COUNTERFACTUAL_SAFES_CREATION_RATE_LIMIT_CALLS_BY_PERIOD ??
-          `${10}`,
+          `${25}`,
       ),
     },
   },


### PR DESCRIPTION
## Summary
This PR adjusts both the Accounts and Counterfactual Safes creation rate limits to be described on 1 hour periods, instead of being 1 minute-based. This is mostly to unblock e2e testing flows which require accounts/CFs creation in a short period of time. 

This doesn't affect the effective rate at which an IP can create accounts: it was 1 per minute previously, and it was changed to 25 per hour (so it is more restrictive now).

## Changes
- Adjusts `ACCOUNT_CREATION_RATE_LIMIT_PERIOD_SECONDS`, `ACCOUNT_CREATION_RATE_LIMIT_CALLS_BY_PERIOD`, and `COUNTERFACTUAL_SAFES_CREATION_RATE_LIMIT_CALLS_BY_PERIOD` default values.
