### PR TITLE
Use Promise.all in NativeStakingMapper

### DIFF
--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -50,11 +50,13 @@ export class NativeStakingMapper {
     isConfirmed: boolean;
     depositExecutionDate: Date | null;
   }): Promise<NativeStakingDepositTransactionInfo> {
-    const chain = await this.chainsRepository.getChain(args.chainId);
-    const deployment = await this.stakingRepository.getDeployment({
-      chainId: args.chainId,
-      address: args.to,
-    });
+    const [chain, deployment] = await Promise.all([
+      this.chainsRepository.getChain(args.chainId),
+      this.stakingRepository.getDeployment({
+        chainId: args.chainId,
+        address: args.to,
+      }),
+    ]);
 
     if (
       deployment.product_type !== 'dedicated' ||
@@ -123,11 +125,13 @@ export class NativeStakingMapper {
     value: string | null;
     transaction: MultisigTransaction | ModuleTransaction | null;
   }): Promise<NativeStakingValidatorsExitTransactionInfo> {
-    const chain = await this.chainsRepository.getChain(args.chainId);
-    const deployment = await this.stakingRepository.getDeployment({
-      chainId: args.chainId,
-      address: args.to,
-    });
+    const [chain, deployment] = await Promise.all([
+      this.chainsRepository.getChain(args.chainId),
+      this.stakingRepository.getDeployment({
+        chainId: args.chainId,
+        address: args.to,
+      }),
+    ]);
 
     if (
       deployment.product_type !== 'dedicated' ||


### PR DESCRIPTION
## Changes
- Optimizes `NativeStakingMapper` by using `Promise.all` to parallelize API calls.
