### PR TITLE
Add new `Campaign` fields

### DIFF
--- a/src/domain/community/entities/__tests__/campaign.builder.ts
+++ b/src/domain/community/entities/__tests__/campaign.builder.ts
@@ -16,7 +16,13 @@ export function campaignBuilder(): IBuilder<Campaign> {
       Array.from({ length: faker.number.int({ min: 0, max: 5 }) }, () =>
         activityMetadataBuilder().build(),
       ),
-    );
+    )
+    .with('rewardValue', faker.number.float().toString())
+    .with('rewardText', faker.lorem.sentence())
+    .with('iconUrl', faker.internet.url())
+    .with('safeAppUrl', faker.internet.url())
+    .with('partnerUrl', faker.internet.url())
+    .with('isPromoted', faker.datatype.boolean());
 }
 
 export function toJson(campaign: Campaign): unknown {

--- a/src/domain/community/entities/campaign.entity.ts
+++ b/src/domain/community/entities/campaign.entity.ts
@@ -1,6 +1,7 @@
 import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { ActivityMetadataSchema } from '@/domain/community/entities/activity-metadata.entity';
 import { z } from 'zod';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
 export type Campaign = z.infer<typeof CampaignSchema>;
 
@@ -12,6 +13,12 @@ export const CampaignSchema = z.object({
   endDate: z.coerce.date(),
   lastUpdated: z.coerce.date().nullish().default(null),
   activitiesMetadata: z.array(ActivityMetadataSchema).nullish().default(null),
+  rewardValue: NumericStringSchema,
+  rewardText: z.string().nullish().default(null),
+  iconUrl: z.string().url().nullish().default(null),
+  safeAppUrl: z.string().url().nullish().default(null),
+  partnerUrl: z.string().url().nullish().default(null),
+  isPromoted: z.boolean(),
 });
 
 export const CampaignPageSchema = buildPageSchema(CampaignSchema);

--- a/src/routes/community/entities/campaign.entity.ts
+++ b/src/routes/community/entities/campaign.entity.ts
@@ -15,6 +15,18 @@ export class Campaign implements DomainCampaign {
   endDate!: Date;
   @ApiPropertyOptional({ type: String, nullable: true })
   lastUpdated!: Date | null;
-  @ApiProperty({ type: [ActivityMetadata] })
+  @ApiPropertyOptional({ type: [ActivityMetadata], nullable: true })
   activitiesMetadata!: ActivityMetadata[] | null;
+  @ApiProperty()
+  rewardValue!: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  rewardText!: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  iconUrl!: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  safeAppUrl!: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  partnerUrl!: string | null;
+  @ApiProperty()
+  isPromoted!: boolean;
 }


### PR DESCRIPTION
## Summary

This adds the [new `Campaign` fields](https://github.com/safe-global/safe-locking-service/pull/173) to the relative entities/schemas.

## Changes

- Extends `CampaignSchema`:
  - `rewardValue` - numeric string
  - `rewardText` - nullable string
  - `iconUrl` - nullable string URL
  - `safeAppUrl` - nullable string URL
  - `partnerUrl` - nullable string URL
  - `isPromoted` - boolean
- Extend route `Campaign` entity
- Extend `campaignBuilder` builder
- Add relative test coverage