### PR TITLE
Avoid casting to determine confirmation state when mapping staking transactions

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -322,10 +322,10 @@ export class MultisigTransactionInfoMapper {
     }
 
     try {
-      const tx = transaction as MultisigTransaction;
       const isConfirmed =
-        !!tx.confirmations &&
-        tx.confirmations.length >= tx.confirmationsRequired;
+        'confirmations' in transaction &&
+        !!transaction.confirmations &&
+        transaction.confirmations.length >= transaction.confirmationsRequired;
 
       return await this.nativeStakingMapper.mapDepositInfo({
         chainId,


### PR DESCRIPTION
## Summary

When determining the confirmation state of native deposit transacitons, we [currently cast a transaction](https://github.com/safe-global/safe-client-gateway/pull/1842#discussion_r1735834124
) that can be either a`MultisigTransaction` or `ModuleTransaction` to `MultisigTransaction`. It is still theoretically possible to deposit via a module, meaning that this cast is not safe.

This avoids casting and instead checks for the existence of the `confirmations` property in the transaction in question, inherently meaning that it is a `MultisigTransaction`.

## Changes

- Check for `confirmations` property instead of casting