### PR TITLE
Add token metadata  to Native Staking transactions

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
@@ -1,4 +1,3 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DataDecodedParameter } from '@/routes/data-decode/entities/data-decoded-parameter.entity';
 import {
   Baseline,
@@ -6,6 +5,8 @@ import {
 } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
 import { NativeStakingDepositInfo } from '@/routes/transactions/entities/staking/native-staking-info.entity';
 import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class NativeStakingDepositConfirmationView
   implements Baseline, NativeStakingDepositInfo
@@ -47,6 +48,9 @@ export class NativeStakingDepositConfirmationView
   @ApiProperty()
   value: number;
 
+  @ApiProperty()
+  tokenInfo: TokenInfo;
+
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
@@ -58,6 +62,7 @@ export class NativeStakingDepositConfirmationView
     monthlyNrr: number;
     annualNrr: number;
     value: number;
+    tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
     this.parameters = args.parameters;
@@ -69,5 +74,6 @@ export class NativeStakingDepositConfirmationView
     this.monthlyNrr = args.monthlyNrr;
     this.annualNrr = args.annualNrr;
     this.value = args.value;
+    this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-info.entity.ts
@@ -4,6 +4,7 @@ import {
   StakingTimeInfo,
   StakingFinancialInfo,
 } from '@/routes/transactions/entities/staking/staking.entity';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
   TransactionInfoType,
@@ -42,6 +43,9 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty()
   annualNrr: number;
 
+  @ApiProperty()
+  tokenInfo: TokenInfo;
+
   constructor(args: {
     status: StakingStatus;
     estimatedEntryTime: number;
@@ -50,6 +54,7 @@ export class NativeStakingDepositTransactionInfo
     fee: number;
     monthlyNrr: number;
     annualNrr: number;
+    tokenInfo: TokenInfo;
   }) {
     super(TransactionInfoType.NativeStakingDeposit, null, null);
     this.status = args.status;
@@ -59,5 +64,6 @@ export class NativeStakingDepositTransactionInfo
     this.fee = args.fee;
     this.monthlyNrr = args.monthlyNrr;
     this.annualNrr = args.annualNrr;
+    this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -1,38 +1,39 @@
-import { INestApplication, NotFoundException } from '@nestjs/common';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { AppModule } from '@/app.module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { NetworkModule } from '@/datasources/network/network.module';
 import {
   INetworkService,
   NetworkService,
 } from '@/datasources/network/network.service.interface';
-import configuration from '@/config/entities/__tests__/configuration';
-import { Test, TestingModule } from '@nestjs/testing';
-import { AppModule } from '@/app.module';
-import { CacheModule } from '@/datasources/cache/cache.module';
-import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
-import { RequestScopedLoggingModule } from '@/logging/logging.module';
-import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import { NetworkModule } from '@/datasources/network/network.module';
-import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
-import { IConfigurationService } from '@/config/configuration.service.interface';
-import { TestAppProvider } from '@/__tests__/test-app.provider';
-import request from 'supertest';
-import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
-import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
-import { orderBuilder } from '@/domain/swaps/entities/__tests__/order.builder';
-import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
-import { setPreSignatureEncoder } from '@/domain/swaps/contracts/__tests__/encoders/gp-v2-encoder.builder';
-import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
-import { faker } from '@faker-js/faker';
-import { Server } from 'net';
-import { encodeFunctionData, getAddress, parseAbi } from 'viem';
-import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { dedicatedStakingStatsBuilder } from '@/datasources/staking-api/entities/__tests__/dedicated-staking-stats.entity.builder';
+import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import {
   multiSendEncoder,
   multiSendTransactionsEncoder,
 } from '@/domain/contracts/__tests__/encoders/multi-send-encoder.builder';
+import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { setPreSignatureEncoder } from '@/domain/swaps/contracts/__tests__/encoders/gp-v2-encoder.builder';
+import { orderBuilder } from '@/domain/swaps/entities/__tests__/order.builder';
+import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { NULL_ADDRESS } from '@/routes/common/constants';
+import { faker } from '@faker-js/faker';
+import { INestApplication, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Server } from 'net';
+import request from 'supertest';
+import { encodeFunctionData, getAddress, parseAbi } from 'viem';
 
 describe('TransactionsViewController tests', () => {
   let app: INestApplication<Server>;
@@ -636,6 +637,14 @@ describe('TransactionsViewController tests', () => {
                 dedicatedStakingStats.gross_apy.last_30d *
                 (1 - +deployment.product_fee!),
               value: Number(value),
+              tokenInfo: {
+                address: NULL_ADDRESS,
+                decimals: chain.nativeCurrency.decimals,
+                logoUri: chain.nativeCurrency.logoUri,
+                name: chain.nativeCurrency.name,
+                symbol: chain.nativeCurrency.symbol,
+                trusted: true,
+              },
             });
         });
 
@@ -725,6 +734,14 @@ describe('TransactionsViewController tests', () => {
                 dedicatedStakingStats.gross_apy.last_30d *
                 (1 - +deployment.product_fee!),
               value: 0, // defaults to 0 if not provided in the request
+              tokenInfo: {
+                address: NULL_ADDRESS,
+                decimals: chain.nativeCurrency.decimals,
+                logoUri: chain.nativeCurrency.logoUri,
+                name: chain.nativeCurrency.name,
+                symbol: chain.nativeCurrency.symbol,
+                trusted: true,
+              },
             });
         });
 

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -1,3 +1,27 @@
+import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
+import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
+import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
+import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
+import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
+import {
+  TransactionDataDto,
+  TransactionDataDtoSchema,
+} from '@/routes/common/entities/transaction-data.dto.entity';
+import {
+  BaselineConfirmationView,
+  ConfirmationView,
+  CowSwapConfirmationView,
+} from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
+import { NativeStakingDepositConfirmationView } from '@/routes/transactions/entities/staking/native-staking-confirmation-view.entity';
+import { KilnNativeStakingHelperModule } from '@/routes/transactions/helpers/kiln-native-staking.helper';
+import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.helper';
+import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.helper';
+import { TwapOrderHelperModule } from '@/routes/transactions/helpers/twap-order.helper';
+import { NativeStakingMapperModule } from '@/routes/transactions/mappers/common/native-staking.mapper';
+import { TransactionsViewService } from '@/routes/transactions/transactions-view.service';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import {
   Body,
   Controller,
@@ -13,29 +37,6 @@ import {
   ApiTags,
   getSchemaPath,
 } from '@nestjs/swagger';
-import {
-  BaselineConfirmationView,
-  ConfirmationView,
-  CowSwapConfirmationView,
-} from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
-import { TransactionsViewService } from '@/routes/transactions/transactions-view.service';
-import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
-import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.helper';
-import {
-  TransactionDataDto,
-  TransactionDataDtoSchema,
-} from '@/routes/common/entities/transaction-data.dto.entity';
-import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
-import { ValidationPipe } from '@/validation/pipes/validation.pipe';
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
-import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { TwapOrderHelperModule } from '@/routes/transactions/helpers/twap-order.helper';
-import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
-import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
-import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.helper';
-import { NativeStakingDepositConfirmationView } from '@/routes/transactions/entities/staking/native-staking-confirmation-view.entity';
-import { KilnNativeStakingHelperModule } from '@/routes/transactions/helpers/kiln-native-staking.helper';
-import { NativeStakingMapperModule } from '@/routes/transactions/mappers/common/native-staking.mapper';
 
 @ApiTags('transactions')
 @Controller({
@@ -82,14 +83,15 @@ export class TransactionsViewController {
 
 @Module({
   imports: [
+    ChainsRepositoryModule,
     DataDecodedRepositoryModule,
     GPv2DecoderModule,
     KilnNativeStakingHelperModule,
     NativeStakingMapperModule,
-    SwapOrderHelperModule,
-    TwapOrderHelperModule,
-    SwapsRepositoryModule,
     SwapAppsHelperModule,
+    SwapOrderHelperModule,
+    SwapsRepositoryModule,
+    TwapOrderHelperModule,
   ],
   providers: [TransactionsViewService, ComposableCowDecoder],
   controllers: [TransactionsViewController],

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -1,5 +1,4 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
 import { IDataDecodedRepository } from '@/domain/data-decoder/data-decoded.repository.interface';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
@@ -7,7 +6,6 @@ import { GPv2Decoder } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.hel
 import { OrderStatus } from '@/domain/swaps/entities/order.entity';
 import { ISwapsRepository } from '@/domain/swaps/swaps.repository';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { NULL_ADDRESS } from '@/routes/common/constants';
 import { TransactionDataDto } from '@/routes/common/entities/transaction-data.dto.entity';
 import {
   BaselineConfirmationView,
@@ -43,8 +41,6 @@ export class TransactionsViewService {
     private readonly configurationService: IConfigurationService,
     private readonly kilnNativeStakingHelper: KilnNativeStakingHelper,
     private readonly nativeStakingMapper: NativeStakingMapper,
-    @Inject(IChainsRepository)
-    private readonly chainsRepository: IChainsRepository,
   ) {
     this.isNativeStakingEnabled = this.configurationService.getOrThrow<boolean>(
       'features.nativeStaking',
@@ -290,20 +286,10 @@ export class TransactionsViewService {
       isConfirmed: false,
       depositExecutionDate: null,
     });
-    const chain = await this.chainsRepository.getChain(args.chainId);
     return new NativeStakingDepositConfirmationView({
       method: args.dataDecoded.method,
       parameters: args.dataDecoded.parameters,
       value: args.value ? Number(args.value) : 0,
-      // tokenInfo is set to the native currency of the chain for native staking deposits
-      tokenInfo: new TokenInfo({
-        address: NULL_ADDRESS,
-        decimals: chain.nativeCurrency.decimals,
-        logoUri: chain.nativeCurrency.logoUri,
-        name: chain.nativeCurrency.name,
-        symbol: chain.nativeCurrency.symbol,
-        trusted: true,
-      }),
       ...depositInfo,
     });
   }

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -1,17 +1,33 @@
-import { Module } from '@nestjs/common';
+import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
+import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
+import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
+import { HumanDescriptionRepositoryModule } from '@/domain/human-description/human-description.repository.interface';
+import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repository.interface';
+import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
+import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
+import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
+import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
+import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interface';
 import { AddressInfoModule } from '@/routes/common/address-info/address-info.module';
+import { GPv2OrderHelper } from '@/routes/transactions/helpers/gp-v2-order.helper';
+import { KilnNativeStakingHelperModule } from '@/routes/transactions/helpers/kiln-native-staking.helper';
+import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.helper';
+import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.helper';
+import { TwapOrderHelperModule } from '@/routes/transactions/helpers/twap-order.helper';
 import { CustomTransactionMapper } from '@/routes/transactions/mappers/common/custom-transaction.mapper';
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { Erc20TransferMapper } from '@/routes/transactions/mappers/common/erc20-transfer.mapper';
 import { Erc721TransferMapper } from '@/routes/transactions/mappers/common/erc721-transfer.mapper';
 import { HumanDescriptionMapper } from '@/routes/transactions/mappers/common/human-description.mapper';
 import { NativeCoinTransferMapper } from '@/routes/transactions/mappers/common/native-coin-transfer.mapper';
+import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
 import { SafeAppInfoMapper } from '@/routes/transactions/mappers/common/safe-app-info.mapper';
 import { SettingsChangeMapper } from '@/routes/transactions/mappers/common/settings-change.mapper';
+import { SwapOrderMapperModule } from '@/routes/transactions/mappers/common/swap-order.mapper';
 import { TransactionDataMapper } from '@/routes/transactions/mappers/common/transaction-data.mapper';
 import { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
+import { TwapOrderMapperModule } from '@/routes/transactions/mappers/common/twap-order.mapper';
 import { CreationTransactionMapper } from '@/routes/transactions/mappers/creation-transaction/creation-transaction.mapper';
-import { GPv2OrderHelper } from '@/routes/transactions/helpers/gp-v2-order.helper';
 import { ModuleTransactionDetailsMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction-details.mapper';
 import { ModuleTransactionStatusMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction-status.mapper';
 import { ModuleTransactionMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction.mapper';
@@ -23,34 +39,20 @@ import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisi
 import { QueuedItemsMapper } from '@/routes/transactions/mappers/queued-items/queued-items.mapper';
 import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transaction-preview.mapper';
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
+import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
+import { TransferImitationMapper } from '@/routes/transactions/mappers/transfers/transfer-imitation.mapper';
 import { TransferInfoMapper } from '@/routes/transactions/mappers/transfers/transfer-info.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
-import { TransferImitationMapper } from '@/routes/transactions/mappers/transfers/transfer-imitation.mapper';
 import { TransactionsController } from '@/routes/transactions/transactions.controller';
 import { TransactionsService } from '@/routes/transactions/transactions.service';
-import { SwapOrderMapperModule } from '@/routes/transactions/mappers/common/swap-order.mapper';
-import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
-import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
-import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
-import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
-import { HumanDescriptionRepositoryModule } from '@/domain/human-description/human-description.repository.interface';
-import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repository.interface';
-import { TokenRepositoryModule } from '@/domain/tokens/token.repository.interface';
-import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.helper';
-import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
-import { TwapOrderMapperModule } from '@/routes/transactions/mappers/common/twap-order.mapper';
-import { TwapOrderHelperModule } from '@/routes/transactions/helpers/twap-order.helper';
-import { SwapTransferInfoMapper } from '@/routes/transactions/mappers/transfers/swap-transfer-info.mapper';
-import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.helper';
-import { KilnNativeStakingHelperModule } from '@/routes/transactions/helpers/kiln-native-staking.helper';
-import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
-import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
+import { Module } from '@nestjs/common';
 
 @Module({
   controllers: [TransactionsController],
   imports: [
     AddressInfoModule,
+    ChainsRepositoryModule,
     ContractsRepositoryModule,
     DataDecodedRepositoryModule,
     HumanDescriptionRepositoryModule,


### PR DESCRIPTION
## Summary
This PR adds `TokenInfo` metadata to Native Staking transaction mappings. This implies the `TokenInfo` metadata will be available in transaction Confirmation View and transaction history/queue.

## Changes
- Adds `TokenInfo` metadata to `NativeStakingDepositTransactionInfo`.
- Adjusts unit tests accordingly.