### PR TITLE
Map `Stake['state']` to relevant staking `status`

### DIFF
--- a/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/stake.entity.builder.ts
@@ -1,5 +1,8 @@
 import { Builder, IBuilder } from '@/__tests__/builder';
-import { Stake } from '@/datasources/staking-api/entities/stake.entity';
+import {
+  Stake,
+  StakeState,
+} from '@/datasources/staking-api/entities/stake.entity';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { faker } from '@faker-js/faker';
 
@@ -11,7 +14,7 @@ export function stakeBuilder(): IBuilder<Stake> {
         length: KilnDecoder.KilnPublicKeyLength,
       }) as `0x${string}`,
     )
-    .with('state', faker.lorem.words())
+    .with('state', faker.helpers.arrayElement(Object.values(StakeState)))
     .with('effective_balance', faker.string.numeric())
     .with('rewards', faker.string.numeric())
     .with('net_claimable_consensus_rewards', faker.string.numeric());

--- a/src/datasources/staking-api/entities/__tests__/stake.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/stake.entity.spec.ts
@@ -1,5 +1,8 @@
 import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
-import { StakeSchema } from '@/datasources/staking-api/entities/stake.entity';
+import {
+  StakeSchema,
+  StakeState,
+} from '@/datasources/staking-api/entities/stake.entity';
 import { faker } from '@faker-js/faker';
 
 describe('StakeSchema', () => {
@@ -11,26 +14,33 @@ describe('StakeSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it.each(['validator_address' as const, 'state' as const])(
-    'should not validate non-string %s values',
-    (key) => {
-      const stake = stakeBuilder().build();
+  it('should fallback to unknown for an invalid state', () => {
+    const stake = stakeBuilder()
+      .with('state', 'invalid_state' as unknown as StakeState)
+      .build();
 
-      // @ts-expect-error - $key is expected to be a string
-      stake[key] = faker.number.int();
+    const result = StakeSchema.safeParse(stake);
 
-      const result = StakeSchema.safeParse(stake);
+    expect(result.success && result.data.state).toBe(StakeState.Unknown);
+  });
 
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'invalid_type',
-        expected: 'string',
-        received: 'number',
-        message: 'Expected string, received number',
-        path: [key],
-      });
-    },
-  );
+  it('should not validate non-string validator_address values', () => {
+    const stake = stakeBuilder().build();
+
+    // @ts-expect-error - validator_address is expected to be a string
+    stake.validator_address = faker.number.int();
+
+    const result = StakeSchema.safeParse(stake);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'invalid_type',
+      expected: 'string',
+      received: 'number',
+      message: 'Expected string, received number',
+      path: ['validator_address'],
+    });
+  });
 
   it('should not validate a `validator_address` with an invalid length', () => {
     const stake = stakeBuilder().with('validator_address', '0x00').build();
@@ -73,13 +83,6 @@ describe('StakeSchema', () => {
         expected: 'string',
         message: 'Required',
         path: ['validator_address'],
-        received: 'undefined',
-      },
-      {
-        code: 'invalid_type',
-        expected: 'string',
-        message: 'Required',
-        path: ['state'],
         received: 'undefined',
       },
       {

--- a/src/datasources/staking-api/entities/stake.entity.ts
+++ b/src/datasources/staking-api/entities/stake.entity.ts
@@ -2,9 +2,25 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
+export enum StakeState {
+  Unknown = 'unknown',
+  Unstaked = 'unstaked',
+  PendingQueued = 'pending_queued',
+  DepositInProgress = 'deposit_in_progress',
+  PendingInitialized = 'pending_initialized',
+  ActiveOngoing = 'active_ongoing',
+  ExitRequested = 'exit_requested',
+  ActiveExiting = 'active_exiting',
+  ExitedUnslashed = 'exited_unslashed',
+  WithdrawalPossible = 'withdrawal_possible',
+  WithdrawalDone = 'withdrawal_done',
+  ActiveSlashed = 'active_slashed',
+  ExitedSlashed = 'exited_slashed',
+}
+
 export const StakeSchema = z.object({
   validator_address: HexSchema.refine((value) => value.length === 98),
-  state: z.string(),
+  state: z.nativeEnum(StakeState).catch(StakeState.Unknown),
   effective_balance: NumericStringSchema,
   rewards: NumericStringSchema,
   // Only returned if onchain_v1_include_net_rewards query is true

--- a/src/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity.ts
@@ -4,7 +4,7 @@ import {
   DecodedType,
 } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
 import { NativeStakingDepositInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
-import { StakingDepositStatus } from '@/routes/transactions/entities/staking/staking.entity';
+import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -17,9 +17,9 @@ export class NativeStakingDepositConfirmationView
   type = DecodedType.KilnNativeStakingDeposit;
 
   @ApiProperty({
-    enum: StakingDepositStatus,
+    enum: StakingStatus,
   })
-  status: StakingDepositStatus;
+  status: StakingStatus;
 
   @ApiProperty()
   method: string;
@@ -69,7 +69,7 @@ export class NativeStakingDepositConfirmationView
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
-    status: StakingDepositStatus;
+    status: StakingStatus;
     estimatedEntryTime: number;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;

--- a/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
@@ -1,6 +1,5 @@
 import {
-  StakingDepositStatus,
-  StakingDepositStatusInfo,
+  StakingStatus,
   StakingTimeInfo,
   StakingFinancialInfo,
 } from '@/routes/transactions/entities/staking/staking.entity';
@@ -11,9 +10,7 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
-export type NativeStakingDepositInfo = StakingDepositStatusInfo &
-  StakingTimeInfo &
-  StakingFinancialInfo;
+export type NativeStakingDepositInfo = StakingTimeInfo & StakingFinancialInfo;
 
 export class NativeStakingDepositTransactionInfo
   extends TransactionInfo
@@ -22,8 +19,8 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty({ enum: [TransactionInfoType.NativeStakingDeposit] })
   override type = TransactionInfoType.NativeStakingDeposit;
 
-  @ApiProperty({ enum: StakingDepositStatus })
-  status: StakingDepositStatus;
+  @ApiProperty({ enum: StakingStatus })
+  status: StakingStatus;
 
   @ApiProperty()
   estimatedEntryTime: number;
@@ -65,7 +62,7 @@ export class NativeStakingDepositTransactionInfo
   tokenInfo: TokenInfo;
 
   constructor(args: {
-    status: StakingDepositStatus;
+    status: StakingStatus;
     estimatedEntryTime: number;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
@@ -3,25 +3,20 @@ import {
   Baseline,
   DecodedType,
 } from '@/routes/transactions/entities/confirmation-view/confirmation-view.entity';
-import {
-  StakingValidatorsExitInfo,
-  StakingValidatorsExitStatus,
-} from '@/routes/transactions/entities/staking/staking.entity';
+import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export class NativeStakingValidatorsExitConfirmationView
-  implements Baseline, StakingValidatorsExitInfo
-{
+export class NativeStakingValidatorsExitConfirmationView implements Baseline {
   @ApiProperty({
     enum: [DecodedType.KilnNativeStakingValidatorsExit],
   })
   type = DecodedType.KilnNativeStakingValidatorsExit;
 
   @ApiProperty({
-    enum: StakingValidatorsExitStatus,
+    enum: StakingStatus,
   })
-  status: StakingValidatorsExitStatus;
+  status: StakingStatus;
 
   @ApiProperty()
   method: string;
@@ -47,7 +42,7 @@ export class NativeStakingValidatorsExitConfirmationView
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
-    status: StakingValidatorsExitStatus;
+    status: StakingStatus;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;
     value: string;

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -1,4 +1,4 @@
-import { StakingValidatorsExitStatus } from '@/routes/transactions/entities/staking/staking.entity';
+import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
@@ -10,8 +10,8 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   @ApiProperty({ enum: [TransactionInfoType.NativeStakingValidatorsExit] })
   override type = TransactionInfoType.NativeStakingValidatorsExit;
 
-  @ApiProperty({ enum: StakingValidatorsExitStatus })
-  status: StakingValidatorsExitStatus;
+  @ApiProperty({ enum: StakingStatus })
+  status: StakingStatus;
 
   @ApiProperty()
   estimatedExitTime: number;
@@ -29,7 +29,7 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   tokenInfo: TokenInfo;
 
   constructor(args: {
-    status: StakingValidatorsExitStatus;
+    status: StakingStatus;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;
     value: string;

--- a/src/routes/transactions/entities/staking/staking.entity.ts
+++ b/src/routes/transactions/entities/staking/staking.entity.ts
@@ -1,25 +1,14 @@
 // Present in all calls for native/pooled/defi staking
-export enum StakingDepositStatus {
-  AwaitingEntry = 'AWAITING_ENTRY',
-  AwaitingExecution = 'AWAITING_EXECUTION',
-  SignatureNeeded = 'SIGNATURE_NEEDED',
-  ValidationStarted = 'VALIDATION_STARTED',
+export enum StakingStatus {
+  NotStaked = 'NOT_STAKED',
+  Activating = 'ACTIVATING',
+  DepositInProgress = 'DEPOSIT_IN_PROGRESS',
+  Active = 'ACTIVE',
+  ExitRequested = 'EXIT_REQUESTED',
+  Exiting = 'EXITING',
+  Exited = 'EXITED',
+  Slashed = 'SLASHED',
 }
-
-export type StakingDepositStatusInfo = {
-  status: StakingDepositStatus;
-};
-
-export enum StakingValidatorsExitStatus {
-  AwaitingExecution = 'AWAITING_EXECUTION',
-  ReadyToWithdraw = 'READY_TO_WITHDRAW',
-  RequestPending = 'REQUEST_PENDING',
-  SignatureNeeded = 'SIGNATURE_NEEDED',
-}
-
-export type StakingValidatorsExitInfo = {
-  status: StakingValidatorsExitStatus;
-};
 
 // Present in all deposit calls for native/pooled staking
 export type StakingTimeInfo = {

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -5,6 +5,7 @@ import {
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
 import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
+import { StakeState } from '@/datasources/staking-api/entities/stake.entity';
 import { ChainsRepository } from '@/domain/chains/chains.repository';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import {
@@ -16,8 +17,10 @@ import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/mul
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { StakingRepository } from '@/domain/staking/staking.repository';
 import { NULL_ADDRESS } from '@/routes/common/constants';
+import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
 import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
 import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
 
 const mockStakingRepository = jest.mocked({
   getDeployment: jest.fn(),
@@ -29,6 +32,24 @@ const mockStakingRepository = jest.mocked({
 const mockChainsRepository = jest.mocked({
   getChain: jest.fn(),
 } as jest.MockedObjectDeep<ChainsRepository>);
+
+// This matches NativeStakingMapper['_getStatus'] but is localized
+// to ensure any later changes accordingly break tests
+const statusMap: { [key in StakeState]: StakingStatus } = {
+  [StakeState.Unknown]: StakingStatus.NotStaked,
+  [StakeState.Unstaked]: StakingStatus.NotStaked,
+  [StakeState.PendingQueued]: StakingStatus.Activating,
+  [StakeState.DepositInProgress]: StakingStatus.DepositInProgress,
+  [StakeState.PendingInitialized]: StakingStatus.DepositInProgress,
+  [StakeState.ActiveOngoing]: StakingStatus.Active,
+  [StakeState.ExitRequested]: StakingStatus.ExitRequested,
+  [StakeState.ActiveExiting]: StakingStatus.Exiting,
+  [StakeState.ExitedUnslashed]: StakingStatus.Exiting,
+  [StakeState.WithdrawalPossible]: StakingStatus.Exiting,
+  [StakeState.WithdrawalDone]: StakingStatus.Exited,
+  [StakeState.ActiveSlashed]: StakingStatus.Slashed,
+  [StakeState.ExitedSlashed]: StakingStatus.Slashed,
+};
 
 describe('NativeStakingMapper', () => {
   let target: NativeStakingMapper;
@@ -47,7 +68,7 @@ describe('NativeStakingMapper', () => {
   });
 
   describe('mapDepositInfo', () => {
-    it('should map a native staking deposit info with SignatureNeeded status', async () => {
+    it('should map a proposed native staking deposit info', async () => {
       const chain = chainBuilder().build();
       const productFee = '0.5';
       const deployment = deploymentBuilder()
@@ -69,6 +90,7 @@ describe('NativeStakingMapper', () => {
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );
+      mockStakingRepository.getStakes.mockResolvedValue([]);
 
       const actual = await target.mapDepositInfo({
         chainId: chain.chainId,
@@ -81,193 +103,7 @@ describe('NativeStakingMapper', () => {
       expect(actual).toEqual(
         expect.objectContaining({
           type: 'NativeStakingDeposit',
-          status: 'SIGNATURE_NEEDED',
-          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
-          estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
-          fee: 0.5,
-          monthlyNrr: 1.5 / 12,
-          annualNrr: 1.5,
-          value: '64000000000000000000',
-          numValidators: 2,
-          expectedAnnualReward: '960000000000000000',
-          expectedMonthlyReward: '80000000000000000',
-          expectedFiatAnnualReward: 9600,
-          expectedFiatMonthlyReward: 800,
-          tokenInfo: {
-            address: NULL_ADDRESS,
-            decimals: chain.nativeCurrency.decimals,
-            logoUri: chain.nativeCurrency.logoUri,
-            name: chain.nativeCurrency.name,
-            symbol: chain.nativeCurrency.symbol,
-            trusted: true,
-          },
-        }),
-      );
-    });
-
-    it('should map a native staking deposit info with AwaitingExecution status', async () => {
-      const chain = chainBuilder().build();
-      const productFee = '0.5';
-      const deployment = deploymentBuilder()
-        .with('product_type', 'dedicated')
-        .with('product_fee', productFee)
-        .build();
-      const networkStats = networkStatsBuilder()
-        .with('eth_price_usd', 10_000)
-        .build();
-      const dedicatedStakingStats = dedicatedStakingStatsBuilder()
-        .with(
-          'gross_apy',
-          dedicatedStakingStatsGrossApyBuilder().with('last_30d', 3).build(),
-        )
-        .build();
-      mockChainsRepository.getChain.mockResolvedValue(chain);
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
-      mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
-        dedicatedStakingStats,
-      );
-
-      const actual = await target.mapDepositInfo({
-        chainId: chain.chainId,
-        to: deployment.address,
-        value: '64000000000000000000',
-        isConfirmed: true, // confirmed
-        depositExecutionDate: null, // not executed
-      });
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          type: 'NativeStakingDeposit',
-          status: 'AWAITING_EXECUTION',
-          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
-          estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
-          fee: 0.5,
-          monthlyNrr: 1.5 / 12,
-          annualNrr: 1.5,
-          value: '64000000000000000000',
-          numValidators: 2,
-          expectedAnnualReward: '960000000000000000',
-          expectedMonthlyReward: '80000000000000000',
-          expectedFiatAnnualReward: 9600,
-          expectedFiatMonthlyReward: 800,
-          tokenInfo: {
-            address: NULL_ADDRESS,
-            decimals: chain.nativeCurrency.decimals,
-            logoUri: chain.nativeCurrency.logoUri,
-            name: chain.nativeCurrency.name,
-            symbol: chain.nativeCurrency.symbol,
-            trusted: true,
-          },
-        }),
-      );
-    });
-
-    it('should map a native staking deposit info with AwaitingEntry status', async () => {
-      const chain = chainBuilder().build();
-      const productFee = '0.5';
-      const deployment = deploymentBuilder()
-        .with('product_type', 'dedicated')
-        .with('product_fee', productFee)
-        .build();
-      const networkStats = networkStatsBuilder()
-        .with('eth_price_usd', 10_000)
-        .with('estimated_entry_time_seconds', 2)
-        .build();
-      const dedicatedStakingStats = dedicatedStakingStatsBuilder()
-        .with(
-          'gross_apy',
-          dedicatedStakingStatsGrossApyBuilder().with('last_30d', 3).build(),
-        )
-        .build();
-      const depositExecutionDate = jest.now();
-      jest.advanceTimersByTime(1_000);
-      mockChainsRepository.getChain.mockResolvedValue(chain);
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
-      mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
-        dedicatedStakingStats,
-      );
-
-      const actual = await target.mapDepositInfo({
-        chainId: chain.chainId,
-        to: deployment.address,
-        value: '64000000000000000000',
-        isConfirmed: true, // confirmed
-        depositExecutionDate: new Date(depositExecutionDate), // execution date < now + entry period
-      });
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          type: 'NativeStakingDeposit',
-          status: 'AWAITING_ENTRY',
-          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
-          estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
-          fee: 0.5,
-          monthlyNrr: 1.5 / 12,
-          annualNrr: 1.5,
-          value: '64000000000000000000',
-          numValidators: 2,
-          expectedAnnualReward: '960000000000000000',
-          expectedMonthlyReward: '80000000000000000',
-          expectedFiatAnnualReward: 9600,
-          expectedFiatMonthlyReward: 800,
-          tokenInfo: {
-            address: NULL_ADDRESS,
-            decimals: chain.nativeCurrency.decimals,
-            logoUri: chain.nativeCurrency.logoUri,
-            name: chain.nativeCurrency.name,
-            symbol: chain.nativeCurrency.symbol,
-            trusted: true,
-          },
-        }),
-      );
-    });
-
-    it('should map a native staking deposit info with ValidationStarted status', async () => {
-      const chain = chainBuilder().build();
-      const productFee = '0.5';
-      const deployment = deploymentBuilder()
-        .with('product_type', 'dedicated')
-        .with('product_fee', productFee)
-        .build();
-      const networkStats = networkStatsBuilder()
-        .with('eth_price_usd', 10_000)
-        .with('estimated_entry_time_seconds', 1)
-        .build();
-      const dedicatedStakingStats = dedicatedStakingStatsBuilder()
-        .with(
-          'gross_apy',
-          dedicatedStakingStatsGrossApyBuilder().with('last_30d', 3).build(),
-        )
-        .build();
-      const depositExecutionDate = jest.now();
-      jest.advanceTimersByTime(2_000);
-      mockChainsRepository.getChain.mockResolvedValue(chain);
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
-      mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
-        dedicatedStakingStats,
-      );
-
-      const actual = await target.mapDepositInfo({
-        chainId: chain.chainId,
-        to: deployment.address,
-        value: '64000000000000000000',
-        isConfirmed: true, // confirmed
-        depositExecutionDate: new Date(depositExecutionDate), // execution date > now + entry period
-      });
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          type: 'NativeStakingDeposit',
-          status: 'VALIDATION_STARTED',
+          status: 'NOT_STAKED',
           estimatedEntryTime: networkStats.estimated_entry_time_seconds,
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
@@ -374,7 +210,7 @@ describe('NativeStakingMapper', () => {
   });
 
   describe('mapValidatorsExitInfo', () => {
-    it('should map a native staking validators exit info with SignatureNeeded status', async () => {
+    it('should map a native staking validators exit info', async () => {
       const chain = chainBuilder().build();
       const deployment = deploymentBuilder()
         .with('product_type', 'dedicated')
@@ -415,220 +251,12 @@ describe('NativeStakingMapper', () => {
       expect(actual).toEqual(
         expect.objectContaining({
           type: 'NativeStakingValidatorsExit',
-          status: 'SIGNATURE_NEEDED',
+          status: statusMap[stakes[0].state],
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds,
           value: stakes[0].net_claimable_consensus_rewards,
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
-          tokenInfo: {
-            address: NULL_ADDRESS,
-            decimals: chain.nativeCurrency.decimals,
-            logoUri: chain.nativeCurrency.logoUri,
-            name: chain.nativeCurrency.name,
-            symbol: chain.nativeCurrency.symbol,
-            trusted: true,
-          },
-        }),
-      );
-    });
-
-    it('should map a native staking validators exit info with RequestPending status', async () => {
-      const chain = chainBuilder().build();
-      const deployment = deploymentBuilder()
-        .with('product_type', 'dedicated')
-        .build();
-      const networkStats = networkStatsBuilder().build();
-      const stakes = [
-        stakeBuilder().with('net_claimable_consensus_rewards', '2').build(),
-        stakeBuilder().with('net_claimable_consensus_rewards', '3').build(),
-      ];
-      const validatorPublicKey = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 3,
-      }); // 3 validators
-      const dataDecoded = dataDecodedBuilder()
-        .with('method', 'requestValidatorsExit')
-        .with('parameters', [
-          dataDecodedParameterBuilder()
-            .with('name', '_publicKeys')
-            .with('type', 'bytes')
-            .with('value', validatorPublicKey)
-            .build(),
-        ])
-        .build();
-      const transaction = multisigTransactionBuilder()
-        .with('confirmationsRequired', 2) // 2 confirmations required
-        .with('confirmations', [
-          confirmationBuilder().build(),
-          confirmationBuilder().build(),
-        ]) // 2 confirmations received
-        .with('executionDate', null) // not executed
-        .with('dataDecoded', dataDecoded)
-        .build();
-      mockChainsRepository.getChain.mockResolvedValue(chain);
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
-      mockStakingRepository.getStakes.mockResolvedValue(stakes);
-
-      const actual = await target.mapValidatorsExitInfo({
-        chainId: chain.chainId,
-        safeAddress: transaction.safe,
-        to: deployment.address,
-        transaction,
-        dataDecoded,
-      });
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          type: 'NativeStakingValidatorsExit',
-          status: 'AWAITING_EXECUTION',
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
-          estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
-          value: (
-            +stakes[0].net_claimable_consensus_rewards! +
-            +stakes[1].net_claimable_consensus_rewards!
-          ).toString(),
-          numValidators: 3, // 3 public keys in the transaction data => 3 validators
-          tokenInfo: {
-            address: NULL_ADDRESS,
-            decimals: chain.nativeCurrency.decimals,
-            logoUri: chain.nativeCurrency.logoUri,
-            name: chain.nativeCurrency.name,
-            symbol: chain.nativeCurrency.symbol,
-            trusted: true,
-          },
-        }),
-      );
-    });
-
-    it('should map a native staking validators exit info with RequestPending status', async () => {
-      const chain = chainBuilder().build();
-      const deployment = deploymentBuilder()
-        .with('product_type', 'dedicated')
-        .build();
-      const networkStats = networkStatsBuilder()
-        .with('estimated_exit_time_seconds', 2)
-        .build();
-      const stakes = [stakeBuilder().build()];
-      const validatorPublicKey = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 3,
-      }); // 3 validators
-      const dataDecoded = dataDecodedBuilder()
-        .with('method', 'requestValidatorsExit')
-        .with('parameters', [
-          dataDecodedParameterBuilder()
-            .with('name', '_publicKeys')
-            .with('type', 'bytes')
-            .with('value', validatorPublicKey)
-            .build(),
-        ])
-        .build();
-      const executionDate = jest.now();
-      jest.advanceTimersByTime(1_000);
-      const transaction = multisigTransactionBuilder()
-        .with('confirmationsRequired', 2) // 2 confirmations required
-        .with('confirmations', [
-          confirmationBuilder().build(),
-          confirmationBuilder().build(),
-        ]) // 2 confirmations received
-        .with('executionDate', new Date(executionDate)) // execution date < now + exit period
-        .with('dataDecoded', dataDecoded)
-        .build();
-      mockChainsRepository.getChain.mockResolvedValue(chain);
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
-      mockStakingRepository.getStakes.mockResolvedValue(stakes);
-
-      const actual = await target.mapValidatorsExitInfo({
-        chainId: chain.chainId,
-        safeAddress: transaction.safe,
-        to: deployment.address,
-        transaction,
-        dataDecoded,
-      });
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          type: 'NativeStakingValidatorsExit',
-          status: 'REQUEST_PENDING',
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
-          estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
-          value: stakes[0].net_claimable_consensus_rewards,
-          numValidators: 3, // 3 public keys in the transaction data => 3 validators
-          tokenInfo: {
-            address: NULL_ADDRESS,
-            decimals: chain.nativeCurrency.decimals,
-            logoUri: chain.nativeCurrency.logoUri,
-            name: chain.nativeCurrency.name,
-            symbol: chain.nativeCurrency.symbol,
-            trusted: true,
-          },
-        }),
-      );
-    });
-
-    it('should map a native staking validators exit info with ReadyToWithdraw status', async () => {
-      const chain = chainBuilder().build();
-      const deployment = deploymentBuilder()
-        .with('product_type', 'dedicated')
-        .build();
-      const networkStats = networkStatsBuilder()
-        .with('estimated_exit_time_seconds', 2)
-        .with('estimated_withdrawal_time_seconds', 1)
-        .build();
-      const stakes = [stakeBuilder().build()];
-      const validatorPublicKey = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 2,
-      }); // 2 validators
-      const dataDecoded = dataDecodedBuilder()
-        .with('method', 'requestValidatorsExit')
-        .with('parameters', [
-          dataDecodedParameterBuilder()
-            .with('name', '_publicKeys')
-            .with('type', 'bytes')
-            .with('value', validatorPublicKey)
-            .build(),
-        ])
-        .build();
-      const executionDate = jest.now();
-      jest.advanceTimersByTime(
-        networkStats.estimated_exit_time_seconds * 1_000 +
-          networkStats.estimated_withdrawal_time_seconds * 1_000 +
-          1_000,
-      ); // now > execution time + exit/withdrawal period
-      const transaction = multisigTransactionBuilder()
-        .with('confirmationsRequired', 2) // 2 confirmations required
-        .with('confirmations', [
-          confirmationBuilder().build(),
-          confirmationBuilder().build(),
-        ]) // 2 confirmations received
-        .with('executionDate', new Date(executionDate))
-        .with('dataDecoded', dataDecoded)
-        .build();
-      mockChainsRepository.getChain.mockResolvedValue(chain);
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
-      mockStakingRepository.getStakes.mockResolvedValue(stakes);
-
-      const actual = await target.mapValidatorsExitInfo({
-        chainId: chain.chainId,
-        safeAddress: transaction.safe,
-        to: deployment.address,
-        transaction,
-        dataDecoded,
-      });
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          type: 'NativeStakingValidatorsExit',
-          status: 'READY_TO_WITHDRAW',
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
-          estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
-          value: stakes[0].net_claimable_consensus_rewards!.toString(),
-          numValidators: 2, // 2 public keys in the transaction data => 2 validators
           tokenInfo: {
             address: NULL_ADDRESS,
             decimals: chain.nativeCurrency.decimals,
@@ -745,9 +373,18 @@ describe('NativeStakingMapper', () => {
         .with('dataDecoded', dataDecoded)
         .build();
       const stakes = [
-        stakeBuilder().with('net_claimable_consensus_rewards', '3.25').build(),
-        stakeBuilder().with('net_claimable_consensus_rewards', '1.25').build(),
-        stakeBuilder().with('net_claimable_consensus_rewards', '1').build(),
+        stakeBuilder()
+          .with('net_claimable_consensus_rewards', '3.25')
+          .with('state', StakeState.WithdrawalDone)
+          .build(),
+        stakeBuilder()
+          .with('net_claimable_consensus_rewards', '1.25')
+          .with('state', StakeState.WithdrawalDone)
+          .build(),
+        stakeBuilder()
+          .with('net_claimable_consensus_rewards', '1')
+          .with('state', StakeState.WithdrawalDone)
+          .build(),
       ];
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
@@ -860,6 +497,76 @@ describe('NativeStakingMapper', () => {
           dataDecoded,
         }),
       ).rejects.toThrow('Native staking deployment not found');
+    });
+  });
+
+  describe('_getStatus', () => {
+    it('should return NOT_STAKED if there are no public keys', async () => {
+      const chainId = faker.string.numeric();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const publicKeys: Array<`0x${string}`> = [];
+
+      const actual = await target._getStatus({
+        chainId,
+        safeAddress,
+        publicKeys,
+      });
+
+      expect(actual).toBe('NOT_STAKED');
+    });
+
+    it('should return NOT_STAKED if there are no stakes', async () => {
+      const chainId = faker.string.numeric();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const publicKeys = [getAddress(faker.finance.ethereumAddress())];
+      mockStakingRepository.getStakes.mockResolvedValue([]);
+
+      const actual = await target._getStatus({
+        chainId,
+        safeAddress,
+        publicKeys,
+      });
+
+      expect(actual).toBe('NOT_STAKED');
+    });
+
+    [
+      StakeState.Unknown,
+      StakeState.Unstaked,
+      StakeState.PendingQueued,
+      StakeState.DepositInProgress,
+      StakeState.PendingInitialized,
+      StakeState.ActiveOngoing,
+      StakeState.ExitRequested,
+      StakeState.ActiveExiting,
+      StakeState.ExitedUnslashed,
+      StakeState.WithdrawalPossible,
+      StakeState.WithdrawalDone,
+      StakeState.ActiveSlashed,
+      StakeState.ExitedSlashed,
+    ].map((state, i, arr) => {
+      const nextState = arr[i + 1];
+
+      it(`should return ${statusMap[state]} if ${state} is the earliest state in returned Stakes`, async () => {
+        const chainId = faker.string.numeric();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const publicKeys = [getAddress(faker.finance.ethereumAddress())];
+        const stakes = [
+          stakeBuilder().with('state', state).build(),
+          ...(nextState
+            ? [stakeBuilder().with('state', nextState).build()]
+            : []),
+        ];
+        mockStakingRepository.getStakes.mockResolvedValue(stakes);
+
+        const actual = await target._getStatus({
+          chainId,
+          safeAddress,
+          publicKeys,
+        });
+
+        expect(actual).toBe(statusMap[state]);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #1949

We currently determine the staking status based upon the estimated entry, exit and withdrawal times. Although this can be correct, it is inherently estimated and we have seen instances where the `status` of a particular staking transaction is incorrect.

This adjusts the `status` retrieval of deposit and exit requests to map the "earliest" validator `state`s as the relevant `status`.

## Changes

- Validate expected `Stake['state']` values.
- Add `StakingState` <> `StakingStatus` mapping.
- Add/update test coverage accordingly.