### PR TITLE
Get claimable rewards from transaction data

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -598,14 +598,12 @@ export class CacheRouter {
    * cache key short and deterministic. Redis and other cache systems
    * may experience performance degradation with long keys.
    *
-   * @param validatorsPublicKeys - Array of validators public keys
+   * @param validatorsPublicKeys - Concatenated validators public keys
    * @returns {@link CacheDir} - Cache directory
    */
-  static getStakingStakesCacheDir(
-    validatorsPublicKeys: `0x${string}`[],
-  ): CacheDir {
+  static getStakingStakesCacheDir(validatorsPublicKeys: string): CacheDir {
     const hash = crypto.createHash('sha256');
-    hash.update(validatorsPublicKeys.join('_'));
+    hash.update(validatorsPublicKeys);
     return new CacheDir(`${this.STAKING_STAKES_KEY}_${hash.digest('hex')}`, '');
   }
 }

--- a/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
@@ -1,6 +1,6 @@
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { Stake } from '@/datasources/staking-api/entities/stake.entity';
-import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { faker } from '@faker-js/faker';
 
 export function stakeBuilder(): IBuilder<Stake> {
@@ -8,7 +8,7 @@ export function stakeBuilder(): IBuilder<Stake> {
     .with(
       'validator_address',
       faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH,
+        length: KilnDecoder.KilnPublicKeyLength,
       }) as `0x${string}`,
     )
     .with('state', faker.lorem.words())

--- a/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
@@ -1,5 +1,6 @@
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { Stake } from '@/datasources/staking-api/entities/stake.entity';
+import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
 import { faker } from '@faker-js/faker';
 
 export function stakeBuilder(): IBuilder<Stake> {
@@ -7,7 +8,7 @@ export function stakeBuilder(): IBuilder<Stake> {
     .with(
       'validator_address',
       faker.string.hexadecimal({
-        length: 96,
+        length: STAKING_PUBLIC_KEY_LENGTH,
       }) as `0x${string}`,
     )
     .with('state', faker.lorem.words())

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -12,6 +12,7 @@ import { pooledStakingStatsBuilder } from '@/datasources/staking-api/entities/__
 import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { DataSourceError } from '@/domain/errors/data-source.error';
+import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
 import { faker } from '@faker-js/faker';
 
 const dataSource = {
@@ -447,8 +448,12 @@ describe('KilnApi', () => {
     it('should return stakes', async () => {
       const validatorsPublicKeys = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
-        () => faker.string.hexadecimal({ length: 66 }) as `0x${string}`,
+        () =>
+          faker.string
+            .hexadecimal({ length: STAKING_PUBLIC_KEY_LENGTH })
+            .slice(2),
       );
+      const concatenatedValidatorsPublicKeys = validatorsPublicKeys.join(',');
       const stakes = Array.from({ length: validatorsPublicKeys.length }, () =>
         stakeBuilder().build(),
       );
@@ -459,20 +464,22 @@ describe('KilnApi', () => {
         data: stakes,
       });
 
-      const actual = await target.getStakes(validatorsPublicKeys);
+      const actual = await target.getStakes(concatenatedValidatorsPublicKeys);
 
       expect(actual).toBe(stakes);
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: CacheRouter.getStakingStakesCacheDir(validatorsPublicKeys),
+        cacheDir: CacheRouter.getStakingStakesCacheDir(
+          concatenatedValidatorsPublicKeys,
+        ),
         url: getStakesUrl,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
           params: {
-            validators: validatorsPublicKeys,
+            validators: concatenatedValidatorsPublicKeys,
           },
         },
         expireTimeSeconds: stakingExpirationTimeInSeconds,
@@ -483,8 +490,12 @@ describe('KilnApi', () => {
     it('should forward errors', async () => {
       const validatorsPublicKeys = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
-        () => faker.string.hexadecimal({ length: 66 }) as `0x${string}`,
+        () =>
+          faker.string
+            .hexadecimal({ length: STAKING_PUBLIC_KEY_LENGTH })
+            .slice(2),
       );
+      const concatenatedValidatorsPublicKeys = validatorsPublicKeys.join(',');
       const getStakesUrl = `${baseUrl}/v1/eth/stakes`;
       const errorMessage = faker.lorem.sentence();
       const statusCode = faker.internet.httpStatusCode({
@@ -500,20 +511,22 @@ describe('KilnApi', () => {
           new Error(errorMessage),
         ),
       );
-      await expect(target.getStakes(validatorsPublicKeys)).rejects.toThrow(
-        expected,
-      );
+      await expect(
+        target.getStakes(concatenatedValidatorsPublicKeys),
+      ).rejects.toThrow(expected);
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: CacheRouter.getStakingStakesCacheDir(validatorsPublicKeys),
+        cacheDir: CacheRouter.getStakingStakesCacheDir(
+          concatenatedValidatorsPublicKeys,
+        ),
         url: getStakesUrl,
         networkRequest: {
           headers: {
             Authorization: `Bearer ${apiKey}`,
           },
           params: {
-            validators: validatorsPublicKeys,
+            validators: concatenatedValidatorsPublicKeys,
           },
         },
         expireTimeSeconds: stakingExpirationTimeInSeconds,

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -12,7 +12,7 @@ import { pooledStakingStatsBuilder } from '@/datasources/staking-api/entities/__
 import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { DataSourceError } from '@/domain/errors/data-source.error';
-import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { faker } from '@faker-js/faker';
 
 const dataSource = {
@@ -450,7 +450,9 @@ describe('KilnApi', () => {
         { length: faker.number.int({ min: 1, max: 5 }) },
         () =>
           faker.string
-            .hexadecimal({ length: STAKING_PUBLIC_KEY_LENGTH })
+            .hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+            })
             .slice(2),
       );
       const concatenatedValidatorsPublicKeys = validatorsPublicKeys.join(',');
@@ -492,7 +494,9 @@ describe('KilnApi', () => {
         { length: faker.number.int({ min: 1, max: 5 }) },
         () =>
           faker.string
-            .hexadecimal({ length: STAKING_PUBLIC_KEY_LENGTH })
+            .hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+            })
             .slice(2),
       );
       const concatenatedValidatorsPublicKeys = validatorsPublicKeys.join(',');

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -170,7 +170,7 @@ export class KilnApi implements IStakingApi {
     }
   }
 
-  async getStakes(validatorsPublicKeys: `0x${string}`[]): Promise<Stake[]> {
+  async getStakes(validatorsPublicKeys: string): Promise<Stake[]> {
     try {
       const url = `${this.baseUrl}/v1/eth/stakes`;
       const cacheDir =

--- a/src/domain/interfaces/staking-api.interface.ts
+++ b/src/domain/interfaces/staking-api.interface.ts
@@ -21,5 +21,5 @@ export interface IStakingApi {
     vault: `0x${string}`;
   }): Promise<Array<DefiVaultStats>>;
 
-  getStakes(validatorsPublicKeys: `0x${string}`[]): Promise<Stake[]>;
+  getStakes(validatorsPublicKeys: string): Promise<Stake[]>;
 }

--- a/src/domain/staking/constants.ts
+++ b/src/domain/staking/constants.ts
@@ -1,0 +1,1 @@
+export const STAKING_PUBLIC_KEY_LENGTH = 96;

--- a/src/domain/staking/constants.ts
+++ b/src/domain/staking/constants.ts
@@ -1,1 +1,0 @@
-export const STAKING_PUBLIC_KEY_LENGTH = 96;

--- a/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
@@ -1,3 +1,4 @@
+import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
 import {
   KilnAbi,
   KilnDecoder,
@@ -51,7 +52,7 @@ describe('KilnDecoder', () => {
   describe('decodeValidatorsExit', () => {
     it('decodes a requestValidatorsExit function call correctly', () => {
       const validatorsPublicKeys = faker.string.hexadecimal({
-        length: 96,
+        length: STAKING_PUBLIC_KEY_LENGTH,
       }) as `0x${string}`;
       const data = encodeFunctionData({
         abi: KilnAbi,
@@ -89,7 +90,7 @@ describe('KilnDecoder', () => {
   describe('decodeBatchWithdrawCLFee', () => {
     it('decodes a batchWithdrawCLFee function call correctly', () => {
       const validatorsPublicKeys = faker.string.hexadecimal({
-        length: 96,
+        length: STAKING_PUBLIC_KEY_LENGTH,
       }) as `0x${string}`;
       const data = encodeFunctionData({
         abi: KilnAbi,

--- a/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
@@ -1,4 +1,3 @@
-import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
 import {
   KilnAbi,
   KilnDecoder,
@@ -52,7 +51,7 @@ describe('KilnDecoder', () => {
   describe('decodeValidatorsExit', () => {
     it('decodes a requestValidatorsExit function call correctly', () => {
       const validatorsPublicKeys = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH,
+        length: KilnDecoder.KilnPublicKeyLength,
       }) as `0x${string}`;
       const data = encodeFunctionData({
         abi: KilnAbi,
@@ -90,7 +89,7 @@ describe('KilnDecoder', () => {
   describe('decodeBatchWithdrawCLFee', () => {
     it('decodes a batchWithdrawCLFee function call correctly', () => {
       const validatorsPublicKeys = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH,
+        length: KilnDecoder.KilnPublicKeyLength,
       }) as `0x${string}`;
       const data = encodeFunctionData({
         abi: KilnAbi,

--- a/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
+++ b/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
@@ -37,6 +37,7 @@ export type KilnBatchWithdrawCLFeeParameters =
 
 @Injectable()
 export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
+  public static readonly KilnPublicKeyLength = 96;
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -29,7 +29,7 @@ export interface IStakingRepository {
 
   getStakes(args: {
     chainId: string;
-    validatorsPublicKeys: `0x${string}`[];
+    validatorsPublicKeys: string;
   }): Promise<Stake[]>;
 
   clearApi(chainId: string): void;

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -93,7 +93,7 @@ export class StakingRepository implements IStakingRepository {
 
   public async getStakes(args: {
     chainId: string;
-    validatorsPublicKeys: `0x${string}`[];
+    validatorsPublicKeys: string;
   }): Promise<Stake[]> {
     const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
     const stakes = await stakingApi.getStakes(args.validatorsPublicKeys);

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
@@ -42,6 +42,9 @@ export class NativeStakingValidatorsExitConfirmationView
   numValidators: number;
 
   @ApiProperty()
+  rewards: string;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -52,6 +55,7 @@ export class NativeStakingValidatorsExitConfirmationView
     estimatedWithdrawalTime: number;
     value: string;
     numValidators: number;
+    rewards: string;
     tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
@@ -61,6 +65,7 @@ export class NativeStakingValidatorsExitConfirmationView
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
     this.value = args.value;
     this.numValidators = args.numValidators;
+    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -26,6 +26,9 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   numValidators: number;
 
   @ApiProperty()
+  rewards: string;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -34,6 +37,7 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     estimatedWithdrawalTime: number;
     value: string;
     numValidators: number;
+    rewards: string;
     tokenInfo: TokenInfo;
   }) {
     super(TransactionInfoType.NativeStakingValidatorsExit, null, null);
@@ -42,6 +46,7 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
     this.value = args.value;
     this.numValidators = args.numValidators;
+    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
@@ -22,17 +22,22 @@ export class NativeStakingWithdrawConfirmationView implements Baseline {
   value: string;
 
   @ApiProperty()
+  rewards: string;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
     value: string;
+    rewards: string;
     tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
     this.parameters = args.parameters;
     this.value = args.value;
+    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-info.entity.ts
@@ -13,11 +13,15 @@ export class NativeStakingWithdrawTransactionInfo extends TransactionInfo {
   value: string;
 
   @ApiProperty()
+  rewards: string;
+
+  @ApiProperty()
   tokenInfo: TokenInfo;
 
-  constructor(args: { value: string; tokenInfo: TokenInfo }) {
+  constructor(args: { value: string; rewards: string; tokenInfo: TokenInfo }) {
     super(TransactionInfoType.NativeStakingWithdraw, null, null);
     this.value = args.value;
+    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/helpers/kiln-native-staking.helper.ts
+++ b/src/routes/transactions/helpers/kiln-native-staking.helper.ts
@@ -1,3 +1,4 @@
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
 import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
 import {
@@ -107,7 +108,7 @@ export class KilnNativeStakingHelper {
 
 @Module({
   imports: [TransactionFinderModule, StakingRepositoryModule],
-  providers: [KilnNativeStakingHelper],
-  exports: [KilnNativeStakingHelper],
+  providers: [KilnNativeStakingHelper, KilnDecoder],
+  exports: [KilnNativeStakingHelper, KilnDecoder],
 })
 export class KilnNativeStakingHelperModule {}

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
 import { confirmationBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
 import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
-import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { StakingRepository } from '@/domain/staking/staking.repository';
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
@@ -382,7 +382,7 @@ describe('NativeStakingMapper', () => {
       const networkStats = networkStatsBuilder().build();
       const stakes = [stakeBuilder().build()];
       const validatorPublicKey = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH * 3,
+        length: KilnDecoder.KilnPublicKeyLength * 3,
       }); // 3 validators
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
@@ -444,7 +444,7 @@ describe('NativeStakingMapper', () => {
         stakeBuilder().with('rewards', '3').build(),
       ];
       const validatorPublicKey = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH * 3,
+        length: KilnDecoder.KilnPublicKeyLength * 3,
       }); // 3 validators
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
@@ -509,7 +509,7 @@ describe('NativeStakingMapper', () => {
         .build();
       const stakes = [stakeBuilder().build()];
       const validatorPublicKey = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH * 3,
+        length: KilnDecoder.KilnPublicKeyLength * 3,
       }); // 3 validators
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
@@ -576,7 +576,7 @@ describe('NativeStakingMapper', () => {
         .build();
       const stakes = [stakeBuilder().build()];
       const validatorPublicKey = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH * 2,
+        length: KilnDecoder.KilnPublicKeyLength * 2,
       }); // 2 validators
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
@@ -716,7 +716,7 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder().build();
       const validatorPublicKey = faker.string.hexadecimal({
-        length: STAKING_PUBLIC_KEY_LENGTH * 2,
+        length: KilnDecoder.KilnPublicKeyLength * 2,
       }); // 2 validators
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
@@ -768,7 +768,7 @@ describe('NativeStakingMapper', () => {
 
       expect(mockStakingRepository.getStakes).toHaveBeenCalledWith({
         chainId: chain.chainId,
-        validatorsPublicKeys: `${validatorPublicKey.slice(2, STAKING_PUBLIC_KEY_LENGTH + 2)},${validatorPublicKey.slice(STAKING_PUBLIC_KEY_LENGTH + 2)}`,
+        validatorsPublicKeys: `${validatorPublicKey.slice(2, KilnDecoder.KilnPublicKeyLength + 2)},${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
       });
     });
 

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -407,7 +407,6 @@ describe('NativeStakingMapper', () => {
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
         to: deployment.address,
-        value: null,
         transaction,
         dataDecoded,
       });
@@ -474,7 +473,6 @@ describe('NativeStakingMapper', () => {
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
         to: deployment.address,
-        value: null,
         transaction,
         dataDecoded,
       });
@@ -542,7 +540,6 @@ describe('NativeStakingMapper', () => {
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
         to: deployment.address,
-        value: null,
         transaction,
         dataDecoded,
       });
@@ -610,7 +607,6 @@ describe('NativeStakingMapper', () => {
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
         to: deployment.address,
-        value: null,
         transaction,
         dataDecoded,
       });
@@ -655,7 +651,6 @@ describe('NativeStakingMapper', () => {
         target.mapValidatorsExitInfo({
           chainId: chain.chainId,
           to: deployment.address,
-          value: null,
           transaction,
           dataDecoded,
         }),
@@ -681,7 +676,6 @@ describe('NativeStakingMapper', () => {
         target.mapValidatorsExitInfo({
           chainId: chain.chainId,
           to: deployment.address,
-          value: null,
           transaction,
           dataDecoded,
         }),
@@ -707,7 +701,6 @@ describe('NativeStakingMapper', () => {
         target.mapValidatorsExitInfo({
           chainId: chain.chainId,
           to: deployment.address,
-          value: null,
           transaction,
           dataDecoded,
         }),
@@ -753,7 +746,6 @@ describe('NativeStakingMapper', () => {
       const actual = await target.mapWithdrawInfo({
         chainId: chain.chainId,
         to: deployment.address,
-        value: null,
         transaction,
         dataDecoded,
       });
@@ -796,7 +788,6 @@ describe('NativeStakingMapper', () => {
         target.mapWithdrawInfo({
           chainId: chain.chainId,
           to: deployment.address,
-          value: null,
           transaction,
           dataDecoded,
         }),
@@ -820,7 +811,6 @@ describe('NativeStakingMapper', () => {
         target.mapWithdrawInfo({
           chainId: chain.chainId,
           to: deployment.address,
-          value: null,
           transaction,
           dataDecoded,
         }),
@@ -844,7 +834,6 @@ describe('NativeStakingMapper', () => {
         target.mapWithdrawInfo({
           chainId: chain.chainId,
           to: deployment.address,
-          value: null,
           transaction,
           dataDecoded,
         }),

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -120,14 +120,13 @@ export class NativeStakingMapper {
    *
    * @param args.chainId - the chain ID of the native staking deployment
    * @param args.to - the address of the native staking deployment
-   * @param args.value - the value of the validators exit transaction
    * @param args.transaction - the transaction object for the validators exit
+   * @param args.dataDecoded - the decoded data of the transaction
    * @returns {@link NativeStakingValidatorsExitTransactionInfo} for the given native staking deployment
    */
   public async mapValidatorsExitInfo(args: {
     chainId: string;
     to: `0x${string}`;
-    value: string | null; // TODO: remove this
     transaction: MultisigTransaction | ModuleTransaction | null;
     dataDecoded: DataDecoded | null;
   }): Promise<NativeStakingValidatorsExitTransactionInfo> {
@@ -147,7 +146,7 @@ export class NativeStakingMapper {
     const dataDecoded = args.transaction?.dataDecoded ?? args.dataDecoded;
     const value = dataDecoded
       ? this.getValueFromDataDecoded(dataDecoded, chain)
-      : Number(args.value ?? 0);
+      : 0;
 
     // TODO: private getNumValidatorsFromDataDecoded(data: DataDecoded): number
     const numValidators = Math.floor(
@@ -158,7 +157,7 @@ export class NativeStakingMapper {
 
     const rewards = dataDecoded
       ? await this.getRewardsFromDataDecoded(dataDecoded, chain)
-      : Number(args.value ?? 0);
+      : 0;
 
     return new NativeStakingValidatorsExitTransactionInfo({
       status: this.mapValidatorsExitStatus(networkStats, args.transaction),
@@ -184,14 +183,13 @@ export class NativeStakingMapper {
    *
    * @param args.chainId - the chain ID of the native staking deployment
    * @param args.to - the address of the native staking deployment
-   * @param args.value - the value of the withdraw transaction
    * @param args.transaction - the transaction object for the withdraw
+   * @param args.dataDecoded - the decoded data of the transaction
    * @returns {@link NativeStakingWithdrawTransactionInfo} for the given native staking deployment
    */
   public async mapWithdrawInfo(args: {
     chainId: string;
     to: `0x${string}`;
-    value: string | null; // TODO: remove this
     transaction: MultisigTransaction | ModuleTransaction | null;
     dataDecoded: DataDecoded | null;
   }): Promise<NativeStakingWithdrawTransactionInfo> {
@@ -207,11 +205,11 @@ export class NativeStakingMapper {
     const dataDecoded = args.transaction?.dataDecoded ?? args.dataDecoded;
     const value = dataDecoded
       ? this.getValueFromDataDecoded(dataDecoded, chain)
-      : Number(args.value ?? 0);
+      : 0;
 
     const rewards = dataDecoded
       ? await this.getRewardsFromDataDecoded(dataDecoded, chain)
-      : Number(args.value ?? 0);
+      : 0;
 
     return new NativeStakingWithdrawTransactionInfo({
       value: getNumberString(value),

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -362,7 +362,7 @@ export class MultisigTransactionInfoMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
   ): Promise<NativeStakingValidatorsExitTransactionInfo | null> {
-    if (!transaction?.data) {
+    if (!transaction?.data || !transaction?.dataDecoded) {
       return null;
     }
 
@@ -394,7 +394,7 @@ export class MultisigTransactionInfoMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
   ): Promise<NativeStakingWithdrawTransactionInfo | null> {
-    if (!transaction?.data) {
+    if (!transaction?.data || !transaction?.dataDecoded) {
       return null;
     }
 

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -383,6 +383,7 @@ export class MultisigTransactionInfoMapper {
         to: nativeStakingValidatorsExitTransaction.to,
         value: transaction.value,
         transaction,
+        dataDecoded: transaction.dataDecoded,
       });
     } catch (error) {
       this.loggingService.warn(error);
@@ -415,6 +416,7 @@ export class MultisigTransactionInfoMapper {
         to: nativeStakingWithdrawTransaction.to,
         value: transaction.value,
         transaction,
+        dataDecoded: transaction.dataDecoded,
       });
     } catch (error) {
       this.loggingService.warn(error);

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -381,7 +381,6 @@ export class MultisigTransactionInfoMapper {
       return await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId,
         to: nativeStakingValidatorsExitTransaction.to,
-        value: transaction.value,
         transaction,
         dataDecoded: transaction.dataDecoded,
       });
@@ -414,7 +413,6 @@ export class MultisigTransactionInfoMapper {
       return await this.nativeStakingMapper.mapWithdrawInfo({
         chainId,
         to: nativeStakingWithdrawTransaction.to,
-        value: transaction.value,
         transaction,
         dataDecoded: transaction.dataDecoded,
       });

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '@/domain/contracts/__tests__/encoders/multi-send-encoder.builder';
 import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
-import { STAKING_PUBLIC_KEY_LENGTH } from '@/domain/staking/constants';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { setPreSignatureEncoder } from '@/domain/swaps/contracts/__tests__/encoders/gp-v2-encoder.builder';
 import { orderBuilder } from '@/domain/swaps/entities/__tests__/order.builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
@@ -1221,7 +1221,7 @@ describe('TransactionsViewController tests', () => {
           const safeAddress = faker.finance.ethereumAddress();
           const networkStats = networkStatsBuilder().build();
           const validatorPublicKey = faker.string.hexadecimal({
-            length: STAKING_PUBLIC_KEY_LENGTH * 2,
+            length: KilnDecoder.KilnPublicKeyLength * 2,
           }); // 2 validators
           const data = encodeFunctionData({
             abi: parseAbi(['function requestValidatorsExit(bytes)']),
@@ -1308,7 +1308,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
-                validators: `${validatorPublicKey.slice(2, STAKING_PUBLIC_KEY_LENGTH + 2)},${validatorPublicKey.slice(STAKING_PUBLIC_KEY_LENGTH + 2)}`,
+                validators: `${validatorPublicKey.slice(2, KilnDecoder.KilnPublicKeyLength + 2)},${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
               },
             }),
           });
@@ -1324,7 +1324,7 @@ describe('TransactionsViewController tests', () => {
           const safeAddress = faker.finance.ethereumAddress();
           const networkStats = networkStatsBuilder().build();
           const validatorPublicKey = faker.string.hexadecimal({
-            length: STAKING_PUBLIC_KEY_LENGTH,
+            length: KilnDecoder.KilnPublicKeyLength,
           });
           const data = encodeFunctionData({
             abi: parseAbi(['function requestValidatorsExit(bytes)']),
@@ -1691,9 +1691,86 @@ describe('TransactionsViewController tests', () => {
             });
         });
 
-        it.todo(
-          'returns the generic confirmation view if the stakes are not available',
-        );
+        it('returns the generic confirmation view if the stakes are not available', async () => {
+          const chain = chainBuilder().with('isTestnet', false).build();
+          const deployment = deploymentBuilder()
+            .with('chain_id', +chain.chainId)
+            .with('product_type', 'dedicated')
+            .with('product_fee', faker.number.float().toString())
+            .build();
+          const safeAddress = faker.finance.ethereumAddress();
+          const networkStats = networkStatsBuilder().build();
+          const validatorPublicKey = faker.string.hexadecimal({
+            length: KilnDecoder.KilnPublicKeyLength * 2,
+          }); // 2 validators
+          const data = encodeFunctionData({
+            abi: parseAbi(['function requestValidatorsExit(bytes)']),
+            functionName: 'requestValidatorsExit',
+            args: [validatorPublicKey as `0x${string}`],
+          });
+          const dataDecoded = dataDecodedBuilder()
+            .with('method', 'requestValidatorsExit')
+            .with('parameters', [
+              {
+                name: '_publicKeys',
+                type: 'bytes',
+                value: validatorPublicKey,
+                valueDecoded: null,
+              },
+            ])
+            .build();
+          networkService.get.mockImplementation(({ url }) => {
+            switch (url) {
+              case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+                return Promise.resolve({ data: chain, status: 200 });
+              case `${stakingApiUrl}/v1/deployments`:
+                return Promise.resolve({
+                  data: { data: [deployment] },
+                  status: 200,
+                });
+              case `${stakingApiUrl}/v1/eth/network-stats`:
+                return Promise.resolve({
+                  data: { data: networkStats },
+                  status: 200,
+                });
+              case `${stakingApiUrl}/v1/eth/stakes`:
+                return Promise.reject(new ServiceUnavailableException());
+              default:
+                return Promise.reject(new Error(`Could not match ${url}`));
+            }
+          });
+          networkService.post.mockImplementation(({ url }) => {
+            if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
+              return Promise.resolve({ data: dataDecoded, status: 200 });
+            }
+            return Promise.reject(new Error(`Could not match ${url}`));
+          });
+
+          await request(app.getHttpServer())
+            .post(
+              `/v1/chains/${chain.chainId}/safes/${safeAddress}/views/transaction-confirmation`,
+            )
+            .send({
+              to: deployment.address,
+              data,
+            })
+            .expect(200)
+            .expect({
+              type: 'GENERIC',
+              method: dataDecoded.method,
+              parameters: dataDecoded.parameters,
+            });
+
+          // check the public keys are passed to the staking service in the expected format
+          expect(networkService.get).toHaveBeenNthCalledWith(4, {
+            url: `${stakingApiUrl}/v1/eth/stakes`,
+            networkRequest: expect.objectContaining({
+              params: {
+                validators: `${validatorPublicKey.slice(2, KilnDecoder.KilnPublicKeyLength + 2)},${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+              },
+            }),
+          });
+        });
       });
 
       describe('withdraw', () => {
@@ -1706,7 +1783,7 @@ describe('TransactionsViewController tests', () => {
             .build();
           const safeAddress = faker.finance.ethereumAddress();
           const validatorPublicKey = faker.string.hexadecimal({
-            length: STAKING_PUBLIC_KEY_LENGTH * 3,
+            length: KilnDecoder.KilnPublicKeyLength * 3,
           }); // 3 validators
           const data = encodeFunctionData({
             abi: parseAbi(['function batchWithdrawCLFee(bytes)']),
@@ -1782,7 +1859,7 @@ describe('TransactionsViewController tests', () => {
         it('returns the native staking `withdraw` confirmation view using local decoding', async () => {
           const chain = chainBuilder().with('isTestnet', false).build();
           const validatorPublicKey = faker.string.hexadecimal({
-            length: STAKING_PUBLIC_KEY_LENGTH * 2,
+            length: KilnDecoder.KilnPublicKeyLength * 2,
           }); // 2 validators
           const deployment = deploymentBuilder()
             .with('chain_id', +chain.chainId)
@@ -2063,9 +2140,71 @@ describe('TransactionsViewController tests', () => {
             });
         });
 
-        it.todo(
-          'returns the generic confirmation view if the stakes are not available',
-        );
+        it('returns the generic confirmation view if the stakes are not available', async () => {
+          const chain = chainBuilder().with('isTestnet', false).build();
+          const validatorPublicKey = faker.string.hexadecimal({
+            length: KilnDecoder.KilnPublicKeyLength * 3,
+          }); // 3 validators
+          const dataDecoded = dataDecodedBuilder()
+            .with('method', 'batchWithdrawCLFee')
+            .with('parameters', [
+              {
+                name: '_publicKeys',
+                type: 'bytes',
+                value: validatorPublicKey,
+                valueDecoded: null,
+              },
+            ])
+            .build();
+          const deployment = deploymentBuilder()
+            .with('chain_id', +chain.chainId)
+            .with('product_type', 'dedicated')
+            .with('product_fee', faker.number.float().toString())
+            .build();
+          const safeAddress = faker.finance.ethereumAddress();
+          const data = encodeFunctionData({
+            abi: parseAbi(['function batchWithdrawCLFee(bytes)']),
+            functionName: 'batchWithdrawCLFee',
+            args: [validatorPublicKey as `0x${string}`],
+          });
+          networkService.get.mockImplementation(({ url }) => {
+            switch (url) {
+              case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+                return Promise.resolve({ data: chain, status: 200 });
+              case `${stakingApiUrl}/v1/deployments`:
+                return Promise.resolve({
+                  data: { data: [deployment] },
+                  status: 200,
+                });
+              case `${stakingApiUrl}/v1/eth/stakes`:
+                return Promise.reject(new ServiceUnavailableException());
+              default:
+                return Promise.reject(new Error(`Could not match ${url}`));
+            }
+          });
+          networkService.post.mockImplementation(({ url }) => {
+            if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
+              return Promise.resolve({ data: dataDecoded, status: 200 });
+            }
+            return Promise.reject(new Error(`Could not match ${url}`));
+          });
+
+          await request(app.getHttpServer())
+            .post(
+              `/v1/chains/${chain.chainId}/safes/${safeAddress}/views/transaction-confirmation`,
+            )
+            .send({
+              to: deployment.address,
+              value: faker.string.numeric(),
+              data,
+            })
+            .expect(200)
+            .expect({
+              type: 'GENERIC',
+              method: dataDecoded.method,
+              parameters: dataDecoded.parameters,
+            });
+        });
       });
     });
   });

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -141,14 +141,12 @@ export class TransactionsViewService {
           ...nativeStakingValidatorsExitTransaction,
           chainId: args.chainId,
           dataDecoded,
-          value: args.transactionDataDto.value ?? null,
         });
       } else if (nativeStakingWithdrawTransaction) {
         return await this.getNativeStakingWithdrawConfirmationView({
           ...nativeStakingWithdrawTransaction,
           chainId: args.chainId,
           dataDecoded,
-          value: args.transactionDataDto.value ?? null,
         });
       } else {
         // Should not reach here
@@ -343,7 +341,6 @@ export class TransactionsViewService {
     to: `0x${string}`;
     data: `0x${string}`;
     dataDecoded: DataDecoded;
-    value: string | null;
   }): Promise<NativeStakingValidatorsExitConfirmationView> {
     const dataDecoded =
       args.dataDecoded.method !== ''
@@ -356,7 +353,6 @@ export class TransactionsViewService {
       await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId: args.chainId,
         to: args.to,
-        value: args.value,
         transaction: null,
         dataDecoded,
       });
@@ -372,7 +368,6 @@ export class TransactionsViewService {
     to: `0x${string}`;
     data: `0x${string}`;
     dataDecoded: DataDecoded;
-    value: string | null;
   }): Promise<NativeStakingWithdrawConfirmationView> {
     const dataDecoded =
       args.dataDecoded.method !== ''
@@ -384,7 +379,6 @@ export class TransactionsViewService {
     const withdrawInfo = await this.nativeStakingMapper.mapWithdrawInfo({
       chainId: args.chainId,
       to: args.to,
-      value: args.value,
       transaction: null,
       dataDecoded,
     });

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -358,6 +358,7 @@ export class TransactionsViewService {
         to: args.to,
         value: args.value,
         transaction: null,
+        dataDecoded,
       });
     return new NativeStakingValidatorsExitConfirmationView({
       method: dataDecoded.method,
@@ -385,6 +386,7 @@ export class TransactionsViewService {
       to: args.to,
       value: args.value,
       transaction: null,
+      dataDecoded,
     });
     return new NativeStakingWithdrawConfirmationView({
       method: dataDecoded.method,


### PR DESCRIPTION
## Summary
This PR adds a new `rewards` field to the `Validators Exit` and the `Withdraw` transaction mappings and their Confirmation Views. This new field calculates the amount of claimable ETH (in wei) via the public keys present in the parameters of the transaction data.

This amount comes from the Staking API `/stakes` endpoint, which requires an array of comma-separated validators' public keys as an argument.

**NOTE:** It was assumed previously that the public keys were stored as an `array` in the transaction data, but the staking provider concatenates all the validator public keys into a `string` and sends it as in the first element of the parameters array. This PR fixes that assumption.

## Changes
- Adds a `rewards` field to the related entities.
- Creates a new `KilnDecoder.KilnPublicKeyLength` constant, to split the string of concatenated public keys.
- Adjusts the related tests.
