### PR TITLE
Ensure event signature is present in topics

### DIFF
--- a/src/datasources/staking-api/entities/__tests__/transaction-status.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/transaction-status.entity.builder.ts
@@ -8,9 +8,9 @@ export function transactionStatusReceiptLogBuilder(): IBuilder<
   return new Builder<TransactionStatus['receipt']['logs'][number]>()
     .with(
       'topics',
-      Array.from({ length: faker.number.int({ min: 0, max: 10 }) }, () => {
+      Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () => {
         return faker.string.hexadecimal({ length: 64 }) as `0x${string}`;
-      }),
+      }) as [`0x${string}`, ...Array<`0x${string}`>],
     )
     .with(
       'data',

--- a/src/datasources/staking-api/entities/transaction-status.entity.ts
+++ b/src/datasources/staking-api/entities/transaction-status.entity.ts
@@ -1,3 +1,4 @@
+import { EventTopicsSchema } from '@/validation/entities/schemas/event-topics.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { z } from 'zod';
 
@@ -5,7 +6,7 @@ import { z } from 'zod';
 // of native staking `deposit` transactions.
 
 export const TransactionStatusReceiptLogSchema = z.object({
-  topics: z.array(HexSchema),
+  topics: EventTopicsSchema,
   data: HexSchema,
 });
 

--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -58,10 +58,7 @@ export class AlertsRepository implements IAlertsRepository {
         address: safeAddress,
       });
 
-      const decodedEvent = this.delayModifierDecoder.decodeEventLog({
-        data: log.data as Hex,
-        topics: log.topics as [Hex, Hex, Hex],
-      });
+      const decodedEvent = this.delayModifierDecoder.decodeEventLog(log);
       const decodedTransactions = this._decodeTransactionAdded(
         decodedEvent.args.data,
       );

--- a/src/routes/alerts/entities/__tests__/alerts.builder.ts
+++ b/src/routes/alerts/entities/__tests__/alerts.builder.ts
@@ -15,9 +15,9 @@ export function alertLogBuilder(): IBuilder<AlertLog> {
       'topics',
       Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
         faker.string.hexadecimal(),
-      ),
+      ) as [`0x${string}`, ...Array<`0x${string}`>],
     )
-    .with('data', faker.string.hexadecimal());
+    .with('data', faker.string.hexadecimal() as `0x${string}`);
 }
 
 export function alertTransactionBuilder(): IBuilder<AlertTransaction> {

--- a/src/routes/alerts/entities/alert.dto.entity.ts
+++ b/src/routes/alerts/entities/alert.dto.entity.ts
@@ -7,8 +7,8 @@ import { z } from 'zod';
 
 export class AlertLog implements z.infer<typeof AlertLogSchema> {
   address!: `0x${string}`;
-  topics!: Array<string>;
-  data!: string;
+  topics!: [signature: `0x${string}`, ...Array<`0x${string}`>];
+  data!: `0x${string}`;
 }
 
 export class AlertTransaction

--- a/src/routes/alerts/entities/schemas/__tests__/alerts.schema.spec.ts
+++ b/src/routes/alerts/entities/schemas/__tests__/alerts.schema.spec.ts
@@ -37,12 +37,26 @@ describe('Alerts schemas', () => {
       );
     });
 
-    it('should allow empty alert log topics', () => {
-      const alertLog = alertLogBuilder().with('topics', []).build();
+    it('should not allow empty alert log event signature', () => {
+      const alertLog = alertLogBuilder()
+        .with(
+          'topics',
+          [] as unknown as [`0x${string}`, ...Array<`0x${string}`>],
+        )
+        .build();
 
       const result = AlertLogSchema.safeParse(alertLog);
 
-      expect(result.success && result.data.topics).toStrictEqual([]);
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'too_small',
+        exact: false,
+        inclusive: true,
+        message: 'No event signature found',
+        minimum: 1,
+        path: ['topics'],
+        type: 'array',
+      });
     });
 
     it('should not allow invalid alert logs', () => {

--- a/src/routes/alerts/entities/schemas/alerts.schema.ts
+++ b/src/routes/alerts/entities/schemas/alerts.schema.ts
@@ -1,11 +1,13 @@
 import { EventType } from '@/routes/alerts/entities/alert.dto.entity';
 import { z } from 'zod';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { EventTopicsSchema } from '@/validation/entities/schemas/event-topics.schema';
 
 export const AlertLogSchema = z.object({
   address: AddressSchema,
-  topics: z.array(z.string()),
-  data: z.string(),
+  topics: EventTopicsSchema,
+  data: HexSchema,
 });
 
 export const AlertTransactionSchema = z.object({

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -137,15 +137,7 @@ export class NativeStakingMapper {
     });
 
     const depositEvents = txStatus.receipt.logs
-      .map((log) => {
-        return this.kilnDecoder.decodeDepositEvent({
-          data: log.data,
-          topics: log.topics as [
-            signature: `0x${string}`,
-            ...args: `0x${string}`[],
-          ],
-        });
-      })
+      .map((log) => this.kilnDecoder.decodeDepositEvent(log))
       .filter(<T>(event: T | null): event is T => event !== null);
 
     if (depositEvents.length === 0) {

--- a/src/validation/entities/schemas/__tests__/event-topics.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/event-topics.schema.spec.ts
@@ -1,0 +1,67 @@
+import { EventTopicsSchema } from '@/validation/entities/schemas/event-topics.schema';
+import { faker } from '@faker-js/faker/.';
+
+describe('EventTopicsSchema', () => {
+  it('validate an EventTopicsSchema', () => {
+    const eventTopics = Array.from(
+      { length: faker.number.int({ min: 1, max: 5 }) },
+      () => faker.string.hexadecimal() as `0x${string}`,
+    );
+
+    const result = EventTopicsSchema.safeParse(eventTopics);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not allow missing event signatures', () => {
+    const result = EventTopicsSchema.safeParse([]);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'too_small',
+      minimum: 1,
+      type: 'array',
+      inclusive: true,
+      exact: false,
+      message: 'No event signature found',
+      path: [],
+    });
+  });
+
+  it('should not allow non-hex topics', () => {
+    const topics = Array.from(
+      { length: faker.number.int({ min: 1, max: 5 }) },
+      () => faker.string.alpha() as `0x${string}`,
+    );
+
+    const result = EventTopicsSchema.safeParse(topics);
+
+    expect(!result.success && result.error.issues.length).toBe(topics.length);
+    expect(!result.success && result.error.issues).toStrictEqual(
+      Array.from({ length: topics.length }, (_, i) => {
+        return {
+          code: 'custom',
+          message: 'Invalid "0x" notated hex string',
+          path: [i],
+        };
+      }),
+    );
+  });
+
+  it('should not validate an invalid EventTopicsSchema', () => {
+    const eventTopics = {
+      invalid: 'eventTopics',
+    };
+
+    const result = EventTopicsSchema.safeParse(eventTopics);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'invalid_type',
+      expected: 'array',
+      message: 'Expected array, received object',
+      path: [],
+      received: 'object',
+    });
+  });
+});

--- a/src/validation/entities/schemas/event-topics.schema.ts
+++ b/src/validation/entities/schemas/event-topics.schema.ts
@@ -1,0 +1,5 @@
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+
+export const EventTopicsSchema = HexSchema.array().nonempty(
+  'No event signature found',
+);


### PR DESCRIPTION
## Summary

All events have a signature, this signature is present as the initial element in the topics. Currently, we cast the topics of both deposit events (staking) and alert events to match this expected type. The type is incorrect as our validation allows for empty topics arrays.

This adds a new `EventTopicsSchema` and uses it in relevant schemas, removing the unnecessary casting thereafter.

## Changes

- Add/use `EventTopicsSchema`.
- Remove unnecessary topic casting.
- Add/update tests accordingly.