### PR TITLE
Compare all deployment type addresses when relaying

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,18 @@ export default tseslint.config(
       ],
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@safe-global/safe-deployments',
+              message:
+                'Please import from @/domain/common/utils/deployments instead.',
+            },
+          ],
+        },
+      ],
       // TODO: Address these rules: (added to update to ESLint 9)
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -1,0 +1,118 @@
+// eslint-disable-next-line no-restricted-imports
+import {
+  getMultiSendCallOnlyDeployments as _getMultiSendCallOnlyDeployments,
+  getMultiSendDeployments as _getMultiSendDeployments,
+  getProxyFactoryDeployments as _getProxyFactoryDeployments,
+  getSafeL2SingletonDeployments as _getSafeL2SingletonDeployments,
+  getSafeSingletonDeployments as _getSafeSingletonDeployments,
+} from '@safe-global/safe-deployments';
+
+/**
+ * Returns a list of official ProxyFactory addresses based on given {@link Filter}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @param {string} args.version - the version to filter deployments by
+ *
+ * @returns {Array<`0x${string}`>} - a list of checksummed ProxyFactory addresses
+ */
+export function getProxyFactoryDeployments(args: Filter): Array<`0x${string}`> {
+  return formatDeployments(_getProxyFactoryDeployments, args);
+}
+
+/**
+ * Returns a list of official L1 singleton addresses based on given {@link Filter}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @param {string} args.version - the version to filter deployments by
+ *
+ * @returns {Array<`0x${string}`>} - a list of checksummed L1 singleton addresses
+ */
+export function getSafeSingletonDeployments(
+  args: Filter,
+): Array<`0x${string}`> {
+  return formatDeployments(_getSafeSingletonDeployments, args);
+}
+
+/**
+ * Returns a list of official L2 singleton addresses based on given {@link Filter}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @param {string} args.version - the version to filter deployments by
+ *
+ * @returns {Array<`0x${string}`>} - a list of checksummed L2 singleton addresses
+ */
+export function getSafeL2SingletonDeployments(
+  args: Filter,
+): Array<`0x${string}`> {
+  return formatDeployments(_getSafeL2SingletonDeployments, args);
+}
+
+/**
+ * Returns a list of official MultiSendCallOnly addresses based on given {@link Filter}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @param {string} args.version - the version to filter deployments by
+ *
+ * @returns {Array<`0x${string}`>} - a list of checksummed MultiSendCallOnly addresses
+ */
+export function getMultiSendCallOnlyDeployments(
+  args: Filter,
+): Array<`0x${string}`> {
+  return formatDeployments(_getMultiSendCallOnlyDeployments, args);
+}
+
+/**
+ * Returns a list of official MultiSend addresses based on given {@link Filter}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @param {string} args.version - the version to filter deployments by
+ *
+ * @returns {Array<`0x${string}`>} - a list of checksummed MultiSend addresses
+ */
+export function getMultiSendDeployments(args: Filter): Array<`0x${string}`> {
+  return formatDeployments(_getMultiSendDeployments, args);
+}
+
+type Filter = {
+  chainId: string;
+  version: string;
+};
+
+/**
+ * Helper to remap {@link SingletonDeploymentV2} to a list of checksummed addresses.
+ *
+ * @param getDeployments - deployment getters from @safe-global/safe-deployments
+ * @param filter - {@link Filter} to filter deployments by
+ *
+ * @returns {Array<`0x${string}`>} - a list of checksummed addresses
+ */
+function formatDeployments(
+  getDeployments:
+    | typeof _getProxyFactoryDeployments
+    | typeof _getSafeSingletonDeployments
+    | typeof _getSafeL2SingletonDeployments
+    | typeof _getMultiSendCallOnlyDeployments
+    | typeof _getMultiSendDeployments,
+  filter: Filter,
+): Array<`0x${string}`> {
+  const deployments = getDeployments({
+    network: filter.chainId,
+    version: filter.version,
+  });
+
+  if (!deployments) {
+    return [];
+  }
+
+  const chainDeployments = deployments.networkAddresses[filter.chainId];
+  if (!chainDeployments) {
+    return [];
+  }
+
+  // Note: can cast as deployment are inherently checksummed
+  if (!Array.isArray(chainDeployments)) {
+    return [chainDeployments as `0x${string}`];
+  }
+
+  return chainDeployments as Array<`0x${string}`>;
+}

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -7,6 +7,11 @@ import {
   getSafeSingletonDeployments as _getSafeSingletonDeployments,
 } from '@safe-global/safe-deployments';
 
+type Filter = {
+  chainId: string;
+  version: string;
+};
+
 /**
  * Returns a list of official ProxyFactory addresses based on given {@link Filter}.
  *
@@ -73,16 +78,11 @@ export function getMultiSendDeployments(args: Filter): Array<`0x${string}`> {
   return formatDeployments(_getMultiSendDeployments, args);
 }
 
-type Filter = {
-  chainId: string;
-  version: string;
-};
-
 /**
  * Helper to remap {@link SingletonDeploymentV2} to a list of checksummed addresses.
  *
- * @param getDeployments - deployment getters from @safe-global/safe-deployments
- * @param filter - {@link Filter} to filter deployments by
+ * @param {Function} getDeployments - function to get deployments
+ * @param {Filter} filter - filter to apply to deployments
  *
  * @returns {Array<`0x${string}`>} - a list of checksummed addresses
  */

--- a/src/domain/relay/limit-addresses.mapper.spec.ts
+++ b/src/domain/relay/limit-addresses.mapper.spec.ts
@@ -29,12 +29,12 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
 import { faker } from '@faker-js/faker';
 import {
-  getMultiSendCallOnlyDeployment,
-  getMultiSendDeployment,
-  getProxyFactoryDeployment,
-  getSafeL2SingletonDeployment,
-  getSafeSingletonDeployment,
-} from '@safe-global/safe-deployments';
+  getMultiSendCallOnlyDeployments,
+  getMultiSendDeployments,
+  getProxyFactoryDeployments,
+  getSafeL2SingletonDeployments,
+  getSafeSingletonDeployments,
+} from '@/domain/common/utils/deployments';
 import { getAddress } from 'viem';
 import configuration from '@/config/entities/configuration';
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
@@ -562,10 +562,12 @@ describe('LimitAddressesMapper', () => {
             const data = multiSendEncoder()
               .with('transactions', multiSendTransactionsEncoder(transactions))
               .encode();
-            const to = getMultiSendCallOnlyDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
+            const to = faker.helpers.arrayElement(
+              getMultiSendCallOnlyDeployments({
+                version,
+                chainId,
+              }),
+            );
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -573,7 +575,7 @@ describe('LimitAddressesMapper', () => {
               version,
               chainId,
               data,
-              to: getAddress(to),
+              to,
             });
             expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
           });
@@ -593,10 +595,12 @@ describe('LimitAddressesMapper', () => {
             const data = multiSendEncoder()
               .with('transactions', multiSendTransactionsEncoder(transactions))
               .encode();
-            const to = getMultiSendCallOnlyDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
+            const to = faker.helpers.arrayElement(
+              getMultiSendCallOnlyDeployments({
+                version,
+                chainId,
+              }),
+            );
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -605,7 +609,7 @@ describe('LimitAddressesMapper', () => {
                 version,
                 chainId,
                 data,
-                to: getAddress(to),
+                to,
               }),
             ).rejects.toThrow(
               'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
@@ -626,10 +630,12 @@ describe('LimitAddressesMapper', () => {
             const data = multiSendEncoder()
               .with('transactions', multiSendTransactionsEncoder(transactions))
               .encode();
-            const to = getMultiSendCallOnlyDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
+            const to = faker.helpers.arrayElement(
+              getMultiSendCallOnlyDeployments({
+                version,
+                chainId,
+              }),
+            );
             // Unofficial mastercopy
             mockSafeRepository.getSafe.mockRejectedValue(
               new Error('Not official mastercopy'),
@@ -640,7 +646,7 @@ describe('LimitAddressesMapper', () => {
                 version,
                 chainId,
                 data,
-                to: getAddress(to),
+                to,
               }),
             ).rejects.toThrow(
               'Safe attempting to relay is not official. Only official Safe singletons are supported.',
@@ -664,10 +670,12 @@ describe('LimitAddressesMapper', () => {
             const data = multiSendEncoder()
               .with('transactions', multiSendTransactionsEncoder(transactions))
               .encode();
-            const to = getMultiSendCallOnlyDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
+            const to = faker.helpers.arrayElement(
+              getMultiSendCallOnlyDeployments({
+                version,
+                chainId,
+              }),
+            );
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -676,7 +684,7 @@ describe('LimitAddressesMapper', () => {
                 version,
                 chainId,
                 data,
-                to: getAddress(to),
+                to,
               }),
             ).rejects.toThrow(
               'Invalid multiSend call. The batch is not all execTransaction calls to same address.',
@@ -784,10 +792,12 @@ describe('LimitAddressesMapper', () => {
             const data = multiSendEncoder()
               .with('transactions', multiSendTransactionsEncoder(transactions))
               .encode();
-            const to = getMultiSendDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
+            const to = faker.helpers.arrayElement(
+              getMultiSendDeployments({
+                version,
+                chainId,
+              }),
+            );
             // Official mastercopy
             mockSafeRepository.getSafe.mockResolvedValue(safe);
 
@@ -795,7 +805,7 @@ describe('LimitAddressesMapper', () => {
               version,
               chainId,
               data,
-              to: getAddress(to),
+              to,
             });
             expect(expectedLimitAddresses).toStrictEqual([safeAddress]);
           });
@@ -852,28 +862,31 @@ describe('LimitAddressesMapper', () => {
                 getAddress(faker.finance.ethereumAddress()),
                 getAddress(faker.finance.ethereumAddress()),
               ];
-              const singleton = getSafeSingletonDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
+              const singleton = faker.helpers.arrayElement(
+                getSafeSingletonDeployments({
+                  version,
+                  chainId,
+                }),
+              );
               const data = createProxyWithNonceEncoder()
-                .with('singleton', getAddress(singleton))
+                .with('singleton', singleton)
                 .with(
                   'initializer',
                   setupEncoder().with('owners', owners).encode(),
                 )
                 .encode();
-              const proxyFactory = getProxyFactoryDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const to = getAddress(proxyFactory);
+              const proxyFactory = faker.helpers.arrayElement(
+                getProxyFactoryDeployments({
+                  version,
+                  chainId,
+                }),
+              );
 
               const expectedLimitAddresses = await target.getLimitAddresses({
                 version,
                 chainId,
                 data,
-                to,
+                to: proxyFactory,
               });
               expect(expectedLimitAddresses).toStrictEqual(owners);
             });
@@ -883,12 +896,14 @@ describe('LimitAddressesMapper', () => {
                 getAddress(faker.finance.ethereumAddress()),
                 getAddress(faker.finance.ethereumAddress()),
               ];
-              const singleton = getSafeSingletonDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
+              const singleton = faker.helpers.arrayElement(
+                getSafeSingletonDeployments({
+                  version,
+                  chainId,
+                }),
+              );
               const data = createProxyWithNonceEncoder()
-                .with('singleton', getAddress(singleton))
+                .with('singleton', singleton)
                 .with(
                   'initializer',
                   setupEncoder().with('owners', owners).encode(),
@@ -916,28 +931,31 @@ describe('LimitAddressesMapper', () => {
                 getAddress(faker.finance.ethereumAddress()),
                 getAddress(faker.finance.ethereumAddress()),
               ];
-              const singleton = getSafeL2SingletonDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
+              const singleton = faker.helpers.arrayElement(
+                getSafeL2SingletonDeployments({
+                  version,
+                  chainId,
+                }),
+              );
               const data = createProxyWithNonceEncoder()
-                .with('singleton', getAddress(singleton))
+                .with('singleton', singleton)
                 .with(
                   'initializer',
                   setupEncoder().with('owners', owners).encode(),
                 )
                 .encode();
-              const proxyFactory = getProxyFactoryDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const to = getAddress(proxyFactory);
+              const proxyFactory = faker.helpers.arrayElement(
+                getProxyFactoryDeployments({
+                  version,
+                  chainId,
+                }),
+              );
 
               const expectedLimitAddresses = await target.getLimitAddresses({
                 version,
                 chainId,
                 data,
-                to,
+                to: proxyFactory,
               });
               expect(expectedLimitAddresses).toStrictEqual(owners);
             });
@@ -947,12 +965,14 @@ describe('LimitAddressesMapper', () => {
                 getAddress(faker.finance.ethereumAddress()),
                 getAddress(faker.finance.ethereumAddress()),
               ];
-              const singleton = getSafeL2SingletonDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
+              const singleton = faker.helpers.arrayElement(
+                getSafeL2SingletonDeployments({
+                  version,
+                  chainId,
+                }),
+              );
               const data = createProxyWithNonceEncoder()
-                .with('singleton', getAddress(singleton))
+                .with('singleton', singleton)
                 .with(
                   'initializer',
                   setupEncoder().with('owners', owners).encode(),
@@ -982,24 +1002,25 @@ describe('LimitAddressesMapper', () => {
             // Unofficial singleton
             const singleton = getAddress(faker.finance.ethereumAddress());
             const data = createProxyWithNonceEncoder()
-              .with('singleton', getAddress(singleton))
+              .with('singleton', singleton)
               .with(
                 'initializer',
                 setupEncoder().with('owners', owners).encode(),
               )
               .encode();
-            const proxyFactory = getProxyFactoryDeployment({
-              version,
-              network: chainId,
-            })!.networkAddresses[chainId];
-            const to = getAddress(proxyFactory);
+            const proxyFactory = faker.helpers.arrayElement(
+              getProxyFactoryDeployments({
+                version,
+                chainId,
+              }),
+            );
 
             await expect(
               target.getLimitAddresses({
                 version,
                 chainId,
                 data,
-                to,
+                to: proxyFactory,
               }),
             ).rejects.toThrow(
               'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
@@ -1016,7 +1037,7 @@ describe('LimitAddressesMapper', () => {
             // Unofficial singleton
             const singleton = getAddress(faker.finance.ethereumAddress());
             const data = createProxyWithNonceEncoder()
-              .with('singleton', getAddress(singleton))
+              .with('singleton', singleton)
               .with(
                 'initializer',
                 setupEncoder().with('owners', owners).encode(),

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -228,14 +228,10 @@ export class LimitAddressesMapper {
     chainId: string;
     address: `0x${string}`;
   }): boolean {
-    const multiSendCallOnlyDeployments = getMultiSendCallOnlyDeployments(args);
-    const isCallOnly = multiSendCallOnlyDeployments.includes(args.address);
-
-    if (isCallOnly) {
-      return true;
-    }
-
-    return getMultiSendDeployments(args).includes(args.address);
+    return (
+      getMultiSendCallOnlyDeployments(args).includes(args.address) ||
+      getMultiSendDeployments(args).includes(args.address)
+    );
   }
 
   private getSafeAddressFromMultiSend = (

--- a/src/domain/relay/limit-addresses.mapper.ts
+++ b/src/domain/relay/limit-addresses.mapper.ts
@@ -235,8 +235,7 @@ export class LimitAddressesMapper {
       return true;
     }
 
-    const multiSendCallDeployments = getMultiSendDeployments(args);
-    return multiSendCallDeployments.includes(args.address);
+    return getMultiSendDeployments(args).includes(args.address);
   }
 
   private getSafeAddressFromMultiSend = (
@@ -298,13 +297,10 @@ export class LimitAddressesMapper {
       return false;
     }
 
-    const safeL1Deployments = getSafeSingletonDeployments(args);
-    const safeL2Deployments = getSafeL2SingletonDeployments(args);
-
-    const isL1Singleton = safeL1Deployments.includes(singleton);
-    const isL2Singleton = safeL2Deployments.includes(singleton);
-
-    return isL1Singleton || isL2Singleton;
+    return (
+      getSafeSingletonDeployments(args).includes(singleton) ||
+      getSafeL2SingletonDeployments(args).includes(singleton)
+    );
   }
 
   private getOwnersFromCreateProxyWithNonce(

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -32,7 +32,7 @@ import { transactionAddedEventBuilder } from '@/domain/alerts/contracts/__tests_
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { getAddress } from 'viem';
-import { getMultiSendCallOnlyDeployment } from '@safe-global/safe-deployments';
+import { getMultiSendCallOnlyDeployments } from '@/domain/common/utils/deployments';
 import {
   multiSendEncoder,
   multiSendTransactionsEncoder,
@@ -396,7 +396,12 @@ describe('Alerts (Unit)', () => {
             .with('data', multiSend.encode())
             .with(
               'to',
-              getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress),
+              faker.helpers.arrayElement(
+                getMultiSendCallOnlyDeployments({
+                  chainId: chain.chainId,
+                  version: '1.3.0',
+                }),
+              ),
             )
             .encode();
 
@@ -634,7 +639,12 @@ describe('Alerts (Unit)', () => {
             .with('data', multiSend.encode())
             .with(
               'to',
-              getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress),
+              faker.helpers.arrayElement(
+                getMultiSendCallOnlyDeployments({
+                  chainId: chain.chainId,
+                  version: '1.3.0',
+                }),
+              ),
             )
             .encode();
 
@@ -704,7 +714,12 @@ describe('Alerts (Unit)', () => {
             .with('data', multiSend.encode())
             .with(
               'to',
-              getAddress(getMultiSendCallOnlyDeployment()!.defaultAddress),
+              faker.helpers.arrayElement(
+                getMultiSendCallOnlyDeployments({
+                  chainId: chain.chainId,
+                  version: '1.3.0',
+                }),
+              ),
             )
             .encode();
 

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -41,12 +41,12 @@ import {
   multiSendTransactionsEncoder,
 } from '@/domain/contracts/__tests__/encoders/multi-send-encoder.builder';
 import {
-  getMultiSendCallOnlyDeployment,
-  getMultiSendDeployment,
-  getProxyFactoryDeployment,
-  getSafeL2SingletonDeployment,
-  getSafeSingletonDeployment,
-} from '@safe-global/safe-deployments';
+  getMultiSendCallOnlyDeployments,
+  getMultiSendDeployments,
+  getProxyFactoryDeployments,
+  getSafeL2SingletonDeployments,
+  getSafeSingletonDeployments,
+} from '@/domain/common/utils/deployments';
 import { createProxyWithNonceEncoder } from '@/domain/relay/contracts/__tests__/encoders/proxy-factory-encoder.builder';
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
@@ -374,10 +374,12 @@ describe('Relay controller', () => {
                     multiSendTransactionsEncoder(transactions),
                   )
                   .encode();
-                const to = getMultiSendCallOnlyDeployment({
-                  version,
-                  network: chainId,
-                })!.networkAddresses[chainId];
+                const to = faker.helpers.arrayElement(
+                  getMultiSendCallOnlyDeployments({
+                    version,
+                    chainId,
+                  }),
+                );
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
@@ -442,10 +444,12 @@ describe('Relay controller', () => {
                     multiSendTransactionsEncoder(transactions),
                   )
                   .encode();
-                const to = getMultiSendDeployment({
-                  version,
-                  network: chainId,
-                })!.networkAddresses[chainId];
+                const to = faker.helpers.arrayElement(
+                  getMultiSendDeployments({
+                    version,
+                    chainId,
+                  }),
+                );
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
@@ -494,17 +498,20 @@ describe('Relay controller', () => {
                     getAddress(faker.finance.ethereumAddress()),
                     getAddress(faker.finance.ethereumAddress()),
                   ];
-                  const singleton = getSafeSingletonDeployment({
-                    version,
-                    network: chainId,
-                  })!.networkAddresses[chainId];
-                  const proxyFactory = getProxyFactoryDeployment({
-                    version,
-                    network: chainId,
-                  })!.networkAddresses[chainId];
-                  const to = getAddress(proxyFactory);
+                  const singleton = faker.helpers.arrayElement(
+                    getSafeSingletonDeployments({
+                      version,
+                      chainId,
+                    }),
+                  );
+                  const to = faker.helpers.arrayElement(
+                    getProxyFactoryDeployments({
+                      version,
+                      chainId,
+                    }),
+                  );
                   const data = createProxyWithNonceEncoder()
-                    .with('singleton', getAddress(singleton))
+                    .with('singleton', singleton)
                     .with(
                       'initializer',
                       setupEncoder().with('owners', owners).encode(),
@@ -554,14 +561,16 @@ describe('Relay controller', () => {
                     getAddress(faker.finance.ethereumAddress()),
                     getAddress(faker.finance.ethereumAddress()),
                   ];
-                  const singleton = getSafeSingletonDeployment({
-                    version,
-                    network: chainId,
-                  })!.networkAddresses[chainId];
+                  const singleton = faker.helpers.arrayElement(
+                    getSafeSingletonDeployments({
+                      version,
+                      chainId,
+                    }),
+                  );
                   // Unofficial ProxyFactory
                   const to = getAddress(faker.finance.ethereumAddress());
                   const data = createProxyWithNonceEncoder()
-                    .with('singleton', getAddress(singleton))
+                    .with('singleton', singleton)
                     .with(
                       'initializer',
                       setupEncoder().with('owners', owners).encode(),
@@ -614,17 +623,20 @@ describe('Relay controller', () => {
                     getAddress(faker.finance.ethereumAddress()),
                     getAddress(faker.finance.ethereumAddress()),
                   ];
-                  const singleton = getSafeL2SingletonDeployment({
-                    version,
-                    network: chainId,
-                  })!.networkAddresses[chainId];
-                  const proxyFactory = getProxyFactoryDeployment({
-                    version,
-                    network: chainId,
-                  })!.networkAddresses[chainId];
-                  const to = getAddress(proxyFactory);
+                  const singleton = faker.helpers.arrayElement(
+                    getSafeL2SingletonDeployments({
+                      version,
+                      chainId,
+                    }),
+                  );
+                  const to = faker.helpers.arrayElement(
+                    getProxyFactoryDeployments({
+                      version,
+                      chainId,
+                    }),
+                  );
                   const data = createProxyWithNonceEncoder()
-                    .with('singleton', getAddress(singleton))
+                    .with('singleton', singleton)
                     .with(
                       'initializer',
                       setupEncoder().with('owners', owners).encode(),
@@ -674,14 +686,16 @@ describe('Relay controller', () => {
                     getAddress(faker.finance.ethereumAddress()),
                     getAddress(faker.finance.ethereumAddress()),
                   ];
-                  const singleton = getSafeL2SingletonDeployment({
-                    version,
-                    network: chainId,
-                  })!.networkAddresses[chainId];
+                  const singleton = faker.helpers.arrayElement(
+                    getSafeL2SingletonDeployments({
+                      version,
+                      chainId,
+                    }),
+                  );
                   // Unofficial ProxyFactory
                   const to = getAddress(faker.finance.ethereumAddress());
                   const data = createProxyWithNonceEncoder()
-                    .with('singleton', getAddress(singleton))
+                    .with('singleton', singleton)
                     .with(
                       'initializer',
                       setupEncoder().with('owners', owners).encode(),
@@ -986,10 +1000,12 @@ describe('Relay controller', () => {
                     multiSendTransactionsEncoder(transactions),
                   )
                   .encode();
-                const to = getMultiSendCallOnlyDeployment({
-                  version,
-                  network: chainId,
-                })!.networkAddresses[chainId];
+                const to = faker.helpers.arrayElement(
+                  getMultiSendCallOnlyDeployments({
+                    version,
+                    chainId,
+                  }),
+                );
                 const taskId = faker.string.uuid();
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
@@ -1052,10 +1068,12 @@ describe('Relay controller', () => {
                     multiSendTransactionsEncoder(transactions),
                   )
                   .encode();
-                const to = getMultiSendCallOnlyDeployment({
-                  version,
-                  network: chainId,
-                })!.networkAddresses[chainId];
+                const to = faker.helpers.arrayElement(
+                  getMultiSendCallOnlyDeployments({
+                    version,
+                    chainId,
+                  }),
+                );
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -1103,10 +1121,12 @@ describe('Relay controller', () => {
                     multiSendTransactionsEncoder(transactions),
                   )
                   .encode();
-                const to = getMultiSendCallOnlyDeployment({
-                  version,
-                  network: chainId,
-                })!.networkAddresses[chainId];
+                const to = faker.helpers.arrayElement(
+                  getMultiSendCallOnlyDeployments({
+                    version,
+                    chainId,
+                  }),
+                );
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
@@ -1374,10 +1394,12 @@ describe('Relay controller', () => {
                   multiSendTransactionsEncoder(transactions),
                 )
                 .encode();
-              const to = getMultiSendCallOnlyDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
+              const to = faker.helpers.arrayElement(
+                getMultiSendCallOnlyDeployments({
+                  version,
+                  chainId,
+                }),
+              );
               const taskId = faker.string.uuid();
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
@@ -1428,15 +1450,18 @@ describe('Relay controller', () => {
                 getAddress(faker.finance.ethereumAddress()),
                 getAddress(faker.finance.ethereumAddress()),
               ];
-              const singleton = getSafeSingletonDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const proxyFactory = getProxyFactoryDeployment({
-                version,
-                network: chainId,
-              })!.networkAddresses[chainId];
-              const to = getAddress(proxyFactory);
+              const singleton = faker.helpers.arrayElement(
+                getSafeSingletonDeployments({
+                  version,
+                  chainId,
+                }),
+              );
+              const to = faker.helpers.arrayElement(
+                getProxyFactoryDeployments({
+                  version,
+                  chainId,
+                }),
+              );
               const data = createProxyWithNonceEncoder()
                 .with('singleton', getAddress(singleton))
                 .with(


### PR DESCRIPTION
## Summary

Resolves #1954

It is possible to get both singular or multiple deployment addresses since https://github.com/safe-global/safe-deployments/pull/668 and, as such, there are respective `get*Deployment` and `get*Deployments` functions.

Since this adjustment in the deployments package, we never took this into account in the project. Therefore, if a chain has both canonical and EIP-155 deployments, for example, we would only be retrieving the first address found.

This adjusts all usage of the deployments package, ensuring we retrieve and compare against all deployment type addresses.

## Changes

- Create helpers to retrieve deployments, and add linting rule to ensure usage of them.
- Modify relaying checks to compare against a list of addresses instead of a singular one.
- Update tests accordingly.