### PR TITLE
Specify status codes on rate limit errors

### DIFF
--- a/src/datasources/accounts/accounts.datasource.spec.ts
+++ b/src/datasources/accounts/accounts.datasource.spec.ts
@@ -155,7 +155,7 @@ describe('AccountsDatasource tests', () => {
           address: getAddress(faker.finance.ethereumAddress()),
           clientIp,
         }),
-      ).rejects.toThrow('Rate limit reached');
+      ).rejects.toThrow('Accounts creation rate limit reached');
 
       const { count } = await sql`SELECT id FROM accounts`;
       expect(count).toBe(accountCreationRateLimitCalls);

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -7,11 +7,11 @@ import {
 import { MAX_TTL } from '@/datasources/cache/constants';
 import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
-import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
 import { AccountDataSetting } from '@/domain/accounts/entities/account-data-setting.entity';
 import { AccountDataType } from '@/domain/accounts/entities/account-data-type.entity';
 import { Account } from '@/domain/accounts/entities/account.entity';
 import { UpsertAccountDataSettingsDto } from '@/domain/accounts/entities/upsert-account-data-settings.dto.entity';
+import { AccountsCreationRateLimitError } from '@/domain/accounts/errors/accounts-creation-rate-limit.error';
 import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
@@ -219,7 +219,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
    * the attempts to create them.
    *
    * If the client IP address is invalid, a warning is logged.
-   * If the client IP address is valid and rate limit is reached, a {@link LimitReachedError} is thrown.
+   * If the client IP address is valid and rate limit is reached, a {@link AccountsCreationRateLimitError} is thrown.
    *
    * @param clientIp - client IP address.
    */
@@ -240,7 +240,7 @@ export class AccountsDatasource implements IAccountsDatasource, OnModuleInit {
         this.loggingService.warn(
           `Limit of ${this.accountCreationRateLimitCalls} reached for IP ${clientIp}`,
         );
-        throw new LimitReachedError();
+        throw new AccountsCreationRateLimitError();
       }
     }
   }

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.spec.ts
@@ -197,7 +197,7 @@ describe('CounterfactualSafesDatasource tests', () => {
             .with('chainId', '11')
             .build(),
         }),
-      ).rejects.toThrow('Rate limit reached');
+      ).rejects.toThrow('Counterfactual Safes creation rate limit reached');
     });
 
     it('should delete the cache for the account Counterfactual Safes', async () => {

--- a/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
+++ b/src/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.ts
@@ -6,9 +6,9 @@ import {
 } from '@/datasources/cache/cache.service.interface';
 import { CachedQueryResolver } from '@/datasources/db/cached-query-resolver';
 import { ICachedQueryResolver } from '@/datasources/db/cached-query-resolver.interface';
-import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
 import { CounterfactualSafe } from '@/domain/accounts/counterfactual-safes/entities/counterfactual-safe.entity';
 import { CreateCounterfactualSafeDto } from '@/domain/accounts/counterfactual-safes/entities/create-counterfactual-safe.dto.entity';
+import { CounterfactualSafesCreationRateLimitError } from '@/domain/accounts/counterfactual-safes/errors/counterfactual-safes-creation-rate-limit.error';
 import { Account } from '@/domain/accounts/entities/account.entity';
 import { ICounterfactualSafesDatasource } from '@/domain/interfaces/counterfactual-safes.datasource.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
@@ -170,7 +170,7 @@ export class CounterfactualSafesDatasource
       this.loggingService.warn(
         `Limit of ${this.counterfactualSafesCreationRateLimitCalls} reached for account ${account.address}`,
       );
-      throw new LimitReachedError();
+      throw new CounterfactualSafesCreationRateLimitError();
     }
   }
 

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -146,7 +146,7 @@ export class ZerionBalancesApi implements IBalancesApi {
       return this._mapBalances(chainName, data.data);
     } catch (error) {
       if (error instanceof LimitReachedError) {
-        throw new DataSourceError(error.message, 429);
+        throw error;
       }
       throw this.httpErrorFactory.from(error);
     }

--- a/src/datasources/network/entities/errors/limit-reached.error.ts
+++ b/src/datasources/network/entities/errors/limit-reached.error.ts
@@ -1,5 +1,7 @@
-export class LimitReachedError extends Error {
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class LimitReachedError extends HttpException {
   constructor() {
-    super(`Rate limit reached`);
+    super(`Rate limit reached`, HttpStatus.TOO_MANY_REQUESTS);
   }
 }

--- a/src/domain/accounts/counterfactual-safes/errors/counterfactual-safes-creation-rate-limit.error.ts
+++ b/src/domain/accounts/counterfactual-safes/errors/counterfactual-safes-creation-rate-limit.error.ts
@@ -1,0 +1,10 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class CounterfactualSafesCreationRateLimitError extends HttpException {
+  constructor() {
+    super(
+      `Counterfactual Safes creation rate limit reached`,
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+  }
+}

--- a/src/domain/accounts/errors/accounts-creation-rate-limit.error.ts
+++ b/src/domain/accounts/errors/accounts-creation-rate-limit.error.ts
@@ -1,0 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class AccountsCreationRateLimitError extends HttpException {
+  constructor() {
+    super(`Accounts creation rate limit reached`, HttpStatus.TOO_MANY_REQUESTS);
+  }
+}


### PR DESCRIPTION
## Summary
This PR sets the correct HTTP status codes for rate limit errors while creating Accounts or Counterfactual Safes.

## Changes
- Makes `LimitReachedError` extend `HttpException`, and adds HTTP status code `429`.
- Creates new `HttpException`  subclasses: `CounterfactualSafesCreationRateLimitError` and `AccountsCreationRateLimitError`.
