### PR TITLE
Implement Safe Creation Transaction retrieval endpoint

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -1,0 +1,178 @@
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { AppModule } from '@/app.module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import { NetworkModule } from '@/datasources/network/network.module';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import {
+  creationTransactionBuilder,
+  toJson as creationTransactionToJson,
+} from '@/domain/safe/entities/__tests__/creation-transaction.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Server } from 'net';
+import request from 'supertest';
+
+describe('Get creation transaction', () => {
+  let app: INestApplication<Server>;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(configuration)],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
+      .compile();
+
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  beforeEach(() => jest.resetAllMocks());
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return the creation transaction', async () => {
+    const chainId = faker.string.numeric();
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const safe = safeBuilder().build();
+    const creationTransaction = creationTransactionBuilder().build();
+    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+    const getCreationTransactionUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/creation/`;
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: chain, status: 200 });
+        case getCreationTransactionUrl:
+          return Promise.resolve({
+            data: creationTransactionToJson(creationTransaction),
+            status: 200,
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/creation/`,
+      )
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toEqual({
+          ...creationTransaction,
+          created: creationTransaction.created.toISOString(),
+        });
+      });
+  });
+
+  it('should forward Transaction Service errors', async () => {
+    const chainId = faker.string.numeric();
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const safe = safeBuilder().build();
+    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+    const getCreationTransactionUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/creation/`;
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: chain, status: 200 });
+        case getCreationTransactionUrl:
+          return Promise.reject(
+            new NetworkResponseError(new URL(getCreationTransactionUrl), {
+              status: 404,
+            } as Response),
+          );
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/creation/`,
+      )
+      .expect(404);
+  });
+
+  it('should fail if the Transaction Service fails', async () => {
+    const chainId = faker.string.numeric();
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const safe = safeBuilder().build();
+    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+    const getCreationTransactionUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/creation/`;
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: chain, status: 200 });
+        case getCreationTransactionUrl:
+          return Promise.reject(new Error());
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/creation/`,
+      )
+      .expect(503);
+  });
+
+  it('should fail if the Config Service fails', async () => {
+    const chainId = faker.string.numeric();
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const safe = safeBuilder().build();
+    const creationTransaction = creationTransactionBuilder().build();
+    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+    const getCreationTransactionUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/creation/`;
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case getChainUrl:
+          return Promise.reject(new Error());
+        case getCreationTransactionUrl:
+          return Promise.resolve({
+            data: creationTransactionToJson(creationTransaction),
+            status: 200,
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/creation/`,
+      )
+      .expect(503);
+  });
+});

--- a/src/routes/transactions/entities/creation-transaction.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction.entity.ts
@@ -1,0 +1,37 @@
+import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreationTransaction {
+  @ApiProperty()
+  created: Date;
+  @ApiProperty()
+  creator: string;
+  @ApiProperty()
+  transactionHash: string;
+  @ApiProperty()
+  factoryAddress: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  masterCopy: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  setupData: string | null;
+  @ApiPropertyOptional({ type: DataDecoded, nullable: true })
+  dataDecoded: DataDecoded | null;
+
+  constructor(
+    created: Date,
+    creator: string,
+    transactionHash: string,
+    factoryAddress: string,
+    masterCopy: string | null,
+    setupData: string | null,
+    dataDecoded: DataDecoded | null,
+  ) {
+    this.created = created;
+    this.creator = creator;
+    this.transactionHash = transactionHash;
+    this.factoryAddress = factoryAddress;
+    this.masterCopy = masterCopy;
+    this.setupData = setupData;
+    this.dataDecoded = dataDecoded;
+  }
+}

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -39,6 +39,7 @@ import { DeleteTransactionDto } from '@/routes/transactions/entities/delete-tran
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { DeleteTransactionDtoSchema } from '@/routes/transactions/entities/schemas/delete-transaction.dto.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { CreationTransaction } from '@/routes/transactions/entities/creation-transaction.entity';
 
 @ApiTags('transactions')
 @Controller({
@@ -270,6 +271,20 @@ export class TransactionsController {
       chainId,
       safeAddress,
       proposeTransactionDto,
+    });
+  }
+
+  @HttpCode(200)
+  @ApiOkResponse({ type: CreationTransaction })
+  @Get('chains/:chainId/safes/:safeAddress/transactions/creation')
+  async getCreationTransaction(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+  ): Promise<CreationTransaction> {
+    return this.transactionsService.getCreationTransaction({
+      chainId,
+      safeAddress,
     });
   }
 }

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -18,6 +18,7 @@ import {
   TRANSFER_PREFIX,
 } from '@/routes/transactions/constants';
 import { ConflictType } from '@/routes/transactions/entities/conflict-type.entity';
+import { CreationTransaction } from '@/routes/transactions/entities/creation-transaction.entity';
 import { IncomingTransfer } from '@/routes/transactions/entities/incoming-transfer.entity';
 import { ModuleTransaction } from '@/routes/transactions/entities/module-transaction.entity';
 import { MultisigTransaction } from '@/routes/transactions/entities/multisig-transaction.entity';
@@ -440,6 +441,13 @@ export class TransactionsService {
       domainTransaction,
       safe,
     );
+  }
+
+  async getCreationTransaction(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CreationTransaction> {
+    return this.safeRepository.getCreationTransaction(args);
   }
 
   /**


### PR DESCRIPTION
## Summary

This adds a new `GET` `/v1/chains/:chainId/safes/:safeAddress/transactions/creation` endpoint for returning the Safe creation transaction data. The payload of this endpoint response follows the schema:

```ts
{
    created: Date,
    creator: string,
    transactionHash: string,
    factoryAddress: string,
    masterCopy: string | null,
    setupData: string | null,
    dataDecoded: DataDecoded | null,
}
```
Where `DataDecoded` is: 

```ts
{
  method: string,
  parameters: {
    name: string,
    type: string,
    value: unknown,
    valueDecoded: Record<string, unknown> | Record<string, unknown>[] | null,
  } | null,
}
```
## Changes

- Add `TransactionsRepository['getCreationTransaction'] method
- Add `CreationTransaction` route-level entity
- Add `GET` `/v1/chains/:chainId/safes/:safeAddress/transactions/creation` route
- Add appropriate test coverage