### PR TITLE
Adjust Native Staking confirmation view numeric types

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-confirmation-view.entity.ts
@@ -46,13 +46,13 @@ export class NativeStakingDepositConfirmationView
   annualNrr: number;
 
   @ApiProperty()
-  value: number;
+  value: string;
 
   @ApiProperty()
-  expectedAnnualReward: number;
+  expectedAnnualReward: string;
 
   @ApiProperty()
-  expectedMonthlyReward: number;
+  expectedMonthlyReward: string;
 
   @ApiProperty()
   expectedFiatAnnualReward: number;
@@ -73,9 +73,9 @@ export class NativeStakingDepositConfirmationView
     fee: number;
     monthlyNrr: number;
     annualNrr: number;
-    value: number;
-    expectedAnnualReward: number;
-    expectedMonthlyReward: number;
+    value: string;
+    expectedAnnualReward: string;
+    expectedMonthlyReward: string;
     expectedFiatAnnualReward: number;
     expectedFiatMonthlyReward: number;
     tokenInfo: TokenInfo;

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -16,6 +16,7 @@ import { dedicatedStakingStatsBuilder } from '@/datasources/staking-api/entities
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { getNumberString } from '@/domain/common/utils/utils';
 import {
   multiSendEncoder,
   multiSendTransactionsEncoder,
@@ -582,7 +583,7 @@ describe('TransactionsViewController tests', () => {
             abi: parseAbi(['function deposit() external payable']),
           });
           const value = faker.string.numeric({ length: 18 });
-          const fiatPrice = 1212.23; // TODO: randomize
+          const fiatPrice = faker.number.float({ min: 0, max: 1_000_000 });
           const nativeCoinPriceProviderResponse = {
             [chain.pricesProvider.nativeCoin!]: {
               usd: fiatPrice,
@@ -656,9 +657,9 @@ describe('TransactionsViewController tests', () => {
               fee: +deployment.product_fee!,
               monthlyNrr,
               annualNrr,
-              value: Number(value),
-              expectedAnnualReward,
-              expectedMonthlyReward,
+              value: getNumberString(Number(value)),
+              expectedAnnualReward: getNumberString(expectedAnnualReward),
+              expectedMonthlyReward: getNumberString(expectedMonthlyReward),
               expectedFiatAnnualReward,
               expectedFiatMonthlyReward,
               tokenInfo: {
@@ -757,9 +758,9 @@ describe('TransactionsViewController tests', () => {
               annualNrr:
                 dedicatedStakingStats.gross_apy.last_30d *
                 (1 - +deployment.product_fee!),
-              value: 0, // defaults to 0 if not provided in the request
-              expectedMonthlyReward: 0, // 0 as value is 0
-              expectedAnnualReward: 0, // 0 as value is 0
+              value: '0', // defaults to 0 if not provided in the request
+              expectedMonthlyReward: '0', // 0 as value is 0
+              expectedAnnualReward: '0', // 0 as value is 0
               expectedFiatMonthlyReward: 0, // 0 as value is 0
               expectedFiatAnnualReward: 0, // 0 as value is 0
               tokenInfo: {

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -1,6 +1,7 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { IBalancesRepository } from '@/domain/balances/balances.repository.interface';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
+import { getNumberString } from '@/domain/common/utils/utils';
 import { IDataDecodedRepository } from '@/domain/data-decoder/data-decoded.repository.interface';
 import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
@@ -307,9 +308,9 @@ export class TransactionsViewService {
     return new NativeStakingDepositConfirmationView({
       method: args.dataDecoded.method,
       parameters: args.dataDecoded.parameters,
-      value,
-      expectedAnnualReward,
-      expectedMonthlyReward,
+      value: getNumberString(value),
+      expectedAnnualReward: getNumberString(expectedAnnualReward),
+      expectedMonthlyReward: getNumberString(expectedMonthlyReward),
       expectedFiatAnnualReward,
       expectedFiatMonthlyReward,
       ...depositInfo,


### PR DESCRIPTION
## Changes
- Changes the following `NativeStakingDepositConfirmationView` fields to numeric `string`: `value`, `expectedAnnualReward`, `expectedMonthlyReward`.
