### PR TITLE
Use Staking API for fiat rewards calculation

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -51,7 +51,6 @@ const zerionBalancesApi = {
   getCollectibles: jest.fn(),
   clearCollectibles: jest.fn(),
   getFiatCodes: jest.fn(),
-  getNativeCoinPrice: jest.fn(),
 } as IBalancesApi;
 
 const zerionBalancesApiMock = jest.mocked(zerionBalancesApi);

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -71,10 +71,6 @@ export class BalancesApiManager implements IBalancesApiManager {
     }
   }
 
-  async getSafeBalancesApi(chainId: string): Promise<IBalancesApi> {
-    return this._getSafeBalancesApi(chainId);
-  }
-
   async getFiatCodes(): Promise<string[]> {
     const [zerionFiatCodes, safeFiatCodes] = await Promise.all([
       this.zerionBalancesApi.getFiatCodes(),

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -284,13 +284,6 @@ export class ZerionBalancesApi implements IBalancesApi {
     await this.cacheService.deleteByKey(key);
   }
 
-  getNativeCoinPrice(): Promise<number | null> {
-    this.loggingService.warn(
-      'Native coin price retrieval is not implemented for Zerion',
-    );
-    return Promise.resolve(null);
-  }
-
   private _getChainName(chain: Chain): string {
     const chainName =
       chain.balancesProvider.chainName ??

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -34,11 +34,6 @@ export interface IBalancesRepository {
   getFiatCodes(): Promise<string[]>;
 
   /**
-   * Gets the price of the native coin of the chain.
-   */
-  getNativeCoinPrice(chain: Chain): Promise<number | null>;
-
-  /**
    * Clears the API associated with {@link chainId}
    */
   clearApi(chainId: string): void;

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -42,11 +42,6 @@ export class BalancesRepository implements IBalancesRepository {
     return this.balancesApiManager.getFiatCodes();
   }
 
-  async getNativeCoinPrice(chain: Chain): Promise<number | null> {
-    const api = await this.balancesApiManager.getSafeBalancesApi(chain.chainId);
-    return api.getNativeCoinPrice(chain);
-  }
-
   clearApi(chainId: string): void {
     this.balancesApiManager.destroyApi(chainId);
   }

--- a/src/domain/interfaces/balances-api.interface.ts
+++ b/src/domain/interfaces/balances-api.interface.ts
@@ -32,6 +32,4 @@ export interface IBalancesApi {
   }): Promise<void>;
 
   getFiatCodes(): Promise<string[]>;
-
-  getNativeCoinPrice(chain: Chain): Promise<number | null>;
 }

--- a/src/domain/interfaces/balances-api.manager.interface.ts
+++ b/src/domain/interfaces/balances-api.manager.interface.ts
@@ -19,12 +19,6 @@ export interface IBalancesApiManager extends IApiManager<IBalancesApi> {
   getApi(chainId: string, safeAddress: `0x${string}`): Promise<IBalancesApi>;
 
   /**
-   * Gets the {@link SafeBalancesApi} implementation associated with the chainId.
-   * @param chainId - the chain identifier to check.
-   */
-  getSafeBalancesApi(chainId: string): Promise<IBalancesApi>;
-
-  /**
    * Gets the list of supported fiat codes.
    * @returns an alphabetically ordered list of uppercase strings representing the supported fiat codes.
    */

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -1,9 +1,5 @@
 import { NetworkStats } from '@/datasources/staking-api/entities/network-stats.entity';
 import {
-  BalancesRepositoryModule,
-  IBalancesRepository,
-} from '@/domain/balances/balances.repository.interface';
-import {
   ChainsRepositoryModule,
   IChainsRepository,
 } from '@/domain/chains/chains.repository.interface';
@@ -25,8 +21,6 @@ export class NativeStakingMapper {
     private readonly stakingRepository: IStakingRepository,
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
-    @Inject(IBalancesRepository)
-    private readonly balancesRepository: IBalancesRepository,
   ) {}
 
   /**
@@ -78,10 +72,8 @@ export class NativeStakingMapper {
     const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);
     const expectedAnnualReward = (nrr / 100) * value;
     const expectedMonthlyReward = expectedAnnualReward / 12;
-    const nativeCoinPrice =
-      await this.balancesRepository.getNativeCoinPrice(chain);
     const expectedFiatAnnualReward =
-      (expectedAnnualReward * (nativeCoinPrice ?? 0)) /
+      (expectedAnnualReward * (networkStats.eth_price_usd ?? 0)) /
       Math.pow(10, chain.nativeCurrency.decimals);
     const expectedFiatMonthlyReward = expectedFiatAnnualReward / 12;
 
@@ -153,11 +145,7 @@ export class NativeStakingMapper {
 }
 
 @Module({
-  imports: [
-    StakingRepositoryModule,
-    ChainsRepositoryModule,
-    BalancesRepositoryModule,
-  ],
+  imports: [StakingRepositoryModule, ChainsRepositoryModule],
   providers: [NativeStakingMapper],
   exports: [NativeStakingMapper],
 })

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -1,4 +1,3 @@
-import { BalancesRepositoryModule } from '@/domain/balances/balances.repository.interface';
 import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
@@ -53,7 +52,6 @@ import { Module } from '@nestjs/common';
   controllers: [TransactionsController],
   imports: [
     AddressInfoModule,
-    BalancesRepositoryModule,
     ChainsRepositoryModule,
     ContractsRepositoryModule,
     DataDecodedRepositoryModule,


### PR DESCRIPTION
## Summary
This PR partially reverts https://github.com/safe-global/safe-client-gateway/pull/1864 as the ETH price is directly provided by the Staking API (Kiln), so there's no need to use `BalancesRepository` and expose a `getNativeCoinPrice` function to get this data.

## Changes
- Reverts the ETH price retrieval via `BalancesRepository`.
- Gets the ETH price on the `NetworkStats` object provided by the Kiln API.
