### PR TITLE
Fix coverage reports configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
       "^src/**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
+    "coveragePathIgnorePatterns": [
+      "main.ts",
+      ".+\\/__tests__\\/.+\\.factory.(t|j)s",
+      ".e2e-spec.ts"
+    ],
     "testEnvironment": "node",
     "moduleNameMapper": {
       "^@/abis/(.*)$": "<rootDir>/abis/$1",

--- a/package.json
+++ b/package.json
@@ -86,13 +86,19 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "^src/**/*.(t|j)s"
+      "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [
-      "main.ts",
       ".+\\/__tests__\\/.+\\.factory.(t|j)s",
-      ".e2e-spec.ts"
+      "/abis/",
+      "/assets/",
+      "/coverage/",
+      "/data/",
+      "/dist/",
+      "/scripts/",
+      ".e2e-spec.ts",
+      "main.ts"
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -86,21 +86,9 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "^src/**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "coveragePathIgnorePatterns": [
-      ".+\\/__tests__\\/.+\\.factory.(t|j)s",
-      ".e2e-spec.ts",
-      "/abis/",
-      "/assets/",
-      "/coverage/",
-      "/data/",
-      "/dist/",
-      "/scripts/",
-      "e2e-setup.ts",
-      "main.ts"
-    ],
     "testEnvironment": "node",
     "moduleNameMapper": {
       "^@/abis/(.*)$": "<rootDir>/abis/$1",

--- a/package.json
+++ b/package.json
@@ -90,9 +90,16 @@
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [
-      "index.ts",
       ".+\\/__tests__\\/.+\\.factory.(t|j)s",
-      ".e2e-spec.ts"
+      ".e2e-spec.ts",
+      "/abis/",
+      "/assets/",
+      "/coverage/",
+      "/data/",
+      "/dist/",
+      "/scripts/",
+      "e2e-setup.ts",
+      "main.ts"
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {


### PR DESCRIPTION
## Summary
Since the `rootDir` change in [this PR](https://github.com/safe-global/safe-client-gateway/commit/50d342ef7961fd6f7ee49f1c5b6d9b6d724dc635#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L85), the coverage reports are taking into consideration all the folders in the root, instead of `/src` only. This PR restores this behavior by ignoring non-relevant folders regarding test coverage.

## Changes
- Adds non-relevant test coverage folders to `coveragePathIgnorePatterns` configuration.
