### PR TITLE
Add `getTransactionStatus` to staking datasource/domain

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -45,6 +45,8 @@ export class CacheRouter {
   private static readonly STAKING_POOLED_STAKING_STATS_KEY =
     'staking_pooled_staking_stats';
   private static readonly STAKING_STAKES_KEY = 'staking_stakes';
+  private static readonly STAKING_TRANSACTION_STATUS_KEY =
+    'staking_transaction_status';
   private static readonly TOKEN_KEY = 'token';
   private static readonly TOKEN_PRICE_KEY = 'token_price';
   private static readonly TOKENS_KEY = 'tokens';
@@ -627,6 +629,16 @@ export class CacheRouter {
     return new CacheDir(
       CacheRouter.getStakingStakesCacheKey(args),
       hash.digest('hex'),
+    );
+  }
+
+  static getStakingTransactionStatusCacheDir(args: {
+    chainId: string;
+    txHash: `0x${string}`;
+  }): CacheDir {
+    return new CacheDir(
+      `${args.chainId}_${CacheRouter.STAKING_TRANSACTION_STATUS_KEY}_${args.txHash}`,
+      '',
     );
   }
 }

--- a/src/datasources/staking-api/entities/__tests__/transaction-status.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/transaction-status.entity.builder.ts
@@ -1,0 +1,83 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+export function transactionStatusReceiptLogBuilder(): IBuilder<
+  TransactionStatus['receipt']['logs'][number]
+> {
+  return new Builder<TransactionStatus['receipt']['logs'][number]>()
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with(
+      'topics',
+      Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => {
+        return faker.string.hexadecimal({ length: 64 }) as `0x${string}`;
+      }),
+    )
+    .with(
+      'data',
+      faker.string.hexadecimal({
+        length: 64,
+      }) as `0x${string}`,
+    )
+    .with(
+      'blockHash',
+      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
+    )
+    .with('blockNumber', faker.string.numeric())
+    .with(
+      'blockTimestamp',
+      faker.string.hexadecimal({ length: 8 }) as `0x${string}`,
+    )
+    .with(
+      'transactionHash',
+      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
+    )
+    .with('transactionIndex', faker.number.int())
+    .with('logIndex', faker.number.int())
+    .with('removed', false);
+}
+
+export function transactionStatusReceiptBuilder(): IBuilder<
+  TransactionStatus['receipt']
+> {
+  const transactionIndex = faker.number.int();
+  return new Builder<TransactionStatus['receipt']>()
+    .with('status', 'success')
+    .with('cumulativeGasUsed', faker.string.numeric())
+    .with(
+      'logs',
+      Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () =>
+        transactionStatusReceiptLogBuilder()
+          .with('transactionIndex', transactionIndex)
+          .build(),
+      ),
+    )
+    .with(
+      'logsBloom',
+      faker.string.hexadecimal({ length: 512 }) as `0x${string}`,
+    )
+    .with('type', 'eip1559')
+    .with(
+      'transactionHash',
+      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
+    )
+    .with('transactionIndex', transactionIndex)
+    .with(
+      'blockHash',
+      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
+    )
+    .with('blockNumber', faker.string.numeric())
+    .with('gasUsed', faker.string.numeric())
+    .with('effectiveGasPrice', faker.string.numeric())
+    .with('from', getAddress(faker.finance.ethereumAddress()))
+    .with('to', getAddress(faker.finance.ethereumAddress()))
+    .with('contractAddress', null);
+}
+
+export function transactionStatusBuilder(): IBuilder<TransactionStatus> {
+  const receipt = transactionStatusReceiptBuilder().build();
+  return new Builder<TransactionStatus>()
+    .with('receipt', receipt)
+    .with('status', receipt.status);
+}

--- a/src/datasources/staking-api/entities/__tests__/transaction-status.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/transaction-status.entity.builder.ts
@@ -1,13 +1,11 @@
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
 import { faker } from '@faker-js/faker';
-import { getAddress } from 'viem';
 
 export function transactionStatusReceiptLogBuilder(): IBuilder<
   TransactionStatus['receipt']['logs'][number]
 > {
   return new Builder<TransactionStatus['receipt']['logs'][number]>()
-    .with('address', getAddress(faker.finance.ethereumAddress()))
     .with(
       'topics',
       Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => {
@@ -19,65 +17,21 @@ export function transactionStatusReceiptLogBuilder(): IBuilder<
       faker.string.hexadecimal({
         length: 64,
       }) as `0x${string}`,
-    )
-    .with(
-      'blockHash',
-      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
-    )
-    .with('blockNumber', faker.string.numeric())
-    .with(
-      'blockTimestamp',
-      faker.string.hexadecimal({ length: 8 }) as `0x${string}`,
-    )
-    .with(
-      'transactionHash',
-      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
-    )
-    .with('transactionIndex', faker.number.int())
-    .with('logIndex', faker.number.int())
-    .with('removed', false);
+    );
 }
 
 export function transactionStatusReceiptBuilder(): IBuilder<
   TransactionStatus['receipt']
 > {
-  const transactionIndex = faker.number.int();
-  return new Builder<TransactionStatus['receipt']>()
-    .with('status', 'success')
-    .with('cumulativeGasUsed', faker.string.numeric())
-    .with(
-      'logs',
-      Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () =>
-        transactionStatusReceiptLogBuilder()
-          .with('transactionIndex', transactionIndex)
-          .build(),
-      ),
-    )
-    .with(
-      'logsBloom',
-      faker.string.hexadecimal({ length: 512 }) as `0x${string}`,
-    )
-    .with('type', 'eip1559')
-    .with(
-      'transactionHash',
-      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
-    )
-    .with('transactionIndex', transactionIndex)
-    .with(
-      'blockHash',
-      faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
-    )
-    .with('blockNumber', faker.string.numeric())
-    .with('gasUsed', faker.string.numeric())
-    .with('effectiveGasPrice', faker.string.numeric())
-    .with('from', getAddress(faker.finance.ethereumAddress()))
-    .with('to', getAddress(faker.finance.ethereumAddress()))
-    .with('contractAddress', null);
+  return new Builder<TransactionStatus['receipt']>().with(
+    'logs',
+    Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () =>
+      transactionStatusReceiptLogBuilder().build(),
+    ),
+  );
 }
 
 export function transactionStatusBuilder(): IBuilder<TransactionStatus> {
   const receipt = transactionStatusReceiptBuilder().build();
-  return new Builder<TransactionStatus>()
-    .with('receipt', receipt)
-    .with('status', receipt.status);
+  return new Builder<TransactionStatus>().with('receipt', receipt);
 }

--- a/src/datasources/staking-api/entities/__tests__/transaction-status.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/transaction-status.entity.spec.ts
@@ -1,0 +1,536 @@
+import {
+  transactionStatusReceiptBuilder,
+  transactionStatusReceiptLogBuilder,
+} from '@/datasources/staking-api/entities/__tests__/transaction-status.entity.builder';
+import {
+  TransactionStatusReceiptLogSchema,
+  TransactionStatusReceiptSchema,
+  TransactionStatusSchema,
+} from '@/datasources/staking-api/entities/transaction-status.entity';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+describe('TransactionStatus', () => {
+  describe('TransactionStatusReceiptLogSchema', () => {
+    it('should validate a valid TransactionStatusReceiptLog', () => {
+      const transactionStatusReceiptLog =
+        transactionStatusReceiptLogBuilder().build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('not allow non-address address', () => {
+      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+        .with('address', faker.string.numeric() as `0x${string}`)
+        .build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid address',
+        path: ['address'],
+      });
+    });
+
+    it('should checksum the address', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase();
+      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+        .with('address', nonChecksummedAddress as `0x${string}`)
+        .build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(result.success && result.data.address).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    });
+
+    it('should not allow non-hex topics', () => {
+      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+        .with('topics', [faker.string.alphanumeric() as `0x${string}`])
+        .build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: ['topics', 0],
+      });
+    });
+
+    it.each([
+      'data' as const,
+      'blockHash' as const,
+      'blockTimestamp' as const,
+      'transactionHash' as const,
+    ])('should not allow non-hex %s', (field) => {
+      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+        .with(field, faker.string.alphanumeric() as `0x${string}`)
+        .build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: [field],
+      });
+    });
+
+    it('should not allow a non-numeric string blockNumber', () => {
+      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+        .with('blockNumber', faker.string.alpha())
+        .build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid base-10 numeric string',
+        path: ['blockNumber'],
+      });
+    });
+
+    it.each(['transactionIndex' as const, 'logIndex' as const])(
+      'should not allow a non-numeric %s',
+      (field) => {
+        const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+          .with(field, faker.string.numeric() as unknown as number)
+          .build();
+
+        const result = TransactionStatusReceiptLogSchema.safeParse(
+          transactionStatusReceiptLog,
+        );
+
+        expect(!result.success && result.error.issues.length).toBe(1);
+        expect(!result.success && result.error.issues[0]).toStrictEqual({
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Expected number, received string',
+          path: [field],
+          received: 'string',
+        });
+      },
+    );
+
+    it('should not allow a non-boolean removed', () => {
+      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
+        .with('removed', faker.string.alphanumeric() as unknown as boolean)
+        .build();
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'invalid_type',
+        expected: 'boolean',
+        message: 'Expected boolean, received string',
+        path: ['removed'],
+        received: 'string',
+      });
+    });
+
+    it('should not validate and invalid TransactionStatusReceiptLog', () => {
+      const transactionStatusReceiptLog = {
+        invalid: 'transactionStatusReceiptLog',
+      };
+
+      const result = TransactionStatusReceiptLogSchema.safeParse(
+        transactionStatusReceiptLog,
+      );
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['address'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['topics'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['data'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['blockHash'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['blockNumber'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['blockTimestamp'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['transactionHash'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['transactionIndex'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['logIndex'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          message: 'Required',
+          path: ['removed'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('TransactionStatusReceiptSchema', () => {
+    it('should validate a valid TransactionStatusReceipt', () => {
+      const transactionStatusReceipt =
+        transactionStatusReceiptBuilder().build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should fallback to unknown status', () => {
+      const transactionStatusReceipt = transactionStatusReceiptBuilder()
+        .with('status', 'invalid' as 'success')
+        .build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(result.success && result.data.status).toBe('unknown');
+    });
+
+    it.each([
+      'cumulativeGasUsed' as const,
+      'blockNumber' as const,
+      'gasUsed' as const,
+      'effectiveGasPrice' as const,
+    ])(`should not allow a non-numeric string %s`, (field) => {
+      const transactionStatusReceipt = transactionStatusReceiptBuilder()
+        .with(field, faker.string.alpha())
+        .build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid base-10 numeric string',
+        path: [field],
+      });
+    });
+
+    it('should allow no topics', () => {
+      const transactionStatusReceipt = transactionStatusReceiptBuilder()
+        .with('logs', [])
+        .build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should fallback to unknown type', () => {
+      const transactionStatusReceipt = transactionStatusReceiptBuilder()
+        .with('type', 'invalid' as 'eip1559')
+        .build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(result.success && result.data.type).toBe('unknown');
+    });
+
+    it.each([
+      'logsBloom' as const,
+      'transactionHash' as const,
+      'blockHash' as const,
+    ])('should not allow a non-hex %s', (field) => {
+      const transactionStatusReceipt = transactionStatusReceiptBuilder()
+        .with(field, faker.string.alpha() as `0x${string}`)
+        .build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: [field],
+      });
+    });
+
+    it('should not allow a non-numeric string transactionIndex', () => {
+      const transactionStatusReceipt = transactionStatusReceiptBuilder()
+        .with('transactionIndex', faker.string.numeric() as unknown as number)
+        .build();
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Expected number, received string',
+        path: ['transactionIndex'],
+        received: 'string',
+      });
+    });
+
+    it.each(['from' as const, 'to' as const, 'contractAddress' as const])(
+      'should not allow a non-address %s',
+      (field) => {
+        const transactionStatusReceipt = transactionStatusReceiptBuilder()
+          .with(field, faker.string.numeric() as `0x${string}`)
+          .build();
+
+        const result = TransactionStatusReceiptSchema.safeParse(
+          transactionStatusReceipt,
+        );
+
+        expect(!result.success && result.error.issues.length).toBe(1);
+        expect(!result.success && result.error.issues[0]).toStrictEqual({
+          code: 'custom',
+          message: 'Invalid address',
+          path: [field],
+        });
+      },
+    );
+
+    it.each(['from' as const, 'to' as const, 'contractAddress' as const])(
+      'should checksum the %s',
+      (field) => {
+        const nonChecksummedAddress = faker.finance
+          .ethereumAddress()
+          .toLowerCase();
+        const transactionStatusReceipt = transactionStatusReceiptBuilder()
+          .with(field, nonChecksummedAddress as `0x${string}`)
+          .build();
+
+        const result = TransactionStatusReceiptSchema.safeParse(
+          transactionStatusReceipt,
+        );
+
+        expect(result.success && result.data[field]).toBe(
+          getAddress(nonChecksummedAddress),
+        );
+      },
+    );
+
+    it('should default contractAddress to null', () => {
+      const transactionStatusReceipt =
+        transactionStatusReceiptBuilder().build();
+      // @ts-expect-error - undefined contractAddress not valid
+      delete transactionStatusReceipt.contractAddress;
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(result.success && result.data.contractAddress).toBe(null);
+    });
+
+    it('should not validate an invalid TransactionStatusReceipt', () => {
+      const transactionStatusReceipt = {
+        invalid: 'transactionStatusReceipt',
+      };
+
+      const result = TransactionStatusReceiptSchema.safeParse(
+        transactionStatusReceipt,
+      );
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['cumulativeGasUsed'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['logs'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['logsBloom'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['transactionHash'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['transactionIndex'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['blockHash'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['blockNumber'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['gasUsed'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['effectiveGasPrice'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['from'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['to'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('TransactionStatusSchema', () => {
+    it('should validate a valid TransactionStatus', () => {
+      const transactionStatus = {
+        receipt: transactionStatusReceiptBuilder().build(),
+        status: 'success',
+      };
+
+      const result = TransactionStatusSchema.safeParse(transactionStatus);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should fallback to unknown status', () => {
+      const transactionStatus = {
+        receipt: transactionStatusReceiptBuilder().build(),
+        status: 'invalid' as 'success',
+      };
+
+      const result = TransactionStatusSchema.safeParse(transactionStatus);
+
+      expect(result.success && result.data.status).toBe('unknown');
+    });
+
+    it('should not validate an invalid TransactionStatus', () => {
+      const transactionStatus = {
+        invalid: 'transactionStatus',
+      };
+
+      const result = TransactionStatusSchema.safeParse(transactionStatus);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'object',
+          message: 'Required',
+          path: ['receipt'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+});

--- a/src/datasources/staking-api/entities/__tests__/transaction-status.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/transaction-status.entity.spec.ts
@@ -8,7 +8,6 @@ import {
   TransactionStatusSchema,
 } from '@/datasources/staking-api/entities/transaction-status.entity';
 import { faker } from '@faker-js/faker/.';
-import { getAddress } from 'viem';
 
 describe('TransactionStatus', () => {
   describe('TransactionStatusReceiptLogSchema', () => {
@@ -21,40 +20,6 @@ describe('TransactionStatus', () => {
       );
 
       expect(result.success).toBe(true);
-    });
-
-    it('not allow non-address address', () => {
-      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
-        .with('address', faker.string.numeric() as `0x${string}`)
-        .build();
-
-      const result = TransactionStatusReceiptLogSchema.safeParse(
-        transactionStatusReceiptLog,
-      );
-
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'custom',
-        message: 'Invalid address',
-        path: ['address'],
-      });
-    });
-
-    it('should checksum the address', () => {
-      const nonChecksummedAddress = faker.finance
-        .ethereumAddress()
-        .toLowerCase();
-      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
-        .with('address', nonChecksummedAddress as `0x${string}`)
-        .build();
-
-      const result = TransactionStatusReceiptLogSchema.safeParse(
-        transactionStatusReceiptLog,
-      );
-
-      expect(result.success && result.data.address).toBe(
-        getAddress(nonChecksummedAddress),
-      );
     });
 
     it('should not allow non-hex topics', () => {
@@ -74,14 +39,9 @@ describe('TransactionStatus', () => {
       });
     });
 
-    it.each([
-      'data' as const,
-      'blockHash' as const,
-      'blockTimestamp' as const,
-      'transactionHash' as const,
-    ])('should not allow non-hex %s', (field) => {
+    it('should not allow non-hex data', () => {
       const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
-        .with(field, faker.string.alphanumeric() as `0x${string}`)
+        .with('data', faker.string.alphanumeric() as `0x${string}`)
         .build();
 
       const result = TransactionStatusReceiptLogSchema.safeParse(
@@ -92,65 +52,7 @@ describe('TransactionStatus', () => {
       expect(!result.success && result.error.issues[0]).toStrictEqual({
         code: 'custom',
         message: 'Invalid "0x" notated hex string',
-        path: [field],
-      });
-    });
-
-    it('should not allow a non-numeric string blockNumber', () => {
-      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
-        .with('blockNumber', faker.string.alpha())
-        .build();
-
-      const result = TransactionStatusReceiptLogSchema.safeParse(
-        transactionStatusReceiptLog,
-      );
-
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'custom',
-        message: 'Invalid base-10 numeric string',
-        path: ['blockNumber'],
-      });
-    });
-
-    it.each(['transactionIndex' as const, 'logIndex' as const])(
-      'should not allow a non-numeric %s',
-      (field) => {
-        const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
-          .with(field, faker.string.numeric() as unknown as number)
-          .build();
-
-        const result = TransactionStatusReceiptLogSchema.safeParse(
-          transactionStatusReceiptLog,
-        );
-
-        expect(!result.success && result.error.issues.length).toBe(1);
-        expect(!result.success && result.error.issues[0]).toStrictEqual({
-          code: 'invalid_type',
-          expected: 'number',
-          message: 'Expected number, received string',
-          path: [field],
-          received: 'string',
-        });
-      },
-    );
-
-    it('should not allow a non-boolean removed', () => {
-      const transactionStatusReceiptLog = transactionStatusReceiptLogBuilder()
-        .with('removed', faker.string.alphanumeric() as unknown as boolean)
-        .build();
-
-      const result = TransactionStatusReceiptLogSchema.safeParse(
-        transactionStatusReceiptLog,
-      );
-
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'invalid_type',
-        expected: 'boolean',
-        message: 'Expected boolean, received string',
-        path: ['removed'],
-        received: 'string',
+        path: ['data'],
       });
     });
 
@@ -166,13 +68,6 @@ describe('TransactionStatus', () => {
       expect(!result.success && result.error.issues).toStrictEqual([
         {
           code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['address'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
           expected: 'array',
           message: 'Required',
           path: ['topics'],
@@ -183,55 +78,6 @@ describe('TransactionStatus', () => {
           expected: 'string',
           message: 'Required',
           path: ['data'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['blockHash'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['blockNumber'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['blockTimestamp'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['transactionHash'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'number',
-          message: 'Required',
-          path: ['transactionIndex'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'number',
-          message: 'Required',
-          path: ['logIndex'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'boolean',
-          message: 'Required',
-          path: ['removed'],
           received: 'undefined',
         },
       ]);
@@ -250,41 +96,7 @@ describe('TransactionStatus', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should fallback to unknown status', () => {
-      const transactionStatusReceipt = transactionStatusReceiptBuilder()
-        .with('status', 'invalid' as 'success')
-        .build();
-
-      const result = TransactionStatusReceiptSchema.safeParse(
-        transactionStatusReceipt,
-      );
-
-      expect(result.success && result.data.status).toBe('unknown');
-    });
-
-    it.each([
-      'cumulativeGasUsed' as const,
-      'blockNumber' as const,
-      'gasUsed' as const,
-      'effectiveGasPrice' as const,
-    ])(`should not allow a non-numeric string %s`, (field) => {
-      const transactionStatusReceipt = transactionStatusReceiptBuilder()
-        .with(field, faker.string.alpha())
-        .build();
-
-      const result = TransactionStatusReceiptSchema.safeParse(
-        transactionStatusReceipt,
-      );
-
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'custom',
-        message: 'Invalid base-10 numeric string',
-        path: [field],
-      });
-    });
-
-    it('should allow no topics', () => {
+    it('should allow no logs', () => {
       const transactionStatusReceipt = transactionStatusReceiptBuilder()
         .with('logs', [])
         .build();
@@ -294,111 +106,6 @@ describe('TransactionStatus', () => {
       );
 
       expect(result.success).toBe(true);
-    });
-
-    it('should fallback to unknown type', () => {
-      const transactionStatusReceipt = transactionStatusReceiptBuilder()
-        .with('type', 'invalid' as 'eip1559')
-        .build();
-
-      const result = TransactionStatusReceiptSchema.safeParse(
-        transactionStatusReceipt,
-      );
-
-      expect(result.success && result.data.type).toBe('unknown');
-    });
-
-    it.each([
-      'logsBloom' as const,
-      'transactionHash' as const,
-      'blockHash' as const,
-    ])('should not allow a non-hex %s', (field) => {
-      const transactionStatusReceipt = transactionStatusReceiptBuilder()
-        .with(field, faker.string.alpha() as `0x${string}`)
-        .build();
-
-      const result = TransactionStatusReceiptSchema.safeParse(
-        transactionStatusReceipt,
-      );
-
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'custom',
-        message: 'Invalid "0x" notated hex string',
-        path: [field],
-      });
-    });
-
-    it('should not allow a non-numeric string transactionIndex', () => {
-      const transactionStatusReceipt = transactionStatusReceiptBuilder()
-        .with('transactionIndex', faker.string.numeric() as unknown as number)
-        .build();
-
-      const result = TransactionStatusReceiptSchema.safeParse(
-        transactionStatusReceipt,
-      );
-
-      expect(!result.success && result.error.issues.length).toBe(1);
-      expect(!result.success && result.error.issues[0]).toStrictEqual({
-        code: 'invalid_type',
-        expected: 'number',
-        message: 'Expected number, received string',
-        path: ['transactionIndex'],
-        received: 'string',
-      });
-    });
-
-    it.each(['from' as const, 'to' as const, 'contractAddress' as const])(
-      'should not allow a non-address %s',
-      (field) => {
-        const transactionStatusReceipt = transactionStatusReceiptBuilder()
-          .with(field, faker.string.numeric() as `0x${string}`)
-          .build();
-
-        const result = TransactionStatusReceiptSchema.safeParse(
-          transactionStatusReceipt,
-        );
-
-        expect(!result.success && result.error.issues.length).toBe(1);
-        expect(!result.success && result.error.issues[0]).toStrictEqual({
-          code: 'custom',
-          message: 'Invalid address',
-          path: [field],
-        });
-      },
-    );
-
-    it.each(['from' as const, 'to' as const, 'contractAddress' as const])(
-      'should checksum the %s',
-      (field) => {
-        const nonChecksummedAddress = faker.finance
-          .ethereumAddress()
-          .toLowerCase();
-        const transactionStatusReceipt = transactionStatusReceiptBuilder()
-          .with(field, nonChecksummedAddress as `0x${string}`)
-          .build();
-
-        const result = TransactionStatusReceiptSchema.safeParse(
-          transactionStatusReceipt,
-        );
-
-        expect(result.success && result.data[field]).toBe(
-          getAddress(nonChecksummedAddress),
-        );
-      },
-    );
-
-    it('should default contractAddress to null', () => {
-      const transactionStatusReceipt =
-        transactionStatusReceiptBuilder().build();
-      // @ts-expect-error - undefined contractAddress not valid
-      delete transactionStatusReceipt.contractAddress;
-
-      const result = TransactionStatusReceiptSchema.safeParse(
-        transactionStatusReceipt,
-      );
-
-      expect(result.success && result.data.contractAddress).toBe(null);
     });
 
     it('should not validate an invalid TransactionStatusReceipt', () => {
@@ -413,79 +120,9 @@ describe('TransactionStatus', () => {
       expect(!result.success && result.error.issues).toStrictEqual([
         {
           code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['cumulativeGasUsed'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
           expected: 'array',
           message: 'Required',
           path: ['logs'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['logsBloom'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['transactionHash'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'number',
-          message: 'Required',
-          path: ['transactionIndex'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['blockHash'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['blockNumber'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['gasUsed'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['effectiveGasPrice'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['from'],
-          received: 'undefined',
-        },
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          message: 'Required',
-          path: ['to'],
           received: 'undefined',
         },
       ]);
@@ -502,17 +139,6 @@ describe('TransactionStatus', () => {
       const result = TransactionStatusSchema.safeParse(transactionStatus);
 
       expect(result.success).toBe(true);
-    });
-
-    it('should fallback to unknown status', () => {
-      const transactionStatus = {
-        receipt: transactionStatusReceiptBuilder().build(),
-        status: 'invalid' as 'success',
-      };
-
-      const result = TransactionStatusSchema.safeParse(transactionStatus);
-
-      expect(result.success && result.data.status).toBe('unknown');
     });
 
     it('should not validate an invalid TransactionStatus', () => {

--- a/src/datasources/staking-api/entities/transaction-status.entity.ts
+++ b/src/datasources/staking-api/entities/transaction-status.entity.ts
@@ -1,0 +1,41 @@
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { z } from 'zod';
+
+export const TransactionStatusReceiptLogSchema = z.object({
+  address: AddressSchema,
+  topics: z.array(HexSchema),
+  data: HexSchema,
+  blockHash: HexSchema,
+  blockNumber: NumericStringSchema,
+  blockTimestamp: HexSchema,
+  transactionHash: HexSchema,
+  transactionIndex: z.number(),
+  logIndex: z.number(),
+  removed: z.boolean(),
+});
+
+export const TransactionStatusReceiptSchema = z.object({
+  status: z.enum(['success', 'unknown']).catch('unknown'),
+  cumulativeGasUsed: NumericStringSchema,
+  logs: z.array(TransactionStatusReceiptLogSchema),
+  logsBloom: HexSchema,
+  type: z.enum(['eip1559', 'unknown']).catch('unknown'),
+  transactionHash: HexSchema,
+  transactionIndex: z.number(),
+  blockHash: HexSchema,
+  blockNumber: NumericStringSchema,
+  gasUsed: NumericStringSchema,
+  effectiveGasPrice: NumericStringSchema,
+  from: AddressSchema,
+  to: AddressSchema,
+  contractAddress: AddressSchema.nullish().default(null),
+});
+
+export const TransactionStatusSchema = z.object({
+  receipt: TransactionStatusReceiptSchema,
+  status: z.enum(['success', 'unknown']).catch('unknown'),
+});
+
+export type TransactionStatus = z.infer<typeof TransactionStatusSchema>;

--- a/src/datasources/staking-api/entities/transaction-status.entity.ts
+++ b/src/datasources/staking-api/entities/transaction-status.entity.ts
@@ -1,41 +1,20 @@
-import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
+// Note: this is a partial schema for decoding `DepositEvent` logs
+// of native staking `deposit` transactions.
+
 export const TransactionStatusReceiptLogSchema = z.object({
-  address: AddressSchema,
   topics: z.array(HexSchema),
   data: HexSchema,
-  blockHash: HexSchema,
-  blockNumber: NumericStringSchema,
-  blockTimestamp: HexSchema,
-  transactionHash: HexSchema,
-  transactionIndex: z.number(),
-  logIndex: z.number(),
-  removed: z.boolean(),
 });
 
 export const TransactionStatusReceiptSchema = z.object({
-  status: z.enum(['success', 'unknown']).catch('unknown'),
-  cumulativeGasUsed: NumericStringSchema,
   logs: z.array(TransactionStatusReceiptLogSchema),
-  logsBloom: HexSchema,
-  type: z.enum(['eip1559', 'unknown']).catch('unknown'),
-  transactionHash: HexSchema,
-  transactionIndex: z.number(),
-  blockHash: HexSchema,
-  blockNumber: NumericStringSchema,
-  gasUsed: NumericStringSchema,
-  effectiveGasPrice: NumericStringSchema,
-  from: AddressSchema,
-  to: AddressSchema,
-  contractAddress: AddressSchema.nullish().default(null),
 });
 
 export const TransactionStatusSchema = z.object({
   receipt: TransactionStatusReceiptSchema,
-  status: z.enum(['success', 'unknown']).catch('unknown'),
 });
 
 export type TransactionStatus = z.infer<typeof TransactionStatusSchema>;

--- a/src/domain/interfaces/staking-api.interface.ts
+++ b/src/domain/interfaces/staking-api.interface.ts
@@ -4,6 +4,7 @@ import { NetworkStats } from '@/datasources/staking-api/entities/network-stats.e
 import { PooledStakingStats } from '@/datasources/staking-api/entities/pooled-staking-stats.entity';
 import { DefiVaultStats } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
 import { Stake } from '@/datasources/staking-api/entities/stake.entity';
+import { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
 
 export const IStakingApi = Symbol('IStakingApi');
 
@@ -24,4 +25,6 @@ export interface IStakingApi {
   }): Promise<Stake[]>;
 
   clearStakes(safeAddress: `0x${string}`): Promise<void>;
+
+  getTransactionStatus(txHash: `0x${string}`): Promise<TransactionStatus>;
 }

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -4,6 +4,7 @@ import { NetworkStats } from '@/datasources/staking-api/entities/network-stats.e
 import { PooledStakingStats } from '@/datasources/staking-api/entities/pooled-staking-stats.entity';
 import { DefiVaultStats } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
 import { Stake } from '@/datasources/staking-api/entities/stake.entity';
+import { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
 
 export const IStakingRepository = Symbol('IStakingRepository');
 
@@ -37,6 +38,11 @@ export interface IStakingRepository {
     chainId: string;
     safeAddress: `0x${string}`;
   }): Promise<void>;
+
+  getTransactionStatus(args: {
+    chainId: string;
+    txHash: `0x${string}`;
+  }): Promise<TransactionStatus>;
 
   clearApi(chainId: string): void;
 }

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -25,6 +25,10 @@ import {
   Stake,
   StakeSchema,
 } from '@/datasources/staking-api/entities/stake.entity';
+import {
+  TransactionStatus,
+  TransactionStatusSchema,
+} from '@/datasources/staking-api/entities/transaction-status.entity';
 
 @Injectable()
 export class StakingRepository implements IStakingRepository {
@@ -107,6 +111,15 @@ export class StakingRepository implements IStakingRepository {
   }): Promise<void> {
     const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
     await stakingApi.clearStakes(args.safeAddress);
+  }
+
+  public async getTransactionStatus(args: {
+    chainId: string;
+    txHash: `0x${string}`;
+  }): Promise<TransactionStatus> {
+    const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
+    const txStatus = await stakingApi.getTransactionStatus(args.txHash);
+    return TransactionStatusSchema.parse(txStatus);
   }
 
   public clearApi(chainId: string): void {


### PR DESCRIPTION
## Summary

This adds a new `IStakingApi['getTransactionStatus']` and propagates it into `IStakingRepository`.

Note: it will be used to retrieve `deposit` event logs for `_publicKey` access in a follow up.

## Changes

- Add `TransactionStatusSchema` and infer `TransactionStatus` entity from it.
- Add relevant builders.
- Add Kiln-specific transaction status retrieval.
- Propagate into staking repository.
- Add new `staking_transaction_status` cache key.
- Add appropriate test coverage.