### PR TITLE
Add AwaitingExecution status to Native Staking transactions

### DIFF
--- a/src/routes/transactions/entities/staking/staking.entity.ts
+++ b/src/routes/transactions/entities/staking/staking.entity.ts
@@ -1,9 +1,10 @@
 // Present in all calls for native/pooled/defi staking
 export enum StakingStatus {
   AwaitingEntry = 'AWAITING_ENTRY',
+  AwaitingExecution = 'AWAITING_EXECUTION',
   RequestedExit = 'REQUESTED_EXIT',
   SignatureNeeded = 'SIGNATURE_NEEDED',
-  Validating = 'VALIDATING',
+  ValidationStarted = 'VALIDATION_STARTED',
   Withdrawn = 'WITHDRAWN',
   Unknown = 'UNKNOWN',
 }

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -35,6 +35,7 @@ export class NativeStakingMapper {
    *
    * @param args.chainId - the chain ID of the native staking deployment
    * @param args.to - the address of the native staking deployment
+   * @param args.value - the value of the deposit transaction
    * @param args.isConfirmed - whether the deposit transaction is confirmed
    * @param args.depositExecutionDate - the date when the deposit transaction was executed
    *
@@ -119,9 +120,9 @@ export class NativeStakingMapper {
    * Maps the {@link StakingStatus} for the given native staking deployment's `deposit` call.
    * - If the deposit transaction is not confirmed, the status is `SignatureNeeded`.
    * - If the deposit transaction is confirmed but the deposit execution date is not available,
-   * the status is `AwaitingEntry`.
+   * the status is `AwaitingExecution`.
    * - If the deposit execution date is available, the status is `AwaitingEntry` if the current
-   * date is before the estimated entry time, otherwise the status is `Validating`.
+   * date is before the estimated entry time, otherwise the status is `ValidationStarted`.
    * - If the status cannot be determined, the status is `Unknown`.
    *
    * @param networkStats - the network stats for the chain where the native staking deployment lives
@@ -139,7 +140,7 @@ export class NativeStakingMapper {
     }
 
     if (!depositExecutionDate) {
-      return StakingStatus.AwaitingEntry;
+      return StakingStatus.AwaitingExecution;
     }
 
     const estimatedDepositEntryTime =
@@ -148,7 +149,7 @@ export class NativeStakingMapper {
 
     return Date.now() <= estimatedDepositEntryTime
       ? StakingStatus.AwaitingEntry
-      : StakingStatus.Validating;
+      : StakingStatus.ValidationStarted;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the `AWAITING_EXECUTION` status to the set of Native Staking transactions statuses.

When a given transaction had all the required confirmations from signers but hadn't been executed, it was incorrectly tagged as `AWAITING_ENTRY`. This PR fixes this to tag transactions in that state as `AWAITING_EXECUTION`.

Also, the `VALIDATING` status was renamed to `VALIDATION_STARTED`, as in the context of the transaction, the associated staking validator might have been undeployed by a subsequent transaction.

## Changes
- Adds `AWAITING_EXECUTION` status to Native Staking transactions statuses.
- Renames `VALIDATING` to `VALIDATION_STARTED`.
