### PR TITLE
Confirm Kiln API enum values

### DIFF
--- a/src/datasources/staking-api/entities/defi-vault-stats.entity.ts
+++ b/src/datasources/staking-api/entities/defi-vault-stats.entity.ts
@@ -2,7 +2,6 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
-// TODO: Confirm all potential values
 export const DefiVaultStatsProtocols = [
   'aave_v3',
   'compound_v3',

--- a/src/datasources/staking-api/entities/deployment.entity.ts
+++ b/src/datasources/staking-api/entities/deployment.entity.ts
@@ -4,11 +4,9 @@ import { z } from 'zod';
 
 export const DeploymentProductTypes = ['defi', 'pooling', 'dedicated'] as const;
 
-// TODO: Confirm all potential values
 export const DeploymentChains = ['eth', 'arb', 'bsc', 'matic', 'op'] as const;
 
-// TODO: Confirm all potential values
-export const DeploymentStatuses = ['active'] as const;
+export const DeploymentStatuses = ['active', 'pending', 'disabled'] as const;
 
 export const DeploymentSchema = z.object({
   id: z.string().uuid(),
@@ -20,7 +18,6 @@ export const DeploymentSchema = z.object({
   chain: z.enum([...DeploymentChains, 'unknown']).catch('unknown'),
   chain_id: z.number(),
   address: AddressSchema,
-  // TODO: Confirm all potential values
   status: z.enum([...DeploymentStatuses, 'unknown']).catch('unknown'),
   product_fee: NumericStringSchema.nullish().default(null),
 });


### PR DESCRIPTION
## Summary

Certain enum values of the Kiln API were unconfirmed for the deployments and DeFi network stats:

- Deployments
  - `chains`
  - `status`
- DeFi stats
  - `chains`
  - `protocols`

Aside from deployment `status`, all other enum values were correct.

Note: the `protocols` of DeFi stats are subject to change but the current values are sufficient for our expected deployments.

## Changes

- Add `'pending'` and `'disabled'` to deployment `status` values
- Remove unnecessary comments