### PR TITLE
Fix test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "./coverage",
     "coveragePathIgnorePatterns": [
       "index.ts",
       ".+\\/__tests__\\/.+\\.factory.(t|j)s",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "src/**/*.(t|j)s",
+      "migrations/**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -81,7 +81,10 @@
       "json",
       "ts"
     ],
-    "testRegex": ".*\\.spec\\.ts$",
+    "testMatch": [
+      "<rootDir>/src/**/*.spec.ts",
+      "<rootDir>/migrations/**/*.spec.ts"
+    ],
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
@@ -90,15 +93,9 @@
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [
+      "index.ts",
       ".+\\/__tests__\\/.+\\.factory.(t|j)s",
-      "/abis/",
-      "/assets/",
-      "/coverage/",
-      "/data/",
-      "/dist/",
-      "/scripts/",
-      ".e2e-spec.ts",
-      "main.ts"
+      ".e2e-spec.ts"
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -81,16 +81,13 @@
       "json",
       "ts"
     ],
-    "testMatch": [
-      "<rootDir>/src/**/*.spec.ts",
-      "<rootDir>/migrations/**/*.spec.ts"
-    ],
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "src/**/*.(t|j)s",
-      "migrations/**/*.(t|j)s"
+      "<rootDir>/src/**/*.(t|j)s",
+      "<rootDir>/migrations/**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -85,9 +85,12 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "roots": [
+      "./src",
+      "./migrations"
+    ],
     "collectCoverageFrom": [
-      "<rootDir>/src/**/*.(t|j)s",
-      "<rootDir>/migrations/**/*.(t|j)s"
+      "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "coverageDirectory": "./coverage",
     "coveragePathIgnorePatterns": [
       "index.ts",
+      ".+\\/__tests__\\/.+\\.builder.(t|j)s",
       ".+\\/__tests__\\/.+\\.factory.(t|j)s",
       ".e2e-spec.ts"
     ],


### PR DESCRIPTION
## Summary

Our coverage report is according to _all_ files (other than those in `node_modules`) as of https://github.com/safe-global/safe-client-gateway/pull/1655. Despite ignoring certain folders (https://github.com/safe-global/safe-client-gateway/pull/1892), the report remains the same.

This adjusts configuration to only return coverage reports for the relative folders (`src` and `migrations`).

## Changes

- Only match and generate coverage reports from `src` and `migrations` folders
- Remove unnecessarily ignored folders