### PR TITLE
Return validator addresses in staking entities

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
@@ -61,6 +61,9 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty()
   tokenInfo: TokenInfo;
 
+  @ApiProperty()
+  validators: Array<`0x${string}`>;
+
   constructor(args: {
     status: StakingStatus;
     estimatedEntryTime: number;
@@ -76,6 +79,7 @@ export class NativeStakingDepositTransactionInfo
     expectedFiatAnnualReward: number;
     expectedFiatMonthlyReward: number;
     tokenInfo: TokenInfo;
+    validators: Array<`0x${string}`>;
   }) {
     super(TransactionInfoType.NativeStakingDeposit, null, null);
     this.status = args.status;
@@ -92,5 +96,6 @@ export class NativeStakingDepositTransactionInfo
     this.expectedFiatAnnualReward = args.expectedFiatAnnualReward;
     this.expectedFiatMonthlyReward = args.expectedFiatMonthlyReward;
     this.tokenInfo = args.tokenInfo;
+    this.validators = args.validators;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
@@ -61,8 +61,10 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty()
   tokenInfo: TokenInfo;
 
-  @ApiProperty()
-  validators: Array<`0x${string}`>;
+  @ApiProperty({
+    description: 'Populated after transaction has been executed',
+  })
+  validators: Array<`0x${string}`> | null;
 
   constructor(args: {
     status: StakingStatus;
@@ -79,7 +81,7 @@ export class NativeStakingDepositTransactionInfo
     expectedFiatAnnualReward: number;
     expectedFiatMonthlyReward: number;
     tokenInfo: TokenInfo;
-    validators: Array<`0x${string}`>;
+    validators: Array<`0x${string}`> | null;
   }) {
     super(TransactionInfoType.NativeStakingDeposit, null, null);
     this.status = args.status;

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
@@ -39,6 +39,9 @@ export class NativeStakingValidatorsExitConfirmationView implements Baseline {
   @ApiProperty()
   tokenInfo: TokenInfo;
 
+  @ApiProperty()
+  validators: Array<`0x${string}`>;
+
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
@@ -48,6 +51,7 @@ export class NativeStakingValidatorsExitConfirmationView implements Baseline {
     value: string;
     numValidators: number;
     tokenInfo: TokenInfo;
+    validators: Array<`0x${string}`>;
   }) {
     this.method = args.method;
     this.parameters = args.parameters;
@@ -57,5 +61,6 @@ export class NativeStakingValidatorsExitConfirmationView implements Baseline {
     this.value = args.value;
     this.numValidators = args.numValidators;
     this.tokenInfo = args.tokenInfo;
+    this.validators = args.validators;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -30,12 +30,16 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   @ApiProperty()
   tokenInfo: TokenInfo;
 
+  @ApiProperty()
+  validators: Array<`0x${string}`>;
+
   constructor(args: {
     status: StakingStatus;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;
     numValidators: number;
     tokenInfo: TokenInfo;
+    validators: Array<`0x${string}`>;
   }) {
     super(TransactionInfoType.NativeStakingValidatorsExit, null, null);
     this.status = args.status;
@@ -43,5 +47,6 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
     this.numValidators = args.numValidators;
     this.tokenInfo = args.tokenInfo;
+    this.validators = args.validators;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
@@ -24,15 +24,20 @@ export class NativeStakingWithdrawConfirmationView implements Baseline {
   @ApiProperty()
   tokenInfo: TokenInfo;
 
+  @ApiProperty()
+  validators: Array<`0x${string}`>;
+
   constructor(args: {
     method: string;
     parameters: DataDecodedParameter[] | null;
     value: string;
     tokenInfo: TokenInfo;
+    validators: Array<`0x${string}`>;
   }) {
     this.method = args.method;
     this.parameters = args.parameters;
     this.value = args.value;
     this.tokenInfo = args.tokenInfo;
+    this.validators = args.validators;
   }
 }

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-info.entity.ts
@@ -15,9 +15,17 @@ export class NativeStakingWithdrawTransactionInfo extends TransactionInfo {
   @ApiProperty()
   tokenInfo: TokenInfo;
 
-  constructor(args: { value: string; tokenInfo: TokenInfo }) {
+  @ApiProperty()
+  validators: Array<`0x${string}`>;
+
+  constructor(args: {
+    value: string;
+    tokenInfo: TokenInfo;
+    validators: Array<`0x${string}`>;
+  }) {
     super(TransactionInfoType.NativeStakingWithdraw, null, null);
     this.value = args.value;
     this.tokenInfo = args.tokenInfo;
+    this.validators = args.validators;
   }
 }

--- a/src/routes/transactions/helpers/kiln-native-staking.helper.spec.ts
+++ b/src/routes/transactions/helpers/kiln-native-staking.helper.spec.ts
@@ -6,7 +6,7 @@ import { StakingRepository } from '@/domain/staking/staking.repository';
 import { KilnNativeStakingHelper } from '@/routes/transactions/helpers/kiln-native-staking.helper';
 import { TransactionFinder } from '@/routes/transactions/helpers/transaction-finder.helper';
 import { faker } from '@faker-js/faker';
-import { getAddress } from 'viem';
+import { concat, getAddress } from 'viem';
 
 const mockStakingRepository = jest.mocked({
   getStakes: jest.fn(),
@@ -134,9 +134,22 @@ describe('KilnNativeStakingHelper', () => {
         'requestValidatorsExit',
         'batchWithdrawCLFee',
       ]);
-      const _publicKeys = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 3,
-      }) as `0x${string}`; // 3 validators
+      const validators = [
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          // Transaction Service returns _publicKeys lowercase
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+      ] as Array<`0x${string}`>;
+      const _publicKeys = concat(validators);
       const dataDecoded = dataDecodedBuilder()
         .with('method', method)
         .with('parameters', [
@@ -201,9 +214,22 @@ describe('KilnNativeStakingHelper', () => {
         'requestValidatorsExit',
         'batchWithdrawCLFee',
       ]);
-      const _publicKeys = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 3,
-      }) as `0x${string}`; // 3 validators
+      const validators = [
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          // Transaction Service returns _publicKeys lowercase
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+      ] as Array<`0x${string}`>;
+      const _publicKeys = concat(validators);
       const dataDecoded = dataDecodedBuilder()
         .with('method', method)
         .with('parameters', [
@@ -218,11 +244,7 @@ describe('KilnNativeStakingHelper', () => {
 
       const result = target.getPublicKeysFromDataDecoded(dataDecoded);
 
-      expect(result).toStrictEqual([
-        `0x${_publicKeys.slice(2, 2 + KilnDecoder.KilnPublicKeyLength)}`,
-        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength, 2 + KilnDecoder.KilnPublicKeyLength * 2)}`,
-        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength * 2, 2 + KilnDecoder.KilnPublicKeyLength * 3)}`,
-      ]);
+      expect(result).toStrictEqual(validators);
     });
 
     it('should return an empty array if non-hex _publicKeys is found', () => {
@@ -253,17 +275,26 @@ describe('KilnNativeStakingHelper', () => {
 
   describe('splitPublicKeys', () => {
     it('should split the _publicKeys into an array of strings of correct length', () => {
-      const _publicKeys = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 3,
-      }) as `0x${string}`;
+      const validators = [
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          // Transaction Service returns _publicKeys lowercase
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+      ] as Array<`0x${string}`>;
+      const _publicKeys = concat(validators);
 
       const result = target.splitPublicKeys(_publicKeys);
 
-      expect(result).toStrictEqual([
-        `0x${_publicKeys.slice(2, 2 + KilnDecoder.KilnPublicKeyLength)}`,
-        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength, 2 + KilnDecoder.KilnPublicKeyLength * 2)}`,
-        `0x${_publicKeys.slice(2 + KilnDecoder.KilnPublicKeyLength * 2, 2 + KilnDecoder.KilnPublicKeyLength * 3)}`,
-      ]);
+      expect(result).toStrictEqual(validators);
     });
   });
 });

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -32,7 +32,7 @@ import { KilnNativeStakingHelper } from '@/routes/transactions/helpers/kiln-nati
 import { TransactionFinder } from '@/routes/transactions/helpers/transaction-finder.helper';
 import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
 import { faker } from '@faker-js/faker';
-import { getAddress } from 'viem';
+import { concat, getAddress } from 'viem';
 
 const mockStakingRepository = jest.mocked({
   getDeployment: jest.fn(),
@@ -323,9 +323,22 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder().build();
       const stakes = [stakeBuilder().build()];
-      const validatorPublicKey = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 3,
-      }); // 3 validators
+      const validators = [
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          // Transaction Service returns _publicKeys lowercase
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+      ] as Array<`0x${string}`>;
+      const validatorPublicKey = concat(validators);
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
         .with('parameters', [
@@ -457,9 +470,18 @@ describe('NativeStakingMapper', () => {
         .with('product_type', 'dedicated')
         .build();
       const networkStats = networkStatsBuilder().build();
-      const validatorPublicKey = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 2,
-      }); // 2 validators
+      const validators = [
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          // Transaction Service returns _publicKeys lowercase
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+      ] as Array<`0x${string}`>;
+      const validatorPublicKey = concat(validators);
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
         .with('parameters', [
@@ -520,10 +542,7 @@ describe('NativeStakingMapper', () => {
       expect(mockStakingRepository.getStakes).toHaveBeenCalledWith({
         chainId: chain.chainId,
         safeAddress,
-        validatorsPublicKeys: [
-          `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)}`,
-          `0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
-        ],
+        validatorsPublicKeys: validators,
       });
     });
 
@@ -533,9 +552,18 @@ describe('NativeStakingMapper', () => {
         .with('product_type', 'dedicated')
         .build();
       const networkStats = networkStatsBuilder().build();
-      const validatorPublicKey = faker.string.hexadecimal({
-        length: KilnDecoder.KilnPublicKeyLength * 2,
-      }); // 2 validators
+      const validators = [
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          // Transaction Service returns _publicKeys lowercase
+          casing: 'lower',
+        }),
+        faker.string.hexadecimal({
+          length: KilnDecoder.KilnPublicKeyLength,
+          casing: 'lower',
+        }),
+      ] as Array<`0x${string}`>;
+      const validatorPublicKey = concat(validators);
       const dataDecoded = dataDecodedBuilder()
         .with('method', 'requestValidatorsExit')
         .with('parameters', [

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -609,6 +609,7 @@ describe('NativeStakingMapper', () => {
             symbol: chain.nativeCurrency.symbol,
             trusted: true,
           },
+          validators,
         }),
       );
 
@@ -708,6 +709,7 @@ describe('NativeStakingMapper', () => {
             symbol: chain.nativeCurrency.symbol,
             trusted: true,
           },
+          validators,
         }),
       );
 

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -157,6 +157,71 @@ describe('NativeStakingMapper', () => {
       );
     });
 
+    it('should map a queued native staking deposit info', async () => {
+      const chain = chainBuilder().build();
+      const productFee = '0.5';
+      const deployment = deploymentBuilder()
+        .with('product_type', 'dedicated')
+        .with('product_fee', productFee)
+        .build();
+      const networkStats = networkStatsBuilder()
+        .with('eth_price_usd', 10_000)
+        .build();
+      const dedicatedStakingStats = dedicatedStakingStatsBuilder()
+        .with(
+          'gross_apy',
+          dedicatedStakingStatsGrossApyBuilder().with('last_30d', 3).build(),
+        )
+        .build();
+      mockChainsRepository.getChain.mockResolvedValue(chain);
+      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
+        dedicatedStakingStats,
+      );
+      mockStakingRepository.getStakes.mockResolvedValue([]);
+      const transaction = multisigTransactionBuilder()
+        .with('executionDate', null)
+        .with('transactionHash', null)
+        .build();
+
+      const actual = await target.mapDepositInfo({
+        chainId: chain.chainId,
+        to: deployment.address,
+        value: '64000000000000000000',
+        transaction,
+      });
+
+      expect(actual).toEqual(
+        expect.objectContaining({
+          type: 'NativeStakingDeposit',
+          status: 'NOT_STAKED',
+          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
+          estimatedExitTime: networkStats.estimated_exit_time_seconds,
+          estimatedWithdrawalTime:
+            networkStats.estimated_withdrawal_time_seconds,
+          fee: 0.5,
+          monthlyNrr: 1.5 / 12,
+          annualNrr: 1.5,
+          value: '64000000000000000000',
+          numValidators: 2,
+          expectedAnnualReward: '960000000000000000',
+          expectedMonthlyReward: '80000000000000000',
+          expectedFiatAnnualReward: 9600,
+          expectedFiatMonthlyReward: 800,
+          tokenInfo: {
+            address: NULL_ADDRESS,
+            decimals: chain.nativeCurrency.decimals,
+            logoUri: chain.nativeCurrency.logoUri,
+            name: chain.nativeCurrency.name,
+            symbol: chain.nativeCurrency.symbol,
+            trusted: true,
+          },
+          validators: null,
+        }),
+      );
+    });
+
     it('should map a native staking deposit info', async () => {
       const chain = chainBuilder().build();
       const productFee = '0.5';
@@ -176,7 +241,14 @@ describe('NativeStakingMapper', () => {
       const stakes = [
         stakeBuilder().with('state', StakeState.DepositInProgress).build(),
       ];
-      const depositEventEvent = depositEventEventBuilder().encode();
+      const pubkey = faker.string.hexadecimal({
+        length: KilnDecoder.KilnPublicKeyLength,
+        // Transaction Service returns _publicKeys lowercase
+        casing: 'lower',
+      });
+      const depositEventEvent = depositEventEventBuilder()
+        .with('pubkey', pubkey as `0x${string}`)
+        .encode();
       const transactionStatus = transactionStatusBuilder()
         .with(
           'receipt',
@@ -234,6 +306,7 @@ describe('NativeStakingMapper', () => {
             symbol: chain.nativeCurrency.symbol,
             trusted: true,
           },
+          validators: [pubkey],
         }),
       );
     });

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -116,6 +116,7 @@ export class NativeStakingMapper {
         symbol: chain.nativeCurrency.symbol,
         trusted: true,
       }),
+      validators: publicKeys,
     });
   }
 
@@ -211,6 +212,7 @@ export class NativeStakingMapper {
         symbol: chain.nativeCurrency.symbol,
         trusted: true,
       }),
+      validators: publicKeys,
     });
   }
 
@@ -246,6 +248,10 @@ export class NativeStakingMapper {
       chainId: args.chainId,
       safeAddress: args.safeAddress,
     });
+    const publicKeys =
+      this.kilnNativeStakingHelper.getPublicKeysFromDataDecoded(
+        args.dataDecoded,
+      );
 
     return new NativeStakingWithdrawTransactionInfo({
       value: getNumberString(value),
@@ -257,6 +263,7 @@ export class NativeStakingMapper {
         symbol: chain.nativeCurrency.symbol,
         trusted: true,
       }),
+      validators: publicKeys,
     });
   }
 

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -116,7 +116,7 @@ export class NativeStakingMapper {
         symbol: chain.nativeCurrency.symbol,
         trusted: true,
       }),
-      validators: publicKeys,
+      validators: args.transaction?.executionDate ? publicKeys : null,
     });
   }
 

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -44,7 +44,7 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import { Server } from 'net';
 import request from 'supertest';
-import { encodeFunctionData, getAddress, parseAbi } from 'viem';
+import { concat, encodeFunctionData, getAddress, parseAbi } from 'viem';
 
 describe('TransactionsViewController tests', () => {
   let app: INestApplication<Server>;
@@ -1348,13 +1348,22 @@ describe('TransactionsViewController tests', () => {
             .build();
           const safeAddress = faker.finance.ethereumAddress();
           const networkStats = networkStatsBuilder().build();
-          const validatorPublicKey = faker.string.hexadecimal({
-            length: KilnDecoder.KilnPublicKeyLength * 2,
-          }); // 2 validators
+          const validators = [
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              // Transaction Service returns _publicKeys lowercase
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+          ] as Array<`0x${string}`>;
+          const validatorPublicKey = concat(validators);
           const data = encodeFunctionData({
             abi: parseAbi(['function requestValidatorsExit(bytes)']),
             functionName: 'requestValidatorsExit',
-            args: [validatorPublicKey as `0x${string}`],
+            args: [validatorPublicKey],
           });
           const dataDecoded = dataDecodedBuilder()
             .with('method', 'requestValidatorsExit')
@@ -1437,6 +1446,7 @@ describe('TransactionsViewController tests', () => {
                 symbol: chain.nativeCurrency.symbol,
                 trusted: true,
               },
+              validators,
             });
 
           // check the public keys are passed to the staking service in the expected format
@@ -1445,7 +1455,7 @@ describe('TransactionsViewController tests', () => {
             networkRequest: expect.objectContaining({
               params: {
                 onchain_v1_include_net_rewards: true,
-                validators: `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)},0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+                validators: validators.join(','),
               },
             }),
           });
@@ -1460,9 +1470,11 @@ describe('TransactionsViewController tests', () => {
             .build();
           const safeAddress = faker.finance.ethereumAddress();
           const networkStats = networkStatsBuilder().build();
-          const validatorPublicKey = faker.string.hexadecimal({
-            length: KilnDecoder.KilnPublicKeyLength,
-          });
+          const validatorPublicKey = faker.string
+            .hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+            })
+            .toLowerCase();
           const data = encodeFunctionData({
             abi: parseAbi(['function requestValidatorsExit(bytes)']),
             functionName: 'requestValidatorsExit',
@@ -1524,7 +1536,7 @@ describe('TransactionsViewController tests', () => {
                 {
                   name: '_publicKeys',
                   type: 'bytes',
-                  value: validatorPublicKey.toLowerCase(),
+                  value: validatorPublicKey,
                   valueDecoded: null,
                 },
               ],
@@ -1545,6 +1557,7 @@ describe('TransactionsViewController tests', () => {
                 symbol: chain.nativeCurrency.symbol,
                 trusted: true,
               },
+              validators: [validatorPublicKey],
             });
 
           // check the public keys are passed to the staking service in the expected format
@@ -1553,7 +1566,7 @@ describe('TransactionsViewController tests', () => {
             networkRequest: expect.objectContaining({
               params: {
                 onchain_v1_include_net_rewards: true,
-                validators: `${validatorPublicKey.toLowerCase()}`,
+                validators: validatorPublicKey,
               },
             }),
           });
@@ -1846,13 +1859,22 @@ describe('TransactionsViewController tests', () => {
             .build();
           const safeAddress = faker.finance.ethereumAddress();
           const networkStats = networkStatsBuilder().build();
-          const validatorPublicKey = faker.string.hexadecimal({
-            length: KilnDecoder.KilnPublicKeyLength * 2,
-          }); // 2 validators
+          const validators = [
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              // Transaction Service returns _publicKeys lowercase
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+          ] as Array<`0x${string}`>;
+          const validatorPublicKey = concat(validators);
           const data = encodeFunctionData({
             abi: parseAbi(['function requestValidatorsExit(bytes)']),
             functionName: 'requestValidatorsExit',
-            args: [validatorPublicKey as `0x${string}`],
+            args: [validatorPublicKey],
           });
           const dataDecoded = dataDecodedBuilder()
             .with('method', 'requestValidatorsExit')
@@ -1913,7 +1935,7 @@ describe('TransactionsViewController tests', () => {
             networkRequest: expect.objectContaining({
               params: {
                 onchain_v1_include_net_rewards: true,
-                validators: `${validatorPublicKey.slice(0, KilnDecoder.KilnPublicKeyLength + 2)},0x${validatorPublicKey.slice(KilnDecoder.KilnPublicKeyLength + 2)}`,
+                validators: validators.join(','),
               },
             }),
           });
@@ -1929,13 +1951,26 @@ describe('TransactionsViewController tests', () => {
             .with('product_fee', faker.number.float().toString())
             .build();
           const safeAddress = faker.finance.ethereumAddress();
-          const validatorPublicKey = faker.string.hexadecimal({
-            length: KilnDecoder.KilnPublicKeyLength * 3,
-          }); // 3 validators
+          const validators = [
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              // Transaction Service returns _publicKeys lowercase
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+          ] as Array<`0x${string}`>;
+          const validatorPublicKey = concat(validators);
           const data = encodeFunctionData({
             abi: parseAbi(['function batchWithdrawCLFee(bytes)']),
             functionName: 'batchWithdrawCLFee',
-            args: [validatorPublicKey as `0x${string}`],
+            args: [validatorPublicKey],
           });
           const dataDecoded = dataDecodedBuilder()
             .with('method', 'batchWithdrawCLFee')
@@ -2006,14 +2041,24 @@ describe('TransactionsViewController tests', () => {
                 symbol: chain.nativeCurrency.symbol,
                 trusted: true,
               },
+              validators,
             });
         });
 
         it('returns the native staking `withdraw` confirmation view using local decoding', async () => {
           const chain = chainBuilder().with('isTestnet', false).build();
-          const validatorPublicKey = faker.string.hexadecimal({
-            length: KilnDecoder.KilnPublicKeyLength * 2,
-          }); // 2 validators
+          const validators = [
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              // Transaction Service returns _publicKeys lowercase
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+          ] as Array<`0x${string}`>;
+          const validatorPublicKey = concat(validators);
           const deployment = deploymentBuilder()
             .with('chain_id', +chain.chainId)
             .with('product_type', 'dedicated')
@@ -2023,7 +2068,7 @@ describe('TransactionsViewController tests', () => {
           const data = encodeFunctionData({
             abi: parseAbi(['function batchWithdrawCLFee(bytes)']),
             functionName: 'batchWithdrawCLFee',
-            args: [`${validatorPublicKey}` as `0x${string}`],
+            args: [validatorPublicKey],
           });
           const stakes = [
             stakeBuilder()
@@ -2074,7 +2119,7 @@ describe('TransactionsViewController tests', () => {
                 {
                   name: '_publicKeys',
                   type: 'bytes',
-                  value: validatorPublicKey.toLowerCase(),
+                  value: validatorPublicKey,
                   valueDecoded: null,
                 },
               ],
@@ -2090,6 +2135,7 @@ describe('TransactionsViewController tests', () => {
                 symbol: chain.nativeCurrency.symbol,
                 trusted: true,
               },
+              validators,
             });
         });
 
@@ -2301,9 +2347,22 @@ describe('TransactionsViewController tests', () => {
 
         it('returns the generic confirmation view if the stakes are not available', async () => {
           const chain = chainBuilder().with('isTestnet', false).build();
-          const validatorPublicKey = faker.string.hexadecimal({
-            length: KilnDecoder.KilnPublicKeyLength * 3,
-          }); // 3 validators
+          const validators = [
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              // Transaction Service returns _publicKeys lowercase
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+            faker.string.hexadecimal({
+              length: KilnDecoder.KilnPublicKeyLength,
+              casing: 'lower',
+            }),
+          ] as Array<`0x${string}`>;
+          const validatorPublicKey = concat(validators);
           const dataDecoded = dataDecodedBuilder()
             .with('method', 'batchWithdrawCLFee')
             .with('parameters', [
@@ -2324,7 +2383,7 @@ describe('TransactionsViewController tests', () => {
           const data = encodeFunctionData({
             abi: parseAbi(['function batchWithdrawCLFee(bytes)']),
             functionName: 'batchWithdrawCLFee',
-            args: [validatorPublicKey as `0x${string}`],
+            args: [validatorPublicKey],
           });
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {


### PR DESCRIPTION
## Summary

As it is [not possible to always return the current value](https://github.com/safe-global/safe-client-gateway/pull/1963) for exit requests, we will not show the number of validators exiting in the transaction list of the UI. For individual validators, it's then possible to see their respective balances on the beacon chain explorer.

This returns the validators under a new `validators` property for all staking entities (apart from pre-executed deposits).

## Changes

- Add `validators` property to:
  - Confirmation view: exit requests and withdrawals
  - Transaction info: deposits (after execution), exit requests and withdrawals