### PR TITLE
Only return `net_claimable_consensus_rewards` as `value` before withdrawal

### DIFF
--- a/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
+++ b/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
@@ -32,6 +32,7 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
   extends Builder<T>
   implements IEncoder<TransactionAddedEvent>
 {
+  // TODO: Extract ABI and non-indexed params as done in Kiln's WithdrawalEventBuilder
   static readonly NON_INDEXED_PARAMS =
     'address to, uint256 value, bytes data, uint8 operation' as const;
   static readonly EVENT_SIGNATURE =

--- a/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/kiln-decoder.helper.spec.ts
@@ -3,6 +3,7 @@ import {
   depositEncoder,
   depositEventEventBuilder,
   requestValidatorsExitEncoder,
+  withdrawalEventBuilder,
 } from '@/domain/staking/contracts/decoders/__tests__/encoders/kiln-encoder.builder';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { ILoggingService } from '@/logging/logging.interface';
@@ -15,7 +16,6 @@ const mockLoggingService = {
   warn: jest.fn(),
 } as jest.MockedObjectDeep<ILoggingService>;
 
-// TODO: Move function encoding to kiln-encoder.builder.ts
 describe('KilnDecoder', () => {
   let kilnDecoder: KilnDecoder;
 
@@ -102,7 +102,7 @@ describe('KilnDecoder', () => {
   });
 
   describe('decodeDepositEvent', () => {
-    it('decodes a deposit event correctly', () => {
+    it('decodes a DepositEvent correctly', () => {
       const depositEventEvent = depositEventEventBuilder();
       const { data, topics } = depositEventEvent.encode();
 
@@ -114,8 +114,11 @@ describe('KilnDecoder', () => {
       ).toStrictEqual(depositEventEvent.build());
     });
 
-    // Note: we cannot test whether null is returned for a non-DepositEvent
-    // as only DepositEvent is included in the ABI
+    it('returns null if the data is not a DepositEvent', () => {
+      const { data, topics } = withdrawalEventBuilder().encode();
+
+      expect(kilnDecoder.decodeDepositEvent({ data, topics })).toBe(null);
+    });
 
     it('returns null if the data is not a DepositEvent', () => {
       const data = faker.string.hexadecimal({ length: 514 }) as `0x${string}`;
@@ -124,6 +127,35 @@ describe('KilnDecoder', () => {
       ] as [signature: `0x${string}`, ...args: `0x${string}`[]];
 
       expect(kilnDecoder.decodeDepositEvent({ data, topics })).toBe(null);
+    });
+  });
+
+  describe('decodeWithdrawalEvent', () => {
+    it('decodes a Withdrawal correctly', () => {
+      const withdrawalEvent = withdrawalEventBuilder();
+      const { data, topics } = withdrawalEvent.encode();
+
+      expect(
+        kilnDecoder.decodeWithdrawal({
+          data,
+          topics,
+        }),
+      ).toStrictEqual(withdrawalEvent.build());
+    });
+
+    it('returns null if the data is not a Withdrawal', () => {
+      const { data, topics } = depositEventEventBuilder().encode();
+
+      expect(kilnDecoder.decodeWithdrawal({ data, topics })).toBe(null);
+    });
+
+    it('returns null if the data is not a Withdrawal', () => {
+      const data = faker.string.hexadecimal({ length: 514 }) as `0x${string}`;
+      const topics = [
+        faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
+      ] as [signature: `0x${string}`, ...args: `0x${string}`[]];
+
+      expect(kilnDecoder.decodeWithdrawal({ data, topics })).toBe(null);
     });
   });
 });

--- a/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
+++ b/src/domain/staking/contracts/decoders/kiln-decoder.helper.ts
@@ -5,6 +5,7 @@ import { parseAbi } from 'viem';
 
 export const KilnAbi = parseAbi([
   'event DepositEvent(bytes pubkey, bytes withdrawal_credentials, bytes amount, bytes signature, bytes index)',
+  'event Withdrawal(address indexed withdrawer, address indexed feeRecipient, bytes32 pubKeyRoot, uint256 rewards, uint256 nodeOperatorFee, uint256 treasuryFee)',
   'function deposit()',
   'function requestValidatorsExit(bytes _publicKeys)',
   'function batchWithdrawCLFee(bytes _publicKeys)',
@@ -121,6 +122,29 @@ export class KilnDecoder extends AbiDecoder<typeof KilnAbi> {
       const decoded = this.decodeEventLog(args);
       if (decoded.eventName !== 'DepositEvent') {
         throw new Error('Data is not of DepositEvent type');
+      }
+      return decoded.args;
+    } catch (e) {
+      this.loggingService.debug(e);
+      return null;
+    }
+  }
+
+  decodeWithdrawal(args: {
+    data: `0x${string}`;
+    topics: [signature: `0x${string}`, ...args: `0x${string}`[]];
+  }): {
+    withdrawer: `0x${string}`;
+    feeRecipient: `0x${string}`;
+    pubKeyRoot: `0x${string}`;
+    rewards: bigint;
+    nodeOperatorFee: bigint;
+    treasuryFee: bigint;
+  } | null {
+    try {
+      const decoded = this.decodeEventLog(args);
+      if (decoded.eventName !== 'Withdrawal') {
+        throw new Error('Data is not of Withdrawal type');
       }
       return decoded.args;
     } catch (e) {

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -6,6 +6,11 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
+/**
+ * Compared to {@link NativeStakingValidatorsExitConfirmationView}, this has no value
+ * as Kiln's API only returns the current `net_claimable_consensus_rewards`. After
+ * withdrawal, `net_claimable_consensus_rewards` resets to 0.
+ */
 export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo {
   @ApiProperty({ enum: [TransactionInfoType.NativeStakingValidatorsExit] })
   override type = TransactionInfoType.NativeStakingValidatorsExit;
@@ -20,9 +25,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   estimatedWithdrawalTime: number;
 
   @ApiProperty()
-  value: string;
-
-  @ApiProperty()
   numValidators: number;
 
   @ApiProperty()
@@ -32,7 +34,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     status: StakingStatus;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;
-    value: string;
     numValidators: number;
     tokenInfo: TokenInfo;
   }) {
@@ -40,7 +41,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     this.status = args.status;
     this.estimatedExitTime = args.estimatedExitTime;
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
-    this.value = args.value;
     this.numValidators = args.numValidators;
     this.tokenInfo = args.tokenInfo;
   }

--- a/src/routes/transactions/helpers/kiln-native-staking.helper.spec.ts
+++ b/src/routes/transactions/helpers/kiln-native-staking.helper.spec.ts
@@ -26,46 +26,70 @@ describe('KilnNativeStakingHelper', () => {
     );
   });
 
-  describe.skip('findDepositTransaction', () => {
-    it('should return a `deposit` transaction', () => {});
+  describe('findDepositTransaction', () => {
+    it.todo('should return a `deposit` transaction');
 
-    it('should return a batched `deposit` transaction', () => {});
+    it.todo('should return a batched `deposit` transaction');
 
-    it('should return null if a `deposit` transaction is not from a known staking contract', () => {});
+    it.todo(
+      'should return null if a `deposit` transaction is not from a known staking contract',
+    );
 
-    it('should return null if a batched `deposit` transaction is not from a known staking contract', () => {});
+    it.todo(
+      'should return null if a batched `deposit` transaction is not from a known staking contract',
+    );
 
-    it('should return null if the transaction is not a `deposit` transaction', () => {});
+    it.todo(
+      'should return null if the transaction is not a `deposit` transaction',
+    );
 
-    it('should return null if the transaction batch contains no `deposit` transaction', () => {});
+    it.todo(
+      'should return null if the transaction batch contains no `deposit` transaction',
+    );
   });
 
-  describe.skip('findValidatorsExitTransaction', () => {
-    it('should return a `requestValidatorsExit` transaction', () => {});
+  describe('findValidatorsExitTransaction', () => {
+    it.todo('should return a `requestValidatorsExit` transaction');
 
-    it('should return a batched `requestValidatorsExit` transaction', () => {});
+    it.todo('should return a batched `requestValidatorsExit` transaction');
 
-    it('should return null if a `requestValidatorsExit` transaction is not from a known staking contract', () => {});
+    it.todo(
+      'should return null if a `requestValidatorsExit` transaction is not from a known staking contract',
+    );
 
-    it('should return null if a requestValidatorsExit `deposit` transaction is not from a known staking contract', () => {});
+    it.todo(
+      'should return null if a requestValidatorsExit `deposit` transaction is not from a known staking contract',
+    );
 
-    it('should return null if the transaction is not a `requestValidatorsExit` transaction', () => {});
+    it.todo(
+      'should return null if the transaction is not a `requestValidatorsExit` transaction',
+    );
 
-    it('should return null if the transaction batch contains no `requestValidatorsExit` transaction', () => {});
+    it.todo(
+      'should return null if the transaction batch contains no `requestValidatorsExit` transaction',
+    );
   });
 
-  describe.skip('findWithdrawTransaction', () => {
-    it('should return a `batchWithdrawCLFee` transaction', () => {});
+  describe('findWithdrawTransaction', () => {
+    it.todo('should return a `batchWithdrawCLFee` transaction');
 
-    it('should return a batched `batchWithdrawCLFee` transaction', () => {});
+    it.todo('should return a batched `batchWithdrawCLFee` transaction');
 
-    it('should return null if a `batchWithdrawCLFee` transaction is not from a known staking contract', () => {});
+    it.todo(
+      'should return null if a `batchWithdrawCLFee` transaction is not from a known staking contract',
+    );
 
-    it('should return null if a batchWithdrawCLFee `deposit` transaction is not from a known staking contract', () => {});
+    it.todo(
+      'should return null if a batchWithdrawCLFee `deposit` transaction is not from a known staking contract',
+    );
 
-    it('should return null if the transaction is not a `batchWithdrawCLFee` transaction', () => {});
+    it.todo(
+      'should return null if the transaction is not a `batchWithdrawCLFee` transaction',
+    );
 
-    it('should return null if the transaction batch contains no `batchWithdrawCLFee` transaction', () => {});
+    it.todo(
+      'should return null if the transaction batch contains no `batchWithdrawCLFee` transaction',
+    );
   });
 
   describe('getValueFromDataDecoded', () => {

--- a/src/routes/transactions/helpers/kiln-native-staking.helper.spec.ts
+++ b/src/routes/transactions/helpers/kiln-native-staking.helper.spec.ts
@@ -1,0 +1,245 @@
+import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
+import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
+import { dataDecodedBuilder } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
+import { StakingRepository } from '@/domain/staking/staking.repository';
+import { KilnNativeStakingHelper } from '@/routes/transactions/helpers/kiln-native-staking.helper';
+import { TransactionFinder } from '@/routes/transactions/helpers/transaction-finder.helper';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+const mockStakingRepository = jest.mocked({
+  getStakes: jest.fn(),
+} as jest.MockedObjectDeep<StakingRepository>);
+
+describe('KilnNativeStakingHelper', () => {
+  let target: KilnNativeStakingHelper;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    const multiSendDecoder = new MultiSendDecoder();
+    const transactionFinder = new TransactionFinder(multiSendDecoder);
+    target = new KilnNativeStakingHelper(
+      transactionFinder,
+      mockStakingRepository,
+    );
+  });
+
+  describe.skip('findDepositTransaction', () => {
+    it('should return a `deposit` transaction', () => {});
+
+    it('should return a batched `deposit` transaction', () => {});
+
+    it('should return null if a `deposit` transaction is not from a known staking contract', () => {});
+
+    it('should return null if a batched `deposit` transaction is not from a known staking contract', () => {});
+
+    it('should return null if the transaction is not a `deposit` transaction', () => {});
+
+    it('should return null if the transaction batch contains no `deposit` transaction', () => {});
+  });
+
+  describe.skip('findValidatorsExitTransaction', () => {
+    it('should return a `requestValidatorsExit` transaction', () => {});
+
+    it('should return a batched `requestValidatorsExit` transaction', () => {});
+
+    it('should return null if a `requestValidatorsExit` transaction is not from a known staking contract', () => {});
+
+    it('should return null if a requestValidatorsExit `deposit` transaction is not from a known staking contract', () => {});
+
+    it('should return null if the transaction is not a `requestValidatorsExit` transaction', () => {});
+
+    it('should return null if the transaction batch contains no `requestValidatorsExit` transaction', () => {});
+  });
+
+  describe.skip('findWithdrawTransaction', () => {
+    it('should return a `batchWithdrawCLFee` transaction', () => {});
+
+    it('should return a batched `batchWithdrawCLFee` transaction', () => {});
+
+    it('should return null if a `batchWithdrawCLFee` transaction is not from a known staking contract', () => {});
+
+    it('should return null if a batchWithdrawCLFee `deposit` transaction is not from a known staking contract', () => {});
+
+    it('should return null if the transaction is not a `batchWithdrawCLFee` transaction', () => {});
+
+    it('should return null if the transaction batch contains no `batchWithdrawCLFee` transaction', () => {});
+  });
+
+  describe('getValueFromDataDecoded', () => {
+    it('should throw if the decoded data is not of a `requestValidatorsExit` or `batchWithdrawCLFee` transaction', async () => {
+      const chainId = faker.string.numeric();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', 'deposit')
+        .with('parameters', [])
+        .build();
+
+      await expect(() =>
+        target.getValueFromDataDecoded({
+          chainId,
+          safeAddress,
+          dataDecoded,
+        }),
+      ).rejects.toThrow('deposit does not contain _publicKeys');
+    });
+
+    it('should return 0 if no public keys are found in the decoded data', async () => {
+      const method = faker.helpers.arrayElement([
+        'requestValidatorsExit',
+        'batchWithdrawCLFee',
+      ]);
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', method)
+        .with('parameters', [])
+        .build();
+
+      const result = await target.getValueFromDataDecoded({
+        chainId: faker.string.numeric(),
+        safeAddress: getAddress(faker.finance.ethereumAddress()),
+        dataDecoded,
+      });
+
+      expect(result).toBe(0);
+    });
+
+    it('should return the total claimable value for all public keys', async () => {
+      const method = faker.helpers.arrayElement([
+        'requestValidatorsExit',
+        'batchWithdrawCLFee',
+      ]);
+      const _publicKeys = faker.string.hexadecimal({
+        length: KilnDecoder.KilnPublicKeyLength * 3,
+      }) as `0x${string}`; // 3 validators
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', method)
+        .with('parameters', [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: _publicKeys,
+            valueDecoded: null,
+          },
+        ])
+        .build();
+      const stakes = [
+        stakeBuilder().build(),
+        stakeBuilder().build(),
+        stakeBuilder().build(),
+      ];
+      mockStakingRepository.getStakes.mockResolvedValue(stakes);
+
+      const result = await target.getValueFromDataDecoded({
+        chainId: faker.string.numeric(),
+        safeAddress: getAddress(faker.finance.ethereumAddress()),
+        dataDecoded,
+      });
+
+      expect(result).toBe(
+        +stakes[0].net_claimable_consensus_rewards! +
+          +stakes[1].net_claimable_consensus_rewards! +
+          +stakes[2].net_claimable_consensus_rewards!,
+      );
+    });
+  });
+
+  describe('getPublicKeysFromDataDecoded', () => {
+    it('should throw if the decoded data is not of a `requestValidatorsExit` or `batchWithdrawCLFee` transaction', () => {
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', 'deposit')
+        .with('parameters', [])
+        .build();
+
+      expect(() => target.getPublicKeysFromDataDecoded(dataDecoded)).toThrow(
+        'deposit does not contain _publicKeys',
+      );
+    });
+
+    it('should return an empty array if no parameters are found', () => {
+      const method = faker.helpers.arrayElement([
+        'requestValidatorsExit',
+        'batchWithdrawCLFee',
+      ]);
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', method)
+        .with('parameters', [])
+        .build();
+
+      const result = target.getPublicKeysFromDataDecoded(dataDecoded);
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('should return an array of split public keys if hex _publicKeys parameter is found', () => {
+      const method = faker.helpers.arrayElement([
+        'requestValidatorsExit',
+        'batchWithdrawCLFee',
+      ]);
+      const _publicKeys = faker.string.hexadecimal({
+        length: KilnDecoder.KilnPublicKeyLength * 3,
+      }) as `0x${string}`; // 3 validators
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', method)
+        .with('parameters', [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: _publicKeys,
+            valueDecoded: null,
+          },
+        ])
+        .build();
+
+      const result = target.getPublicKeysFromDataDecoded(dataDecoded);
+
+      expect(result).toStrictEqual([
+        `0x${_publicKeys.slice(2, 2 + KilnDecoder.KilnPublicKeyLength)}`,
+        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength, 2 + KilnDecoder.KilnPublicKeyLength * 2)}`,
+        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength * 2, 2 + KilnDecoder.KilnPublicKeyLength * 3)}`,
+      ]);
+    });
+
+    it('should return an empty array if non-hex _publicKeys is found', () => {
+      const method = faker.helpers.arrayElement([
+        'requestValidatorsExit',
+        'batchWithdrawCLFee',
+      ]);
+      const _publicKeys = faker.string.alpha({
+        length: KilnDecoder.KilnPublicKeyLength,
+      }) as `0x${string}`;
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', method)
+        .with('parameters', [
+          {
+            name: '_publicKeys',
+            type: 'bytes',
+            value: _publicKeys,
+            valueDecoded: null,
+          },
+        ])
+        .build();
+
+      const result = target.getPublicKeysFromDataDecoded(dataDecoded);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('splitPublicKeys', () => {
+    it('should split the _publicKeys into an array of strings of correct length', () => {
+      const _publicKeys = faker.string.hexadecimal({
+        length: KilnDecoder.KilnPublicKeyLength * 3,
+      }) as `0x${string}`;
+
+      const result = target.splitPublicKeys(_publicKeys);
+
+      expect(result).toStrictEqual([
+        `0x${_publicKeys.slice(2, 2 + KilnDecoder.KilnPublicKeyLength)}`,
+        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength, 2 + KilnDecoder.KilnPublicKeyLength * 2)}`,
+        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength * 2, 2 + KilnDecoder.KilnPublicKeyLength * 3)}`,
+      ]);
+    });
+  });
+});

--- a/src/routes/transactions/helpers/kiln-native-staking.helper.ts
+++ b/src/routes/transactions/helpers/kiln-native-staking.helper.ts
@@ -1,3 +1,4 @@
+import { DataDecoded } from '@/domain/data-decoder/entities/data-decoded.entity';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
 import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
@@ -5,11 +6,17 @@ import {
   TransactionFinder,
   TransactionFinderModule,
 } from '@/routes/transactions/helpers/transaction-finder.helper';
-import { Inject, Injectable, Module } from '@nestjs/common';
-import { toFunctionSelector } from 'viem';
+import {
+  Inject,
+  Injectable,
+  Module,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { isHex, toFunctionSelector } from 'viem';
 
 @Injectable()
 export class KilnNativeStakingHelper {
+  // TODO: Extract from KilnAbi
   private static readonly DEPOSIT_SIGNATURE =
     'function deposit() external payable';
   private static readonly VALIDATORS_EXIT_SIGNATURE =
@@ -103,6 +110,92 @@ export class KilnNativeStakingHelper {
       to: args.transaction.to,
       data: args.transaction.data,
     };
+  }
+
+  /**
+   * Gets the net value (staked + rewards) to withdraw from the native staking deployment
+   * based on the length of the publicKeys field in the transaction data.
+   *
+   * Note: this can only be used with `validatorsExit` or `batchWithdrawCLFee` transactions
+   * as the have `_publicKeys` field in the decoded data.
+   *
+   * Each {@link KilnDecoder.KilnPublicKeyLength} characters represent a validator to withdraw,
+   * and each native staking validator has a fixed amount of 32 ETH to withdraw.
+   *
+   * @param dataDecoded - the decoded data of the transaction
+   * @param chainId - the ID of the chain where the native staking deployment lives
+   * @param safeAddress - the Safe staking
+   * @returns the net value to withdraw from the native staking deployment
+   */
+  public async getValueFromDataDecoded(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+    dataDecoded: DataDecoded;
+  }): Promise<number> {
+    const publicKeys = this.getPublicKeysFromDataDecoded(args.dataDecoded);
+    if (publicKeys.length === 0) {
+      return 0;
+    }
+    const stakes = await this.stakingRepository.getStakes({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+      validatorsPublicKeys: publicKeys,
+    });
+    return stakes.reduce((acc, stake) => {
+      const netValue = stake.net_claimable_consensus_rewards ?? '0';
+      return acc + Number(netValue);
+    }, 0);
+  }
+
+  /**
+   * Gets public keys from decoded `requestValidatorsExit` or `batchWithdrawCLFee` transactions
+   * @param dataDecoded - the transaction decoded data.
+   * @returns the public keys from the transaction decoded data.
+   */
+  public getPublicKeysFromDataDecoded(
+    dataDecoded: DataDecoded,
+  ): Array<`0x${string}`> {
+    if (
+      !['requestValidatorsExit', 'batchWithdrawCLFee'].includes(
+        dataDecoded.method,
+      )
+    ) {
+      throw new UnprocessableEntityException(
+        `${dataDecoded.method} does not contain _publicKeys`,
+      );
+    }
+
+    const publicKeys = dataDecoded.parameters?.find((parameter) => {
+      return parameter.name === '_publicKeys';
+    });
+    return isHex(publicKeys?.value)
+      ? this.splitPublicKeys(publicKeys.value)
+      : [];
+  }
+
+  /**
+   * Splits the public keys into an array of public keys.
+   *
+   * Each {@link KilnDecoder.KilnPublicKeyLength} characters represent a validator to withdraw, so the public keys
+   * are split into an array of strings of length {@link KilnDecoder.KilnPublicKeyLength}.
+   *
+   * @param publicKeys - the public keys to split
+   * @returns
+   */
+  public splitPublicKeys(publicKeys: `0x${string}`): `0x${string}`[] {
+    // Remove initial `0x` of decoded `_publicKeys`
+    const publicKeysString = publicKeys.slice(2);
+    const publicKeysArray: `0x${string}`[] = [];
+    for (
+      let i = 0;
+      i < publicKeysString.length;
+      i += KilnDecoder.KilnPublicKeyLength
+    ) {
+      publicKeysArray.push(
+        `0x${publicKeysString.slice(i, i + KilnDecoder.KilnPublicKeyLength)}`,
+      );
+    }
+    return publicKeysArray;
   }
 }
 

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -13,18 +13,23 @@ import {
 import { StakeState } from '@/datasources/staking-api/entities/stake.entity';
 import { ChainsRepository } from '@/domain/chains/chains.repository';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
 import {
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
 } from '@/domain/data-decoder/entities/__tests__/data-decoded.builder';
-import { confirmationBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
 import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
-import { depositEventEventBuilder } from '@/domain/staking/contracts/decoders/__tests__/encoders/kiln-encoder.builder';
+import {
+  depositEventEventBuilder,
+  withdrawalEventBuilder,
+} from '@/domain/staking/contracts/decoders/__tests__/encoders/kiln-encoder.builder';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
 import { StakingRepository } from '@/domain/staking/staking.repository';
 import { ILoggingService } from '@/logging/logging.interface';
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { StakingStatus } from '@/routes/transactions/entities/staking/staking.entity';
+import { KilnNativeStakingHelper } from '@/routes/transactions/helpers/kiln-native-staking.helper';
+import { TransactionFinder } from '@/routes/transactions/helpers/transaction-finder.helper';
 import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
@@ -71,11 +76,18 @@ describe('NativeStakingMapper', () => {
     jest.resetAllMocks();
     jest.useFakeTimers();
 
+    const multiSendDecoder = new MultiSendDecoder();
+    const transactionFinder = new TransactionFinder(multiSendDecoder);
+    const kilnNativeStakingHelper = new KilnNativeStakingHelper(
+      transactionFinder,
+      mockStakingRepository,
+    );
     const kilnDecoder = new KilnDecoder(mockLoggingService);
     target = new NativeStakingMapper(
       mockStakingRepository,
       mockChainsRepository,
       kilnDecoder,
+      kilnNativeStakingHelper,
       mockLoggingService,
     );
   });
@@ -325,8 +337,6 @@ describe('NativeStakingMapper', () => {
         ])
         .build();
       const transaction = multisigTransactionBuilder()
-        .with('confirmationsRequired', 2) // 2 confirmations required
-        .with('confirmations', [confirmationBuilder().build()]) // only 1 confirmation
         .with('dataDecoded', dataDecoded)
         .build();
       mockChainsRepository.getChain.mockResolvedValue(chain);
@@ -349,7 +359,6 @@ describe('NativeStakingMapper', () => {
           estimatedExitTime: networkStats.estimated_exit_time_seconds,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds,
-          value: stakes[0].net_claimable_consensus_rewards,
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
           tokenInfo: {
             address: NULL_ADDRESS,
@@ -442,7 +451,7 @@ describe('NativeStakingMapper', () => {
   });
 
   describe('mapWithdrawInfo', () => {
-    it('should map a native staking withdraw info', async () => {
+    it('should map a proposed native staking withdraw info', async () => {
       const chain = chainBuilder().build();
       const deployment = deploymentBuilder()
         .with('product_type', 'dedicated')
@@ -461,11 +470,7 @@ describe('NativeStakingMapper', () => {
             .build(),
         ])
         .build();
-      const transaction = multisigTransactionBuilder()
-        .with('confirmationsRequired', 2) // 2 confirmations required
-        .with('confirmations', [confirmationBuilder().build()]) // only 1 confirmation
-        .with('dataDecoded', dataDecoded)
-        .build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const stakes = [
         stakeBuilder()
           .with('net_claimable_consensus_rewards', '3.25')
@@ -487,9 +492,9 @@ describe('NativeStakingMapper', () => {
 
       const actual = await target.mapWithdrawInfo({
         chainId: chain.chainId,
-        safeAddress: transaction.safe,
+        safeAddress: safeAddress,
         to: deployment.address,
-        transaction,
+        transaction: null,
         dataDecoded,
       });
 
@@ -514,11 +519,101 @@ describe('NativeStakingMapper', () => {
 
       expect(mockStakingRepository.getStakes).toHaveBeenCalledWith({
         chainId: chain.chainId,
-        safeAddress: transaction.safe,
+        safeAddress,
         validatorsPublicKeys: [
           `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)}`,
           `0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
         ],
+      });
+    });
+
+    it('should map a native staking withdraw info', async () => {
+      const chain = chainBuilder().build();
+      const deployment = deploymentBuilder()
+        .with('product_type', 'dedicated')
+        .build();
+      const networkStats = networkStatsBuilder().build();
+      const validatorPublicKey = faker.string.hexadecimal({
+        length: KilnDecoder.KilnPublicKeyLength * 2,
+      }); // 2 validators
+      const dataDecoded = dataDecodedBuilder()
+        .with('method', 'requestValidatorsExit')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', '_publicKeys')
+            .with('type', 'bytes')
+            .with('value', validatorPublicKey)
+            .build(),
+        ])
+        .build();
+      const withdrawalEvent = withdrawalEventBuilder();
+      const withdrawalEventParams = withdrawalEvent.build();
+      const withdrawalEventEncoded = withdrawalEvent.encode();
+      const transactionStatus = transactionStatusBuilder()
+        .with(
+          'receipt',
+          transactionStatusReceiptBuilder()
+            .with('logs', [
+              transactionStatusReceiptLogBuilder()
+                .with('data', withdrawalEventEncoded.data)
+                .with('topics', withdrawalEventEncoded.topics)
+                .build(),
+            ])
+            .build(),
+        )
+        .build();
+      const transaction = multisigTransactionBuilder()
+        .with('dataDecoded', dataDecoded)
+        .build();
+      const stakes = [
+        stakeBuilder()
+          .with('net_claimable_consensus_rewards', '3.25')
+          .with('state', StakeState.WithdrawalDone)
+          .build(),
+        stakeBuilder()
+          .with('net_claimable_consensus_rewards', '1.25')
+          .with('state', StakeState.WithdrawalDone)
+          .build(),
+        stakeBuilder()
+          .with('net_claimable_consensus_rewards', '1')
+          .with('state', StakeState.WithdrawalDone)
+          .build(),
+      ];
+      mockChainsRepository.getChain.mockResolvedValue(chain);
+      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getStakes.mockResolvedValue(stakes);
+      mockStakingRepository.getTransactionStatus.mockResolvedValue(
+        transactionStatus,
+      );
+
+      const actual = await target.mapWithdrawInfo({
+        chainId: chain.chainId,
+        safeAddress: transaction.safe,
+        to: deployment.address,
+        transaction,
+        dataDecoded,
+      });
+
+      expect(actual).toEqual(
+        expect.objectContaining({
+          type: 'NativeStakingWithdraw',
+          value: withdrawalEventParams.rewards.toString(),
+          tokenInfo: {
+            address: NULL_ADDRESS,
+            decimals: chain.nativeCurrency.decimals,
+            logoUri: chain.nativeCurrency.logoUri,
+            name: chain.nativeCurrency.name,
+            symbol: chain.nativeCurrency.symbol,
+            trusted: true,
+          },
+        }),
+      );
+
+      expect(mockStakingRepository.getStakes).not.toHaveBeenCalled();
+      expect(mockStakingRepository.getTransactionStatus).toHaveBeenCalledWith({
+        chainId: chain.chainId,
+        txHash: transaction.transactionHash,
       });
     });
 

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -24,6 +24,7 @@ import { SwapOrderHelper } from '@/routes/transactions/helpers/swap-order.helper
 import { TwapOrderHelper } from '@/routes/transactions/helpers/twap-order.helper';
 import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
 import { Inject, Injectable } from '@nestjs/common';
+import { getNumberString } from '@/domain/common/utils/utils';
 
 @Injectable({})
 export class TransactionsViewService {
@@ -351,17 +352,26 @@ export class TransactionsViewService {
     if (!dataDecoded) {
       throw new Error('Transaction data could not be decoded');
     }
-    const validatorsExitInfo =
-      await this.nativeStakingMapper.mapValidatorsExitInfo({
+    const [validatorsExitInfo, value] = await Promise.all([
+      this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId: args.chainId,
         safeAddress: args.safeAddress,
         to: args.to,
         transaction: null,
         dataDecoded,
-      });
+      }),
+      this.kilnNativeStakingHelper.getValueFromDataDecoded({
+        dataDecoded,
+        chainId: args.chainId,
+        safeAddress: args.safeAddress,
+      }),
+    ]);
+
     return new NativeStakingValidatorsExitConfirmationView({
       method: dataDecoded.method,
       parameters: dataDecoded.parameters,
+      // Kiln's API only has a value until stake has been withdrawn
+      value: getNumberString(value),
       ...validatorsExitInfo,
     });
   }


### PR DESCRIPTION
## Summary

Resolves #1951

We explicitly return the `net_claimable_consensus_rewards` from Kiln's `v1/eth/stakes` endpoint. This is the combined value of staked ETH and current rewards. However, after successful execution of a withdrawal, this value changes to `0`.

This makes the following changes to accomodate for the above:

When exit requests are being proposed, the net claimable rewards theoretically still exists on Kiln's API. It is therefore returned in the confirmation view entity. After execution, it is no longer there. Therefore, it has been removed from the `txInfo` as the value would disappear when moving to the history. (Web will display number of validators instead.)

Withdrawal requests now fetch the net claimable rewards when queued but instead decode the value from the relevant `Withdrawal` events of an executed withdrawal.

## Changes

- Remove `value` from `NativeStakingValidatorsExitTransactionInfo`.
- Implement `Withdrawal` event decoding.
- Move methods shared between transaction/confirmation view mapping to `KilnNativeStakingHelper`.
- Add relative `Withdrawal` encoder/builder.
- Decode `value` of withdrawals after execution.
- Add/update tests accordingly.