### PR TITLE
Add KilnApi caching

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -111,6 +111,7 @@ export default (): ReturnType<typeof configuration> => ({
     rpc: faker.number.int(),
     holesky: faker.number.int(),
     indexing: faker.number.int(),
+    staking: faker.number.int(),
     notFound: {
       default: faker.number.int(),
       contract: faker.number.int(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -164,6 +164,7 @@ export default () => ({
     rpc: parseInt(process.env.EXPIRATION_TIME_RPC_SECONDS ?? `${15}`),
     holesky: parseInt(process.env.HOLESKY_EXPIRATION_TIME_SECONDS ?? `${60}`),
     indexing: parseInt(process.env.EXPIRATION_TIME_INDEXING_SECONDS ?? `${5}`),
+    staking: parseInt(process.env.EXPIRATION_TIME_STAKING_SECONDS ?? `${60}`),
     notFound: {
       default: parseInt(
         process.env.DEFAULT_NOT_FOUND_EXPIRE_TIME_SECONDS ?? `${30}`,

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -1,9 +1,9 @@
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
 export class CacheRouter {
-  private static readonly ACCOUNT_KEY = 'account';
   private static readonly ACCOUNT_DATA_SETTINGS_KEY = 'account_data_settings';
   private static readonly ACCOUNT_DATA_TYPES_KEY = 'account_data_types';
+  private static readonly ACCOUNT_KEY = 'account';
   private static readonly ALL_TRANSACTIONS_KEY = 'all_transactions';
   private static readonly AUTH_NONCE_KEY = 'auth_nonce';
   private static readonly BACKBONE_KEY = 'backbone';
@@ -25,6 +25,7 @@ export class CacheRouter {
   private static readonly MULTISIG_TRANSACTIONS_KEY = 'multisig_transactions';
   private static readonly NATIVE_COIN_PRICE_KEY = 'native_coin_price';
   private static readonly OWNERS_SAFE_KEY = 'owner_safes';
+  private static readonly RATE_LIMIT_KEY = 'rate_limit';
   private static readonly RELAY_KEY = 'relay';
   private static readonly RPC_REQUESTS_KEY = 'rpc_requests';
   private static readonly SAFE_APPS_KEY = 'safe_apps';
@@ -34,6 +35,14 @@ export class CacheRouter {
   private static readonly SAFE_FIAT_CODES_KEY = 'safe_fiat_codes';
   private static readonly SAFE_KEY = 'safe';
   private static readonly SINGLETONS_KEY = 'singletons';
+  private static readonly STAKING_DEDICATED_STAKING_STATS_KEY =
+    'staking_dedicated_staking_stats';
+  private static readonly STAKING_DEFI_VAULT_STATS_KEY =
+    'staking_defi_vault_stats';
+  private static readonly STAKING_DEPLOYMENTS_KEY = 'staking_deployments';
+  private static readonly STAKING_NETWORK_STATS_KEY = 'staking_network_stats';
+  private static readonly STAKING_POOLED_STAKING_STATS_KEY =
+    'staking_pooled_staking_stats';
   private static readonly TOKEN_KEY = 'token';
   private static readonly TOKEN_PRICE_KEY = 'token_price';
   private static readonly TOKENS_KEY = 'tokens';
@@ -41,7 +50,6 @@ export class CacheRouter {
   private static readonly TRANSFERS_KEY = 'transfers';
   private static readonly ZERION_BALANCES_KEY = 'zerion_balances';
   private static readonly ZERION_COLLECTIBLES_KEY = 'zerion_collectibles';
-  private static readonly RATE_LIMIT_KEY = 'rate_limit';
 
   static getAuthNonceCacheKey(nonce: string): string {
     return `${CacheRouter.AUTH_NONCE_KEY}_${nonce}`;
@@ -552,6 +560,32 @@ export class CacheRouter {
     return new CacheDir(
       CacheRouter.getRpcRequestsKey(args.chainId),
       `${args.method}_${args.params}`,
+    );
+  }
+
+  static getStakingDeploymentsCacheDir(): CacheDir {
+    return new CacheDir(this.STAKING_DEPLOYMENTS_KEY, '');
+  }
+
+  static getStakingNetworkStatsCacheDir(): CacheDir {
+    return new CacheDir(this.STAKING_NETWORK_STATS_KEY, '');
+  }
+
+  static getStakingDedicatedStakingStatsCacheDir(): CacheDir {
+    return new CacheDir(this.STAKING_DEDICATED_STAKING_STATS_KEY, '');
+  }
+
+  static getStakingPooledStakingStatsCacheDir(pool: `0x${string}`): CacheDir {
+    return new CacheDir(`${this.STAKING_POOLED_STAKING_STATS_KEY}_${pool}`, '');
+  }
+
+  static getStakingDefiVaultStatsCacheDir(args: {
+    chainId: string;
+    vault: `0x${string}`;
+  }): CacheDir {
+    return new CacheDir(
+      `${args.chainId}_${this.STAKING_DEFI_VAULT_STATS_KEY}_${args.vault}`,
+      '',
     );
   }
 }

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -595,8 +595,7 @@ export class CacheRouter {
    * Calculate cache directory for staking stakes.
    *
    * Note: This function hashes the validators public keys to keep the
-   * cache key short and deterministic. The probability of collision is
-   * 0.00000271% for each 1,000,000 sets of validators public keys.
+   * cache key short and deterministic.
    *
    * @param validatorsPublicKeys - Array of validators public keys
    * @returns {@link CacheDir} - Cache directory
@@ -606,7 +605,6 @@ export class CacheRouter {
   ): CacheDir {
     const hash = crypto.createHash('sha256');
     hash.update(validatorsPublicKeys.join('_'));
-    const hashed = hash.digest('hex').substring(0, 16);
-    return new CacheDir(`${this.STAKING_STAKES_KEY}_${hashed}`, '');
+    return new CacheDir(`${this.STAKING_STAKES_KEY}_${hash.digest('hex')}`, '');
   }
 }

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -594,8 +594,9 @@ export class CacheRouter {
   /**
    * Calculate cache directory for staking stakes.
    *
-   * Note: This function hashes the validators public keys to keep the
-   * cache key short and deterministic.
+   * Note: This function hashes the validators' public keys to keep the
+   * cache key short and deterministic. Redis and other cache systems
+   * may experience performance degradation with long keys.
    *
    * @param validatorsPublicKeys - Array of validators public keys
    * @returns {@link CacheDir} - Cache directory

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -1,19 +1,26 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
-import { INetworkService } from '@/datasources/network/network.service.interface';
-import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { dedicatedStakingStatsBuilder } from '@/datasources/staking-api/entities/__tests__/dedicated-staking-stats.entity.builder';
+import { defiVaultStatsBuilder } from '@/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder';
+import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
 import { pooledStakingStatsBuilder } from '@/datasources/staking-api/entities/__tests__/pooled-staking-stats.entity.builder';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { faker } from '@faker-js/faker';
-import { defiVaultStatsBuilder } from '@/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder';
 
-const networkService = jest.mocked({
+const dataSource = {
   get: jest.fn(),
-} as jest.MockedObjectDeep<INetworkService>);
-const mockNetworkService = jest.mocked(networkService);
+} as jest.MockedObjectDeep<CacheFirstDataSource>;
+const mockDataSource = jest.mocked(dataSource);
+
+const configurationService = {
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>;
+const mockConfigurationService = jest.mocked(configurationService);
 
 describe('KilnApi', () => {
   let target: KilnApi;
@@ -21,6 +28,8 @@ describe('KilnApi', () => {
   let baseUrl: string;
   let apiKey: string;
   let httpErrorFactory: HttpErrorFactory;
+  let stakingExpirationTimeInSeconds: number;
+  let notFoundExpireTimeSeconds: number;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -28,7 +37,25 @@ describe('KilnApi', () => {
     baseUrl = faker.internet.url({ appendSlash: false });
     apiKey = faker.string.hexadecimal({ length: 32 });
     httpErrorFactory = new HttpErrorFactory();
-    target = new KilnApi(baseUrl, apiKey, mockNetworkService, httpErrorFactory);
+    stakingExpirationTimeInSeconds = faker.number.int();
+    notFoundExpireTimeSeconds = faker.number.int();
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'expirationTimeInSeconds.staking') {
+        return stakingExpirationTimeInSeconds;
+      }
+      if (key === 'expirationTimeInSeconds.notFound.default') {
+        return notFoundExpireTimeSeconds;
+      }
+      throw Error(`Unexpected key: ${key}`);
+    });
+
+    target = new KilnApi(
+      baseUrl,
+      apiKey,
+      mockDataSource,
+      httpErrorFactory,
+      mockConfigurationService,
+    );
   });
 
   describe('getDeployments', () => {
@@ -37,25 +64,26 @@ describe('KilnApi', () => {
         { length: faker.number.int({ min: 1, max: 5 }) },
         () => deploymentBuilder().build(),
       );
-      networkService.get.mockResolvedValue({
+      dataSource.get.mockResolvedValue({
         status: 200,
         // Note: Kiln always return { data: T }
-        data: {
-          data: deployments,
-        },
+        data: deployments,
       });
 
       const actual = await target.getDeployments();
 
       expect(actual).toBe(deployments);
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir('staking_deployments', ''),
         url: `${baseUrl}/v1/deployments`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
 
@@ -66,7 +94,7 @@ describe('KilnApi', () => {
         types: ['clientError', 'serverError'],
       });
       const expected = new DataSourceError(errorMessage, statusCode);
-      networkService.get.mockRejectedValueOnce(
+      dataSource.get.mockRejectedValueOnce(
         new NetworkResponseError(
           new URL(getDeploymentsUrl),
           {
@@ -78,14 +106,17 @@ describe('KilnApi', () => {
 
       await expect(target.getDeployments()).rejects.toThrow(expected);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
-        url: getDeploymentsUrl,
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir('staking_deployments', ''),
+        url: `${baseUrl}/v1/deployments`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
   });
@@ -93,25 +124,26 @@ describe('KilnApi', () => {
   describe('getNetworkStats', () => {
     it('should return network stats', async () => {
       const networkStats = networkStatsBuilder().build();
-      networkService.get.mockResolvedValue({
+      dataSource.get.mockResolvedValue({
         status: 200,
         // Note: Kiln always return { data: T }
-        data: {
-          data: networkStats,
-        },
+        data: networkStats,
       });
 
       const actual = await target.getNetworkStats();
 
       expect(actual).toBe(networkStats);
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir('staking_network_stats', ''),
         url: `${baseUrl}/v1/eth/network-stats`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
 
@@ -122,7 +154,7 @@ describe('KilnApi', () => {
         types: ['clientError', 'serverError'],
       });
       const expected = new DataSourceError(errorMessage, statusCode);
-      networkService.get.mockRejectedValueOnce(
+      dataSource.get.mockRejectedValueOnce(
         new NetworkResponseError(
           new URL(getNetworkStatsUrl),
           {
@@ -134,14 +166,17 @@ describe('KilnApi', () => {
 
       await expect(target.getNetworkStats()).rejects.toThrow(expected);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
-        url: getNetworkStatsUrl,
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir('staking_network_stats', ''),
+        url: `${baseUrl}/v1/eth/network-stats`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
   });
@@ -149,26 +184,27 @@ describe('KilnApi', () => {
   describe('getDedicatedStakingStats', () => {
     it('should return the dedicated staking stats', async () => {
       const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
-      networkService.get.mockResolvedValue({
+      dataSource.get.mockResolvedValue({
         status: 200,
         // Note: Kiln always return { data: T }
-        data: {
-          data: dedicatedStakingStats,
-        },
+        data: dedicatedStakingStats,
       });
 
       const actual = await target.getDedicatedStakingStats();
 
       expect(actual).toBe(dedicatedStakingStats);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir('staking_dedicated_staking_stats', ''),
         url: `${baseUrl}/v1/eth/kiln-stats`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
 
@@ -179,7 +215,7 @@ describe('KilnApi', () => {
         types: ['clientError', 'serverError'],
       });
       const expected = new DataSourceError(errorMessage, statusCode);
-      networkService.get.mockRejectedValueOnce(
+      dataSource.get.mockRejectedValueOnce(
         new NetworkResponseError(
           new URL(getDedicatedStakingStats),
           {
@@ -190,14 +226,17 @@ describe('KilnApi', () => {
       );
       await expect(target.getDedicatedStakingStats()).rejects.toThrow(expected);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir('staking_dedicated_staking_stats', ''),
         url: getDedicatedStakingStats,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
   });
@@ -205,12 +244,10 @@ describe('KilnApi', () => {
   describe('getPooledStakingStats', () => {
     it('should return the pooled staking integration', async () => {
       const pooledStakingStats = pooledStakingStatsBuilder().build();
-      networkService.get.mockResolvedValue({
+      dataSource.get.mockResolvedValue({
         status: 200,
         // Note: Kiln always return { data: T }
-        data: {
-          data: pooledStakingStats,
-        },
+        data: pooledStakingStats,
       });
 
       const actual = await target.getPooledStakingStats(
@@ -219,8 +256,12 @@ describe('KilnApi', () => {
 
       expect(actual).toBe(pooledStakingStats);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir(
+          `staking_pooled_staking_stats_${pooledStakingStats.address}`,
+          '',
+        ),
         url: `${baseUrl}/v1/eth/onchain/v2/network-stats`,
         networkRequest: {
           headers: {
@@ -230,18 +271,20 @@ describe('KilnApi', () => {
             integration: pooledStakingStats.address,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
 
     it('should forward errors', async () => {
-      const pooledStaking = pooledStakingStatsBuilder().build();
+      const pooledStakingStats = pooledStakingStatsBuilder().build();
       const getPooledStakingStatsUrl = `${baseUrl}/v1/eth/onchain/v2/network-stats`;
       const errorMessage = faker.lorem.sentence();
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
       });
       const expected = new DataSourceError(errorMessage, statusCode);
-      networkService.get.mockRejectedValueOnce(
+      dataSource.get.mockRejectedValueOnce(
         new NetworkResponseError(
           new URL(getPooledStakingStatsUrl),
           {
@@ -251,20 +294,26 @@ describe('KilnApi', () => {
         ),
       );
       await expect(
-        target.getPooledStakingStats(pooledStaking.address),
+        target.getPooledStakingStats(pooledStakingStats.address),
       ).rejects.toThrow(expected);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
-        url: getPooledStakingStatsUrl,
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir(
+          `staking_pooled_staking_stats_${pooledStakingStats.address}`,
+          '',
+        ),
+        url: `${baseUrl}/v1/eth/onchain/v2/network-stats`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
           params: {
-            integration: pooledStaking.address,
+            integration: pooledStakingStats.address,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
   });
@@ -285,12 +334,10 @@ describe('KilnApi', () => {
         .with('chain', chain)
         .with('chain_id', chain_id)
         .build();
-      networkService.get.mockResolvedValue({
+      dataSource.get.mockResolvedValue({
         status: 200,
         // Note: Kiln always return { data: T }
-        data: {
-          data: [defiVaultStats],
-        },
+        data: [defiVaultStats],
       });
 
       const actual = await target.getDefiVaultStats({
@@ -300,8 +347,12 @@ describe('KilnApi', () => {
 
       expect(actual).toStrictEqual([defiVaultStats]);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir(
+          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${defiVaultStats.vault}`,
+          '',
+        ),
         url: `${baseUrl}/v1/defi/network-stats`,
         networkRequest: {
           headers: {
@@ -311,6 +362,8 @@ describe('KilnApi', () => {
             vaults: `${defiVaultStats.chain}_${defiVaultStats.vault}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
 
@@ -327,7 +380,7 @@ describe('KilnApi', () => {
         }),
       ).rejects.toThrow();
 
-      expect(networkService.get).not.toHaveBeenCalled();
+      expect(dataSource.get).not.toHaveBeenCalled();
     });
 
     it('should forward errors', async () => {
@@ -351,7 +404,7 @@ describe('KilnApi', () => {
         types: ['clientError', 'serverError'],
       });
       const expected = new DataSourceError(errorMessage, statusCode);
-      networkService.get.mockRejectedValueOnce(
+      dataSource.get.mockRejectedValueOnce(
         new NetworkResponseError(
           new URL(getDefiVaultStatsUrl),
           {
@@ -367,9 +420,13 @@ describe('KilnApi', () => {
         }),
       ).rejects.toThrow(expected);
 
-      expect(networkService.get).toHaveBeenCalledTimes(1);
-      expect(networkService.get).toHaveBeenNthCalledWith(1, {
-        url: getDefiVaultStatsUrl,
+      expect(dataSource.get).toHaveBeenCalledTimes(1);
+      expect(dataSource.get).toHaveBeenNthCalledWith(1, {
+        cacheDir: new CacheDir(
+          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${defiVaultStats.vault}`,
+          '',
+        ),
+        url: `${baseUrl}/v1/defi/network-stats`,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
@@ -378,6 +435,8 @@ describe('KilnApi', () => {
             vaults: `${defiVaultStats.chain}_${defiVaultStats.vault}`,
           },
         },
+        expireTimeSeconds: stakingExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
       });
     });
   });

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -1,87 +1,124 @@
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { INetworkService } from '@/datasources/network/network.service.interface';
 import { IStakingApi } from '@/domain/interfaces/staking-api.interface';
 import { NetworkStats } from '@/datasources/staking-api/entities/network-stats.entity';
 import { PooledStakingStats } from '@/datasources/staking-api/entities/pooled-staking-stats.entity';
 import { DedicatedStakingStats } from '@/datasources/staking-api/entities/dedicated-staking-stats.entity';
 import { Deployment } from '@/datasources/staking-api/entities/deployment.entity';
 import { DefiVaultStats } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { CacheRouter } from '@/datasources/cache/cache.router';
 
 export class KilnApi implements IStakingApi {
+  private readonly stakingExpirationTimeInSeconds: number;
+  private readonly defaultNotFoundExpirationTimeSeconds: number;
+
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string,
-    private readonly networkService: INetworkService,
+    private readonly dataSource: CacheFirstDataSource,
     private readonly httpErrorFactory: HttpErrorFactory,
-  ) {}
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.stakingExpirationTimeInSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.staking',
+      );
+    this.defaultNotFoundExpirationTimeSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.notFound.default',
+      );
+  }
 
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDeployments(): Promise<Array<Deployment>> {
     try {
       const url = `${this.baseUrl}/v1/deployments`;
+      const cacheDir = CacheRouter.getStakingDeploymentsCacheDir();
       // Note: Kiln always return { data: T }
-      const { data } = await this.networkService.get<{
+      const { data } = await this.dataSource.get<{
         data: Array<Deployment>;
       }>({
+        cacheDir,
         url,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
           },
         },
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.stakingExpirationTimeInSeconds,
       });
-      return data.data;
+      return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getNetworkStats(): Promise<NetworkStats> {
     try {
       const url = `${this.baseUrl}/v1/eth/network-stats`;
+      const cacheDir = CacheRouter.getStakingNetworkStatsCacheDir();
       // Note: Kiln always return { data: T }
-      const { data } = await this.networkService.get<{ data: NetworkStats }>({
+      const { data } = await this.dataSource.get<{ data: NetworkStats }>({
+        cacheDir,
         url,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
           },
         },
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.stakingExpirationTimeInSeconds,
       });
-      return data.data;
+      return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDedicatedStakingStats(): Promise<DedicatedStakingStats> {
     try {
       const url = `${this.baseUrl}/v1/eth/kiln-stats`;
+      const cacheDir = CacheRouter.getStakingDedicatedStakingStatsCacheDir();
       // Note: Kiln always return { data: T }
-      const { data } = await this.networkService.get<{
+      const { data } = await this.dataSource.get<{
         data: DedicatedStakingStats;
       }>({
+        cacheDir,
         url,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
           },
         },
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.stakingExpirationTimeInSeconds,
       });
-      return data.data;
+      return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getPooledStakingStats(
     pool: `0x${string}`,
   ): Promise<PooledStakingStats> {
     try {
       const url = `${this.baseUrl}/v1/eth/onchain/v2/network-stats`;
+      const cacheDir = CacheRouter.getStakingPooledStakingStatsCacheDir(pool);
       // Note: Kiln always return { data: T }
-      const { data } = await this.networkService.get<{
+      const { data } = await this.dataSource.get<{
         data: PooledStakingStats;
       }>({
+        cacheDir,
         url,
         networkRequest: {
           headers: {
@@ -91,23 +128,29 @@ export class KilnApi implements IStakingApi {
             integration: pool,
           },
         },
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.stakingExpirationTimeInSeconds,
       });
-      return data.data;
+      return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDefiVaultStats(args: {
     chainId: string;
     vault: `0x${string}`;
   }): Promise<Array<DefiVaultStats>> {
     try {
       const url = `${this.baseUrl}/v1/defi/network-stats`;
+      const cacheDir = CacheRouter.getStakingDefiVaultStatsCacheDir(args);
       // Note: Kiln always return { data: T }
-      const { data } = await this.networkService.get<{
+      const { data } = await this.dataSource.get<{
         data: Array<DefiVaultStats>;
       }>({
+        cacheDir,
         url,
         networkRequest: {
           headers: {
@@ -117,8 +160,10 @@ export class KilnApi implements IStakingApi {
             vaults: this.getDefiVaultIdentifier(args),
           },
         },
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.stakingExpirationTimeInSeconds,
       });
-      return data.data;
+      return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }

--- a/src/datasources/staking-api/staking-api.manager.ts
+++ b/src/datasources/staking-api/staking-api.manager.ts
@@ -1,13 +1,10 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import {
-  INetworkService,
-  NetworkService,
-} from '@/datasources/network/network.service.interface';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
-import { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
 import { IStakingApi } from '@/domain/interfaces/staking-api.interface';
+import { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
 import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
@@ -15,7 +12,7 @@ export class StakingApiManager implements IStakingApiManager {
   private readonly apis: Record<string, IStakingApi> = {};
 
   constructor(
-    @Inject(NetworkService) private readonly networkService: INetworkService,
+    private readonly dataSource: CacheFirstDataSource,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     @Inject(IConfigApi) private readonly configApi: IConfigApi,
@@ -39,8 +36,9 @@ export class StakingApiManager implements IStakingApiManager {
     this.apis[chainId] = new KilnApi(
       baseUrl,
       apiKey,
-      this.networkService,
+      this.dataSource,
       this.httpErrorFactory,
+      this.configurationService,
     );
 
     return Promise.resolve(this.apis[chainId]);

--- a/src/datasources/staking-api/staking-api.module.ts
+++ b/src/datasources/staking-api/staking-api.module.ts
@@ -3,9 +3,10 @@ import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 import { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
 import { StakingApiManager } from '@/datasources/staking-api/staking-api.manager';
+import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data.source.module';
 
 @Module({
-  imports: [ConfigApiModule],
+  imports: [CacheFirstDataSourceModule, ConfigApiModule],
   providers: [
     { provide: IStakingApiManager, useClass: StakingApiManager },
     HttpErrorFactory,


### PR DESCRIPTION
## Summary
This PR adds a caching layer to `KilnApi`, by switching its `NetworkService` dependency to `CacheFirstDatasource`. All the endpoints in `KilnApi` are now cached after a successful call, for `EXPIRATION_TIME_STAKING_SECONDS` seconds (defaulting to 60 seconds), without a programmatic invalidation mechanism.

## Changes
- Changes the way `KilnApi` interacts with the network by changing `INetworkService` to `CacheFirstDataSource`, and therefore adding caching.
- Adds `CacheDirs` for all the `KilnApi` endpoints to `CacheRouter`.