### PR TITLE
Remove trailing slashes from Transaction Service URLs

### DIFF
--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -550,6 +550,30 @@ describe('Chain schemas', () => {
       },
     );
 
+    it.each(['transactionService' as const, 'vpcTransactionService' as const])(
+      'accept non-trailing slash %s as is',
+      (field) => {
+        const url = faker.internet.url({ appendSlash: false });
+        const chain = chainBuilder().with(field, url).build();
+
+        const result = ChainSchema.safeParse(chain);
+
+        expect(result.success && result.data[field]).toBe(url);
+      },
+    );
+
+    it.each(['transactionService' as const, 'vpcTransactionService' as const])(
+      'should remove trailing slashes from %s',
+      (field) => {
+        const url = faker.internet.url({ appendSlash: false });
+        const chain = chainBuilder().with(field, `${url}/`).build();
+
+        const result = ChainSchema.safeParse(chain);
+
+        expect(result.success && result.data[field]).toBe(url);
+      },
+    );
+
     it.each([
       ['chainId' as const],
       ['chainName' as const],

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -105,8 +105,16 @@ export const ChainSchema = z.object({
   nativeCurrency: NativeCurrencySchema,
   pricesProvider: PricesProviderSchema,
   balancesProvider: BalancesProviderSchema,
-  transactionService: z.string().url(),
-  vpcTransactionService: z.string().url(),
+  transactionService: z
+    .string()
+    .url()
+    // We expect the URL to be without trailing slash
+    .transform((url) => url.replace(/\/$/, '')),
+  vpcTransactionService: z
+    .string()
+    .url()
+    // We expect the URL to be without trailing slash
+    .transform((url) => url.replace(/\/$/, '')),
   theme: ThemeSchema,
   gasPrice: GasPriceSchema,
   ensRegistryAddress: AddressSchema.nullish().default(null),


### PR DESCRIPTION
## Summary

Resolves #1929

It is possible that `Chain['transactionService' | 'vpcTransactionService']` have trailing slashes, which breaks requests to the Transaction Service as we expect none to be present.

This refines the incoming values, removing the trailing slash if present.

## Changes

- Remove trailing slashes from `Chain['transactionService' | 'vpcTransactionService']` if present
- Add appropriate test coverage