### PR TITLE
Remove authentication for GET Counterfactual Safes endpoints

### DIFF
--- a/src/datasources/accounts/counterfactual-safes/__tests__/test.counterfactual-safes.datasource.module.ts
+++ b/src/datasources/accounts/counterfactual-safes/__tests__/test.counterfactual-safes.datasource.module.ts
@@ -4,7 +4,7 @@ import { Module } from '@nestjs/common';
 const counterfactualSafesDatasource = {
   createCounterfactualSafe: jest.fn(),
   getCounterfactualSafe: jest.fn(),
-  getCounterfactualSafesForAccount: jest.fn(),
+  getCounterfactualSafesForAddress: jest.fn(),
   deleteCounterfactualSafe: jest.fn(),
   deleteCounterfactualSafesForAccount: jest.fn(),
 } as jest.MockedObjectDeep<ICounterfactualSafesDatasource>;

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
@@ -210,7 +210,7 @@ describe('CounterfactualSafesDatasource tests', () => {
         createCounterfactualSafeDto:
           createCounterfactualSafeDtoBuilder().build(),
       });
-      await target.getCounterfactualSafesForAccount(account);
+      await target.getCounterfactualSafesForAddress(address);
       const cacheDir = new CacheDir(`counterfactual_safes_${address}`, '');
       await fakeCacheService.set(
         cacheDir,
@@ -241,7 +241,7 @@ describe('CounterfactualSafesDatasource tests', () => {
       });
 
       const actual = await target.getCounterfactualSafe({
-        account,
+        address,
         chainId: counterfactualSafe.chain_id,
         predictedAddress: counterfactualSafe.predicted_address,
       });
@@ -261,12 +261,12 @@ describe('CounterfactualSafesDatasource tests', () => {
 
       // first call is not cached
       const actual = await target.getCounterfactualSafe({
-        account,
+        address,
         chainId: counterfactualSafe.chain_id,
         predictedAddress: counterfactualSafe.predicted_address,
       });
       await target.getCounterfactualSafe({
-        account,
+        address,
         chainId: counterfactualSafe.chain_id,
         predictedAddress: counterfactualSafe.predicted_address,
       });
@@ -293,22 +293,19 @@ describe('CounterfactualSafesDatasource tests', () => {
 
     it('should not cache if the Counterfactual Safe is not found', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
-      const [account] = await sql<
-        Account[]
-      >`INSERT INTO accounts (address) VALUES (${address}) RETURNING *`;
       const counterfactualSafe = createCounterfactualSafeDtoBuilder().build();
 
       // should not cache the Counterfactual Safe
       await expect(
         target.getCounterfactualSafe({
-          account,
+          address,
           chainId: counterfactualSafe.chainId,
           predictedAddress: counterfactualSafe.predictedAddress,
         }),
       ).rejects.toThrow('Error getting Counterfactual Safe.');
       await expect(
         target.getCounterfactualSafe({
-          account,
+          address,
           chainId: counterfactualSafe.chainId,
           predictedAddress: counterfactualSafe.predictedAddress,
         }),
@@ -333,8 +330,8 @@ describe('CounterfactualSafesDatasource tests', () => {
     });
   });
 
-  describe('getCounterfactualSafesForAccount', () => {
-    it('should get the Counterfactual Safes for an account', async () => {
+  describe('getCounterfactualSafesForAddress', () => {
+    it('should get the Counterfactual Safes for an address', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
       const [account] = await sql<
         Account[]
@@ -354,7 +351,7 @@ describe('CounterfactualSafesDatasource tests', () => {
         }),
       ]);
 
-      const actual = await target.getCounterfactualSafesForAccount(account);
+      const actual = await target.getCounterfactualSafesForAddress(address);
       expect(actual).toStrictEqual(expect.arrayContaining(counterfactualSafes));
     });
 
@@ -379,8 +376,8 @@ describe('CounterfactualSafesDatasource tests', () => {
       ]);
 
       // first call is not cached
-      const actual = await target.getCounterfactualSafesForAccount(account);
-      await target.getCounterfactualSafesForAccount(account);
+      const actual = await target.getCounterfactualSafesForAddress(address);
+      await target.getCounterfactualSafesForAddress(address);
 
       expect(actual).toStrictEqual(expect.arrayContaining(counterfactualSafes));
       const cacheDir = new CacheDir(`counterfactual_safes_${address}`, '');
@@ -448,7 +445,7 @@ describe('CounterfactualSafesDatasource tests', () => {
 
       // the Counterfactual Safe is cached
       await target.getCounterfactualSafe({
-        account,
+        address,
         chainId: counterfactualSafe.chain_id,
         predictedAddress: counterfactualSafe.predicted_address,
       });
@@ -469,7 +466,7 @@ describe('CounterfactualSafesDatasource tests', () => {
       ).resolves.not.toThrow();
       await expect(
         target.getCounterfactualSafe({
-          account,
+          address,
           chainId: counterfactualSafe.chain_id,
           predictedAddress: counterfactualSafe.predicted_address,
         }),
@@ -528,7 +525,7 @@ describe('CounterfactualSafesDatasource tests', () => {
       ).resolves.not.toThrow();
 
       // database is cleared
-      const actual = await target.getCounterfactualSafesForAccount(account);
+      const actual = await target.getCounterfactualSafesForAddress(address);
       expect(actual).toHaveLength(0);
       // cache is cleared
       expect(

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
@@ -67,7 +67,7 @@ export class CounterfactualSafesDatasource
   }
 
   async getCounterfactualSafe(args: {
-    account: Account;
+    address: `0x${string}`;
     chainId: string;
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe> {
@@ -81,7 +81,7 @@ export class CounterfactualSafesDatasource
       cacheDir,
       query: this.sql<CounterfactualSafe[]>`
         SELECT * FROM counterfactual_safes 
-        WHERE account_id = ${args.account.id}
+        WHERE account_id = (SELECT id FROM accounts WHERE address = ${args.address})
           AND chain_id = ${args.chainId}
           AND predicted_address = ${args.predictedAddress}`,
       ttl: this.defaultExpirationTimeInSeconds,
@@ -94,16 +94,15 @@ export class CounterfactualSafesDatasource
     return counterfactualSafe;
   }
 
-  getCounterfactualSafesForAccount(
-    account: Account,
+  getCounterfactualSafesForAddress(
+    address: `0x${string}`,
   ): Promise<CounterfactualSafe[]> {
-    const cacheDir = CacheRouter.getCounterfactualSafesCacheDir(
-      account.address,
-    );
+    const cacheDir = CacheRouter.getCounterfactualSafesCacheDir(address);
     return this.cachedQueryResolver.get<CounterfactualSafe[]>({
       cacheDir,
       query: this.sql<CounterfactualSafe[]>`
-        SELECT * FROM counterfactual_safes WHERE account_id = ${account.id}`,
+        SELECT * FROM counterfactual_safes WHERE account_id = 
+          (SELECT id FROM accounts WHERE address = ${address})`,
       ttl: this.defaultExpirationTimeInSeconds,
     });
   }

--- a/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.interface.ts
+++ b/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.interface.ts
@@ -12,16 +12,12 @@ export const ICounterfactualSafesRepository = Symbol(
 
 export interface ICounterfactualSafesRepository {
   getCounterfactualSafe(args: {
-    authPayload: AuthPayload;
     address: `0x${string}`;
     chainId: string;
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe>;
 
-  getCounterfactualSafes(args: {
-    authPayload: AuthPayload;
-    address: `0x${string}`;
-  }): Promise<CounterfactualSafe[]>;
+  getCounterfactualSafes(address: `0x${string}`): Promise<CounterfactualSafe[]>;
 
   createCounterfactualSafe(args: {
     authPayload: AuthPayload;

--- a/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.ts
+++ b/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.ts
@@ -34,49 +34,21 @@ export class CounterfactualSafesRepository
    * Checks that the account has the CounterfactualSafes data setting enabled.
    */
   async getCounterfactualSafe(args: {
-    authPayload: AuthPayload;
     address: `0x${string}`;
     chainId: string;
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe> {
-    if (!args.authPayload.isForSigner(args.address)) {
-      throw new UnauthorizedException();
-    }
-    await this.checkCounterfactualSafesIsEnabled({
-      authPayload: args.authPayload,
-      address: args.address,
-    });
-    const account = await this.accountsRepository.getAccount({
-      authPayload: args.authPayload,
-      address: args.address,
-    });
-    return this.datasource.getCounterfactualSafe({
-      account,
-      chainId: args.chainId,
-      predictedAddress: args.predictedAddress,
-    });
+    return this.datasource.getCounterfactualSafe(args);
   }
 
   /**
    * Gets all the Counterfactual Safes associated with an account address.
    * Checks that the account has the CounterfactualSafes data setting enabled.
    */
-  async getCounterfactualSafes(args: {
-    authPayload: AuthPayload;
-    address: `0x${string}`;
-  }): Promise<CounterfactualSafe[]> {
-    if (!args.authPayload.isForSigner(args.address)) {
-      throw new UnauthorizedException();
-    }
-    await this.checkCounterfactualSafesIsEnabled({
-      authPayload: args.authPayload,
-      address: args.address,
-    });
-    const account = await this.accountsRepository.getAccount({
-      authPayload: args.authPayload,
-      address: args.address,
-    });
-    return this.datasource.getCounterfactualSafesForAccount(account);
+  async getCounterfactualSafes(
+    address: `0x${string}`,
+  ): Promise<CounterfactualSafe[]> {
+    return this.datasource.getCounterfactualSafesForAddress(address);
   }
 
   /**
@@ -105,7 +77,7 @@ export class CounterfactualSafesRepository
 
     try {
       return await this.datasource.getCounterfactualSafe({
-        account,
+        address: args.address,
         chainId: args.createCounterfactualSafeDto.chainId,
         predictedAddress: args.createCounterfactualSafeDto.predictedAddress,
       });

--- a/src/domain/interfaces/counterfactual-safes.datasource.interface.ts
+++ b/src/domain/interfaces/counterfactual-safes.datasource.interface.ts
@@ -13,13 +13,13 @@ export interface ICounterfactualSafesDatasource {
   }): Promise<CounterfactualSafe>;
 
   getCounterfactualSafe(args: {
-    account: Account;
+    address: `0x${string}`;
     chainId: string;
     predictedAddress: `0x${string}`;
   }): Promise<CounterfactualSafe>;
 
-  getCounterfactualSafesForAccount(
-    account: Account,
+  getCounterfactualSafesForAddress(
+    address: `0x${string}`,
   ): Promise<CounterfactualSafe[]>;
 
   deleteCounterfactualSafe(args: {

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.ts
@@ -26,16 +26,13 @@ export class CounterfactualSafesController {
 
   @ApiOkResponse({ type: CounterfactualSafe })
   @Get(':address/counterfactual-safes/:chainId/:predictedAddress')
-  @UseGuards(AuthGuard)
   async getCounterfactualSafe(
-    @Auth() authPayload: AuthPayload,
     @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
     @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('predictedAddress', new ValidationPipe(AddressSchema))
     predictedAddress: `0x${string}`,
   ): Promise<CounterfactualSafe> {
     return this.service.getCounterfactualSafe({
-      authPayload,
       address,
       chainId,
       predictedAddress,
@@ -44,15 +41,10 @@ export class CounterfactualSafesController {
 
   @ApiOkResponse({ type: CounterfactualSafe, isArray: true })
   @Get(':address/counterfactual-safes')
-  @UseGuards(AuthGuard)
   async getCounterfactualSafes(
-    @Auth() authPayload: AuthPayload,
     @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
   ): Promise<CounterfactualSafe[]> {
-    return this.service.getCounterfactualSafes({
-      authPayload,
-      address,
-    });
+    return this.service.getCounterfactualSafes(address);
   }
 
   @ApiOkResponse({ type: CounterfactualSafe })

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.service.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.service.ts
@@ -13,7 +13,6 @@ export class CounterfactualSafesService {
   ) {}
 
   async getCounterfactualSafe(args: {
-    authPayload: AuthPayload;
     address: `0x${string}`;
     chainId: string;
     predictedAddress: `0x${string}`;
@@ -23,12 +22,11 @@ export class CounterfactualSafesService {
     return this.mapCounterfactualSafe(domainCounterfactualSafe);
   }
 
-  async getCounterfactualSafes(args: {
-    authPayload: AuthPayload;
-    address: `0x${string}`;
-  }): Promise<CounterfactualSafe[]> {
+  async getCounterfactualSafes(
+    address: `0x${string}`,
+  ): Promise<CounterfactualSafe[]> {
     const domainCounterfactualSafes =
-      await this.repository.getCounterfactualSafes(args);
+      await this.repository.getCounterfactualSafes(address);
     return domainCounterfactualSafes.map((counterfactualSafe) =>
       this.mapCounterfactualSafe(counterfactualSafe),
     );


### PR DESCRIPTION
## Summary
This PR removes the necessity of including an `accessToken` in the request in order to access the following endpoints:
- `GET /api/v1/accounts/:address/counterfactual-safes'
- `GET /api/v1/accounts/:address/counterfactual-safes/:chainId/:predictedAddress'

## Changes
- Removes the requirement of an `accessToken` to get Counterfactual Safes. `AuthGuard` is not longer guarding these routes, and `AuthPayload` is no longer being collected/processed.
- Renames `getCounterfactualSafesForAccount` to `getCounterfactualSafesForAddress`. The input parameter is also modified to be a plan `address` instead of an `account`.
- Tests are adjusted accordingly.
