### PR TITLE
Filter out invalid Chain items

### DIFF
--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
+import { buildLenientPageSchema } from '@/domain/entities/schemas/lenient-page.schema.factory';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 
 export const NativeCurrencySchema = z.object({
   name: z.string(),
@@ -118,4 +118,4 @@ export const ChainSchema = z.object({
 
 // TODO: Merge schema definitions with ChainEntity.
 
-export const ChainPageSchema = buildPageSchema(ChainSchema);
+export const ChainLenientPageSchema = buildLenientPageSchema(ChainSchema);

--- a/src/domain/entities/schemas/lenient-page.schema.factory.ts
+++ b/src/domain/entities/schemas/lenient-page.schema.factory.ts
@@ -1,0 +1,21 @@
+import { TypeOf, z } from 'zod';
+import { Page } from '@/domain/entities/page.entity';
+
+/**
+ * Builds a lenient page schema that filters out invalid items from the results array.
+ */
+export function buildLenientPageSchema<T extends z.ZodTypeAny>(
+  itemSchema: T,
+): z.ZodType<Page<z.infer<T>>> {
+  return z.object({
+    count: z.number().nullable(),
+    next: z.string().nullable(),
+    previous: z.string().nullable(),
+    results: z.array(z.any()).transform((items) =>
+      items.flatMap((item) => {
+        const result = itemSchema.safeParse(item);
+        return result.success ? [result.data as TypeOf<T>] : [];
+      }),
+    ),
+  });
+}

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -200,7 +200,7 @@ describe('Chains Controller (Unit)', () => {
       });
     });
 
-    it('Failure: received data is not valid', async () => {
+    it('should exclude items not passing validation', async () => {
       networkService.get.mockResolvedValueOnce({
         data: {
           ...chainsResponse,
@@ -209,10 +209,66 @@ describe('Chains Controller (Unit)', () => {
         status: 200,
       });
 
-      await request(app.getHttpServer()).get('/v1/chains').expect(500).expect({
-        statusCode: 500,
-        message: 'Internal server error',
-      });
+      await request(app.getHttpServer())
+        .get('/v1/chains')
+        .expect(200)
+        .expect({
+          count: chainsResponse.count,
+          next: chainsResponse.next,
+          previous: chainsResponse.previous,
+          results: [
+            {
+              chainId: chainsResponse.results[0].chainId,
+              chainName: chainsResponse.results[0].chainName,
+              description: chainsResponse.results[0].description,
+              chainLogoUri: chainsResponse.results[0].chainLogoUri,
+              l2: chainsResponse.results[0].l2,
+              isTestnet: chainsResponse.results[0].isTestnet,
+              shortName: chainsResponse.results[0].shortName,
+              rpcUri: chainsResponse.results[0].rpcUri,
+              safeAppsRpcUri: chainsResponse.results[0].safeAppsRpcUri,
+              publicRpcUri: chainsResponse.results[0].publicRpcUri,
+              blockExplorerUriTemplate:
+                chainsResponse.results[0].blockExplorerUriTemplate,
+              nativeCurrency: chainsResponse.results[0].nativeCurrency,
+              transactionService: chainsResponse.results[0].transactionService,
+              theme: chainsResponse.results[0].theme,
+              gasPrice: chainsResponse.results[0].gasPrice,
+              ensRegistryAddress: getAddress(
+                chainsResponse.results[0].ensRegistryAddress!,
+              ),
+              disabledWallets: chainsResponse.results[0].disabledWallets,
+              features: chainsResponse.results[0].features,
+              balancesProvider: chainsResponse.results[0].balancesProvider,
+              contractAddresses: chainsResponse.results[0].contractAddresses,
+            },
+            {
+              chainId: chainsResponse.results[1].chainId,
+              chainName: chainsResponse.results[1].chainName,
+              description: chainsResponse.results[1].description,
+              chainLogoUri: chainsResponse.results[1].chainLogoUri,
+              l2: chainsResponse.results[1].l2,
+              isTestnet: chainsResponse.results[1].isTestnet,
+              shortName: chainsResponse.results[1].shortName,
+              rpcUri: chainsResponse.results[1].rpcUri,
+              safeAppsRpcUri: chainsResponse.results[1].safeAppsRpcUri,
+              publicRpcUri: chainsResponse.results[1].publicRpcUri,
+              blockExplorerUriTemplate:
+                chainsResponse.results[1].blockExplorerUriTemplate,
+              nativeCurrency: chainsResponse.results[1].nativeCurrency,
+              transactionService: chainsResponse.results[1].transactionService,
+              theme: chainsResponse.results[1].theme,
+              gasPrice: chainsResponse.results[1].gasPrice,
+              ensRegistryAddress: getAddress(
+                chainsResponse.results[1].ensRegistryAddress!,
+              ),
+              disabledWallets: chainsResponse.results[1].disabledWallets,
+              features: chainsResponse.results[1].features,
+              balancesProvider: chainsResponse.results[1].balancesProvider,
+              contractAddresses: chainsResponse.results[1].contractAddresses,
+            },
+          ],
+        });
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
       expect(networkService.get).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
When using `buildPageSchema` to validate a `Page<T>` of items, all the items in the `Page<T>` must conform to the `T` schema. Otherwise, the validation of the `Page<T>` fails.

This PR adds a `buildLenientPageSchema`, that filters out the items that do not pass the validation, instead of throwing an error.

## Changes
- Adds `buildLenientPageSchema` function.
- Changes `ChainsRepository.getChains` function to use a _lenient_ page validation, and log out the failing items.