### PR TITLE
Rename StakingStatus enums

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity.ts
@@ -4,7 +4,7 @@ import {
   DecodedType,
 } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
 import { NativeStakingDepositInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
-import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
+import { StakingDepositStatus } from '@/routes/transactions/entities/staking/staking.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -17,9 +17,9 @@ export class NativeStakingDepositConfirmationView
   type = DecodedType.KilnNativeStakingDeposit;
 
   @ApiProperty({
-    enum: StakingStatus,
+    enum: StakingDepositStatus,
   })
-  status: StakingStatus;
+  status: StakingDepositStatus;
 
   @ApiProperty()
   method: string;
@@ -69,7 +69,7 @@ export class NativeStakingDepositConfirmationView
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
-    status: StakingStatus;
+    status: StakingDepositStatus;
     estimatedEntryTime: number;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;

--- a/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
@@ -1,6 +1,6 @@
 import {
-  StakingStatus,
-  StakingStatusInfo,
+  StakingDepositStatus,
+  StakingDepositStatusInfo,
   StakingTimeInfo,
   StakingFinancialInfo,
 } from '@/routes/transactions/entities/staking/staking.entity';
@@ -11,7 +11,7 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
-export type NativeStakingDepositInfo = StakingStatusInfo &
+export type NativeStakingDepositInfo = StakingDepositStatusInfo &
   StakingTimeInfo &
   StakingFinancialInfo;
 
@@ -22,8 +22,8 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty({ enum: [TransactionInfoType.NativeStakingDeposit] })
   override type = TransactionInfoType.NativeStakingDeposit;
 
-  @ApiProperty({ enum: StakingStatus })
-  status: StakingStatus;
+  @ApiProperty({ enum: StakingDepositStatus })
+  status: StakingDepositStatus;
 
   @ApiProperty()
   estimatedEntryTime: number;
@@ -65,7 +65,7 @@ export class NativeStakingDepositTransactionInfo
   tokenInfo: TokenInfo;
 
   constructor(args: {
-    status: StakingStatus;
+    status: StakingDepositStatus;
     estimatedEntryTime: number;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;

--- a/src/routes/transactions/entities/staking/staking.entity.ts
+++ b/src/routes/transactions/entities/staking/staking.entity.ts
@@ -1,18 +1,13 @@
-// TODO: rename to StakingDepositStatus
 // Present in all calls for native/pooled/defi staking
-export enum StakingStatus {
+export enum StakingDepositStatus {
   AwaitingEntry = 'AWAITING_ENTRY',
   AwaitingExecution = 'AWAITING_EXECUTION',
-  RequestedExit = 'REQUESTED_EXIT',
   SignatureNeeded = 'SIGNATURE_NEEDED',
-  Unknown = 'UNKNOWN',
   ValidationStarted = 'VALIDATION_STARTED',
-  Withdrawn = 'WITHDRAWN',
 }
 
-// TODO: rename to StakingDepositStatusInfo
-export type StakingStatusInfo = {
-  status: StakingStatus;
+export type StakingDepositStatusInfo = {
+  status: StakingDepositStatus;
 };
 
 export enum StakingValidatorsExitStatus {

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -16,7 +16,7 @@ import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entit
 import { NativeStakingValidatorsExitTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-validators-exit-info.entity';
 import { NativeStakingWithdrawTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-withdraw-info.entity';
 import {
-  StakingStatus,
+  StakingDepositStatus,
   StakingValidatorsExitStatus,
 } from '@/routes/transactions/entities/staking/staking.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
@@ -234,29 +234,29 @@ export class NativeStakingMapper {
   }
 
   /**
-   * Maps the {@link StakingStatus} for the given native staking deployment's `deposit` call.
-   * - If the deposit transaction is not confirmed, the status is {@link StakingStatus.SignatureNeeded}.
+   * Maps the {@link StakingDepositStatus} for the given native staking deployment's `deposit` call.
+   * - If the deposit transaction is not confirmed, the status is {@link StakingDepositStatus.SignatureNeeded}.
    * - If the deposit transaction is confirmed but the deposit execution date is not available,
-   * the status is {@link StakingStatus.AwaitingExecution}.
-   * - If the deposit execution date is available, the status is {@link StakingStatus.AwaitingEntry} if the current
-   * date is before the estimated entry time, otherwise the status is {@link StakingStatus.ValidationStarted}.
+   * the status is {@link StakingDepositStatus.AwaitingExecution}.
+   * - If the deposit execution date is available, the status is {@link StakingDepositStatus.AwaitingEntry} if the current
+   * date is before the estimated entry time, otherwise the status is {@link StakingDepositStatus.ValidationStarted}.
    *
    * @param networkStats - the network stats for the chain where the native staking deployment lives.
    * @param isConfirmed - whether the deposit transaction is confirmed.
    * @param depositExecutionDate - the date when the deposit transaction was executed.
-   * @returns - the {@link StakingStatus} status of the deposit transaction.
+   * @returns - the {@link StakingDepositStatus} status of the deposit transaction.
    */
   private mapDepositStatus(
     networkStats: NetworkStats,
     isConfirmed: boolean,
     depositExecutionDate: Date | null,
-  ): StakingStatus {
+  ): StakingDepositStatus {
     if (!isConfirmed) {
-      return StakingStatus.SignatureNeeded;
+      return StakingDepositStatus.SignatureNeeded;
     }
 
     if (!depositExecutionDate) {
-      return StakingStatus.AwaitingExecution;
+      return StakingDepositStatus.AwaitingExecution;
     }
 
     const estimatedDepositEntryTime =
@@ -264,8 +264,8 @@ export class NativeStakingMapper {
       networkStats.estimated_entry_time_seconds * 1000;
 
     return Date.now() <= estimatedDepositEntryTime
-      ? StakingStatus.AwaitingEntry
-      : StakingStatus.ValidationStarted;
+      ? StakingDepositStatus.AwaitingEntry
+      : StakingDepositStatus.ValidationStarted;
   }
 
   /**


### PR DESCRIPTION
## Changes
- Renames `StakingStatus` to `StakingDepositStatus` as it only contains the statuses for `deposit` transactions.
- Renames `StakingStatusInfo` to `StakingDepositStatusInfo` as it only contains the statuses for `deposit` transactions.
- Removes `RequestedExit`, `Unknown` and `Withdrawn` statuses from `StakingDepositStatus` as they are not used anywhere.
