### PR TITLE
Ensure route `CreationTransaction` correctly implements that of domain

### DIFF
--- a/src/routes/data-decode/entities/data-decoded-parameter.entity.ts
+++ b/src/routes/data-decode/entities/data-decoded-parameter.entity.ts
@@ -1,19 +1,20 @@
+import { DataDecodedParameter as DomainDataDecodedParameter } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class DataDecodedParameter {
+export class DataDecodedParameter implements DomainDataDecodedParameter {
   @ApiProperty()
   name: string;
   @ApiProperty()
   type: string;
   @ApiProperty()
-  value: unknown;
+  value: Required<unknown>;
   @ApiProperty()
-  valueDecoded?: Record<string, unknown> | Record<string, unknown>[] | null;
+  valueDecoded: Record<string, unknown> | Record<string, unknown>[] | null;
 
   constructor(
     name: string,
     type: string,
-    value: unknown,
+    value: Required<unknown>,
     valueDecoded: Record<string, unknown> | Record<string, unknown>[] | null,
   ) {
     this.name = name;

--- a/src/routes/data-decode/entities/data-decoded.entity.ts
+++ b/src/routes/data-decode/entities/data-decoded.entity.ts
@@ -1,7 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DataDecodedParameter } from '@/routes/data-decode/entities/data-decoded-parameter.entity';
+import { DataDecoded as DomainDataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 
-export class DataDecoded {
+export class DataDecoded implements DomainDataDecoded {
   @ApiProperty()
   method: string;
   @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })

--- a/src/routes/transactions/entities/creation-transaction.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction.entity.ts
@@ -1,29 +1,30 @@
+import { CreationTransaction as DomainCreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
 import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export class CreationTransaction {
+export class CreationTransaction implements DomainCreationTransaction {
   @ApiProperty()
   created: Date;
   @ApiProperty()
-  creator: string;
+  creator: `0x${string}`;
   @ApiProperty()
-  transactionHash: string;
+  transactionHash: `0x${string}`;
   @ApiProperty()
-  factoryAddress: string;
+  factoryAddress: `0x${string}`;
   @ApiPropertyOptional({ type: String, nullable: true })
-  masterCopy: string | null;
+  masterCopy: `0x${string}` | null;
   @ApiPropertyOptional({ type: String, nullable: true })
-  setupData: string | null;
+  setupData: `0x${string}` | null;
   @ApiPropertyOptional({ type: DataDecoded, nullable: true })
   dataDecoded: DataDecoded | null;
 
   constructor(
     created: Date,
-    creator: string,
-    transactionHash: string,
-    factoryAddress: string,
-    masterCopy: string | null,
-    setupData: string | null,
+    creator: `0x${string}`,
+    transactionHash: `0x${string}`,
+    factoryAddress: `0x${string}`,
+    masterCopy: `0x${string}` | null,
+    setupData: `0x${string}` | null,
     dataDecoded: DataDecoded | null,
   ) {
     this.created = created;


### PR DESCRIPTION
## Summary

The route-level `CreationTransaction` entity does not currently correctly implement that of the domain, e.g. addresses are not `0x${string}` but `string`. This adjusts it to extend the `CreationTransaction` of the domain, adjusting the types accordingly.

Note: the associated changes to the data decoded entities were required to appease TypeScript.

## Changes

- Implement the domain-level `CreationTransaction` in the route-level entity
- Implement the domain-level `DataDecoded` in the route-level entity
- Implement the domain-level `DataDecodedParameter` in the route-level entity