### PR TITLE
Add missing Swagger definitions for Native Staking Transactions

### DIFF
--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -16,6 +16,9 @@ import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer
 import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
 import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
 import { TwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/twap-order-info.entity';
+import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
+import { NativeStakingValidatorsExitTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-validators-exit-info.entity';
+import { NativeStakingWithdrawTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-withdraw-info.entity';
 
 @ApiExtraModels(
   CreationTransactionInfo,
@@ -27,6 +30,9 @@ import { TwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/t
   SwapOrderTransactionInfo,
   SwapTransferTransactionInfo,
   TwapOrderTransactionInfo,
+  NativeStakingDepositTransactionInfo,
+  NativeStakingValidatorsExitTransactionInfo,
+  NativeStakingWithdrawTransactionInfo,
 )
 export class Transaction {
   @ApiProperty()
@@ -46,6 +52,9 @@ export class Transaction {
       { $ref: getSchemaPath(SwapTransferTransactionInfo) },
       { $ref: getSchemaPath(TwapOrderTransactionInfo) },
       { $ref: getSchemaPath(TransferTransactionInfo) },
+      { $ref: getSchemaPath(NativeStakingDepositTransactionInfo) },
+      { $ref: getSchemaPath(NativeStakingValidatorsExitTransactionInfo) },
+      { $ref: getSchemaPath(NativeStakingWithdrawTransactionInfo) },
     ],
   })
   txInfo: TransactionInfo;

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
 import { NativeStakingDepositConfirmationView } from '@/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity';
 import { NativeStakingValidatorsExitConfirmationView } from '@/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity';
+import { NativeStakingWithdrawConfirmationView } from '@/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity';
 import { KilnNativeStakingHelperModule } from '@/routes/transactions/helpers/kiln-native-staking.helper';
 import { SwapAppsHelperModule } from '@/routes/transactions/helpers/swap-apps.helper';
 import { SwapOrderHelperModule } from '@/routes/transactions/helpers/swap-order.helper';
@@ -55,6 +56,7 @@ export class TransactionsViewController {
         { $ref: getSchemaPath(CowSwapConfirmationView) },
         { $ref: getSchemaPath(NativeStakingDepositConfirmationView) },
         { $ref: getSchemaPath(NativeStakingValidatorsExitConfirmationView) },
+        { $ref: getSchemaPath(NativeStakingWithdrawConfirmationView) },
       ],
     },
   })
@@ -63,6 +65,7 @@ export class TransactionsViewController {
     CowSwapConfirmationView,
     NativeStakingDepositConfirmationView,
     NativeStakingValidatorsExitConfirmationView,
+    NativeStakingWithdrawConfirmationView,
   )
   @ApiOperation({
     summary: 'Confirm Transaction View',


### PR DESCRIPTION
## Changes
- Adds missing OpenAPI definitions for native staking related `Transaction` types on the Transaction Queue, History, and Confirmation Views.
