### PR TITLE
Revert "Remove fallback for Kiln's unverified contracts (#1919)"

### DIFF
--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -1,4 +1,5 @@
 import { DataDecodedRepositoryModule } from '@/domain/data-decoder/data-decoded.repository.interface';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { ComposableCowDecoder } from '@/domain/swaps/contracts/decoders/composable-cow-decoder.helper';
 import { GPv2DecoderModule } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
 import { SwapsRepositoryModule } from '@/domain/swaps/swaps-repository.module';
@@ -97,7 +98,7 @@ export class TransactionsViewController {
     SwapsRepositoryModule,
     TwapOrderHelperModule,
   ],
-  providers: [TransactionsViewService, ComposableCowDecoder],
+  providers: [TransactionsViewService, ComposableCowDecoder, KilnDecoder],
   controllers: [TransactionsViewController],
 })
 export class TransactionsViewControllerModule {}


### PR DESCRIPTION
## Summary

The fallback value for the unverified contracts was previously removed as we were informed that all were verified. However, `0xf448e20F8a69aeb88a7dFB837e6aFaB5E7bCF80e` has yet to be. This resulted in a `404` error being returned on the confirmation endpoint.

This reverts the offending commit.

Note: a follow up PR will look into moving the fallback values to where transactions are "found" to simplify the process and not require usage of the endpoint in question.

## Changes

- Revert commit a85dee8015df526f2e718d69bb384cf985a85a4b.