### PR TITLE
Add numValidators to Native Staking confirmation view

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
@@ -49,6 +49,9 @@ export class NativeStakingDepositConfirmationView
   value: number;
 
   @ApiProperty()
+  numValidators: number;
+
+  @ApiProperty()
   expectedAnnualReward: number;
 
   @ApiProperty()
@@ -74,6 +77,7 @@ export class NativeStakingDepositConfirmationView
     monthlyNrr: number;
     annualNrr: number;
     value: number;
+    numValidators: number;
     expectedAnnualReward: number;
     expectedMonthlyReward: number;
     expectedFiatAnnualReward: number;
@@ -90,6 +94,7 @@ export class NativeStakingDepositConfirmationView
     this.monthlyNrr = args.monthlyNrr;
     this.annualNrr = args.annualNrr;
     this.value = args.value;
+    this.numValidators = args.numValidators;
     this.expectedAnnualReward = args.expectedAnnualReward;
     this.expectedMonthlyReward = args.expectedMonthlyReward;
     this.expectedFiatAnnualReward = args.expectedFiatAnnualReward;

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -16,6 +16,7 @@ import { dedicatedStakingStatsBuilder } from '@/datasources/staking-api/entities
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { getNumberString } from '@/domain/common/utils/utils';
 import {
   multiSendEncoder,
   multiSendTransactionsEncoder,
@@ -581,7 +582,7 @@ describe('TransactionsViewController tests', () => {
           const data = encodeFunctionData({
             abi: parseAbi(['function deposit() external payable']),
           });
-          const value = faker.string.numeric({ length: 18 });
+          const value = getNumberString(64 * 10 ** 18 + 1);
           const fiatPrice = 1212.23; // TODO: randomize
           const nativeCoinPriceProviderResponse = {
             [chain.pricesProvider.nativeCoin!]: {
@@ -657,6 +658,7 @@ describe('TransactionsViewController tests', () => {
               monthlyNrr,
               annualNrr,
               value: Number(value),
+              numValidators: 2,
               expectedAnnualReward,
               expectedMonthlyReward,
               expectedFiatAnnualReward,
@@ -758,6 +760,7 @@ describe('TransactionsViewController tests', () => {
                 dedicatedStakingStats.gross_apy.last_30d *
                 (1 - +deployment.product_fee!),
               value: 0, // defaults to 0 if not provided in the request
+              numValidators: 0, // 0 as value is 0
               expectedMonthlyReward: 0, // 0 as value is 0
               expectedAnnualReward: 0, // 0 as value is 0
               expectedFiatMonthlyReward: 0, // 0 as value is 0

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -294,6 +294,9 @@ export class TransactionsViewService {
     });
     const value = args.value ? Number(args.value) : 0;
     const chain = await this.chainsRepository.getChain(args.chainId);
+    const numValidators = Math.floor(
+      value / Math.pow(10, chain.nativeCurrency.decimals) / 32,
+    );
     const nativeCoinPrice =
       await this.balancesRepository.getNativeCoinPrice(chain);
 
@@ -308,6 +311,7 @@ export class TransactionsViewService {
       method: args.dataDecoded.method,
       parameters: args.dataDecoded.parameters,
       value,
+      numValidators,
       expectedAnnualReward,
       expectedMonthlyReward,
       expectedFiatAnnualReward,

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -26,6 +26,7 @@ import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable({})
 export class TransactionsViewService {
+  private static readonly ETH_ETHERS_PER_VALIDATOR = 32;
   private readonly isNativeStakingEnabled: boolean;
 
   constructor(
@@ -295,7 +296,9 @@ export class TransactionsViewService {
     const value = args.value ? Number(args.value) : 0;
     const chain = await this.chainsRepository.getChain(args.chainId);
     const numValidators = Math.floor(
-      value / Math.pow(10, chain.nativeCurrency.decimals) / 32,
+      value /
+        Math.pow(10, chain.nativeCurrency.decimals) /
+        TransactionsViewService.ETH_ETHERS_PER_VALIDATOR,
     );
     const nativeCoinPrice =
       await this.balancesRepository.getNativeCoinPrice(chain);


### PR DESCRIPTION
Closes #1867 

## Changes
- Adds `numValidators` field to the Native Staking transaction confirmation view.
