### PR TITLE
Add transaction decoding for native staking `deposit` calls

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -135,6 +135,7 @@ export default (): ReturnType<typeof configuration> => ({
     accounts: false,
     pushNotifications: false,
     nativeStaking: false,
+    nativeStakingDecoding: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -206,6 +206,8 @@ export default () => ({
     pushNotifications:
       process.env.FF_PUSH_NOTIFICATIONS?.toLowerCase() === 'true',
     nativeStaking: process.env.FF_NATIVE_STAKING?.toLowerCase() === 'true',
+    nativeStakingDecoding:
+      process.env.FF_NATIVE_STAKING_DECODING?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -43,6 +43,9 @@ import { TwapOrderMapperModule } from '@/routes/transactions/mappers/common/twap
 import { TwapOrderHelperModule } from '@/routes/transactions/helpers/twap-order.helper';
 import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
 import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.helper';
+import { KilnNativeStakingHelperModule } from '@/routes/transactions/helpers/kiln-native-staking.helper';
+import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
+import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
 
 @Module({
   controllers: [TransactionsController],
@@ -54,6 +57,8 @@ import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.he
     SafeRepositoryModule,
     SafeAppsRepositoryModule,
     GPv2DecoderModule,
+    KilnNativeStakingHelperModule,
+    StakingRepositoryModule,
     SwapAppsHelperModule,
     SwapOrderMapperModule,
     SwapOrderHelperModule,
@@ -80,6 +85,7 @@ import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.he
     MultisigTransactionMapper,
     MultisigTransactionStatusMapper,
     NativeCoinTransferMapper,
+    NativeStakingMapper,
     QueuedItemsMapper,
     SafeAppInfoMapper,
     SettingsChangeMapper,


### PR DESCRIPTION
## Summary

Note: this is part of multiple PRs to break down https://github.com/safe-global/safe-client-gateway/pull/1824.

This calls the native staking `deposit` mapper in the `MultisigTransactionInfoMapper`, should a `deposit` call to an official staking deployment be found.

## Changes

- Add `features.nativeStakingDecodinng` feature flag
- "Find" and map native staking `deposit` calls