### PR TITLE
Return all estimated staking times in milliseconds

### DIFF
--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -120,10 +120,10 @@ describe('NativeStakingMapper', () => {
         expect.objectContaining({
           type: 'NativeStakingDeposit',
           status: 'NOT_STAKED',
-          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
+          estimatedEntryTime: networkStats.estimated_entry_time_seconds * 1_000,
+          estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
           estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
+            networkStats.estimated_withdrawal_time_seconds * 1_000,
           fee: 0.5,
           monthlyNrr: 1.5 / 12,
           annualNrr: 1.5,
@@ -201,10 +201,10 @@ describe('NativeStakingMapper', () => {
         expect.objectContaining({
           type: 'NativeStakingDeposit',
           status: 'DEPOSIT_IN_PROGRESS',
-          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
+          estimatedEntryTime: networkStats.estimated_entry_time_seconds * 1_000,
+          estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
           estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
+            networkStats.estimated_withdrawal_time_seconds * 1_000,
           fee: 0.5,
           monthlyNrr: 1.5 / 12,
           annualNrr: 1.5,
@@ -346,9 +346,9 @@ describe('NativeStakingMapper', () => {
         expect.objectContaining({
           type: 'NativeStakingValidatorsExit',
           status: statusMap[stakes[0].state],
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
+          estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
           estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
+            networkStats.estimated_withdrawal_time_seconds * 1_000,
           value: stakes[0].net_claimable_consensus_rewards,
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
           tokenInfo: {

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -91,9 +91,10 @@ export class NativeStakingMapper {
 
     return new NativeStakingDepositTransactionInfo({
       status,
-      estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-      estimatedExitTime: networkStats.estimated_exit_time_seconds,
-      estimatedWithdrawalTime: networkStats.estimated_withdrawal_time_seconds,
+      estimatedEntryTime: networkStats.estimated_entry_time_seconds * 1_000,
+      estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
+      estimatedWithdrawalTime:
+        networkStats.estimated_withdrawal_time_seconds * 1_000,
       fee,
       monthlyNrr: nrr / 12,
       annualNrr: nrr,
@@ -205,8 +206,9 @@ export class NativeStakingMapper {
     });
     return new NativeStakingValidatorsExitTransactionInfo({
       status,
-      estimatedExitTime: networkStats.estimated_exit_time_seconds,
-      estimatedWithdrawalTime: networkStats.estimated_withdrawal_time_seconds,
+      estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
+      estimatedWithdrawalTime:
+        networkStats.estimated_withdrawal_time_seconds * 1_000,
       value: getNumberString(value),
       numValidators,
       tokenInfo: new TokenInfo({

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -652,10 +652,12 @@ describe('TransactionsViewController tests', () => {
               method: dataDecoded.method,
               status: 'NOT_STAKED',
               parameters: dataDecoded.parameters,
-              estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-              estimatedExitTime: networkStats.estimated_exit_time_seconds,
+              estimatedEntryTime:
+                networkStats.estimated_entry_time_seconds * 1_000,
+              estimatedExitTime:
+                networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
-                networkStats.estimated_withdrawal_time_seconds,
+                networkStats.estimated_withdrawal_time_seconds * 1_000,
               fee: +deployment.product_fee!,
               monthlyNrr,
               annualNrr,
@@ -754,10 +756,12 @@ describe('TransactionsViewController tests', () => {
               method: dataDecoded.method,
               status: 'NOT_STAKED',
               parameters: dataDecoded.parameters,
-              estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-              estimatedExitTime: networkStats.estimated_exit_time_seconds,
+              estimatedEntryTime:
+                networkStats.estimated_entry_time_seconds * 1_000,
+              estimatedExitTime:
+                networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
-                networkStats.estimated_withdrawal_time_seconds,
+                networkStats.estimated_withdrawal_time_seconds * 1_000,
               fee: +deployment.product_fee!,
               monthlyNrr,
               annualNrr,
@@ -855,10 +859,12 @@ describe('TransactionsViewController tests', () => {
               method: 'deposit',
               status: 'NOT_STAKED',
               parameters: [],
-              estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-              estimatedExitTime: networkStats.estimated_exit_time_seconds,
+              estimatedEntryTime:
+                networkStats.estimated_entry_time_seconds * 1_000,
+              estimatedExitTime:
+                networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
-                networkStats.estimated_withdrawal_time_seconds,
+                networkStats.estimated_withdrawal_time_seconds * 1_000,
               fee: +deployment.product_fee!,
               monthlyNrr,
               annualNrr,
@@ -960,10 +966,12 @@ describe('TransactionsViewController tests', () => {
               method: dataDecoded.method,
               parameters: dataDecoded.parameters,
               status: 'NOT_STAKED',
-              estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-              estimatedExitTime: networkStats.estimated_exit_time_seconds,
+              estimatedEntryTime:
+                networkStats.estimated_entry_time_seconds * 1_000,
+              estimatedExitTime:
+                networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
-                networkStats.estimated_withdrawal_time_seconds,
+                networkStats.estimated_withdrawal_time_seconds * 1_000,
               fee: +deployment.product_fee!,
               monthlyNrr:
                 (dedicatedStakingStats.gross_apy.last_30d *
@@ -1421,9 +1429,10 @@ describe('TransactionsViewController tests', () => {
               method: dataDecoded.method,
               parameters: dataDecoded.parameters,
               status: 'ACTIVE',
-              estimatedExitTime: networkStats.estimated_exit_time_seconds,
+              estimatedExitTime:
+                networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
-                networkStats.estimated_withdrawal_time_seconds,
+                networkStats.estimated_withdrawal_time_seconds * 1_000,
               value: (
                 +stakes[0].net_claimable_consensus_rewards! +
                 +stakes[1].net_claimable_consensus_rewards!
@@ -1529,9 +1538,10 @@ describe('TransactionsViewController tests', () => {
                 },
               ],
               status: 'ACTIVE',
-              estimatedExitTime: networkStats.estimated_exit_time_seconds,
+              estimatedExitTime:
+                networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
-                networkStats.estimated_withdrawal_time_seconds,
+                networkStats.estimated_withdrawal_time_seconds * 1_000,
               value: (
                 +stakes[0].net_claimable_consensus_rewards! +
                 +stakes[1].net_claimable_consensus_rewards!


### PR DESCRIPTION
## Summary

We currently return all estimated staking times _as is_ from Kiln (in seconds). It is standard practice throughout the project to return timestamps in milliseconds.

This adjusts the staking mapping to return all staking times in milliseconds.

## Changes

- Convert all staking times to milliseconds.
- Update tests accordingly.