### PR TITLE
Use instance chain ID within `IStakingApi`

### DIFF
--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -340,14 +340,21 @@ describe('KilnApi', () => {
 
   describe('getDefiVaultStats', () => {
     it('should return the defi vault stats', async () => {
-      const [chain, chainId] = faker.helpers.arrayElement(
-        Object.entries(KilnApi.DefiVaultStatsChains),
+      const chainIds = {
+        eth: 1,
+        arb: 42161,
+        bsc: 56,
+        matic: 137,
+        op: 10,
+      };
+      const [chain, chain_id] = faker.helpers.arrayElement(
+        Object.entries(chainIds) as Array<[keyof typeof chainIds, number]>,
       );
       // Ensure target is created with supported chain
-      createTarget(chainId);
+      createTarget(chain_id.toString());
       const defiVaultStats = defiVaultStatsBuilder()
-        .with('chain', chain as keyof typeof KilnApi.DefiVaultStatsChains)
-        .with('chain_id', +chainId)
+        .with('chain', chain)
+        .with('chain_id', chain_id)
         .build();
       dataSource.get.mockResolvedValue({
         status: 200,
@@ -396,14 +403,21 @@ describe('KilnApi', () => {
     });
 
     it('should forward errors', async () => {
-      const [chain, chainId] = faker.helpers.arrayElement(
-        Object.entries(KilnApi.DefiVaultStatsChains),
+      const chainIds = {
+        eth: 1,
+        arb: 42161,
+        bsc: 56,
+        matic: 137,
+        op: 10,
+      };
+      const [chain, chain_id] = faker.helpers.arrayElement(
+        Object.entries(chainIds) as Array<[keyof typeof chainIds, number]>,
       );
       // Ensure target is created with supported chain
-      createTarget(chainId);
+      createTarget(chain_id.toString());
       const defiVaultStats = defiVaultStatsBuilder()
-        .with('chain', chain as keyof typeof KilnApi.DefiVaultStatsChains)
-        .with('chain_id', +chainId)
+        .with('chain', chain)
+        .with('chain_id', chain_id)
         .build();
       const getDefiVaultStatsUrl = `${baseUrl}/v1/defi/network-stats`;
       const errorMessage = faker.lorem.sentence();

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -340,27 +340,15 @@ describe('KilnApi', () => {
   });
 
   describe('getDefiVaultStats', () => {
-    const defiVaultsStatsChainIdentifiers: {
-      [key in (typeof DefiVaultStatsChains)[number]]: number;
-    } = {
-      eth: 1,
-      arb: 42161,
-      bsc: 56,
-      matic: 137,
-      op: 10,
-    };
-
     it('should return the defi vault stats', async () => {
-      const [chain, chain_id] = faker.helpers.arrayElement(
-        Object.entries(defiVaultsStatsChainIdentifiers) as Array<
-          [keyof typeof defiVaultsStatsChainIdentifiers, number]
-        >,
+      const [chain, chainId] = faker.helpers.arrayElement(
+        Object.entries(KilnApi.DefiVaultStatsChains),
       );
       // Ensure target is created with supported chain
-      createTarget(chain_id.toString());
+      createTarget(chainId);
       const defiVaultStats = defiVaultStatsBuilder()
-        .with('chain', chain)
-        .with('chain_id', chain_id)
+        .with('chain', chain as keyof typeof KilnApi.DefiVaultStatsChains)
+        .with('chain_id', +chainId)
         .build();
       dataSource.get.mockResolvedValue({
         status: 200,
@@ -409,16 +397,14 @@ describe('KilnApi', () => {
     });
 
     it('should forward errors', async () => {
-      const [chain, chain_id] = faker.helpers.arrayElement(
-        Object.entries(defiVaultsStatsChainIdentifiers) as Array<
-          [keyof typeof defiVaultsStatsChainIdentifiers, number]
-        >,
+      const [chain, chainId] = faker.helpers.arrayElement(
+        Object.entries(KilnApi.DefiVaultStatsChains),
       );
       // Ensure target is created with supported chain
-      createTarget(chain_id.toString());
+      createTarget(chainId);
       const defiVaultStats = defiVaultStatsBuilder()
-        .with('chain', chain)
-        .with('chain_id', chain_id)
+        .with('chain', chain as keyof typeof KilnApi.DefiVaultStatsChains)
+        .with('chain_id', +chainId)
         .build();
       const getDefiVaultStatsUrl = `${baseUrl}/v1/defi/network-stats`;
       const errorMessage = faker.lorem.sentence();

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -11,7 +11,6 @@ import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
 import { pooledStakingStatsBuilder } from '@/datasources/staking-api/entities/__tests__/pooled-staking-stats.entity.builder';
 import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
-import { DefiVaultStatsChains } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -15,6 +15,16 @@ import { Stake } from '@/datasources/staking-api/entities/stake.entity';
 import { IStakingApi } from '@/domain/interfaces/staking-api.interface';
 
 export class KilnApi implements IStakingApi {
+  public static DefiVaultStatsChains: {
+    [key in (typeof DefiVaultStatsChains)[number]]: string;
+  } = {
+    eth: '1',
+    arb: '42161',
+    bsc: '56',
+    matic: '137',
+    op: '10',
+  };
+
   private readonly stakingExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
 
@@ -245,18 +255,11 @@ export class KilnApi implements IStakingApi {
    * @see https://docs.api.kiln.fi/reference/getdefinetworkstats
    */
   private getDefiVaultIdentifier(vault: `0x${string}`): string {
-    const chains: {
-      [key in (typeof DefiVaultStatsChains)[number]]: string;
-    } = {
-      eth: '1',
-      arb: '42161',
-      bsc: '56',
-      matic: '137',
-      op: '10',
-    };
-    const chain = Object.entries(chains).find(([, chainId]) => {
-      return chainId === this.chainId;
-    });
+    const chain = Object.entries(KilnApi.DefiVaultStatsChains).find(
+      ([, chainId]) => {
+        return chainId === this.chainId;
+      },
+    );
 
     if (chain) {
       const chainIdentifier = chain[0];

--- a/src/domain/interfaces/staking-api.interface.ts
+++ b/src/domain/interfaces/staking-api.interface.ts
@@ -16,10 +16,7 @@ export interface IStakingApi {
 
   getPooledStakingStats(pool: `0x${string}`): Promise<PooledStakingStats>;
 
-  getDefiVaultStats(args: {
-    chainId: string;
-    vault: `0x${string}`;
-  }): Promise<Array<DefiVaultStats>>;
+  getDefiVaultStats(vault: `0x${string}`): Promise<Array<DefiVaultStats>>;
 
   getStakes(args: {
     safeAddress: `0x${string}`;

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -84,7 +84,7 @@ export class StakingRepository implements IStakingRepository {
     vault: `0x${string}`;
   }): Promise<DefiVaultStats> {
     const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
-    const defiStats = await stakingApi.getDefiVaultStats(args);
+    const defiStats = await stakingApi.getDefiVaultStats(args.vault);
     // Cannot be >1 contract deployed at the same address so return first element
     return defiStats.map((defiStats) =>
       DefiVaultStatsSchema.parse(defiStats),


### PR DESCRIPTION
## Summary

Instances of `IStakingApi` have are chain-specific and are passed a `chainId`. This value is used in cache keys.

This modifies `KilnApi['getDefiVaultStats']` to use the instance `chainId` instead of using that passed as an argument.

## Changes

- Improve typing of chain identifiers for DeFi vault stat requests
- Fetch stats with `chainId` of instance
- Update tests accordingly