### PR TITLE
Add getCounter and setCounter to ICacheService

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
-
 describe('FakeCacheService', () => {
   let target: FakeCacheService;
 
@@ -85,5 +84,25 @@ describe('FakeCacheService', () => {
       const result = await target.increment(key, undefined);
       expect(result).toEqual(initialValue + i);
     }
+  });
+
+  it('sets and gets the value of a counter key', async () => {
+    const key = faker.string.alphanumeric();
+    const value = faker.number.int({ min: 100 });
+    await target.setCounter(key, value, undefined);
+
+    await expect(target.getCounter(key)).resolves.toBe(value);
+  });
+
+  it('sets, increments and gets the value of a counter key', async () => {
+    const key = faker.string.alphanumeric();
+    const value = faker.number.int({ min: 100 });
+    await target.setCounter(key, value, undefined);
+
+    await target.increment(key, undefined);
+    await target.increment(key, undefined);
+    await target.increment(key, undefined);
+
+    await expect(target.getCounter(key)).resolves.toBe(value + 3);
   });
 });

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -1,6 +1,7 @@
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { ICacheReadiness } from '@/domain/interfaces/cache-readiness.interface';
+import { isNumber } from 'lodash';
 
 export class FakeCacheService implements ICacheService, ICacheReadiness {
   private cache: Record<string, Record<string, string> | number> = {};
@@ -30,6 +31,11 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
       1, // non-falsy expireTimeSeconds, otherwise it wouldn't be written
     );
     return Promise.resolve(1);
+  }
+
+  getCounter(key: string): Promise<number | null> {
+    const value = this.cache[key];
+    return isNumber(value) ? Promise.resolve(value) : Promise.resolve(null);
   }
 
   hGet(cacheDir: CacheDir): Promise<string | undefined> {
@@ -70,5 +76,15 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
     currentValue = currentValue ? currentValue + 1 : 1;
     this.cache[cacheKey] = currentValue;
     return Promise.resolve(currentValue);
+  }
+
+  setCounter(
+    key: string,
+    value: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    expireTimeSeconds: number | undefined,
+  ): Promise<void> {
+    this.cache[key] = value;
+    return Promise.resolve();
   }
 }

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -1,7 +1,6 @@
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { ICacheReadiness } from '@/domain/interfaces/cache-readiness.interface';
-import { isNumber } from 'lodash';
 
 export class FakeCacheService implements ICacheService, ICacheReadiness {
   private cache: Record<string, Record<string, string> | number> = {};
@@ -35,7 +34,9 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
 
   getCounter(key: string): Promise<number | null> {
     const value = this.cache[key];
-    return isNumber(value) ? Promise.resolve(value) : Promise.resolve(null);
+    return Number.isInteger(value) && typeof value === 'number'
+      ? Promise.resolve(value)
+      : Promise.resolve(null);
   }
 
   hGet(cacheDir: CacheDir): Promise<string | undefined> {

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -3,6 +3,8 @@ import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 export const CacheService = Symbol('ICacheService');
 
 export interface ICacheService {
+  getCounter(key: string): Promise<number | null>;
+
   hSet(
     cacheDir: CacheDir,
     value: string,
@@ -17,4 +19,10 @@ export interface ICacheService {
     cacheKey: string,
     expireTimeSeconds: number | undefined,
   ): Promise<number>;
+
+  setCounter(
+    key: string,
+    value: number,
+    expireTimeSeconds: number | undefined,
+  ): Promise<void>;
 }

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -175,6 +175,28 @@ describe('RedisCacheService', () => {
     expect(ttl).toBeLessThanOrEqual(expireTime);
   });
 
+  it('sets and gets the value of a counter key', async () => {
+    const key = faker.string.alphanumeric();
+    const value = faker.number.int({ min: 100 });
+    await redisCacheService.setCounter(key, value, MAX_TTL);
+
+    const result = await redisCacheService.getCounter(key);
+    expect(result).toEqual(value);
+  });
+
+  it('sets, increments and gets the value of a counter key', async () => {
+    const key = faker.string.alphanumeric();
+    const value = faker.number.int({ min: 100 });
+    await redisCacheService.setCounter(key, value, MAX_TTL);
+
+    await redisCacheService.increment(key, undefined);
+    await redisCacheService.increment(key, undefined);
+    await redisCacheService.increment(key, undefined);
+
+    const result = await redisCacheService.getCounter(key);
+    expect(result).toEqual(value + 3);
+  });
+
   it('stores a key for MAX_TTL seconds', async () => {
     const key = faker.string.alphanumeric();
     const value = faker.string.sample();

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -31,6 +31,12 @@ export class RedisCacheService
     return this.client.ping();
   }
 
+  async getCounter(key: string): Promise<number | null> {
+    const keyWithPrefix = this._prefixKey(key);
+    const value = await this.client.get(keyWithPrefix);
+    return value ? Number(value) : null;
+  }
+
   async hSet(
     cacheDir: CacheDir,
     value: string,
@@ -80,6 +86,14 @@ export class RedisCacheService
     }
     const [incrRes] = await transaction.get(cacheKey).exec();
     return Number(incrRes);
+  }
+
+  async setCounter(
+    key: string,
+    value: number,
+    expireTimeSeconds: number,
+  ): Promise<void> {
+    await this.client.set(key, value, { EX: expireTimeSeconds, NX: true });
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR implements shared counters via the cache layer. It adds functions to set/get numeric counter values via `ICacheService`.

## Changes
- Adds `getCounter` and `setCounter` functions to `ICacheService` and its implementations.
- Adds related testing.
