### PR TITLE
Ensure Address Checksum in Deployments lookup

### DIFF
--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -21,6 +21,7 @@ import {
   DefiVaultStats,
   DefiVaultStatsSchema,
 } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class StakingRepository implements IStakingRepository {
@@ -36,7 +37,8 @@ export class StakingRepository implements IStakingRepository {
     const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
     const deployments = await stakingApi.getDeployments();
     const deployment = deployments.find(({ chain_id, address }) => {
-      return chain_id.toString() && address === args.address;
+      // Note: addresses might not be checksummed at this point
+      return chain_id.toString() && getAddress(address) === args.address;
     });
     return DeploymentSchema.parse(deployment);
   }


### PR DESCRIPTION
## Summary
This PR checksums the `address` from `StakingApi` before the lookup in `StakingRepository`. Some staking providers like Kiln might not ensure the addresses being checksummed, and therefore the deployment associated with a checksummed address might not be found.

## Changes
- Checksums the `Deployment.address` coming from `StakingApi` before searching by address value.
