### PR TITLE
Fix lint caused by staking API

### DIFF
--- a/src/datasources/staking-api/entities/__tests__/pooled-staking-stats.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/pooled-staking-stats.entity.spec.ts
@@ -161,7 +161,7 @@ describe('PooledStakingSchema', () => {
     const result = PooledStakingStatsSchema.safeParse(pooledStakingStats);
 
     expect(!result.success && result.error.issues.length).toBe(1);
-    expect(!result.success && result.error.issues[0]).toStrictEqual;
+    expect(!result.success && result.error.issues[0].path[0]).toBe(key);
   });
 
   it('should not validate an invalid PooledStakingStats object', () => {

--- a/src/domain/interfaces/staking-api.manager.interface.ts
+++ b/src/domain/interfaces/staking-api.manager.interface.ts
@@ -3,4 +3,5 @@ import { IStakingApi } from '@/domain/interfaces/staking-api.interface';
 
 export const IStakingApiManager = Symbol('IStakingApiManager');
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IStakingApiManager extends IApiManager<IStakingApi> {}


### PR DESCRIPTION
## Summary

The staking API (https://github.com/safe-global/safe-client-gateway/pull/1823) PR was created (and worked on) before updating ESLint (https://github.com/safe-global/safe-client-gateway/pull/1820). It therefore had some "new" errors meaning it broke the CI.

This fixes the above errors.

## Changes

- Assert the path in `PooledStakingStatsSchema` tests
- Ignore the empty object in the `IStakingManager` interface