### PR TITLE
Only return net `value`

### DIFF
--- a/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
@@ -13,5 +13,6 @@ export function stakeBuilder(): IBuilder<Stake> {
     )
     .with('state', faker.lorem.words())
     .with('effective_balance', faker.string.numeric())
-    .with('rewards', faker.string.numeric());
+    .with('rewards', faker.string.numeric())
+    .with('net_claimable_consensus_rewards', faker.string.numeric());
 }

--- a/src/datasources/staking-api/entities/__tests__/stake.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/stake.entity.spec.ts
@@ -45,21 +45,22 @@ describe('StakeSchema', () => {
     });
   });
 
-  it.each(['effective_balance' as const, 'rewards' as const])(
-    'should not validate non-numeric string %s values',
-    (key) => {
-      const stake = stakeBuilder().with(key, faker.lorem.word()).build();
+  it.each([
+    'effective_balance' as const,
+    'rewards' as const,
+    'net_claimable_consensus_rewards' as const,
+  ])('should not validate non-numeric string %s values', (key) => {
+    const stake = stakeBuilder().with(key, faker.lorem.word()).build();
 
-      const result = StakeSchema.safeParse(stake);
+    const result = StakeSchema.safeParse(stake);
 
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'custom',
-        message: 'Invalid base-10 numeric string',
-        path: [key],
-      });
-    },
-  );
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'custom',
+      message: 'Invalid base-10 numeric string',
+      path: [key],
+    });
+  });
 
   it('should not validate an invalid Stake object', () => {
     const stake = { invalid: 'Stake' };

--- a/src/datasources/staking-api/entities/stake.entity.ts
+++ b/src/datasources/staking-api/entities/stake.entity.ts
@@ -7,6 +7,8 @@ export const StakeSchema = z.object({
   state: z.string(),
   effective_balance: NumericStringSchema,
   rewards: NumericStringSchema,
+  // Only returned if onchain_v1_include_net_rewards query is true
+  net_claimable_consensus_rewards: NumericStringSchema.nullish().default(null),
 });
 
 export type Stake = z.infer<typeof StakeSchema>;

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -498,6 +498,7 @@ describe('KilnApi', () => {
             Authorization: `Bearer ${apiKey}`,
           },
           params: {
+            onchain_v1_include_net_rewards: true,
             validators: concatenatedValidatorsPublicKeys,
           },
         },
@@ -551,6 +552,7 @@ describe('KilnApi', () => {
             Authorization: `Bearer ${apiKey}`,
           },
           params: {
+            onchain_v1_include_net_rewards: true,
             validators: concatenatedValidatorsPublicKeys,
           },
         },

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -207,6 +207,8 @@ export class KilnApi implements IStakingApi {
           },
           params: {
             validators: args.validatorsPublicKeys.join(','),
+            // Adds net_claimable_consensus_rewards to response
+            onchain_v1_include_net_rewards: true,
           },
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
@@ -42,9 +42,6 @@ export class NativeStakingValidatorsExitConfirmationView
   numValidators: number;
 
   @ApiProperty()
-  rewards: string;
-
-  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -55,7 +52,6 @@ export class NativeStakingValidatorsExitConfirmationView
     estimatedWithdrawalTime: number;
     value: string;
     numValidators: number;
-    rewards: string;
     tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
@@ -65,7 +61,6 @@ export class NativeStakingValidatorsExitConfirmationView
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
     this.value = args.value;
     this.numValidators = args.numValidators;
-    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -26,9 +26,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   numValidators: number;
 
   @ApiProperty()
-  rewards: string;
-
-  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
@@ -37,7 +34,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     estimatedWithdrawalTime: number;
     value: string;
     numValidators: number;
-    rewards: string;
     tokenInfo: TokenInfo;
   }) {
     super(TransactionInfoType.NativeStakingValidatorsExit, null, null);
@@ -46,7 +42,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
     this.value = args.value;
     this.numValidators = args.numValidators;
-    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
@@ -22,22 +22,17 @@ export class NativeStakingWithdrawConfirmationView implements Baseline {
   value: string;
 
   @ApiProperty()
-  rewards: string;
-
-  @ApiProperty()
   tokenInfo: TokenInfo;
 
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
     value: string;
-    rewards: string;
     tokenInfo: TokenInfo;
   }) {
     this.method = args.method;
     this.parameters = args.parameters;
     this.value = args.value;
-    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-info.entity.ts
@@ -13,15 +13,11 @@ export class NativeStakingWithdrawTransactionInfo extends TransactionInfo {
   value: string;
 
   @ApiProperty()
-  rewards: string;
-
-  @ApiProperty()
   tokenInfo: TokenInfo;
 
-  constructor(args: { value: string; rewards: string; tokenInfo: TokenInfo }) {
+  constructor(args: { value: string; tokenInfo: TokenInfo }) {
     super(TransactionInfoType.NativeStakingWithdraw, null, null);
     this.value = args.value;
-    this.rewards = args.rewards;
     this.tokenInfo = args.tokenInfo;
   }
 }

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -419,9 +419,8 @@ describe('NativeStakingMapper', () => {
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds,
-          value: '96000000000000000000', // 3 public keys in the transaction data => 3 validators * 32 eth
+          value: stakes[0].net_claimable_consensus_rewards,
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
-          rewards: stakes[0].rewards,
           tokenInfo: {
             address: NULL_ADDRESS,
             decimals: chain.nativeCurrency.decimals,
@@ -441,8 +440,8 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder().build();
       const stakes = [
-        stakeBuilder().with('rewards', '2').build(),
-        stakeBuilder().with('rewards', '3').build(),
+        stakeBuilder().with('net_claimable_consensus_rewards', '2').build(),
+        stakeBuilder().with('net_claimable_consensus_rewards', '3').build(),
       ];
       const validatorPublicKey = faker.string.hexadecimal({
         length: KilnDecoder.KilnPublicKeyLength * 3,
@@ -486,9 +485,11 @@ describe('NativeStakingMapper', () => {
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds,
-          value: '96000000000000000000', // 3 public keys in the transaction data => 3 validators * 32 eth
+          value: (
+            +stakes[0].net_claimable_consensus_rewards! +
+            +stakes[1].net_claimable_consensus_rewards!
+          ).toString(),
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
-          rewards: '5',
           tokenInfo: {
             address: NULL_ADDRESS,
             decimals: chain.nativeCurrency.decimals,
@@ -554,9 +555,8 @@ describe('NativeStakingMapper', () => {
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds,
-          value: '96000000000000000000', // 3 public keys in the transaction data => 3 validators * 32 eth
+          value: stakes[0].net_claimable_consensus_rewards,
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
-          rewards: stakes[0].rewards,
           tokenInfo: {
             address: NULL_ADDRESS,
             decimals: chain.nativeCurrency.decimals,
@@ -627,9 +627,8 @@ describe('NativeStakingMapper', () => {
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds,
-          value: '64000000000000000000', // 2 public keys in the transaction data => 2 validators * 32 eth
+          value: stakes[0].net_claimable_consensus_rewards!.toString(),
           numValidators: 2, // 2 public keys in the transaction data => 2 validators
-          rewards: stakes[0].rewards,
           tokenInfo: {
             address: NULL_ADDRESS,
             decimals: chain.nativeCurrency.decimals,
@@ -746,9 +745,9 @@ describe('NativeStakingMapper', () => {
         .with('dataDecoded', dataDecoded)
         .build();
       const stakes = [
-        stakeBuilder().with('rewards', '3.25').build(),
-        stakeBuilder().with('rewards', '1.25').build(),
-        stakeBuilder().with('rewards', '1').build(),
+        stakeBuilder().with('net_claimable_consensus_rewards', '3.25').build(),
+        stakeBuilder().with('net_claimable_consensus_rewards', '1.25').build(),
+        stakeBuilder().with('net_claimable_consensus_rewards', '1').build(),
       ];
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
@@ -766,8 +765,11 @@ describe('NativeStakingMapper', () => {
       expect(actual).toEqual(
         expect.objectContaining({
           type: 'NativeStakingWithdraw',
-          value: '64000000000000000000',
-          rewards: '5.5', // stakes rewards sum
+          value: (
+            +stakes[0].net_claimable_consensus_rewards! +
+            +stakes[1].net_claimable_consensus_rewards! +
+            +stakes[2].net_claimable_consensus_rewards!
+          ).toString(),
           tokenInfo: {
             address: NULL_ADDRESS,
             decimals: chain.nativeCurrency.decimals,

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -1240,8 +1240,12 @@ describe('TransactionsViewController tests', () => {
             ])
             .build();
           const stakes = [
-            stakeBuilder().with('rewards', '1000000').build(),
-            stakeBuilder().with('rewards', '2000000').build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '1000000')
+              .build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '2000000')
+              .build(),
           ];
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1290,8 +1294,10 @@ describe('TransactionsViewController tests', () => {
               estimatedExitTime: networkStats.estimated_exit_time_seconds,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds,
-              value: '64000000000000000000',
-              rewards: '3000000',
+              value: (
+                +stakes[0].net_claimable_consensus_rewards! +
+                +stakes[1].net_claimable_consensus_rewards!
+              ).toString(),
               numValidators: 2,
               tokenInfo: {
                 address: NULL_ADDRESS,
@@ -1308,6 +1314,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
+                onchain_v1_include_net_rewards: true,
                 validators: `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)},0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
               },
             }),
@@ -1332,8 +1339,12 @@ describe('TransactionsViewController tests', () => {
             args: [validatorPublicKey as `0x${string}`],
           });
           const stakes = [
-            stakeBuilder().with('rewards', '4000000').build(),
-            stakeBuilder().with('rewards', '2000000').build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '4000000')
+              .build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '2000000')
+              .build(),
           ];
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1389,9 +1400,11 @@ describe('TransactionsViewController tests', () => {
               estimatedExitTime: networkStats.estimated_exit_time_seconds,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds,
-              value: '32000000000000000000',
+              value: (
+                +stakes[0].net_claimable_consensus_rewards! +
+                +stakes[1].net_claimable_consensus_rewards!
+              ).toString(),
               numValidators: 1,
-              rewards: '6000000',
               tokenInfo: {
                 address: NULL_ADDRESS,
                 decimals: chain.nativeCurrency.decimals,
@@ -1407,6 +1420,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
+                onchain_v1_include_net_rewards: true,
                 validators: `${validatorPublicKey.toLowerCase()}`,
               },
             }),
@@ -1766,6 +1780,7 @@ describe('TransactionsViewController tests', () => {
             url: `${stakingApiUrl}/v1/eth/stakes`,
             networkRequest: expect.objectContaining({
               params: {
+                onchain_v1_include_net_rewards: true,
                 validators: `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)},0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
               },
             }),
@@ -1802,8 +1817,12 @@ describe('TransactionsViewController tests', () => {
             ])
             .build();
           const stakes = [
-            stakeBuilder().with('rewards', '1000000').build(),
-            stakeBuilder().with('rewards', '2000000').build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '1000000')
+              .build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '2000000')
+              .build(),
           ];
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1843,8 +1862,10 @@ describe('TransactionsViewController tests', () => {
               type: 'KILN_NATIVE_STAKING_WITHDRAW',
               method: dataDecoded.method,
               parameters: dataDecoded.parameters,
-              value: '96000000000000000000',
-              rewards: '3000000',
+              value: (
+                +stakes[0].net_claimable_consensus_rewards! +
+                +stakes[1].net_claimable_consensus_rewards!
+              ).toString(),
               tokenInfo: {
                 address: NULL_ADDRESS,
                 decimals: chain.nativeCurrency.decimals,
@@ -1873,8 +1894,12 @@ describe('TransactionsViewController tests', () => {
             args: [`${validatorPublicKey}` as `0x${string}`],
           });
           const stakes = [
-            stakeBuilder().with('rewards', '6000000').build(),
-            stakeBuilder().with('rewards', '2000000').build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '6000000')
+              .build(),
+            stakeBuilder()
+              .with('net_claimable_consensus_rewards', '2000000')
+              .build(),
           ];
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1921,8 +1946,10 @@ describe('TransactionsViewController tests', () => {
                   valueDecoded: null,
                 },
               ],
-              value: '64000000000000000000',
-              rewards: '8000000',
+              value: (
+                +stakes[0].net_claimable_consensus_rewards! +
+                +stakes[1].net_claimable_consensus_rewards!
+              ).toString(),
               tokenInfo: {
                 address: NULL_ADDRESS,
                 decimals: chain.nativeCurrency.decimals,


### PR DESCRIPTION
## Summary

Resolves #1938

We currently return an assumed `value` by number of validators, e.g. 1 x validator = 32 ETH. This does not, however, take into account slashing. The value [can be between 31-32 ETH](https://github.com/kilnfi/staking-contracts/blob/84981714f054fd68e61a080ff99c02e3c4303284/src/contracts/ConsensusLayerFeeDispatcher.sol#L74).

The `rewards` we return is also historically accumulative. The user can therefore only claim a partial amount of this.

After discussion with Kiln, we now have access to a new net value that combines to claimable staked ETH and rewards. This is now returned as the `value` of validator exit request/withdrawals and `rewards` removed. They are combined as we don't show one or the other in the UI.

## Changes

- Add `net_claimable_consensus_rewards` to `Stake` schema/entity.
- Add new query to `KilnApi['getStakes']`.
- Remove all instances of `rewards`.
- Return value based on new new `net_claimable_consensus_rewards` value.
- Update tests accordingly.