### PR TITLE
Map Native Staking calculated fields on transactions queue/history

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-info.entity.ts
@@ -44,6 +44,24 @@ export class NativeStakingDepositTransactionInfo
   annualNrr: number;
 
   @ApiProperty()
+  value: string;
+
+  @ApiProperty()
+  numValidators: number;
+
+  @ApiProperty()
+  expectedAnnualReward: string;
+
+  @ApiProperty()
+  expectedMonthlyReward: string;
+
+  @ApiProperty()
+  expectedFiatAnnualReward: number;
+
+  @ApiProperty()
+  expectedFiatMonthlyReward: number;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -54,6 +72,12 @@ export class NativeStakingDepositTransactionInfo
     fee: number;
     monthlyNrr: number;
     annualNrr: number;
+    value: string;
+    numValidators: number;
+    expectedAnnualReward: string;
+    expectedMonthlyReward: string;
+    expectedFiatAnnualReward: number;
+    expectedFiatMonthlyReward: number;
     tokenInfo: TokenInfo;
   }) {
     super(TransactionInfoType.NativeStakingDeposit, null, null);
@@ -64,6 +88,12 @@ export class NativeStakingDepositTransactionInfo
     this.fee = args.fee;
     this.monthlyNrr = args.monthlyNrr;
     this.annualNrr = args.annualNrr;
+    this.value = args.value;
+    this.numValidators = args.numValidators;
+    this.expectedAnnualReward = args.expectedAnnualReward;
+    this.expectedMonthlyReward = args.expectedMonthlyReward;
+    this.expectedFiatAnnualReward = args.expectedFiatAnnualReward;
+    this.expectedFiatMonthlyReward = args.expectedFiatMonthlyReward;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -330,6 +330,7 @@ export class MultisigTransactionInfoMapper {
       return await this.nativeStakingMapper.mapDepositInfo({
         chainId,
         to: nativeStakingTransaction.to,
+        value: transaction.value,
         isConfirmed,
         depositExecutionDate: transaction.executionDate,
       });

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -1,5 +1,3 @@
-import { BalancesRepositoryModule } from '@/domain/balances/balances.repository.interface';
-import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
 import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
@@ -84,8 +82,6 @@ export class TransactionsViewController {
 
 @Module({
   imports: [
-    BalancesRepositoryModule,
-    ChainsRepositoryModule,
     DataDecodedRepositoryModule,
     GPv2DecoderModule,
     KilnNativeStakingHelperModule,

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -1,3 +1,4 @@
+import { BalancesRepositoryModule } from '@/domain/balances/balances.repository.interface';
 import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
@@ -52,6 +53,7 @@ import { Module } from '@nestjs/common';
   controllers: [TransactionsController],
   imports: [
     AddressInfoModule,
+    BalancesRepositoryModule,
     ChainsRepositoryModule,
     ContractsRepositoryModule,
     DataDecodedRepositoryModule,


### PR DESCRIPTION
## Summary
This PR adds the following fields (already present in the Confirmation View) to the queue/history transaction mappings:

```
  value: string;
  numValidators: number;
  expectedAnnualReward: string;
  expectedMonthlyReward: string;
  expectedFiatAnnualReward: number;
  expectedFiatMonthlyReward: number;
```

## Changes
- Adds `value`, `numValidators`, `expectedAnnualReward`, `expectedMonthlyReward, `expectedFiatAnnualReward`, `expectedFiatMonthlyReward` to the `NativeStakingDepositTransactionInfo` (and therefore to the queue/history `TransactionInfos`.
