### PR TITLE
Add annual/monthly rewards calculation

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
@@ -49,6 +49,12 @@ export class NativeStakingDepositConfirmationView
   value: number;
 
   @ApiProperty()
+  expectedAnnualReward: number;
+
+  @ApiProperty()
+  expectedMonthlyReward: number;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -62,6 +68,8 @@ export class NativeStakingDepositConfirmationView
     monthlyNrr: number;
     annualNrr: number;
     value: number;
+    expectedAnnualReward: number;
+    expectedMonthlyReward: number;
     tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
@@ -74,6 +82,8 @@ export class NativeStakingDepositConfirmationView
     this.monthlyNrr = args.monthlyNrr;
     this.annualNrr = args.annualNrr;
     this.value = args.value;
+    this.expectedAnnualReward = args.expectedAnnualReward;
+    this.expectedMonthlyReward = args.expectedMonthlyReward;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -637,6 +637,15 @@ describe('TransactionsViewController tests', () => {
                 dedicatedStakingStats.gross_apy.last_30d *
                 (1 - +deployment.product_fee!),
               value: Number(value),
+              expectedMonthlyReward:
+                ((dedicatedStakingStats.gross_apy.last_30d *
+                  (1 - +deployment.product_fee!)) /
+                  12) *
+                Number(value),
+              expectedAnnualReward:
+                dedicatedStakingStats.gross_apy.last_30d *
+                (1 - +deployment.product_fee!) *
+                Number(value),
               tokenInfo: {
                 address: NULL_ADDRESS,
                 decimals: chain.nativeCurrency.decimals,
@@ -734,6 +743,8 @@ describe('TransactionsViewController tests', () => {
                 dedicatedStakingStats.gross_apy.last_30d *
                 (1 - +deployment.product_fee!),
               value: 0, // defaults to 0 if not provided in the request
+              expectedMonthlyReward: 0, // 0 as value is 0
+              expectedAnnualReward: 0, // 0 as value is 0
               tokenInfo: {
                 address: NULL_ADDRESS,
                 decimals: chain.nativeCurrency.decimals,

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -286,10 +286,13 @@ export class TransactionsViewService {
       isConfirmed: false,
       depositExecutionDate: null,
     });
+    const value = args.value ? Number(args.value) : 0;
     return new NativeStakingDepositConfirmationView({
       method: args.dataDecoded.method,
       parameters: args.dataDecoded.parameters,
-      value: args.value ? Number(args.value) : 0,
+      value,
+      expectedMonthlyReward: depositInfo.monthlyNrr * value,
+      expectedAnnualReward: depositInfo.annualNrr * value,
       ...depositInfo,
     });
   }


### PR DESCRIPTION
Closes #1860 

## Summary
This PR adds a calculation for getting both `expectedMonthlyRewards` and `expectedAnnualRewards` values in the Confirmation View transaction screen for native staking.

## Changes
- Add `expectedMonthlyRewards` and `expectedAnnualRewards` in wei to Native Staking Transaction Confirmation View.
