### PR TITLE
Add missing `ApiQuery` decorators for Swagger

### DIFF
--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -6,7 +6,7 @@ import {
   ParseBoolPipe,
   Query,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { BalancesService } from '@/routes/balances/balances.service';
 import { Balances } from '@/routes/balances/entities/balances.entity';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
@@ -21,6 +21,8 @@ export class BalancesController {
   constructor(private readonly balancesService: BalancesService) {}
 
   @ApiOkResponse({ type: Balances })
+  @ApiQuery({ name: 'trusted', required: false, type: Boolean })
+  @ApiQuery({ name: 'exclude_spam', required: false, type: Boolean })
   @Get('chains/:chainId/safes/:safeAddress/balances/:fiatCode')
   async getBalances(
     @Param('chainId') chainId: string,

--- a/src/routes/community/community.controller.ts
+++ b/src/routes/community/community.controller.ts
@@ -46,6 +46,8 @@ export class CommunityController {
   }
 
   @Get('/campaigns/:resourceId/activities')
+  @ApiQuery({ name: 'cursor', required: false, type: String })
+  @ApiQuery({ name: 'holder', required: false, type: String })
   async getCampaignActivities(
     @Param('resourceId') resourceId: string,
     @RouteUrlDecorator() routeUrl: URL,

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -42,7 +42,11 @@ export class SafesController {
     return this.service.getNonces({ chainId, safeAddress });
   }
 
-  @ApiQuery({ name: 'wallet_address', required: false })
+  @ApiQuery({ name: 'wallet_address', required: false, type: String })
+  @ApiQuery({ name: 'currency', required: true, type: String })
+  @ApiQuery({ name: 'safes', required: true, type: String })
+  @ApiQuery({ name: 'trusted', required: false, type: Boolean })
+  @ApiQuery({ name: 'exclude_spam', required: false, type: Boolean })
   @Get('safes')
   async getSafeOverview(
     @Query('currency') currency: string,

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -118,6 +118,7 @@ export class TransactionsController {
   @ApiQuery({ name: 'to', required: false, type: String })
   @ApiQuery({ name: 'module', required: false, type: String })
   @ApiQuery({ name: 'cursor', required: false, type: String })
+  @ApiQuery({ name: 'transaction_hash', required: false, type: String })
   async getModuleTransactions(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
@@ -163,6 +164,7 @@ export class TransactionsController {
   @ApiQuery({ name: 'value', required: false, type: String })
   @ApiQuery({ name: 'token_address', required: false, type: String })
   @ApiQuery({ name: 'cursor', required: false, type: String })
+  @ApiQuery({ name: 'trusted', required: false, type: Boolean })
   async getIncomingTransfers(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
@@ -240,6 +242,8 @@ export class TransactionsController {
   })
   @ApiQuery({ name: 'cursor', required: false, type: String })
   @ApiQuery({ name: 'timezone', required: false, type: String })
+  @ApiQuery({ name: 'trusted', required: false, type: Boolean })
+  @ApiQuery({ name: 'imitation', required: false, type: Boolean })
   async getTransactionsHistory(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,


### PR DESCRIPTION
## Summary

Resolves #1747

Some optional queries are currently marked a required on Swagger. This adds the missing `ApiQuery` decorators for said queries.

## Changes

- Add missing `ApiQuery` decorators where `Query`s are present.