### PR TITLE
Add OpenAPI definitions for auth routes

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -4,7 +4,15 @@ import { AuthService } from '@/routes/auth/auth.service';
 import { AuthNonce } from '@/routes/auth/entities/auth-nonce.entity';
 import { SiweDto, SiweDtoSchema } from '@/routes/auth/entities/siwe.dto.entity';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
-import { Body, Controller, Get, Inject, Post, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Inject,
+  Post,
+  Res,
+} from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 
@@ -42,6 +50,7 @@ export class AuthController {
     return this.authService.getNonce();
   }
 
+  @HttpCode(200)
   @Post('verify')
   @ApiOkResponse({
     description: 'Empty response body. JWT token is set as response cookie.',

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -1,18 +1,11 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { getMillisecondsUntil } from '@/domain/common/utils/time';
 import { AuthService } from '@/routes/auth/auth.service';
+import { AuthNonce } from '@/routes/auth/entities/auth-nonce.entity';
 import { SiweDto, SiweDtoSchema } from '@/routes/auth/entities/siwe.dto.entity';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
-import {
-  Body,
-  Controller,
-  Get,
-  HttpCode,
-  Inject,
-  Post,
-  Res,
-} from '@nestjs/common';
-import { ApiExcludeController } from '@nestjs/swagger';
+import { Body, Controller, Get, Inject, Post, Res } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 
 /**
@@ -24,8 +17,8 @@ import { Response } from 'express';
  * 3. If verification succeeds, JWT token is added to `access_token`
  *    Set-Cookie.
  */
+@ApiTags('auth')
 @Controller({ path: 'auth', version: '1' })
-@ApiExcludeController()
 export class AuthController {
   static readonly ACCESS_TOKEN_COOKIE_NAME = 'access_token';
   static readonly ACCESS_TOKEN_COOKIE_SAME_SITE_LAX = 'lax';
@@ -43,15 +36,16 @@ export class AuthController {
     );
   }
 
+  @ApiOkResponse({ type: AuthNonce })
   @Get('nonce')
-  async getNonce(): Promise<{
-    nonce: string;
-  }> {
+  async getNonce(): Promise<AuthNonce> {
     return this.authService.getNonce();
   }
 
-  @HttpCode(200)
   @Post('verify')
+  @ApiOkResponse({
+    description: 'Empty response body. JWT token is set as response cookie.',
+  })
   async verify(
     @Res({ passthrough: true })
     res: Response,

--- a/src/routes/auth/entities/auth-nonce.entity.ts
+++ b/src/routes/auth/entities/auth-nonce.entity.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AuthNonce {
+  @ApiProperty()
+  nonce!: string;
+}

--- a/src/routes/auth/entities/siwe.dto.entity.ts
+++ b/src/routes/auth/entities/siwe.dto.entity.ts
@@ -1,7 +1,18 @@
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
 
-export type SiweDto = z.infer<typeof SiweDtoSchema>;
+export class SiweDto implements z.infer<typeof SiweDtoSchema> {
+  @ApiProperty()
+  message!: string;
+  @ApiProperty()
+  signature!: `0x${string}`;
+
+  constructor(props: SiweDto) {
+    this.message = props.message;
+    this.signature = props.signature;
+  }
+}
 
 export const SiweDtoSchema = z.object({
   message: z.string(),


### PR DESCRIPTION
## Summary
This PR adds the OpenAPI/Swagger specification for the authentication-related routes.

## Changes
- Add OpenAPI specification for `GET /api/v1/auth/nonce`.
- Add OpenAPI specification for `POST /api/v1/auth/verify`.
