### PR TITLE
Make Campaign.rewardValue field nullable

### DIFF
--- a/src/domain/community/entities/campaign.entity.ts
+++ b/src/domain/community/entities/campaign.entity.ts
@@ -13,7 +13,7 @@ export const CampaignSchema = z.object({
   endDate: z.coerce.date(),
   lastUpdated: z.coerce.date().nullish().default(null),
   activitiesMetadata: z.array(ActivityMetadataSchema).nullish().default(null),
-  rewardValue: NumericStringSchema,
+  rewardValue: NumericStringSchema.nullish().default(null),
   rewardText: z.string().nullish().default(null),
   iconUrl: z.string().url().nullish().default(null),
   safeAppUrl: z.string().url().nullish().default(null),

--- a/src/domain/community/entities/schemas/__tests__/campaign.schema.spec.ts
+++ b/src/domain/community/entities/schemas/__tests__/campaign.schema.spec.ts
@@ -30,6 +30,7 @@ describe('CampaignSchema', () => {
   it.each([
     'lastUpdated' as const,
     'activitiesMetadata' as const,
+    'rewardValue' as const,
     'rewardText' as const,
     'iconUrl' as const,
     'safeAppUrl' as const,
@@ -89,7 +90,6 @@ describe('CampaignSchema', () => {
     'description' as const,
     'startDate' as const,
     'endDate' as const,
-    'rewardValue' as const,
     'isPromoted' as const,
   ])('should not validate a missing %s', (key) => {
     const campaign = campaignBuilder().build();
@@ -138,13 +138,6 @@ describe('CampaignSchema', () => {
           code: 'invalid_date',
           path: ['endDate'],
           message: 'Invalid date',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          received: 'undefined',
-          path: ['rewardValue'],
-          message: 'Required',
         },
         {
           code: 'invalid_type',

--- a/src/routes/community/entities/campaign.entity.ts
+++ b/src/routes/community/entities/campaign.entity.ts
@@ -17,8 +17,8 @@ export class Campaign implements DomainCampaign {
   lastUpdated!: Date | null;
   @ApiPropertyOptional({ type: [ActivityMetadata], nullable: true })
   activitiesMetadata!: ActivityMetadata[] | null;
-  @ApiProperty()
-  rewardValue!: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  rewardValue!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   rewardText!: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })


### PR DESCRIPTION
## Summary
This PR makes the `Campaign.rewardValue` property nullable, as it's defined in the upstream service source: https://github.com/safe-global/safe-locking-service/blob/df4f7ed9b4c0b684952323f4e267fdcd45dbddda/safe_locking_service/campaigns/migrations/0006_campaign_icon_campaign_is_promoted_and_more.py#L41

## Changes
- Makes `rewardValue` nullable.
- Modifies schema unit tests accordingly.
