### PR TITLE
Add StakingStatus to native staking deposit transactions

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-info.entity.ts
@@ -21,9 +21,7 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty({ enum: [TransactionInfoType.NativeStakingDeposit] })
   override type = TransactionInfoType.NativeStakingDeposit;
 
-  @ApiProperty({
-    enum: StakingStatus,
-  })
+  @ApiProperty({ enum: StakingStatus })
   status: StakingStatus;
 
   @ApiProperty()

--- a/src/routes/transactions/entities/staking/staking.entity.ts
+++ b/src/routes/transactions/entities/staking/staking.entity.ts
@@ -1,12 +1,11 @@
-/**
- * Present in all calls for native/pooled/defi staking
- *
- * TODO: Confirm with design but something like:
- * - Queued: pending
- * - History: entering, active/validating, exiting, awaiting withdrawal, exited/withdrawn
- */
+// Present in all calls for native/pooled/defi staking
 export enum StakingStatus {
-  Unknown = 'unknown',
+  AwaitingEntry = 'AWAITING_ENTRY',
+  RequestedExit = 'REQUESTED_EXIT',
+  SignatureNeeded = 'SIGNATURE_NEEDED',
+  Validating = 'VALIDATING',
+  Withdrawn = 'WITHDRAWN',
+  Unknown = 'UNKNOWN',
 }
 
 export type StakingStatusInfo = {

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -1,3 +1,4 @@
+import { NetworkStats } from '@/datasources/staking-api/entities/network-stats.entity';
 import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
 import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
 import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-info.entity';
@@ -17,12 +18,16 @@ export class NativeStakingMapper {
    *
    * @param args.chainId - the chain ID of the native staking deployment
    * @param args.to - the address of the native staking deployment
+   * @param args.isConfirmed - whether the deposit transaction is confirmed
+   * @param args.depositExecutionDate - the date when the deposit transaction was executed
    *
    * @returns {@link NativeStakingDepositTransactionInfo} for the given native staking deployment
    */
   public async mapDepositInfo(args: {
     chainId: string;
     to: `0x${string}`;
+    isConfirmed: boolean;
+    depositExecutionDate: Date | null;
   }): Promise<NativeStakingDepositTransactionInfo> {
     const deployment = await this.stakingRepository.getDeployment({
       chainId: args.chainId,
@@ -48,8 +53,11 @@ export class NativeStakingMapper {
     const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);
 
     return new NativeStakingDepositTransactionInfo({
-      // TODO: Implement once confirmed with design
-      status: StakingStatus.Unknown,
+      status: this.mapStatus(
+        networkStats,
+        args.isConfirmed,
+        args.depositExecutionDate,
+      ),
       estimatedEntryTime: networkStats.estimated_entry_time_seconds,
       estimatedExitTime: networkStats.estimated_exit_time_seconds,
       estimatedWithdrawalTime: networkStats.estimated_withdrawal_time_seconds,
@@ -58,6 +66,42 @@ export class NativeStakingMapper {
       monthlyNrr: nrr,
       annualNrr: nrr,
     });
+  }
+
+  /**
+   * Maps the {@link StakingStatus} for the given native staking deployment's `deposit` call.
+   * - If the deposit transaction is not confirmed, the status is `SignatureNeeded`.
+   * - If the deposit transaction is confirmed but the deposit execution date is not available,
+   * the status is `AwaitingEntry`.
+   * - If the deposit execution date is available, the status is `AwaitingEntry` if the current
+   * date is before the estimated entry time, otherwise the status is `Validating`.
+   * - If the status cannot be determined, the status is `Unknown`.
+   *
+   * @param networkStats - the network stats for the chain where the native staking deployment lives
+   * @param isConfirmed - whether the deposit transaction is confirmed
+   * @param depositExecutionDate - the date when the deposit transaction was executed
+   * @returns
+   */
+  private mapStatus(
+    networkStats: NetworkStats,
+    isConfirmed: boolean,
+    depositExecutionDate: Date | null,
+  ): StakingStatus {
+    if (!isConfirmed) {
+      return StakingStatus.SignatureNeeded;
+    }
+
+    if (!depositExecutionDate) {
+      return StakingStatus.AwaitingEntry;
+    }
+
+    const estimatedDepositEntryTime =
+      depositExecutionDate.getTime() +
+      networkStats.estimated_entry_time_seconds * 1000;
+
+    return Date.now() <= estimatedDepositEntryTime
+      ? StakingStatus.AwaitingEntry
+      : StakingStatus.Validating;
   }
 }
 

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -322,9 +322,16 @@ export class MultisigTransactionInfoMapper {
     }
 
     try {
+      const tx = transaction as MultisigTransaction;
+      const isConfirmed =
+        !!tx.confirmations &&
+        tx.confirmations.length >= tx.confirmationsRequired;
+
       return await this.nativeStakingMapper.mapDepositInfo({
         chainId,
         to: nativeStakingTransaction.to,
+        isConfirmed,
+        depositExecutionDate: transaction.executionDate,
       });
     } catch (error) {
       this.loggingService.warn(error);

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -619,7 +619,7 @@ describe('TransactionsViewController tests', () => {
             .expect({
               type: 'KILN_NATIVE_STAKING_DEPOSIT',
               method: dataDecoded.method,
-              status: 'unknown',
+              status: 'SIGNATURE_NEEDED',
               parameters: dataDecoded.parameters,
               estimatedEntryTime: networkStats.estimated_entry_time_seconds,
               estimatedExitTime: networkStats.estimated_exit_time_seconds,
@@ -707,7 +707,7 @@ describe('TransactionsViewController tests', () => {
               type: 'KILN_NATIVE_STAKING_DEPOSIT',
               method: dataDecoded.method,
               parameters: dataDecoded.parameters,
-              status: 'unknown',
+              status: 'SIGNATURE_NEEDED',
               estimatedEntryTime: networkStats.estimated_entry_time_seconds,
               estimatedExitTime: networkStats.estimated_exit_time_seconds,
               estimatedWithdrawalTime:

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -278,7 +278,12 @@ export class TransactionsViewService {
     data: `0x${string}`;
     dataDecoded: DataDecoded;
   }): Promise<NativeStakingDepositConfirmationView> {
-    const depositInfo = await this.nativeStakingMapper.mapDepositInfo(args);
+    const depositInfo = await this.nativeStakingMapper.mapDepositInfo({
+      chainId: args.chainId,
+      to: args.to,
+      isConfirmed: false,
+      depositExecutionDate: null,
+    });
     return new NativeStakingDepositConfirmationView({
       method: args.dataDecoded.method,
       parameters: args.dataDecoded.parameters,


### PR DESCRIPTION
## Summary
This PR adds `StakingStatus` enum values, and maps this status for a staking `deposit` transaction type, according to its execution timestamp. The implemented mapping follows these rules: 
   * If the deposit transaction is not confirmed, the status is `SignatureNeeded`.
   * If the deposit transaction is confirmed but the deposit execution date is not available, the status is `AwaitingEntry`.
   * If the deposit execution date is available, the status is `AwaitingEntry` if the current date is before the estimated entry time, otherwise, the status is `Validating`.
   * If the status cannot be determined, the status is `Unknown`.

## Changes
- Adds `StakingStatus` values and mappings.
