### PR TITLE
Add caching layer to RPC requests

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -108,6 +108,7 @@ export default (): ReturnType<typeof configuration> => ({
   },
   expirationTimeInSeconds: {
     default: faker.number.int(),
+    rpc: faker.number.int(),
     holesky: faker.number.int(),
     notFound: {
       default: faker.number.int(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -161,6 +161,7 @@ export default () => ({
   },
   expirationTimeInSeconds: {
     default: parseInt(process.env.EXPIRATION_TIME_DEFAULT_SECONDS ?? `${60}`),
+    rpc: parseInt(process.env.EXPIRATION_TIME_RPC_SECONDS ?? `${15}`),
     holesky: parseInt(process.env.HOLESKY_EXPIRATION_TIME_SECONDS ?? `${60}`),
     notFound: {
       default: parseInt(

--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -1,5 +1,6 @@
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { BlockchainApiManager } from '@/datasources/blockchain/blockchain-api.manager';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { rpcUriBuilder } from '@/domain/chains/entities/__tests__/rpc-uri.builder';
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
@@ -12,14 +13,25 @@ const configApiMock = jest.mocked({
 
 describe('BlockchainApiManager', () => {
   let target: BlockchainApiManager;
+  let fakeCacheService: FakeCacheService;
   const infuraApiKey = faker.string.hexadecimal({ length: 32 });
+  const expirationTimeInSeconds = faker.number.int();
 
   beforeEach(() => {
     jest.resetAllMocks();
 
+    fakeCacheService = new FakeCacheService();
     const fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('blockchain.infura.apiKey', infuraApiKey);
-    target = new BlockchainApiManager(fakeConfigurationService, configApiMock);
+    fakeConfigurationService.set(
+      'expirationTimeInSeconds.rpc',
+      expirationTimeInSeconds,
+    );
+    target = new BlockchainApiManager(
+      fakeConfigurationService,
+      configApiMock,
+      fakeCacheService,
+    );
   });
 
   describe('getApi', () => {
@@ -83,6 +95,50 @@ describe('BlockchainApiManager', () => {
       const cachedApi = await target.getApi(chain.chainId);
 
       expect(api).not.toBe(cachedApi);
+    });
+  });
+
+  describe('createCachedRpcClient', () => {
+    it('caches RPC requests', async () => {
+      const chain = chainBuilder().build();
+      const client = target._createCachedRpcClient(chain);
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      fetchSpy.mockImplementation((_: unknown) => {
+        return Promise.resolve({
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+          ok: true,
+          status: 200,
+          json: () => {
+            // Return chain ID
+            return Promise.resolve({
+              result: faker.string.hexadecimal(),
+            });
+          },
+        } as Response);
+      });
+
+      await client.getChainId();
+
+      // Should be cached
+      await client.getChainId();
+      await client.getChainId();
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenNthCalledWith(1, chain.rpcUri.value, {
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 0,
+          method: 'eth_chainId',
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      });
+
+      fetchSpy.mockRestore();
     });
   });
 });

--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -91,7 +91,7 @@ describe('BlockchainApiManager', () => {
       configApiMock.getChain.mockResolvedValue(chain);
 
       const api = await target.getApi(chain.chainId);
-      await target.destroyApi(chain.chainId);
+      target.destroyApi(chain.chainId);
       const cachedApi = await target.getApi(chain.chainId);
 
       expect(api).not.toBe(cachedApi);

--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -91,7 +91,7 @@ describe('BlockchainApiManager', () => {
       configApiMock.getChain.mockResolvedValue(chain);
 
       const api = await target.getApi(chain.chainId);
-      target.destroyApi(chain.chainId);
+      await target.destroyApi(chain.chainId);
       const cachedApi = await target.getApi(chain.chainId);
 
       expect(api).not.toBe(cachedApi);

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -1,25 +1,43 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
 import { Chain as DomainChain } from '@/domain/chains/entities/chain.entity';
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
 import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { Inject, Injectable } from '@nestjs/common';
-import { Chain, PublicClient, createPublicClient, http } from 'viem';
+import {
+  Chain,
+  PublicClient,
+  RpcRequestError,
+  createPublicClient,
+  custom,
+} from 'viem';
+import { getHttpRpcClient } from 'viem/utils';
 
 @Injectable()
 export class BlockchainApiManager implements IBlockchainApiManager {
   private static readonly INFURA_URL_PATTERN = 'infura';
   private readonly blockchainApiMap: Record<string, PublicClient> = {};
   private readonly infuraApiKey: string;
+  private readonly rpcExpirationTimeInSeconds: number;
 
   constructor(
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     @Inject(IConfigApi) private readonly configApi: IConfigApi,
+    @Inject(CacheService) private readonly cacheService: ICacheService,
   ) {
     this.infuraApiKey = this.configurationService.getOrThrow<string>(
       'blockchain.infura.apiKey',
     );
+    this.rpcExpirationTimeInSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.rpc',
+      );
   }
 
   async getApi(chainId: string): Promise<PublicClient> {
@@ -29,21 +47,81 @@ export class BlockchainApiManager implements IBlockchainApiManager {
     }
 
     const chain = await this.configApi.getChain(chainId);
-    this.blockchainApiMap[chainId] = this.createClient(chain);
+    this.blockchainApiMap[chainId] = this._createCachedRpcClient(chain);
 
     return this.blockchainApiMap[chainId];
   }
 
-  destroyApi(chainId: string): void {
-    if (this.blockchainApiMap?.[chainId]) {
-      delete this.blockchainApiMap[chainId];
+  async destroyApi(chainId: string): Promise<void> {
+    if (!this.blockchainApiMap?.[chainId]) {
+      return;
     }
+
+    delete this.blockchainApiMap[chainId];
+
+    const key = CacheRouter.getRpcRequestsKey(chainId);
+    await this.cacheService.deleteByKey(key);
   }
 
-  private createClient(chain: DomainChain): PublicClient {
+  /**
+   * Creates a {@link PublicClient} with a cache layer for RPC requests
+   * @param domainChain {@link DomainChain} to create the client for
+   */
+  _createCachedRpcClient(domainChain: DomainChain): PublicClient {
+    const chain = this.formatChain(domainChain);
+
+    const rpcUrl = chain.rpcUrls.default.http[0];
+    const rpcClient = getHttpRpcClient(rpcUrl);
+
+    const request = async (body: {
+      method: string;
+      params?: unknown;
+    }): Promise<unknown> => {
+      const cacheDir = CacheRouter.getRpcRequestsCacheDir({
+        chainId: domainChain.chainId,
+        method: body.method,
+        params: ((): string => {
+          try {
+            // We cannot be certain of the shape of the params object
+            return JSON.stringify(body.params);
+          } catch {
+            return '';
+          }
+        })(),
+      });
+
+      const cache = await this.cacheService.get(cacheDir);
+
+      if (cache != null) {
+        return JSON.parse(cache);
+      }
+
+      const { error, result } = await rpcClient.request({
+        body,
+      });
+
+      if (error) {
+        throw new RpcRequestError({
+          body,
+          error,
+          url: rpcUrl,
+        });
+      }
+
+      await this.cacheService.set(
+        cacheDir,
+        JSON.stringify(result),
+        this.rpcExpirationTimeInSeconds,
+      );
+
+      return result;
+    };
+
     return createPublicClient({
-      chain: this.formatChain(chain),
-      transport: http(),
+      chain,
+      transport: custom({
+        request,
+      }),
     });
   }
 

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -93,14 +93,18 @@ export class BlockchainApiManager implements IBlockchainApiManager {
       const cache = await this.cacheService.get(cacheDir);
 
       if (cache != null) {
-        return JSON.parse(cache);
+        return cache;
       }
 
       const { error, result } = await rpcClient.request({
         body,
       });
 
-      if (error) {
+      if (
+        error ||
+        // Result will always be a string, but we need to check for the type
+        typeof result !== 'string'
+      ) {
         throw new RpcRequestError({
           body,
           error,
@@ -110,7 +114,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
 
       await this.cacheService.set(
         cacheDir,
-        JSON.stringify(result),
+        result,
         this.rpcExpirationTimeInSeconds,
       );
 

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -52,7 +52,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
     return this.blockchainApiMap[chainId];
   }
 
-  async destroyApi(chainId: string): Promise<void> {
+  destroyApi(chainId: string): void {
     if (!this.blockchainApiMap?.[chainId]) {
       return;
     }
@@ -60,7 +60,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
     delete this.blockchainApiMap[chainId];
 
     const key = CacheRouter.getRpcRequestsKey(chainId);
-    await this.cacheService.deleteByKey(key);
+    void this.cacheService.deleteByKey(key);
   }
 
   /**

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -25,6 +25,7 @@ export class CacheRouter {
   private static readonly NATIVE_COIN_PRICE_KEY = 'native_coin_price';
   private static readonly OWNERS_SAFE_KEY = 'owner_safes';
   private static readonly RELAY_KEY = 'relay';
+  private static readonly RPC_REQUESTS_KEY = 'rpc_requests';
   private static readonly SAFE_APPS_KEY = 'safe_apps';
   private static readonly SAFE_BALANCES_KEY = 'safe_balances';
   private static readonly SAFE_COLLECTIBLES_KEY = 'safe_collectibles';
@@ -531,6 +532,21 @@ export class CacheRouter {
     return new CacheDir(
       `${CacheRouter.COUNTERFACTUAL_SAFES_KEY}_${address}`,
       '',
+    );
+  }
+
+  static getRpcRequestsKey(chainId: string): string {
+    return `${chainId}_${CacheRouter.RPC_REQUESTS_KEY}`;
+  }
+
+  static getRpcRequestsCacheDir(args: {
+    chainId: string;
+    method: string;
+    params: string;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getRpcRequestsKey(args.chainId),
+      `${args.method}_${args.params}`,
     );
   }
 }

--- a/src/domain/interfaces/api.manager.interface.ts
+++ b/src/domain/interfaces/api.manager.interface.ts
@@ -1,5 +1,5 @@
 export interface IApiManager<T> {
   getApi(chainId: string, ...rest: unknown[]): Promise<T>;
 
-  destroyApi(chainId: string): void;
+  destroyApi(chainId: string): void | Promise<void>;
 }

--- a/src/domain/interfaces/api.manager.interface.ts
+++ b/src/domain/interfaces/api.manager.interface.ts
@@ -1,5 +1,5 @@
 export interface IApiManager<T> {
   getApi(chainId: string, ...rest: unknown[]): Promise<T>;
 
-  destroyApi(chainId: string): void | Promise<void>;
+  destroyApi(chainId: string): void;
 }


### PR DESCRIPTION
## Summary

For each RPC call we currently make a request. As we intend to fetch more data on-chain, e.g. staking details, indexed block timestamp, this implements a caching layer for all RPC requests to reduce this number.

## Changes

- Add `expirationTimeInSeconds.rpc` with a default valut of 15 seconds, modifying via the `EXPIRATION_TIME_RPC_SECONDS` env. var.
- Change `createClient` to create a `PublicClient` with a caching layer on all RPC requests.
  - Add new `rpc_requests` cache key.
- Add relative tests.