### PR TITLE
Add value/numValidators for ValidatorsExit transactions mappings

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -368,17 +368,11 @@ export class MultisigTransactionInfoMapper {
     }
 
     try {
-      const isConfirmed =
-        'confirmations' in transaction &&
-        !!transaction.confirmations &&
-        transaction.confirmations.length >= transaction.confirmationsRequired;
-
       return await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId,
         to: nativeStakingValidatorsExitTransaction.to,
         value: transaction.value,
-        isConfirmed,
-        validatorsExitExecutionDate: transaction.executionDate,
+        transaction,
       });
     } catch (error) {
       this.loggingService.warn(error);

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -1183,6 +1183,7 @@ describe('TransactionsViewController tests', () => {
               },
             });
         });
+        // TODO: add error cases
       });
     });
   });

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -326,8 +326,7 @@ export class TransactionsViewService {
         chainId: args.chainId,
         to: args.to,
         value: args.value,
-        isConfirmed: false,
-        validatorsExitExecutionDate: null,
+        transaction: null,
       });
     return new NativeStakingValidatorsExitConfirmationView({
       method: args.dataDecoded.method,


### PR DESCRIPTION
## Summary
This PR adds missing fields to transaction mappings for the history/queue of Native Staking Validators Exit transactions.

## Changes
- Adds `value` and `numValidators` calculations based on the transaction data.
