### PR TITLE
Add annual/monthly fiat rewards calculation

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -51,6 +51,7 @@ const zerionBalancesApi = {
   getCollectibles: jest.fn(),
   clearCollectibles: jest.fn(),
   getFiatCodes: jest.fn(),
+  getNativeCoinPrice: jest.fn(),
 } as IBalancesApi;
 
 const zerionBalancesApiMock = jest.mocked(zerionBalancesApi);

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -71,6 +71,10 @@ export class BalancesApiManager implements IBalancesApiManager {
     }
   }
 
+  async getSafeBalancesApi(chainId: string): Promise<IBalancesApi> {
+    return this._getSafeBalancesApi(chainId);
+  }
+
   async getFiatCodes(): Promise<string[]> {
     const [zerionFiatCodes, safeFiatCodes] = await Promise.all([
       this.zerionBalancesApi.getFiatCodes(),

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -132,6 +132,16 @@ export class SafeBalancesApi implements IBalancesApi {
     return this.coingeckoApi.getFiatCodes();
   }
 
+  /**
+   * Gets the USD price of the native coin of the chain associated with {@link chainId}.
+   */
+  async getNativeCoinPrice(chain: Chain): Promise<number | null> {
+    return this.coingeckoApi.getNativeCoinPrice({
+      chain,
+      fiatCode: 'USD',
+    });
+  }
+
   private async _mapBalances(
     balances: Balance[],
     fiatCode: string,

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -284,6 +284,13 @@ export class ZerionBalancesApi implements IBalancesApi {
     await this.cacheService.deleteByKey(key);
   }
 
+  getNativeCoinPrice(): Promise<number | null> {
+    this.loggingService.warn(
+      'Native coin price retrieval is not implemented for Zerion',
+    );
+    return Promise.resolve(null);
+  }
+
   private _getChainName(chain: Chain): string {
     const chainName =
       chain.balancesProvider.chainName ??

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -34,6 +34,11 @@ export interface IBalancesRepository {
   getFiatCodes(): Promise<string[]>;
 
   /**
+   * Gets the price of the native coin of the chain.
+   */
+  getNativeCoinPrice(chain: Chain): Promise<number | null>;
+
+  /**
    * Clears the API associated with {@link chainId}
    */
   clearApi(chainId: string): void;

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -42,6 +42,11 @@ export class BalancesRepository implements IBalancesRepository {
     return this.balancesApiManager.getFiatCodes();
   }
 
+  async getNativeCoinPrice(chain: Chain): Promise<number | null> {
+    const api = await this.balancesApiManager.getSafeBalancesApi(chain.chainId);
+    return api.getNativeCoinPrice(chain);
+  }
+
   clearApi(chainId: string): void {
     this.balancesApiManager.destroyApi(chainId);
   }

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -32,4 +32,6 @@ export interface IBalancesApi {
   }): Promise<void>;
 
   getFiatCodes(): Promise<string[]>;
+
+  getNativeCoinPrice(chain: Chain): Promise<number | null>;
 }

--- a/src/domain/interfaces/balances-api.manager.interface.ts
+++ b/src/domain/interfaces/balances-api.manager.interface.ts
@@ -19,6 +19,12 @@ export interface IBalancesApiManager extends IApiManager<IBalancesApi> {
   getApi(chainId: string, safeAddress: `0x${string}`): Promise<IBalancesApi>;
 
   /**
+   * Gets the {@link SafeBalancesApi} implementation associated with the chainId.
+   * @param chainId - the chain identifier to check.
+   */
+  getSafeBalancesApi(chainId: string): Promise<IBalancesApi>;
+
+  /**
    * Gets the list of supported fiat codes.
    * @returns an alphabetically ordered list of uppercase strings representing the supported fiat codes.
    */

--- a/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
@@ -55,6 +55,12 @@ export class NativeStakingDepositConfirmationView
   expectedMonthlyReward: number;
 
   @ApiProperty()
+  expectedFiatAnnualReward: number;
+
+  @ApiProperty()
+  expectedFiatMonthlyReward: number;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -70,6 +76,8 @@ export class NativeStakingDepositConfirmationView
     value: number;
     expectedAnnualReward: number;
     expectedMonthlyReward: number;
+    expectedFiatAnnualReward: number;
+    expectedFiatMonthlyReward: number;
     tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
@@ -84,6 +92,8 @@ export class NativeStakingDepositConfirmationView
     this.value = args.value;
     this.expectedAnnualReward = args.expectedAnnualReward;
     this.expectedMonthlyReward = args.expectedMonthlyReward;
+    this.expectedFiatAnnualReward = args.expectedFiatAnnualReward;
+    this.expectedFiatMonthlyReward = args.expectedFiatMonthlyReward;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -1,3 +1,4 @@
+import { BalancesRepositoryModule } from '@/domain/balances/balances.repository.interface';
 import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
@@ -83,6 +84,7 @@ export class TransactionsViewController {
 
 @Module({
   imports: [
+    BalancesRepositoryModule,
     ChainsRepositoryModule,
     DataDecodedRepositoryModule,
     GPv2DecoderModule,

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -1,4 +1,6 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
+import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
 import { IDataDecodedRepository } from '@/domain/data-decoder/data-decoded.repository.interface';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
@@ -41,6 +43,10 @@ export class TransactionsViewService {
     private readonly configurationService: IConfigurationService,
     private readonly kilnNativeStakingHelper: KilnNativeStakingHelper,
     private readonly nativeStakingMapper: NativeStakingMapper,
+    @Inject(IChainsRepository)
+    private readonly chainsRepository: IChainsRepository,
+    @Inject(IBalancesRepository)
+    private readonly balancesRepository: IBalancesRepository,
   ) {
     this.isNativeStakingEnabled = this.configurationService.getOrThrow<boolean>(
       'features.nativeStaking',
@@ -287,12 +293,25 @@ export class TransactionsViewService {
       depositExecutionDate: null,
     });
     const value = args.value ? Number(args.value) : 0;
+    const chain = await this.chainsRepository.getChain(args.chainId);
+    const nativeCoinPrice =
+      await this.balancesRepository.getNativeCoinPrice(chain);
+
+    const expectedAnnualReward = (depositInfo.annualNrr / 100) * value;
+    const expectedMonthlyReward = expectedAnnualReward / 12;
+    const expectedFiatAnnualReward =
+      (expectedAnnualReward * (nativeCoinPrice ?? 0)) /
+      Math.pow(10, chain.nativeCurrency.decimals);
+    const expectedFiatMonthlyReward = expectedFiatAnnualReward / 12;
+
     return new NativeStakingDepositConfirmationView({
       method: args.dataDecoded.method,
       parameters: args.dataDecoded.parameters,
       value,
-      expectedMonthlyReward: depositInfo.monthlyNrr * value,
-      expectedAnnualReward: depositInfo.annualNrr * value,
+      expectedAnnualReward,
+      expectedMonthlyReward,
+      expectedFiatAnnualReward,
+      expectedFiatMonthlyReward,
       ...depositInfo,
     });
   }


### PR DESCRIPTION
Closes #1863 

## Summary
This PR adds fiat rewards calculation to Native Staking Transactions confirmation views.

**NOTE:** The fiat prices are given in USD.

## Changes
- Add `expectedFiatAnnualReward` and `expectedFiatMonthlyReward` to `NativeStakingDepositConfirmationView`.
- Adds a new `getNativeCoinPrice` method to `IBalancesApi` and `IBalancesRepository`, to make it possible to retrieve the native coin fiat price in USD.
