### PR TITLE
Taking withdrawal time into account when calculating exit status

### DIFF
--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -573,6 +573,7 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder()
         .with('estimated_exit_time_seconds', 2)
+        .with('estimated_withdrawal_time_seconds', 1)
         .build();
       const stakes = [stakeBuilder().build()];
       const validatorPublicKey = faker.string.hexadecimal({
@@ -589,7 +590,11 @@ describe('NativeStakingMapper', () => {
         ])
         .build();
       const executionDate = jest.now();
-      jest.advanceTimersByTime(3_000); // now > execution time + exit period
+      jest.advanceTimersByTime(
+        networkStats.estimated_exit_time_seconds * 1_000 +
+          networkStats.estimated_withdrawal_time_seconds * 1_000 +
+          1_000,
+      ); // now > execution time + exit/withdrawal period
       const transaction = multisigTransactionBuilder()
         .with('confirmationsRequired', 2) // 2 confirmations required
         .with('confirmations', [

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -293,7 +293,8 @@ export class NativeStakingMapper {
 
     const estimatedCompletionTime =
       transaction.executionDate.getTime() +
-      networkStats.estimated_exit_time_seconds * 1000;
+      networkStats.estimated_exit_time_seconds * 1000 +
+      networkStats.estimated_withdrawal_time_seconds * 1000;
 
     return Date.now() <= estimatedCompletionTime
       ? StakingValidatorsExitStatus.RequestPending

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -267,7 +267,7 @@ export class NativeStakingMapper {
    * - If the transaction is confirmed but the execution date is not available, the status
    * is {@link StakingValidatorsExitStatus.AwaitingExecution}.
    * - If the execution date is available, the status is {@link StakingValidatorsExitStatus.RequestPending} if the
-   * current date is before the estimated exit time, otherwise the status is {@link StakingValidatorsExitStatus.ReadyToWithdraw}.
+   * current date is before the estimated exit + withdrawal time, otherwise the status is {@link StakingValidatorsExitStatus.ReadyToWithdraw}.
    *
    * @param networkStats - the network stats for the chain where the native staking deployment lives.
    * @param transaction - the validators exit transaction.


### PR DESCRIPTION
## Summary

For exit requests, we include a status relative to the estimated exit time. Currently, we state that validators can be withdrawn after only this period. In order to withdraw, however, we need to take into account both the estimated exit and withdrawal times.

This adjusts the relative `status`, taking the extra withdraw period into account before returning the `READY_TO_WITHDRAW` status for validator exit requests.

## Changes

- Add the `estimated_withdrawal_time_seconds` to the `estimatedCompletionTime`
- Update tests accordingly