### PR TITLE
Include the executed database migration names in startup logs

### DIFF
--- a/src/datasources/db/postgres-database.migration.hook.spec.ts
+++ b/src/datasources/db/postgres-database.migration.hook.spec.ts
@@ -58,6 +58,19 @@ describe('PostgresDatabaseMigrationHook tests', () => {
     configurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'application.runMigrations') return true;
     });
+    const executed = [
+      {
+        path: faker.system.filePath(),
+        id: faker.number.int(),
+        name: faker.string.sample(),
+      },
+      {
+        path: faker.system.filePath(),
+        id: faker.number.int(),
+        name: faker.string.sample(),
+      },
+    ];
+    migrator.migrate.mockResolvedValue(executed);
     target = new PostgresDatabaseMigrationHook(
       sql,
       migrator,
@@ -70,7 +83,7 @@ describe('PostgresDatabaseMigrationHook tests', () => {
     expect(loggingService.info).toHaveBeenCalledTimes(2);
     expect(loggingService.info).toHaveBeenCalledWith('Checking migrations');
     expect(loggingService.info).toHaveBeenCalledWith(
-      'Pending migrations executed',
+      `Pending migrations executed: [${executed[0].name}, ${executed[1].name}]`,
     );
   });
 });

--- a/src/datasources/db/postgres-database.migration.hook.ts
+++ b/src/datasources/db/postgres-database.migration.hook.ts
@@ -48,9 +48,11 @@ export class PostgresDatabaseMigrationHook implements OnModuleInit {
     try {
       this.loggingService.info('Checking migrations');
       await this.acquireLock();
-      await this.migrator.migrate();
+      const executed = await this.migrator.migrate();
       await this.releaseLock();
-      this.loggingService.info('Pending migrations executed');
+      this.loggingService.info(
+        `Pending migrations executed: [${executed.map((m) => m.name).join(', ')}]`,
+      );
     } catch (e) {
       this.loggingService.error(`Error running migrations: ${asError(e)}`);
     }

--- a/src/datasources/db/postgres-database.migrator.spec.ts
+++ b/src/datasources/db/postgres-database.migrator.spec.ts
@@ -83,7 +83,8 @@ describe('PostgresDatabaseMigrator tests', () => {
       }
 
       // Test migration and expect migrations to be recorded
-      await expect(target.migrate(folder)).resolves.not.toThrow();
+      const executed = await target.migrate(folder);
+      expect(executed).toHaveLength(3);
       await expect(sql`SELECT * FROM migrations`).resolves.toStrictEqual([
         {
           id: 1,
@@ -115,7 +116,8 @@ describe('PostgresDatabaseMigrator tests', () => {
       );
 
       // Migrate (only initial migration should be recorded)
-      await target.migrate(folder);
+      const executed = await target.migrate(folder);
+      expect(executed).toHaveLength(1);
       const recordedMigrations = await sql`SELECT * FROM migrations`;
       expect(recordedMigrations).toStrictEqual([
         {
@@ -134,7 +136,8 @@ describe('PostgresDatabaseMigrator tests', () => {
       }
 
       // Migrate from last run migration
-      await target.migrate(folder);
+      const remaining = await target.migrate(folder);
+      expect(remaining).toHaveLength(2);
       await expect(sql`SELECT * FROM migrations`).resolves.toStrictEqual([
         {
           id: 1,

--- a/src/datasources/db/postgres-database.migrator.ts
+++ b/src/datasources/db/postgres-database.migrator.ts
@@ -33,13 +33,13 @@ export class PostgresDatabaseMigrator {
   constructor(@Inject('DB_INSTANCE') private readonly sql: Sql) {}
 
   /**
-   * Runs/records migrations not present in the {@link PostgresMigrator.MIGRATIONS_TABLE} table.
+   * Runs/records migrations not present in the {@link PostgresDatabaseMigrator.MIGRATIONS_TABLE} table.
    *
    * Note: all migrations are run in a single transaction for optimal performance.
    */
   async migrate(
     path = PostgresDatabaseMigrator.MIGRATIONS_FOLDER,
-  ): Promise<void> {
+  ): Promise<Migration[]> {
     const migrations = this.getMigrations(path);
 
     await this.assertMigrationsTable();
@@ -53,6 +53,8 @@ export class PostgresDatabaseMigrator {
         await this.setLastRunMigration({ transaction, migration: current });
       }
     });
+
+    return remaining;
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR modifies the log line related to the execution of database migrations. It includes the executed migration names in the logs.

## Changes
- Modifies migration execution log to include migration names
