### PR TITLE
Add chain-based event filtering

### DIFF
--- a/src/domain/chains/chains.repository.interface.ts
+++ b/src/domain/chains/chains.repository.interface.ts
@@ -43,6 +43,13 @@ export interface IChainsRepository {
    * @param chainId
    */
   getIndexingStatus(chainId: string): Promise<IndexingStatus>;
+
+  /**
+   * Checks if the {@link Chain} associated with {@link chainId} is supported.
+   *
+   * @param chainId
+   */
+  isSupportedChain(chainId: string): Promise<boolean>;
 }
 
 @Module({

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -58,4 +58,10 @@ export class ChainsRepository implements IChainsRepository {
     const indexingStatus = await transactionApi.getIndexingStatus();
     return IndexingStatusSchema.parse(indexingStatus);
   }
+
+  async isSupportedChain(chainId: string): Promise<boolean> {
+    return this.getChain(chainId)
+      .then(() => true)
+      .catch(() => false);
+  }
 }

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -1,0 +1,3 @@
+describe('Hooks Repository (Unit)', () => {
+  it.todo('should filter out events that contain an unsupported chainId');
+});

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -67,6 +67,7 @@ const mockTransactionsRepository = jest.mocked({
 const mockLoggingService = jest.mocked({
   error: jest.fn(),
   info: jest.fn(),
+  warn: jest.fn(),
 } as jest.MockedObjectDeep<ILoggingService>);
 
 const mockQueuesRepository = jest.mocked({

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -83,22 +83,25 @@ const mockEventNotificationsHelper = jest.mocked({
 } as jest.MockedObjectDeep<EventNotificationsHelper>);
 
 describe('HooksRepository (Unit)', () => {
-  const hooksRepository = new HooksRepository(
-    mockBalancesRepository,
-    mockBlockchainRepository,
-    mockChainsRepository,
-    mockCollectiblesRepository,
-    mockMessagesRepository,
-    mockSafeAppsRepository,
-    mockSafeRepository,
-    mockStakingRepository,
-    mockTransactionsRepository,
-    mockLoggingService,
-    mockQueuesRepository,
-    mockConfigurationService,
-  );
+  let hooksRepository: HooksRepository;
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    hooksRepository = new HooksRepository(
+      mockBalancesRepository,
+      mockBlockchainRepository,
+      mockChainsRepository,
+      mockCollectiblesRepository,
+      mockMessagesRepository,
+      mockSafeAppsRepository,
+      mockSafeRepository,
+      mockStakingRepository,
+      mockTransactionsRepository,
+      mockLoggingService,
+      mockQueuesRepository,
+      mockConfigurationService,
+    );
+    jest.clearAllMocks();
+  });
 
   it('should process events for known chains and memoize the chain lookup', async () => {
     const chain = chainBuilder().build();
@@ -135,28 +138,31 @@ describe('HooksRepository (Unit)', () => {
     mockChainsRepository.getChain.mockResolvedValue(chain);
     mockChainsRepository.clearChain.mockResolvedValue();
 
+    await hooksRepository.onEvent(event);
+    await hooksRepository.onEvent(event);
+    await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(
       chainUpdateEventBuilder().with('chainId', chain.chainId).build(),
     );
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
 
-    // 2 calls to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
+    // 3 calls to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(3);
 
-    // 2 calls to repositories
-    expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(2);
+    // 5 calls to repositories
+    expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(5);
     expect(mockCollectiblesRepository.clearCollectibles).toHaveBeenCalledTimes(
-      2,
+      5,
     );
     expect(
       mockSafeRepository.clearAllExecutedTransactions,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(5);
     expect(mockSafeRepository.clearMultisigTransactions).toHaveBeenCalledTimes(
-      2,
+      5,
     );
-    expect(mockSafeRepository.clearTransfers).toHaveBeenCalledTimes(2);
-    expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(2);
+    expect(mockSafeRepository.clearTransfers).toHaveBeenCalledTimes(5);
+    expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(5);
   });
 
   it('should not process events for unknown chains', async () => {
@@ -183,23 +189,26 @@ describe('HooksRepository (Unit)', () => {
 });
 
 describe('HooksRepositoryWithNotifications (Unit)', () => {
-  const hooksRepositoryWithNotifications = new HooksRepositoryWithNotifications(
-    mockBalancesRepository,
-    mockBlockchainRepository,
-    mockChainsRepository,
-    mockCollectiblesRepository,
-    mockMessagesRepository,
-    mockSafeAppsRepository,
-    mockSafeRepository,
-    mockStakingRepository,
-    mockTransactionsRepository,
-    mockLoggingService,
-    mockQueuesRepository,
-    mockConfigurationService,
-    mockEventNotificationsHelper,
-  );
+  let hooksRepositoryWithNotifications: HooksRepositoryWithNotifications;
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    hooksRepositoryWithNotifications = new HooksRepositoryWithNotifications(
+      mockBalancesRepository,
+      mockBlockchainRepository,
+      mockChainsRepository,
+      mockCollectiblesRepository,
+      mockMessagesRepository,
+      mockSafeAppsRepository,
+      mockSafeRepository,
+      mockStakingRepository,
+      mockTransactionsRepository,
+      mockLoggingService,
+      mockQueuesRepository,
+      mockConfigurationService,
+      mockEventNotificationsHelper,
+    );
+    jest.clearAllMocks();
+  });
 
   it('should process events for known chains and memoize the chain lookup', async () => {
     const chain = chainBuilder().build();
@@ -236,28 +245,31 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
     mockChainsRepository.getChain.mockResolvedValue(chain);
     mockChainsRepository.clearChain.mockResolvedValue();
 
+    await hooksRepositoryWithNotifications.onEvent(event);
+    await hooksRepositoryWithNotifications.onEvent(event);
+    await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(
       chainUpdateEventBuilder().with('chainId', chain.chainId).build(),
     );
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
 
-    // 2 calls to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
+    // 3 calls to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(3);
 
-    // 2 calls to repositories
-    expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(2);
+    // 5 calls to repositories
+    expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(5);
     expect(mockCollectiblesRepository.clearCollectibles).toHaveBeenCalledTimes(
-      2,
+      5,
     );
     expect(
       mockSafeRepository.clearAllExecutedTransactions,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(5);
     expect(mockSafeRepository.clearMultisigTransactions).toHaveBeenCalledTimes(
-      2,
+      5,
     );
-    expect(mockSafeRepository.clearTransfers).toHaveBeenCalledTimes(2);
-    expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(2);
+    expect(mockSafeRepository.clearTransfers).toHaveBeenCalledTimes(5);
+    expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(5);
   });
 
   it('should not process events for unknown chains', async () => {

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -18,7 +18,6 @@ import { TransactionsRepository } from '@/domain/transactions/transactions.repos
 import { ILoggingService } from '@/logging/logging.interface';
 import { chainUpdateEventBuilder } from '@/routes/hooks/entities/__tests__/chain-update.builder';
 import { incomingTokenEventBuilder } from '@/routes/hooks/entities/__tests__/incoming-token.builder';
-import { NotFoundException } from '@nestjs/common';
 
 const mockBalancesRepository = jest.mocked({
   clearApi: jest.fn(),
@@ -32,6 +31,7 @@ const mockBlockchainRepository = jest.mocked({
 const mockChainsRepository = jest.mocked({
   getChain: jest.fn(),
   clearChain: jest.fn(),
+  isSupportedChain: jest.fn(),
 } as jest.MockedObjectDeep<ChainsRepository>);
 
 const mockCollectiblesRepository = jest.mocked({
@@ -108,16 +108,18 @@ describe('HooksRepository (Unit)', () => {
     const event = incomingTokenEventBuilder()
       .with('chainId', chain.chainId)
       .build();
-    mockChainsRepository.getChain.mockResolvedValue(chain);
+    mockChainsRepository.isSupportedChain.mockResolvedValue(true);
 
     // same event 3 times
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
 
-    // only one call to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(1);
-    expect(mockChainsRepository.getChain).toHaveBeenCalledWith(event.chainId);
+    // only one call to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(1);
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledWith(
+      event.chainId,
+    );
 
     // 3 calls to repositories
     expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(3);
@@ -139,7 +141,7 @@ describe('HooksRepository (Unit)', () => {
     const event = incomingTokenEventBuilder()
       .with('chainId', chain.chainId)
       .build();
-    mockChainsRepository.getChain.mockResolvedValue(chain);
+    mockChainsRepository.isSupportedChain.mockResolvedValue(true);
     mockChainsRepository.clearChain.mockResolvedValue();
 
     await hooksRepository.onEvent(event);
@@ -151,8 +153,8 @@ describe('HooksRepository (Unit)', () => {
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
 
-    // 2 calls to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
+    // 2 calls to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(2);
 
     // 5 calls to repositories
     expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(5);
@@ -174,14 +176,14 @@ describe('HooksRepository (Unit)', () => {
     const event = incomingTokenEventBuilder()
       .with('chainId', chain.chainId)
       .build();
-    mockChainsRepository.getChain.mockRejectedValue(new NotFoundException());
+    mockChainsRepository.isSupportedChain.mockResolvedValue(false);
 
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
 
-    // only one call to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(1);
+    // only one call to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(1);
 
     // event not processed, no calls to repositories
     expect(mockBalancesRepository.clearBalances).not.toHaveBeenCalled();
@@ -222,16 +224,18 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
     const event = incomingTokenEventBuilder()
       .with('chainId', chain.chainId)
       .build();
-    mockChainsRepository.getChain.mockResolvedValue(chain);
+    mockChainsRepository.isSupportedChain.mockResolvedValue(true);
 
     // same event 3 times
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
 
-    // only one call to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(1);
-    expect(mockChainsRepository.getChain).toHaveBeenCalledWith(event.chainId);
+    // only one call to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(1);
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledWith(
+      event.chainId,
+    );
 
     // 3 calls to repositories
     expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(3);
@@ -253,7 +257,7 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
     const event = incomingTokenEventBuilder()
       .with('chainId', chain.chainId)
       .build();
-    mockChainsRepository.getChain.mockResolvedValue(chain);
+    mockChainsRepository.isSupportedChain.mockResolvedValue(true);
     mockChainsRepository.clearChain.mockResolvedValue();
 
     await hooksRepositoryWithNotifications.onEvent(event);
@@ -265,8 +269,8 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
 
-    // 2 calls to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
+    // 2 calls to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(2);
 
     // 5 calls to repositories
     expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(5);
@@ -288,14 +292,14 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
     const event = incomingTokenEventBuilder()
       .with('chainId', chain.chainId)
       .build();
-    mockChainsRepository.getChain.mockRejectedValue(new NotFoundException());
+    mockChainsRepository.isSupportedChain.mockResolvedValue(false);
 
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
 
-    // only one call to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(1);
+    // only one call to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(1);
 
     // event not processed, no calls to repositories
     expect(mockBalancesRepository.clearBalances).not.toHaveBeenCalled();

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -1,3 +1,186 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { BalancesRepository } from '@/domain/balances/balances.repository';
+import { BlockchainRepository } from '@/domain/blockchain/blockchain.repository';
+import { ChainsRepository } from '@/domain/chains/chains.repository';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { CollectiblesRepository } from '@/domain/collectibles/collectibles.repository';
+import { HooksRepository } from '@/domain/hooks/hooks.repository';
+import { MessagesRepository } from '@/domain/messages/messages.repository';
+import { QueuesRepository } from '@/domain/queues/queues-repository';
+import { SafeAppsRepository } from '@/domain/safe-apps/safe-apps.repository';
+import { SafeRepository } from '@/domain/safe/safe.repository';
+import { StakingRepository } from '@/domain/staking/staking.repository';
+import { TransactionsRepository } from '@/domain/transactions/transactions.repository';
+import { ILoggingService } from '@/logging/logging.interface';
+import { chainUpdateEventBuilder } from '@/routes/hooks/entities/__tests__/chain-update.builder';
+import { incomingTokenEventBuilder } from '@/routes/hooks/entities/__tests__/incoming-token.builder';
+import { faker } from '@faker-js/faker';
+import { NotFoundException } from '@nestjs/common';
+
+const mockBalancesRepository = jest.mocked({
+  clearApi: jest.fn(),
+  clearBalances: jest.fn(),
+} as jest.MockedObjectDeep<BalancesRepository>);
+
+const mockBlockchainRepository = jest.mocked({
+  clearApi: jest.fn(),
+} as jest.MockedObjectDeep<BlockchainRepository>);
+
+const mockChainsRepository = jest.mocked({
+  getChain: jest.fn(),
+  clearChain: jest.fn(),
+} as jest.MockedObjectDeep<ChainsRepository>);
+
+const mockCollectiblesRepository = jest.mocked({
+  clearCollectibles: jest.fn(),
+} as jest.MockedObjectDeep<CollectiblesRepository>);
+
+const mockMessagesRepository = jest.mocked({
+  clearMessages: jest.fn(),
+} as unknown as jest.MockedObjectDeep<MessagesRepository>);
+
+const mockSafeAppsRepository = jest.mocked({
+  clearSafeApps: jest.fn(),
+} as jest.MockedObjectDeep<SafeAppsRepository>);
+
+const mockSafeRepository = jest.mocked({
+  clearTransfers: jest.fn(),
+  clearMultisigTransaction: jest.fn(),
+  clearAllExecutedTransactions: jest.fn(),
+  clearMultisigTransactions: jest.fn(),
+  clearModuleTransactions: jest.fn(),
+  clearIncomingTransfers: jest.fn(),
+  clearSafe: jest.fn(),
+} as jest.MockedObjectDeep<SafeRepository>);
+
+const mockStakingRepository = jest.mocked({
+  clearApi: jest.fn(),
+} as jest.MockedObjectDeep<StakingRepository>);
+
+const mockTransactionsRepository = jest.mocked({
+  clearApi: jest.fn(),
+} as jest.MockedObjectDeep<TransactionsRepository>);
+
+const mockLoggingService = jest.mocked({
+  error: jest.fn(),
+  info: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
+const mockQueuesRepository = jest.mocked({
+  subscribe: jest.fn(),
+} as jest.MockedObjectDeep<QueuesRepository>);
+
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+// const mockEventNotificationsHelper = jest.mocked({
+//   onEventEnqueueNotifications: jest.fn(),
+// } as jest.MockedObjectDeep<EventNotificationsHelper>);
+
+let target: HooksRepository;
+
+beforeAll(() => {
+  target = new HooksRepository(
+    mockBalancesRepository,
+    mockBlockchainRepository,
+    mockChainsRepository,
+    mockCollectiblesRepository,
+    mockMessagesRepository,
+    mockSafeAppsRepository,
+    mockSafeRepository,
+    mockStakingRepository,
+    mockTransactionsRepository,
+    mockLoggingService,
+    mockQueuesRepository,
+    mockConfigurationService,
+  );
+});
+
+beforeEach(() => jest.clearAllMocks());
+
 describe('Hooks Repository (Unit)', () => {
-  it.todo('should filter out events that contain an unsupported chainId');
+  it('should process events for known chains and memoize the chain lookup', async () => {
+    const chain = chainBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', faker.string.numeric({ exclude: chain.chainId }))
+      .build();
+    mockChainsRepository.getChain.mockResolvedValue(chain);
+
+    // same event 3 times
+    await target.onEvent(event);
+    await target.onEvent(event);
+    await target.onEvent(event);
+
+    // only one call to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(1);
+    expect(mockChainsRepository.getChain).toHaveBeenCalledWith(event.chainId);
+
+    // 3 calls to repositories
+    expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(3);
+    expect(mockCollectiblesRepository.clearCollectibles).toHaveBeenCalledTimes(
+      3,
+    );
+    expect(
+      mockSafeRepository.clearAllExecutedTransactions,
+    ).toHaveBeenCalledTimes(3);
+    expect(mockSafeRepository.clearMultisigTransactions).toHaveBeenCalledTimes(
+      3,
+    );
+    expect(mockSafeRepository.clearTransfers).toHaveBeenCalledTimes(3);
+    expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(3);
+  });
+
+  it('should clear the chain lookup cache on a CHAIN_UPDATE event', async () => {
+    const chain = chainBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', faker.string.numeric({ exclude: chain.chainId }))
+      .build();
+    mockChainsRepository.getChain.mockResolvedValue(chain);
+    mockChainsRepository.clearChain.mockResolvedValue();
+
+    await target.onEvent(
+      chainUpdateEventBuilder().with('chainId', chain.chainId).build(),
+    );
+    await target.onEvent(event);
+
+    // 2 calls to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
+
+    // only one call to repositories
+    expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(1);
+    expect(mockCollectiblesRepository.clearCollectibles).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      mockSafeRepository.clearAllExecutedTransactions,
+    ).toHaveBeenCalledTimes(1);
+    expect(mockSafeRepository.clearMultisigTransactions).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mockSafeRepository.clearTransfers).toHaveBeenCalledTimes(1);
+    expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not process events for unknown chains', async () => {
+    const event = incomingTokenEventBuilder().build();
+    mockChainsRepository.getChain.mockRejectedValue(new NotFoundException());
+
+    await target.onEvent(event);
+    await target.onEvent(event);
+    await target.onEvent(event);
+
+    // only one call to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(1);
+
+    // event not processed, no calls to repositories
+    expect(mockBalancesRepository.clearBalances).not.toHaveBeenCalled();
+    expect(mockCollectiblesRepository.clearCollectibles).not.toHaveBeenCalled();
+    expect(
+      mockSafeRepository.clearAllExecutedTransactions,
+    ).not.toHaveBeenCalled();
+    expect(mockSafeRepository.clearMultisigTransactions).not.toHaveBeenCalled();
+    expect(mockSafeRepository.clearTransfers).not.toHaveBeenCalled();
+    expect(mockSafeRepository.clearIncomingTransfers).not.toHaveBeenCalled();
+  });
 });

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -105,7 +105,9 @@ describe('HooksRepository (Unit)', () => {
 
   it('should process events for known chains and memoize the chain lookup', async () => {
     const chain = chainBuilder().build();
-    const event = incomingTokenEventBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
     mockChainsRepository.getChain.mockResolvedValue(chain);
 
     // same event 3 times
@@ -134,7 +136,9 @@ describe('HooksRepository (Unit)', () => {
 
   it('should clear the chain lookup cache on a CHAIN_UPDATE event', async () => {
     const chain = chainBuilder().build();
-    const event = incomingTokenEventBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
     mockChainsRepository.getChain.mockResolvedValue(chain);
     mockChainsRepository.clearChain.mockResolvedValue();
 
@@ -147,8 +151,8 @@ describe('HooksRepository (Unit)', () => {
     await hooksRepository.onEvent(event);
     await hooksRepository.onEvent(event);
 
-    // 3 calls to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(3);
+    // 2 calls to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
 
     // 5 calls to repositories
     expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(5);
@@ -166,7 +170,10 @@ describe('HooksRepository (Unit)', () => {
   });
 
   it('should not process events for unknown chains', async () => {
-    const event = incomingTokenEventBuilder().build();
+    const chain = chainBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
     mockChainsRepository.getChain.mockRejectedValue(new NotFoundException());
 
     await hooksRepository.onEvent(event);
@@ -212,7 +219,9 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
 
   it('should process events for known chains and memoize the chain lookup', async () => {
     const chain = chainBuilder().build();
-    const event = incomingTokenEventBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
     mockChainsRepository.getChain.mockResolvedValue(chain);
 
     // same event 3 times
@@ -241,7 +250,9 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
 
   it('should clear the chain lookup cache on a CHAIN_UPDATE event', async () => {
     const chain = chainBuilder().build();
-    const event = incomingTokenEventBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
     mockChainsRepository.getChain.mockResolvedValue(chain);
     mockChainsRepository.clearChain.mockResolvedValue();
 
@@ -254,8 +265,8 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
     await hooksRepositoryWithNotifications.onEvent(event);
     await hooksRepositoryWithNotifications.onEvent(event);
 
-    // 3 calls to getChain
-    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(3);
+    // 2 calls to getChain
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
 
     // 5 calls to repositories
     expect(mockBalancesRepository.clearBalances).toHaveBeenCalledTimes(5);
@@ -273,7 +284,10 @@ describe('HooksRepositoryWithNotifications (Unit)', () => {
   });
 
   it('should not process events for unknown chains', async () => {
-    const event = incomingTokenEventBuilder().build();
+    const chain = chainBuilder().build();
+    const event = incomingTokenEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
     mockChainsRepository.getChain.mockRejectedValue(new NotFoundException());
 
     await hooksRepositoryWithNotifications.onEvent(event);

--- a/src/domain/hooks/hooks.repository.ts
+++ b/src/domain/hooks/hooks.repository.ts
@@ -58,7 +58,9 @@ export class HooksRepositoryWithNotifications implements IHooksRepository {
     private readonly eventNotificationsHelper: EventNotificationsHelper,
   ) {
     this.queueName = this.configurationService.getOrThrow<string>('amqp.queue');
-    this.isSupportedChainMemo = memoize(this.isSupportedChain);
+    this.isSupportedChainMemo = memoize(
+      this.chainsRepository.isSupportedChain.bind(this.chainsRepository),
+    );
   }
 
   onModuleInit(): Promise<void> {
@@ -87,18 +89,11 @@ export class HooksRepositoryWithNotifications implements IHooksRepository {
       });
     } else {
       this.loggingService.warn({
-        type: 'unsupported_event_chain',
+        type: 'unsupported_chain_event',
         chainId: event.chainId,
         eventType: event.type,
       });
     }
-  }
-
-  private async isSupportedChain(chainId: string): Promise<boolean> {
-    return this.chainsRepository
-      .getChain(chainId)
-      .then(() => true)
-      .catch(() => false);
   }
 
   private async onEventClearCache(event: Event): Promise<void[]> {
@@ -485,7 +480,9 @@ export class HooksRepository implements IHooksRepository {
     private readonly configurationService: IConfigurationService,
   ) {
     this.queueName = this.configurationService.getOrThrow<string>('amqp.queue');
-    this.isSupportedChainMemo = memoize(this.isSupportedChain);
+    this.isSupportedChainMemo = memoize(
+      this.chainsRepository.isSupportedChain.bind(this.chainsRepository),
+    );
   }
 
   onModuleInit(): Promise<void> {
@@ -511,18 +508,11 @@ export class HooksRepository implements IHooksRepository {
       });
     } else {
       this.loggingService.warn({
-        type: 'unsupported_event_chain',
+        type: 'unsupported_chain_event',
         chainId: event.chainId,
         eventType: event.type,
       });
     }
-  }
-
-  private async isSupportedChain(chainId: string): Promise<boolean> {
-    return this.chainsRepository
-      .getChain(chainId)
-      .then(() => true)
-      .catch(() => false);
   }
 
   private async onEventClearCache(event: Event): Promise<void[]> {

--- a/src/domain/hooks/hooks.repository.ts
+++ b/src/domain/hooks/hooks.repository.ts
@@ -74,7 +74,6 @@ export class HooksRepositoryWithNotifications implements IHooksRepository {
 
   async onEvent(event: Event): Promise<unknown> {
     const isSupportedChainId = await this.isSupportedChainId(event.chainId);
-
     if (isSupportedChainId) {
       return Promise.allSettled([
         this.onEventClearCache(event),
@@ -488,9 +487,19 @@ export class HooksRepository implements IHooksRepository {
   }
 
   async onEvent(event: Event): Promise<unknown> {
-    return this.onEventClearCache(event).finally(() => {
-      this.onEventLog(event);
-    });
+    const isSupportedChainId = await this.isSupportedChainId(event.chainId);
+    if (isSupportedChainId) {
+      return this.onEventClearCache(event).finally(() => {
+        this.onEventLog(event);
+      });
+    }
+  }
+
+  private async isSupportedChainId(chainId: string): Promise<boolean> {
+    return this.chainsRepository
+      .getChain(chainId)
+      .then(() => true)
+      .catch(() => false);
   }
 
   private async onEventClearCache(event: Event): Promise<void[]> {

--- a/src/domain/hooks/hooks.repository.ts
+++ b/src/domain/hooks/hooks.repository.ts
@@ -77,7 +77,7 @@ export class HooksRepositoryWithNotifications implements IHooksRepository {
   }
 
   async onEvent(event: Event): Promise<unknown> {
-    const isSupportedChainId = await this.isSupportedChainId(event.chainId);
+    const isSupportedChainId = await this.isSupportedChainIdMemo(event.chainId);
     if (isSupportedChainId) {
       return Promise.allSettled([
         this.onEventClearCache(event),

--- a/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -14,6 +14,7 @@ import { RedisClientType } from 'redis';
 import { getAddress } from 'viem';
 import { Server } from 'net';
 import { TEST_SAFE } from '@/routes/common/__tests__/constants';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 
 describe('Events queue processing e2e tests', () => {
   let app: INestApplication<Server>;
@@ -492,14 +493,14 @@ describe('Events queue processing e2e tests', () => {
       type: 'CHAIN_UPDATE',
     },
   ])('$type clears chain', async (payload) => {
-    const chainId = faker.string.numeric();
-    const cacheDir = new CacheDir(`${chainId}_chain`, '');
+    const chain = chainBuilder().build();
+    const cacheDir = new CacheDir(`${chain.chainId}_chain`, '');
     await redisClient.hSet(
       `${cacheKeyPrefix}-${cacheDir.key}`,
       cacheDir.field,
-      faker.string.alpha(),
+      JSON.stringify(chain),
     );
-    const data = { chainId, ...payload };
+    const data = { chainId: chain.chainId, ...payload };
 
     await channel.sendToQueue(queueName, data);
 

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -1059,7 +1059,7 @@ describe('Post Hook Events for Cache (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({
-              data: chainBuilder().with('chainId', chain.chainId).build(),
+              data: chain,
               status: 200,
             });
           default:

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -792,17 +792,25 @@ describe('Post Hook Events for Cache (Unit)', () => {
       type: 'CHAIN_UPDATE',
     },
   ])('$type clears chain', async (payload) => {
-    const chainId = faker.string.numeric();
-    const cacheDir = new CacheDir(`${chainId}_chain`, '');
+    const chain = chainBuilder().build();
+    const cacheDir = new CacheDir(`${chain.chainId}_chain`, '');
     await fakeCacheService.set(
       cacheDir,
-      faker.string.alpha(),
+      JSON.stringify(chain),
       faker.number.int({ min: 1 }),
     );
     const data = {
-      chainId: chainId,
+      chainId: chain.chainId,
       ...payload,
     };
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain, status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
 
     await request(app.getHttpServer())
       .post(`/hooks/events`)
@@ -818,17 +826,28 @@ describe('Post Hook Events for Cache (Unit)', () => {
       type: 'CHAIN_UPDATE',
     },
   ])('$type clears chains', async (payload) => {
-    const chainId = faker.string.numeric();
+    const chain = chainBuilder().build();
     const cacheDir = new CacheDir(`chains`, '');
     await fakeCacheService.set(
       cacheDir,
-      faker.string.alpha(),
+      JSON.stringify(chain),
       faker.number.int({ min: 1 }),
     );
     const data = {
-      chainId: chainId,
+      chainId: chain.chainId,
       ...payload,
     };
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({
+            data: chainBuilder().with('chainId', chain.chainId).build(),
+            status: 200,
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
 
     await request(app.getHttpServer())
       .post(`/hooks/events`)
@@ -977,17 +996,28 @@ describe('Post Hook Events for Cache (Unit)', () => {
       type: 'SAFE_APPS_UPDATE',
     },
   ])('$type clears safe apps', async (payload) => {
-    const chainId = faker.string.numeric();
-    const cacheDir = new CacheDir(`${chainId}_safe_apps`, '');
+    const chain = chainBuilder().build();
+    const cacheDir = new CacheDir(`${chain.chainId}_safe_apps`, '');
     await fakeCacheService.set(
       cacheDir,
-      faker.string.alpha(),
+      JSON.stringify(chain),
       faker.number.int({ min: 1 }),
     );
     const data = {
-      chainId: chainId,
+      chainId: chain.chainId,
       ...payload,
     };
+    networkService.get.mockImplementation(({ url }) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({
+            data: chainBuilder().with('chainId', chain.chainId).build(),
+            status: 200,
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
 
     await request(app.getHttpServer())
       .post(`/hooks/events`)
@@ -1014,17 +1044,28 @@ describe('Post Hook Events for Cache (Unit)', () => {
         },
       });
       await initApp(testConfiguration);
-      const chainId = faker.string.numeric();
+      const chain = chainBuilder().build();
       const cacheDir = new CacheDir(`chains`, '');
       await fakeCacheService.set(
         cacheDir,
-        faker.string.alpha(),
+        JSON.stringify(chain),
         faker.number.int({ min: 1 }),
       );
       const data = {
-        chainId: chainId,
+        chainId: chain.chainId,
         ...payload,
       };
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({
+              data: chainBuilder().with('chainId', chain.chainId).build(),
+              status: 200,
+            });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
 
       await request(app.getHttpServer())
         .post(`/hooks/events`)
@@ -1052,17 +1093,29 @@ describe('Post Hook Events for Cache (Unit)', () => {
         },
       });
       await initApp(testConfiguration);
-      const chainId = faker.string.numeric();
-      const cacheDir = new CacheDir(`${chainId}_safe_apps`, '');
+      const chain = chainBuilder().build();
+      const cacheDir = new CacheDir(`${chain.chainId}_safe_apps`, '');
       await fakeCacheService.set(
         cacheDir,
-        faker.string.alpha(),
+        JSON.stringify(chain),
         faker.number.int({ min: 1 }),
       );
       const data = {
-        chainId: chainId,
+        chainId: chain.chainId,
         ...payload,
       };
+
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({
+              data: chainBuilder().with('chainId', chain.chainId).build(),
+              status: 200,
+            });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
 
       await request(app.getHttpServer())
         .post(`/hooks/events`)

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -1011,7 +1011,7 @@ describe('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chain.chainId).build(),
+            data: chain,
             status: 200,
           });
         default:

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -1109,7 +1109,7 @@ describe('Post Hook Events for Cache (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({
-              data: chainBuilder().with('chainId', chain.chainId).build(),
+              data: chain,
               status: 200,
             });
           default:

--- a/src/routes/hooks/hooks-notifications.spec.ts
+++ b/src/routes/hooks/hooks-notifications.spec.ts
@@ -154,7 +154,18 @@ describe('Post Hook Events for Notifications (Unit)', () => {
         cloudMessagingToken: faker.string.alphanumeric(),
       }),
     );
+    const chain = chainBuilder().build();
     notificationsDatasource.getSubscribersBySafe.mockResolvedValue(subscribers);
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
+        return Promise.resolve({
+          data: chain,
+          status: 200,
+        });
+      } else {
+        return Promise.reject(`No matching rule for url: ${url}`);
+      }
+    });
 
     await request(app.getHttpServer())
       .post(`/hooks/events`)
@@ -1978,7 +1989,18 @@ describe('Post Hook Events for Notifications (Unit)', () => {
         cloudMessagingToken: faker.string.alphanumeric(),
       }),
     );
+    const chain = chainBuilder().build();
     notificationsDatasource.getSubscribersBySafe.mockResolvedValue(subscribers);
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
+        return Promise.resolve({
+          data: chain,
+          status: 200,
+        });
+      } else {
+        return Promise.reject(`No matching rule for url: ${url}`);
+      }
+    });
 
     pushNotificationsApi.enqueueNotification
       // Specific error regarding unregistered/stale tokens


### PR DESCRIPTION
## Summary
This PR adds a check to the `onEvent` callback of `HooksRepositoryWithNotifications/HooksRepository` to check the `chainId` in the event being processed is related to a known `Chain`. If it isn't, a warning log is emitted, instead of letting the service execute the event handler (and fail).

**Note: Ideally the unsupported events should be grouped to reduce the amount of potential logs. A forthcoming PR will take care of the grouping.**

## Changes
- Adds `isSupportedChain` to `IChainsRepository` (and its memorization wrapper `isSupportedChainMemo`to `HooksRepositoryWithNotifications/HooksRepository`). This function checks the validity of the chain in the event being processed.
- Adds the related tests.
