### PR TITLE
Set AUTH_VALIDITY_PERIOD_SECONDS as access token default validity

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -54,7 +54,7 @@ export default () => ({
       process.env.AUTH_NONCE_TTL_SECONDS ?? `${5 * 60}`,
     ),
     maxValidityPeriodSeconds: parseInt(
-      process.env.AUTH_VALIDITY_PERIOD_SECONDS ?? `${15 * 60}`,
+      process.env.AUTH_VALIDITY_PERIOD_SECONDS ?? `${24 * 60 * 60}`, // 24 hours
     ),
   },
   balances: {

--- a/src/domain/siwe/siwe.repository.interface.ts
+++ b/src/domain/siwe/siwe.repository.interface.ts
@@ -8,6 +8,8 @@ export const ISiweRepository = Symbol('ISiweRepository');
 export interface ISiweRepository {
   generateNonce(): Promise<{ nonce: string }>;
 
+  getMaxValidityDate(): Date;
+
   isValidMessage(args: {
     message: string;
     signature: `0x${string}`;

--- a/src/domain/siwe/siwe.repository.ts
+++ b/src/domain/siwe/siwe.repository.ts
@@ -111,6 +111,10 @@ export class SiweRepository implements ISiweRepository {
     }
   }
 
+  getMaxValidityDate(): Date {
+    return new Date(Date.now() + this.maxValidityPeriodInSeconds * 1_000);
+  }
+
   /**
    * Verifies signature of signed SiWe message, either by EOA or smart contract
    *

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -46,9 +46,9 @@ export class AuthService {
       ...(notBefore && {
         nbf: new Date(notBefore),
       }),
-      ...(expirationTime && {
-        exp: new Date(expirationTime),
-      }),
+      exp: expirationTime
+        ? new Date(expirationTime)
+        : this.siweRepository.getMaxValidityDate(),
     });
 
     return {


### PR DESCRIPTION
## Summary
This PR modifies the service to take the value `AUTH_VALIDITY_PERIOD_SECONDS` from the configuration as a default value for the `exp` attribute of the issued JWTs (and also the `maxAge`) value for the auth cookies.

## Changes
- Takes `AUTH_VALIDITY_PERIOD_SECONDS`  as the default value when not specified by the client on the SiWE message.
- Increases the default for this value to 24 hours.
