### PR TITLE
Add Native Staking transaction data decoders

### DIFF
--- a/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
@@ -1,0 +1,126 @@
+import {
+  KilnAbi,
+  KilnDecoder,
+} from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker';
+import { encodeFunctionData } from 'viem';
+
+const mockLoggingService = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+describe('KilnDecoder', () => {
+  let kilnDecoder: KilnDecoder;
+
+  beforeEach(() => {
+    kilnDecoder = new KilnDecoder(mockLoggingService);
+  });
+
+  describe('decodeDeposit', () => {
+    it('decodes a deposit function call correctly', () => {
+      const data = encodeFunctionData({
+        abi: KilnAbi,
+        functionName: 'deposit',
+        args: [],
+      });
+      expect(kilnDecoder.decodeDeposit(data)).toEqual({
+        method: 'deposit',
+        parameters: [],
+      });
+    });
+
+    it('returns null if the data is not a deposit function call', () => {
+      const data = faker.string.hexadecimal({ length: 1 }) as `0x${string}`;
+      expect(kilnDecoder.decodeDeposit(data)).toBeNull();
+    });
+
+    it('returns null if the data is another Kiln function call', () => {
+      const data = encodeFunctionData({
+        abi: KilnAbi,
+        functionName: 'requestValidatorsExit',
+        args: [faker.string.hexadecimal({ length: 1 }) as `0x${string}`],
+      });
+      expect(kilnDecoder.decodeDeposit(data)).toBeNull();
+    });
+  });
+
+  describe('decodeValidatorsExit', () => {
+    it('decodes a requestValidatorsExit function call correctly', () => {
+      const validatorsPublicKeys = faker.string.hexadecimal({
+        length: 96,
+      }) as `0x${string}`;
+      const data = encodeFunctionData({
+        abi: KilnAbi,
+        functionName: 'requestValidatorsExit',
+        args: [validatorsPublicKeys],
+      });
+      expect(kilnDecoder.decodeValidatorsExit(data)).toEqual({
+        method: 'requestValidatorsExit',
+        parameters: [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: validatorsPublicKeys.toLocaleLowerCase(),
+            valueDecoded: null,
+          },
+        ],
+      });
+    });
+
+    it('returns null if the data is not a requestValidatorsExit function call', () => {
+      const data = faker.string.hexadecimal({ length: 1 }) as `0x${string}`;
+      expect(kilnDecoder.decodeValidatorsExit(data)).toBeNull();
+    });
+
+    it('returns null if the data is another Kiln function call', () => {
+      const data = encodeFunctionData({
+        abi: KilnAbi,
+        functionName: 'batchWithdrawCLFee',
+        args: [faker.string.hexadecimal({ length: 1 }) as `0x${string}`],
+      });
+      expect(kilnDecoder.decodeValidatorsExit(data)).toBeNull();
+    });
+  });
+
+  describe('decodeBatchWithdrawCLFee', () => {
+    it('decodes a batchWithdrawCLFee function call correctly', () => {
+      const validatorsPublicKeys = faker.string.hexadecimal({
+        length: 96,
+      }) as `0x${string}`;
+      const data = encodeFunctionData({
+        abi: KilnAbi,
+        functionName: 'batchWithdrawCLFee',
+        args: [validatorsPublicKeys],
+      });
+      expect(kilnDecoder.decodeBatchWithdrawCLFee(data)).toEqual({
+        method: 'batchWithdrawCLFee',
+        parameters: [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: validatorsPublicKeys.toLocaleLowerCase(),
+            valueDecoded: null,
+          },
+        ],
+      });
+    });
+
+    it('returns null if the data is not a batchWithdrawCLFee function call', () => {
+      const data = faker.string.hexadecimal({ length: 1 }) as `0x${string}`;
+      expect(kilnDecoder.decodeBatchWithdrawCLFee(data)).toBeNull();
+    });
+
+    it('returns null if the data is another Kiln function call', () => {
+      const data = encodeFunctionData({
+        abi: KilnAbi,
+        functionName: 'requestValidatorsExit',
+        args: [faker.string.hexadecimal({ length: 1 }) as `0x${string}`],
+      });
+      expect(kilnDecoder.decodeBatchWithdrawCLFee(data)).toBeNull();
+    });
+  });
+});

--- a/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
@@ -28,7 +28,6 @@ describe('KilnDecoder', () => {
         args: [],
       });
       expect(kilnDecoder.decodeDeposit(data)).toEqual({
-        method: 'deposit',
         parameters: [],
       });
     });
@@ -59,7 +58,6 @@ describe('KilnDecoder', () => {
         args: [validatorsPublicKeys],
       });
       expect(kilnDecoder.decodeValidatorsExit(data)).toEqual({
-        method: 'requestValidatorsExit',
         parameters: [
           {
             name: '_publicKeys',
@@ -97,7 +95,6 @@ describe('KilnDecoder', () => {
         args: [validatorsPublicKeys],
       });
       expect(kilnDecoder.decodeBatchWithdrawCLFee(data)).toEqual({
-        method: 'batchWithdrawCLFee',
         parameters: [
           {
             name: '_publicKeys',

--- a/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
@@ -28,6 +28,7 @@ describe('KilnDecoder', () => {
         args: [],
       });
       expect(kilnDecoder.decodeDeposit(data)).toEqual({
+        method: 'deposit',
         parameters: [],
       });
     });
@@ -58,6 +59,7 @@ describe('KilnDecoder', () => {
         args: [validatorsPublicKeys],
       });
       expect(kilnDecoder.decodeValidatorsExit(data)).toEqual({
+        method: 'requestValidatorsExit',
         parameters: [
           {
             name: '_publicKeys',
@@ -95,6 +97,7 @@ describe('KilnDecoder', () => {
         args: [validatorsPublicKeys],
       });
       expect(kilnDecoder.decodeBatchWithdrawCLFee(data)).toEqual({
+        method: 'batchWithdrawCLFee',
         parameters: [
           {
             name: '_publicKeys',

--- a/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
+++ b/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
@@ -1,0 +1,124 @@
+import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
+import { LoggingService, ILoggingService } from '@/logging/logging.interface';
+import { Inject, Injectable } from '@nestjs/common';
+
+export const KilnAbi = [
+  {
+    inputs: [],
+    name: 'deposit',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'bytes', name: '_publicKeys', type: 'bytes' }],
+    name: 'requestValidatorsExit',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'bytes', name: '_publicKeys', type: 'bytes' }],
+    name: 'batchWithdrawCLFee',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+export type KilnRequestValidatorsExitParameters = {
+  name: '_publicKeys';
+  type: 'bytes';
+  value: `0x${string}`;
+  valueDecoded: null;
+};
+export type KilnBatchWithdrawCLFeeParameters =
+  KilnRequestValidatorsExitParameters;
+
+@Injectable()
+export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {
+    super(KilnAbi);
+  }
+
+  decodeDeposit(
+    data: `0x${string}`,
+  ): { method: string; parameters: [] } | null {
+    if (!this.helpers.isDeposit(data)) {
+      return null;
+    }
+    try {
+      const decoded = this.decodeFunctionData({ data });
+      if (decoded.functionName !== 'deposit') {
+        throw new Error('Data is not of deposit type');
+      }
+      return {
+        method: decoded.functionName,
+        parameters: [],
+      };
+    } catch (e) {
+      this.loggingService.debug(e);
+      return null;
+    }
+  }
+
+  decodeValidatorsExit(data: `0x${string}`): {
+    method: string;
+    parameters: KilnRequestValidatorsExitParameters[];
+  } | null {
+    if (!this.helpers.isRequestValidatorsExit(data)) {
+      return null;
+    }
+    try {
+      const decoded = this.decodeFunctionData({ data });
+      if (decoded.functionName !== 'requestValidatorsExit') {
+        throw new Error('Data is not of requestValidatorsExit type');
+      }
+      return {
+        method: decoded.functionName,
+        parameters: [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: decoded.args[0],
+            valueDecoded: null,
+          },
+        ],
+      };
+    } catch (e) {
+      this.loggingService.debug(e);
+      return null;
+    }
+  }
+
+  decodeBatchWithdrawCLFee(data: `0x${string}`): {
+    method: string;
+    parameters: KilnBatchWithdrawCLFeeParameters[];
+  } | null {
+    if (!this.helpers.isBatchWithdrawCLFee(data)) {
+      return null;
+    }
+    try {
+      const decoded = this.decodeFunctionData({ data });
+      if (decoded.functionName !== 'batchWithdrawCLFee') {
+        throw new Error('Data is not of batchWithdrawCLFee type');
+      }
+      return {
+        method: decoded.functionName,
+        parameters: [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: decoded.args[0],
+            valueDecoded: null,
+          },
+        ],
+      };
+    } catch (e) {
+      this.loggingService.debug(e);
+      return null;
+    }
+  }
+}

--- a/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
+++ b/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
@@ -43,7 +43,9 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
     super(KilnAbi);
   }
 
-  decodeDeposit(data: `0x${string}`): { parameters: [] } | null {
+  decodeDeposit(
+    data: `0x${string}`,
+  ): { method: string; parameters: [] } | null {
     if (!this.helpers.isDeposit(data)) {
       return null;
     }
@@ -53,6 +55,7 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
         throw new Error('Data is not of deposit type');
       }
       return {
+        method: decoded.functionName,
         parameters: [],
       };
     } catch (e) {
@@ -62,6 +65,7 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
   }
 
   decodeValidatorsExit(data: `0x${string}`): {
+    method: string;
     parameters: KilnRequestValidatorsExitParameters[];
   } | null {
     if (!this.helpers.isRequestValidatorsExit(data)) {
@@ -73,6 +77,7 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
         throw new Error('Data is not of requestValidatorsExit type');
       }
       return {
+        method: decoded.functionName,
         parameters: [
           {
             name: '_publicKeys',
@@ -89,6 +94,7 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
   }
 
   decodeBatchWithdrawCLFee(data: `0x${string}`): {
+    method: string;
     parameters: KilnBatchWithdrawCLFeeParameters[];
   } | null {
     if (!this.helpers.isBatchWithdrawCLFee(data)) {
@@ -100,6 +106,7 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
         throw new Error('Data is not of batchWithdrawCLFee type');
       }
       return {
+        method: decoded.functionName,
         parameters: [
           {
             name: '_publicKeys',

--- a/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
+++ b/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
@@ -43,9 +43,7 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
     super(KilnAbi);
   }
 
-  decodeDeposit(
-    data: `0x${string}`,
-  ): { method: string; parameters: [] } | null {
+  decodeDeposit(data: `0x${string}`): { parameters: [] } | null {
     if (!this.helpers.isDeposit(data)) {
       return null;
     }
@@ -55,7 +53,6 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
         throw new Error('Data is not of deposit type');
       }
       return {
-        method: decoded.functionName,
         parameters: [],
       };
     } catch (e) {
@@ -65,7 +62,6 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
   }
 
   decodeValidatorsExit(data: `0x${string}`): {
-    method: string;
     parameters: KilnRequestValidatorsExitParameters[];
   } | null {
     if (!this.helpers.isRequestValidatorsExit(data)) {
@@ -77,7 +73,6 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
         throw new Error('Data is not of requestValidatorsExit type');
       }
       return {
-        method: decoded.functionName,
         parameters: [
           {
             name: '_publicKeys',
@@ -94,7 +89,6 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
   }
 
   decodeBatchWithdrawCLFee(data: `0x${string}`): {
-    method: string;
     parameters: KilnBatchWithdrawCLFeeParameters[];
   } | null {
     if (!this.helpers.isBatchWithdrawCLFee(data)) {
@@ -106,7 +100,6 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
         throw new Error('Data is not of batchWithdrawCLFee type');
       }
       return {
-        method: decoded.functionName,
         parameters: [
           {
             name: '_publicKeys',

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -636,7 +636,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_DEPOSIT',
-              method: 'deposit',
+              method: dataDecoded.method,
               status: 'SIGNATURE_NEEDED',
               parameters: dataDecoded.parameters,
               estimatedEntryTime: networkStats.estimated_entry_time_seconds,
@@ -827,7 +827,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_DEPOSIT',
-              method: 'deposit',
+              method: dataDecoded.method,
               parameters: dataDecoded.parameters,
               status: 'SIGNATURE_NEEDED',
               estimatedEntryTime: networkStats.estimated_entry_time_seconds,
@@ -1263,7 +1263,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_VALIDATORS_EXIT',
-              method: 'requestValidatorsExit',
+              method: dataDecoded.method,
               parameters: dataDecoded.parameters,
               status: 'SIGNATURE_NEEDED',
               estimatedExitTime: networkStats.estimated_exit_time_seconds,
@@ -1689,7 +1689,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_WITHDRAW',
-              method: 'batchWithdrawCLFee',
+              method: dataDecoded.method,
               parameters: dataDecoded.parameters,
               value,
               tokenInfo: {

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -636,7 +636,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_DEPOSIT',
-              method: dataDecoded.method,
+              method: 'deposit',
               status: 'SIGNATURE_NEEDED',
               parameters: dataDecoded.parameters,
               estimatedEntryTime: networkStats.estimated_entry_time_seconds,
@@ -827,7 +827,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_DEPOSIT',
-              method: dataDecoded.method,
+              method: 'deposit',
               parameters: dataDecoded.parameters,
               status: 'SIGNATURE_NEEDED',
               estimatedEntryTime: networkStats.estimated_entry_time_seconds,
@@ -1263,7 +1263,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_VALIDATORS_EXIT',
-              method: dataDecoded.method,
+              method: 'requestValidatorsExit',
               parameters: dataDecoded.parameters,
               status: 'SIGNATURE_NEEDED',
               estimatedExitTime: networkStats.estimated_exit_time_seconds,
@@ -1689,7 +1689,7 @@ describe('TransactionsViewController tests', () => {
             .expect(200)
             .expect({
               type: 'KILN_NATIVE_STAKING_WITHDRAW',
-              method: dataDecoded.method,
+              method: 'batchWithdrawCLFee',
               parameters: dataDecoded.parameters,
               value,
               tokenInfo: {

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -1,4 +1,5 @@
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
 import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
 import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
@@ -94,7 +95,7 @@ export class TransactionsViewController {
     SwapsRepositoryModule,
     TwapOrderHelperModule,
   ],
-  providers: [TransactionsViewService, ComposableCowDecoder],
+  providers: [TransactionsViewService, ComposableCowDecoder, KilnDecoder],
   controllers: [TransactionsViewController],
 })
 export class TransactionsViewControllerModule {}

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -332,7 +332,7 @@ export class TransactionsViewService {
       depositExecutionDate: null,
     });
     return new NativeStakingDepositConfirmationView({
-      method: 'deposit',
+      method: dataDecoded.method,
       parameters: dataDecoded.parameters,
       ...depositInfo,
     });
@@ -360,7 +360,7 @@ export class TransactionsViewService {
         transaction: null,
       });
     return new NativeStakingValidatorsExitConfirmationView({
-      method: 'requestValidatorsExit',
+      method: dataDecoded.method,
       parameters: dataDecoded.parameters,
       ...validatorsExitInfo,
     });
@@ -387,7 +387,7 @@ export class TransactionsViewService {
       transaction: null,
     });
     return new NativeStakingWithdrawConfirmationView({
-      method: 'batchWithdrawCLFee',
+      method: dataDecoded.method,
       parameters: dataDecoded.parameters,
       ...withdrawInfo,
     });

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -64,15 +64,10 @@ export class TransactionsViewService {
       })
       .catch(() => {
         // Fallback for unverified contracts
-        const { data } = args.transactionDataDto;
-        const fallbackDataDecoded =
-          this.kilnDecoder.decodeDeposit(data) ??
-          this.kilnDecoder.decodeValidatorsExit(data) ??
-          this.kilnDecoder.decodeBatchWithdrawCLFee(data);
-        if (!fallbackDataDecoded) {
-          throw new Error('Transaction data could not be decoded');
-        }
-        return fallbackDataDecoded;
+        return {
+          method: '',
+          parameters: null,
+        };
       });
 
     const swapOrderData = this.swapOrderHelper.findSwapOrder(
@@ -322,6 +317,13 @@ export class TransactionsViewService {
     dataDecoded: DataDecoded;
     value: string | null;
   }): Promise<NativeStakingDepositConfirmationView> {
+    const dataDecoded =
+      args.dataDecoded.method !== ''
+        ? args.dataDecoded
+        : this.kilnDecoder.decodeDeposit(args.data);
+    if (!dataDecoded) {
+      throw new Error('Transaction data could not be decoded');
+    }
     const depositInfo = await this.nativeStakingMapper.mapDepositInfo({
       chainId: args.chainId,
       to: args.to,
@@ -330,8 +332,8 @@ export class TransactionsViewService {
       depositExecutionDate: null,
     });
     return new NativeStakingDepositConfirmationView({
-      method: args.dataDecoded.method,
-      parameters: args.dataDecoded.parameters,
+      method: 'deposit',
+      parameters: dataDecoded.parameters,
       ...depositInfo,
     });
   }
@@ -343,6 +345,13 @@ export class TransactionsViewService {
     dataDecoded: DataDecoded;
     value: string | null;
   }): Promise<NativeStakingValidatorsExitConfirmationView> {
+    const dataDecoded =
+      args.dataDecoded.method !== ''
+        ? args.dataDecoded
+        : this.kilnDecoder.decodeValidatorsExit(args.data);
+    if (!dataDecoded) {
+      throw new Error('Transaction data could not be decoded');
+    }
     const validatorsExitInfo =
       await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId: args.chainId,
@@ -351,8 +360,8 @@ export class TransactionsViewService {
         transaction: null,
       });
     return new NativeStakingValidatorsExitConfirmationView({
-      method: args.dataDecoded.method,
-      parameters: args.dataDecoded.parameters,
+      method: 'requestValidatorsExit',
+      parameters: dataDecoded.parameters,
       ...validatorsExitInfo,
     });
   }
@@ -364,6 +373,13 @@ export class TransactionsViewService {
     dataDecoded: DataDecoded;
     value: string | null;
   }): Promise<NativeStakingWithdrawConfirmationView> {
+    const dataDecoded =
+      args.dataDecoded.method !== ''
+        ? args.dataDecoded
+        : this.kilnDecoder.decodeBatchWithdrawCLFee(args.data);
+    if (!dataDecoded) {
+      throw new Error('Transaction data could not be decoded');
+    }
     const withdrawInfo = await this.nativeStakingMapper.mapWithdrawInfo({
       chainId: args.chainId,
       to: args.to,
@@ -371,8 +387,8 @@ export class TransactionsViewService {
       transaction: null,
     });
     return new NativeStakingWithdrawConfirmationView({
-      method: args.dataDecoded.method,
-      parameters: args.dataDecoded.parameters,
+      method: 'batchWithdrawCLFee',
+      parameters: dataDecoded.parameters,
       ...withdrawInfo,
     });
   }


### PR DESCRIPTION
## Summary
As part of the Native Staking transaction mapping implementation in the CGW, this PR adds _local_ decoding for these transactions. 

The point of this PR is to mitigate the risk of not having the Kiln contracts available (or the data-decoding endpoint unreachable) on the Safe Transaction Service (the main source for transaction data decoding). This PR provides a fallback for that scenario.

## Changes
- Adds `KilnDecoder` along with the Kiln Native Staking contract ABIs.
- Adds a fallback to `TransactionsViewService` that tries to decode the data in case the Transaction Service cannot.
