### PR TITLE
Split `_publicKeys` into `0x`-prefixed keys

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -598,12 +598,14 @@ export class CacheRouter {
    * cache key short and deterministic. Redis and other cache systems
    * may experience performance degradation with long keys.
    *
-   * @param validatorsPublicKeys - Concatenated validators public keys
+   * @param validatorsPublicKeys - Array of validators public keys
    * @returns {@link CacheDir} - Cache directory
    */
-  static getStakingStakesCacheDir(validatorsPublicKeys: string): CacheDir {
+  static getStakingStakesCacheDir(
+    validatorsPublicKeys: Array<`0x${string}`>,
+  ): CacheDir {
     const hash = crypto.createHash('sha256');
-    hash.update(validatorsPublicKeys);
+    hash.update(validatorsPublicKeys.join('_'));
     return new CacheDir(`${this.STAKING_STAKES_KEY}_${hash.digest('hex')}`, '');
   }
 }

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -449,11 +449,9 @@ describe('KilnApi', () => {
       const validatorsPublicKeys = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
         () =>
-          faker.string
-            .hexadecimal({
-              length: KilnDecoder.KilnPublicKeyLength,
-            })
-            .slice(2),
+          faker.string.hexadecimal({
+            length: KilnDecoder.KilnPublicKeyLength,
+          }) as `0x${string}`,
       );
       const concatenatedValidatorsPublicKeys = validatorsPublicKeys.join(',');
       const stakes = Array.from({ length: validatorsPublicKeys.length }, () =>
@@ -466,15 +464,13 @@ describe('KilnApi', () => {
         data: stakes,
       });
 
-      const actual = await target.getStakes(concatenatedValidatorsPublicKeys);
+      const actual = await target.getStakes(validatorsPublicKeys);
 
       expect(actual).toBe(stakes);
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: CacheRouter.getStakingStakesCacheDir(
-          concatenatedValidatorsPublicKeys,
-        ),
+        cacheDir: CacheRouter.getStakingStakesCacheDir(validatorsPublicKeys),
         url: getStakesUrl,
         networkRequest: {
           headers: {
@@ -493,11 +489,9 @@ describe('KilnApi', () => {
       const validatorsPublicKeys = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
         () =>
-          faker.string
-            .hexadecimal({
-              length: KilnDecoder.KilnPublicKeyLength,
-            })
-            .slice(2),
+          faker.string.hexadecimal({
+            length: KilnDecoder.KilnPublicKeyLength,
+          }) as `0x${string}`,
       );
       const concatenatedValidatorsPublicKeys = validatorsPublicKeys.join(',');
       const getStakesUrl = `${baseUrl}/v1/eth/stakes`;
@@ -515,15 +509,13 @@ describe('KilnApi', () => {
           new Error(errorMessage),
         ),
       );
-      await expect(
-        target.getStakes(concatenatedValidatorsPublicKeys),
-      ).rejects.toThrow(expected);
+      await expect(target.getStakes(validatorsPublicKeys)).rejects.toThrow(
+        expected,
+      );
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: CacheRouter.getStakingStakesCacheDir(
-          concatenatedValidatorsPublicKeys,
-        ),
+        cacheDir: CacheRouter.getStakingStakesCacheDir(validatorsPublicKeys),
         url: getStakesUrl,
         networkRequest: {
           headers: {

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -170,7 +170,9 @@ export class KilnApi implements IStakingApi {
     }
   }
 
-  async getStakes(validatorsPublicKeys: string): Promise<Stake[]> {
+  async getStakes(
+    validatorsPublicKeys: Array<`0x${string}`>,
+  ): Promise<Stake[]> {
     try {
       const url = `${this.baseUrl}/v1/eth/stakes`;
       const cacheDir =
@@ -186,7 +188,7 @@ export class KilnApi implements IStakingApi {
             Authorization: `Bearer ${this.apiKey}`,
           },
           params: {
-            validators: validatorsPublicKeys,
+            validators: validatorsPublicKeys.join(','),
           },
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,

--- a/src/domain/interfaces/staking-api.interface.ts
+++ b/src/domain/interfaces/staking-api.interface.ts
@@ -21,5 +21,5 @@ export interface IStakingApi {
     vault: `0x${string}`;
   }): Promise<Array<DefiVaultStats>>;
 
-  getStakes(validatorsPublicKeys: string): Promise<Stake[]>;
+  getStakes(validatorsPublicKeys: Array<`0x${string}`>): Promise<Stake[]>;
 }

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -29,7 +29,7 @@ export interface IStakingRepository {
 
   getStakes(args: {
     chainId: string;
-    validatorsPublicKeys: string;
+    validatorsPublicKeys: Array<`0x${string}`>;
   }): Promise<Stake[]>;
 
   clearApi(chainId: string): void;

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -93,7 +93,7 @@ export class StakingRepository implements IStakingRepository {
 
   public async getStakes(args: {
     chainId: string;
-    validatorsPublicKeys: string;
+    validatorsPublicKeys: Array<`0x${string}`>;
   }): Promise<Stake[]> {
     const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
     const stakes = await stakingApi.getStakes(args.validatorsPublicKeys);

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -768,7 +768,10 @@ describe('NativeStakingMapper', () => {
 
       expect(mockStakingRepository.getStakes).toHaveBeenCalledWith({
         chainId: chain.chainId,
-        validatorsPublicKeys: `${validatorPublicKey.slice(2, KilnDecoder.KilnPublicKeyLength + 2)},${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+        validatorsPublicKeys: [
+          `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)}`,
+          `0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+        ],
       });
     });
 

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -320,8 +320,6 @@ export class NativeStakingMapper {
     );
   }
 
-  // TODO: move the following private functions to KilnApi/StakingRepository.
-
   /**
    * Gets the rewards to withdraw from the native staking deployment
    * based on the length of the publicKeys field in the transaction data.
@@ -343,7 +341,7 @@ export class NativeStakingMapper {
     }
     const stakes = await this.stakingRepository.getStakes({
       chainId: chain.chainId,
-      validatorsPublicKeys: this.splitPublicKeys(publicKeys).join(','),
+      validatorsPublicKeys: this.splitPublicKeys(publicKeys),
     });
     return stakes.reduce((acc, stake) => acc + Number(stake.rewards), 0);
   }
@@ -374,21 +372,22 @@ export class NativeStakingMapper {
    * Splits the public keys into an array of public keys.
    *
    * Each {@link KilnDecoder.KilnPublicKeyLength} characters represent a validator to withdraw, so the public keys
-   * are split into an array of strings of length {@link KilnDecoder.KilnPublicKeyLength}. The initial `0x` is removed.
+   * are split into an array of strings of length {@link KilnDecoder.KilnPublicKeyLength}.
    *
    * @param publicKeys - the public keys to split
    * @returns
    */
-  private splitPublicKeys(publicKeys: `0x${string}`): string[] {
+  private splitPublicKeys(publicKeys: `0x${string}`): `0x${string}`[] {
+    // Remove initial `0x` of decoded `_publicKeys`
     const publicKeysString = publicKeys.slice(2);
-    const publicKeysArray = [];
+    const publicKeysArray: `0x${string}`[] = [];
     for (
       let i = 0;
       i < publicKeysString.length;
       i += KilnDecoder.KilnPublicKeyLength
     ) {
       publicKeysArray.push(
-        `${publicKeysString.slice(i, i + KilnDecoder.KilnPublicKeyLength)}`,
+        `0x${publicKeysString.slice(i, i + KilnDecoder.KilnPublicKeyLength)}`,
       );
     }
     return publicKeysArray;

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -1308,7 +1308,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
-                validators: `${validatorPublicKey.slice(2, KilnDecoder.KilnPublicKeyLength + 2)},${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+                validators: `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)},0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
               },
             }),
           });
@@ -1407,7 +1407,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
-                validators: `${validatorPublicKey.toLowerCase().slice(2)}`,
+                validators: `${validatorPublicKey.toLowerCase()}`,
               },
             }),
           });
@@ -1766,7 +1766,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
-                validators: `${validatorPublicKey.slice(2, KilnDecoder.KilnPublicKeyLength + 2)},${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+                validators: `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)},0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
               },
             }),
           });


### PR DESCRIPTION
## Summary

Decoded `_publicKeys` are a singular hex string, consisting of concatenated public keys. Currently, we split them into strings without a `0x` prefix.

This adjusts the logic to split the keys into `0x`-prefixed strings, moving Kiln-specific logic (concatenating strings) to the relative datasource.

## Changes

- Concatenate public keys:
  - Within cache key
  - Within reward fetching from Kiln
- Update tests accordingly