### PR TITLE
Improve caching of a Safe's `Stakes`

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -605,9 +605,9 @@ export class CacheRouter {
    * cache field short and deterministic. Redis and other cache systems
    * may experience performance degradation with long fields.
    *
-   * @param chainId - Chain ID
-   * @param safeAddress - Safe address
-   * @param validatorsPublicKeys - Array of validators public keys
+   * @param {string} args.chainId - Chain ID
+   * @param {string} args.safeAddress - Safe address
+   * @param {string} args.validatorsPublicKeys - Array of validators public keys
    * @returns {@link CacheDir} - Cache directory
    */
   static getStakingStakesCacheDir(args: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -591,21 +591,35 @@ export class CacheRouter {
     );
   }
 
+  static getStakingStakesCacheKey(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): string {
+    return `${args.chainId}_${CacheRouter.STAKING_STAKES_KEY}_${args.safeAddress}`;
+  }
+
   /**
    * Calculate cache directory for staking stakes.
    *
    * Note: This function hashes the validators' public keys to keep the
-   * cache key short and deterministic. Redis and other cache systems
-   * may experience performance degradation with long keys.
+   * cache field short and deterministic. Redis and other cache systems
+   * may experience performance degradation with long fields.
    *
+   * @param chainId - Chain ID
+   * @param safeAddress - Safe address
    * @param validatorsPublicKeys - Array of validators public keys
    * @returns {@link CacheDir} - Cache directory
    */
-  static getStakingStakesCacheDir(
-    validatorsPublicKeys: Array<`0x${string}`>,
-  ): CacheDir {
+  static getStakingStakesCacheDir(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+    validatorsPublicKeys: Array<`0x${string}`>;
+  }): CacheDir {
     const hash = crypto.createHash('sha256');
-    hash.update(validatorsPublicKeys.join('_'));
-    return new CacheDir(`${this.STAKING_STAKES_KEY}_${hash.digest('hex')}`, '');
+    hash.update(args.validatorsPublicKeys.join('_'));
+    return new CacheDir(
+      CacheRouter.getStakingStakesCacheKey(args),
+      hash.digest('hex'),
+    );
   }
 }

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -591,6 +591,13 @@ export class CacheRouter {
     );
   }
 
+  /**
+   * Calculated the chain/Safe-specific cache key of {@link Stake}.
+   *
+   * @param {string} args.chainId - Chain ID
+   * @param {string} args.safeAddress - Safe address
+   * @returns {string} - Cache key
+   */
   static getStakingStakesCacheKey(args: {
     chainId: string;
     safeAddress: `0x${string}`;

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -178,8 +178,8 @@ export class KilnApi implements IStakingApi {
    *
    * The {@param args.safeAddress} is only used for caching purposes.
    *
-   * @param args.safeAddress - Safe address
-   * @param args.validatorsPublicKeys - Validators public keys
+   * @param {string} args.safeAddress - Safe address
+   * @param {string} args.validatorsPublicKeys - Validators public keys
    *
    * @returns {@link Stake} array
    * @see https://docs.api.kiln.fi/reference/getethstakes
@@ -218,6 +218,11 @@ export class KilnApi implements IStakingApi {
     }
   }
 
+  /**
+   * Clears the {@link Stake} cache for the {@param safeAddress}.
+   *
+   * @param {string} safeAddress - Safe address
+   */
   async clearStakes(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getStakingStakesCacheKey({
       chainId: this.chainId,

--- a/src/datasources/staking-api/staking-api.manager.ts
+++ b/src/datasources/staking-api/staking-api.manager.ts
@@ -1,5 +1,9 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
@@ -17,6 +21,8 @@ export class StakingApiManager implements IStakingApiManager {
     private readonly configurationService: IConfigurationService,
     @Inject(IConfigApi) private readonly configApi: IConfigApi,
     private readonly httpErrorFactory: HttpErrorFactory,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
   ) {}
 
   async getApi(chainId: string): Promise<IStakingApi> {
@@ -39,6 +45,8 @@ export class StakingApiManager implements IStakingApiManager {
       this.dataSource,
       this.httpErrorFactory,
       this.configurationService,
+      this.cacheService,
+      chain.chainId,
     );
 
     return Promise.resolve(this.apis[chainId]);

--- a/src/domain/hooks/hooks.repository.ts
+++ b/src/domain/hooks/hooks.repository.ts
@@ -167,6 +167,10 @@ export class HooksRepositoryWithNotifications implements IHooksRepository {
             chainId: event.chainId,
             address: event.address,
           }),
+          this.stakingRepository.clearStakes({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
       // A new confirmation for a pending transaction affects:
@@ -567,6 +571,10 @@ export class HooksRepository implements IHooksRepository {
           this.safeRepository.clearSafe({
             chainId: event.chainId,
             address: event.address,
+          }),
+          this.stakingRepository.clearStakes({
+            chainId: event.chainId,
+            safeAddress: event.address,
           }),
         );
         break;

--- a/src/domain/hooks/hooks.repository.ts
+++ b/src/domain/hooks/hooks.repository.ts
@@ -124,6 +124,10 @@ export class HooksRepositoryWithNotifications implements IHooksRepository {
             chainId: event.chainId,
             safeAddress: event.address,
           }),
+          this.stakingRepository.clearStakes({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
           this.safeRepository.clearModuleTransactions({
             chainId: event.chainId,
             safeAddress: event.address,
@@ -526,6 +530,10 @@ export class HooksRepository implements IHooksRepository {
       case TransactionEventType.MODULE_TRANSACTION:
         promises.push(
           this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.stakingRepository.clearStakes({
             chainId: event.chainId,
             safeAddress: event.address,
           }),

--- a/src/domain/interfaces/staking-api.interface.ts
+++ b/src/domain/interfaces/staking-api.interface.ts
@@ -21,5 +21,10 @@ export interface IStakingApi {
     vault: `0x${string}`;
   }): Promise<Array<DefiVaultStats>>;
 
-  getStakes(validatorsPublicKeys: Array<`0x${string}`>): Promise<Stake[]>;
+  getStakes(args: {
+    safeAddress: `0x${string}`;
+    validatorsPublicKeys: Array<`0x${string}`>;
+  }): Promise<Stake[]>;
+
+  clearStakes(safeAddress: `0x${string}`): Promise<void>;
 }

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -29,8 +29,14 @@ export interface IStakingRepository {
 
   getStakes(args: {
     chainId: string;
+    safeAddress: `0x${string}`;
     validatorsPublicKeys: Array<`0x${string}`>;
   }): Promise<Stake[]>;
+
+  clearStakes(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<void>;
 
   clearApi(chainId: string): void;
 }

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -93,11 +93,20 @@ export class StakingRepository implements IStakingRepository {
 
   public async getStakes(args: {
     chainId: string;
+    safeAddress: `0x${string}`;
     validatorsPublicKeys: Array<`0x${string}`>;
   }): Promise<Stake[]> {
     const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
-    const stakes = await stakingApi.getStakes(args.validatorsPublicKeys);
+    const stakes = await stakingApi.getStakes(args);
     return stakes.map((stake) => StakeSchema.parse(stake));
+  }
+
+  public async clearStakes(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<void> {
+    const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
+    await stakingApi.clearStakes(args.safeAddress);
   }
 
   public clearApi(chainId: string): void {

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -470,6 +470,11 @@ describe('Post Hook Events for Cache (Unit)', () => {
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
+    {
+      type: 'MODULE_TRANSACTION',
+      module: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    },
   ])('$type clears Safe stakes', async (payload) => {
     const safeAddress = faker.finance.ethereumAddress();
     const chainId = faker.string.numeric();

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -406,6 +406,7 @@ describe('NativeStakingMapper', () => {
 
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
+        safeAddress: transaction.safe,
         to: deployment.address,
         transaction,
         dataDecoded,
@@ -472,6 +473,7 @@ describe('NativeStakingMapper', () => {
 
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
+        safeAddress: transaction.safe,
         to: deployment.address,
         transaction,
         dataDecoded,
@@ -539,6 +541,7 @@ describe('NativeStakingMapper', () => {
 
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
+        safeAddress: transaction.safe,
         to: deployment.address,
         transaction,
         dataDecoded,
@@ -606,6 +609,7 @@ describe('NativeStakingMapper', () => {
 
       const actual = await target.mapValidatorsExitInfo({
         chainId: chain.chainId,
+        safeAddress: transaction.safe,
         to: deployment.address,
         transaction,
         dataDecoded,
@@ -650,6 +654,7 @@ describe('NativeStakingMapper', () => {
       await expect(
         target.mapValidatorsExitInfo({
           chainId: chain.chainId,
+          safeAddress: transaction.safe,
           to: deployment.address,
           transaction,
           dataDecoded,
@@ -675,6 +680,7 @@ describe('NativeStakingMapper', () => {
       await expect(
         target.mapValidatorsExitInfo({
           chainId: chain.chainId,
+          safeAddress: transaction.safe,
           to: deployment.address,
           transaction,
           dataDecoded,
@@ -700,6 +706,7 @@ describe('NativeStakingMapper', () => {
       await expect(
         target.mapValidatorsExitInfo({
           chainId: chain.chainId,
+          safeAddress: transaction.safe,
           to: deployment.address,
           transaction,
           dataDecoded,
@@ -745,6 +752,7 @@ describe('NativeStakingMapper', () => {
 
       const actual = await target.mapWithdrawInfo({
         chainId: chain.chainId,
+        safeAddress: transaction.safe,
         to: deployment.address,
         transaction,
         dataDecoded,
@@ -768,6 +776,7 @@ describe('NativeStakingMapper', () => {
 
       expect(mockStakingRepository.getStakes).toHaveBeenCalledWith({
         chainId: chain.chainId,
+        safeAddress: transaction.safe,
         validatorsPublicKeys: [
           `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)}`,
           `0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
@@ -790,6 +799,7 @@ describe('NativeStakingMapper', () => {
       await expect(
         target.mapWithdrawInfo({
           chainId: chain.chainId,
+          safeAddress: transaction.safe,
           to: deployment.address,
           transaction,
           dataDecoded,
@@ -813,6 +823,7 @@ describe('NativeStakingMapper', () => {
       await expect(
         target.mapWithdrawInfo({
           chainId: chain.chainId,
+          safeAddress: transaction.safe,
           to: deployment.address,
           transaction,
           dataDecoded,
@@ -836,6 +847,7 @@ describe('NativeStakingMapper', () => {
       await expect(
         target.mapWithdrawInfo({
           chainId: chain.chainId,
+          safeAddress: transaction.safe,
           to: deployment.address,
           transaction,
           dataDecoded,

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -390,6 +390,7 @@ export class MultisigTransactionInfoMapper {
     try {
       return await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId,
+        safeAddress: transaction.safe,
         to: nativeStakingValidatorsExitTransaction.to,
         transaction,
         dataDecoded,
@@ -430,6 +431,7 @@ export class MultisigTransactionInfoMapper {
     try {
       return await this.nativeStakingMapper.mapWithdrawInfo({
         chainId,
+        safeAddress: transaction.safe,
         to: nativeStakingWithdrawTransaction.to,
         transaction,
         dataDecoded,

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -140,11 +140,13 @@ export class TransactionsViewService {
         return await this.getNativeStakingValidatorsExitConfirmationView({
           ...nativeStakingValidatorsExitTransaction,
           chainId: args.chainId,
+          safeAddress: args.safeAddress,
           dataDecoded,
         });
       } else if (nativeStakingWithdrawTransaction) {
         return await this.getNativeStakingWithdrawConfirmationView({
           ...nativeStakingWithdrawTransaction,
+          safeAddress: args.safeAddress,
           chainId: args.chainId,
           dataDecoded,
         });
@@ -338,6 +340,7 @@ export class TransactionsViewService {
 
   private async getNativeStakingValidatorsExitConfirmationView(args: {
     chainId: string;
+    safeAddress: `0x${string}`;
     to: `0x${string}`;
     data: `0x${string}`;
     dataDecoded: DataDecoded;
@@ -352,6 +355,7 @@ export class TransactionsViewService {
     const validatorsExitInfo =
       await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId: args.chainId,
+        safeAddress: args.safeAddress,
         to: args.to,
         transaction: null,
         dataDecoded,
@@ -365,6 +369,7 @@ export class TransactionsViewService {
 
   private async getNativeStakingWithdrawConfirmationView(args: {
     chainId: string;
+    safeAddress: `0x${string}`;
     to: `0x${string}`;
     data: `0x${string}`;
     dataDecoded: DataDecoded;
@@ -378,6 +383,7 @@ export class TransactionsViewService {
     }
     const withdrawInfo = await this.nativeStakingMapper.mapWithdrawInfo({
       chainId: args.chainId,
+      safeAddress: args.safeAddress,
       to: args.to,
       transaction: null,
       dataDecoded,


### PR DESCRIPTION
## Summary

Resolves #1914.

Currently we indefinitely (with a set TTL) cache the `Stakes` response according to `_publicKeys`. It is never cleared when a Safe executes a transaction, meaning that the status will not update if withdrawn.

This modifies the current caching to ensure entries are chain/Safe specific and clear when the Safe in question executes a transaciton.

## Changes

- Modify `staking_stakes` cache key to include the `chainId` and `safeAddress`, moving the `_publicKeys` hash to the cache field.
- Add method to `IStakingApi` to clear the above cache, propagated to `IStakingRepository`.
- Clear the cache on `EXECUTED_MULTISIG_TRANSACTION` events.
- Add/update tests accordingly.