### PR TITLE
Return multiple of 32 for `value` of `requestValidatorsExit`

### DIFF
--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -6,11 +6,6 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
-/**
- * Compared to {@link NativeStakingValidatorsExitConfirmationView}, this has no value
- * as Kiln's API only returns the current `net_claimable_consensus_rewards`. After
- * withdrawal, `net_claimable_consensus_rewards` resets to 0.
- */
 export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo {
   @ApiProperty({ enum: [TransactionInfoType.NativeStakingValidatorsExit] })
   override type = TransactionInfoType.NativeStakingValidatorsExit;
@@ -25,6 +20,9 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
   estimatedWithdrawalTime: number;
 
   @ApiProperty()
+  value: string;
+
+  @ApiProperty()
   numValidators: number;
 
   @ApiProperty()
@@ -37,6 +35,7 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     status: StakingStatus;
     estimatedExitTime: number;
     estimatedWithdrawalTime: number;
+    value: string;
     numValidators: number;
     tokenInfo: TokenInfo;
     validators: Array<`0x${string}`>;
@@ -45,6 +44,7 @@ export class NativeStakingValidatorsExitTransactionInfo extends TransactionInfo 
     this.status = args.status;
     this.estimatedExitTime = args.estimatedExitTime;
     this.estimatedWithdrawalTime = args.estimatedWithdrawalTime;
+    this.value = args.value;
     this.numValidators = args.numValidators;
     this.tokenInfo = args.tokenInfo;
     this.validators = args.validators;

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -196,10 +196,10 @@ describe('NativeStakingMapper', () => {
         expect.objectContaining({
           type: 'NativeStakingDeposit',
           status: 'NOT_STAKED',
-          estimatedEntryTime: networkStats.estimated_entry_time_seconds,
-          estimatedExitTime: networkStats.estimated_exit_time_seconds,
+          estimatedEntryTime: networkStats.estimated_entry_time_seconds * 1_000,
+          estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
           estimatedWithdrawalTime:
-            networkStats.estimated_withdrawal_time_seconds,
+            networkStats.estimated_withdrawal_time_seconds * 1_000,
           fee: 0.5,
           monthlyNrr: 1.5 / 12,
           annualNrr: 1.5,
@@ -445,6 +445,7 @@ describe('NativeStakingMapper', () => {
           estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
           estimatedWithdrawalTime:
             networkStats.estimated_withdrawal_time_seconds * 1_000,
+          value: '96000000000000000000', // 3 x 32 ETH
           numValidators: 3, // 3 public keys in the transaction data => 3 validators
           tokenInfo: {
             address: NULL_ADDRESS,
@@ -454,6 +455,7 @@ describe('NativeStakingMapper', () => {
             symbol: chain.nativeCurrency.symbol,
             trusted: true,
           },
+          validators,
         }),
       );
     });

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -191,6 +191,10 @@ export class NativeStakingMapper {
         args.dataDecoded,
       );
 
+    const value =
+      publicKeys.length *
+      NativeStakingMapper.ETH_ETHERS_PER_VALIDATOR *
+      Math.pow(10, chain.nativeCurrency.decimals);
     const [status, networkStats] = await Promise.all([
       this._getStatus({
         chainId: args.chainId,
@@ -205,6 +209,7 @@ export class NativeStakingMapper {
       estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
       estimatedWithdrawalTime:
         networkStats.estimated_withdrawal_time_seconds * 1_000,
+      value: getNumberString(value),
       numValidators,
       tokenInfo: new TokenInfo({
         address: NULL_ADDRESS,

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -1385,14 +1385,8 @@ describe('TransactionsViewController tests', () => {
             ])
             .build();
           const stakes = [
-            stakeBuilder()
-              .with('net_claimable_consensus_rewards', '1000000')
-              .with('state', StakeState.ActiveOngoing)
-              .build(),
-            stakeBuilder()
-              .with('net_claimable_consensus_rewards', '2000000')
-              .with('state', StakeState.ActiveOngoing)
-              .build(),
+            stakeBuilder().with('state', StakeState.ActiveOngoing).build(),
+            stakeBuilder().with('state', StakeState.ActiveOngoing).build(),
           ];
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1442,10 +1436,7 @@ describe('TransactionsViewController tests', () => {
                 networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds * 1_000,
-              value: (
-                +stakes[0].net_claimable_consensus_rewards! +
-                +stakes[1].net_claimable_consensus_rewards!
-              ).toString(),
+              value: '64000000000000000000', // 2 x 32 ETH,
               numValidators: 2,
               tokenInfo: {
                 address: NULL_ADDRESS,
@@ -1490,14 +1481,8 @@ describe('TransactionsViewController tests', () => {
             args: [validatorPublicKey as `0x${string}`],
           });
           const stakes = [
-            stakeBuilder()
-              .with('net_claimable_consensus_rewards', '4000000')
-              .with('state', StakeState.ActiveOngoing)
-              .build(),
-            stakeBuilder()
-              .with('net_claimable_consensus_rewards', '2000000')
-              .with('state', StakeState.ActiveOngoing)
-              .build(),
+            stakeBuilder().with('state', StakeState.ActiveOngoing).build(),
+            stakeBuilder().with('state', StakeState.ActiveOngoing).build(),
           ];
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
@@ -1554,10 +1539,7 @@ describe('TransactionsViewController tests', () => {
                 networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds * 1_000,
-              value: (
-                +stakes[0].net_claimable_consensus_rewards! +
-                +stakes[1].net_claimable_consensus_rewards!
-              ).toString(),
+              value: '32000000000000000000', // 32 ETH,
               numValidators: 1,
               tokenInfo: {
                 address: NULL_ADDRESS,

--- a/src/routes/transactions/transactions-view.service.ts
+++ b/src/routes/transactions/transactions-view.service.ts
@@ -24,7 +24,6 @@ import { SwapOrderHelper } from '@/routes/transactions/helpers/swap-order.helper
 import { TwapOrderHelper } from '@/routes/transactions/helpers/twap-order.helper';
 import { NativeStakingMapper } from '@/routes/transactions/mappers/common/native-staking.mapper';
 import { Inject, Injectable } from '@nestjs/common';
-import { getNumberString } from '@/domain/common/utils/utils';
 
 @Injectable({})
 export class TransactionsViewService {
@@ -352,26 +351,18 @@ export class TransactionsViewService {
     if (!dataDecoded) {
       throw new Error('Transaction data could not be decoded');
     }
-    const [validatorsExitInfo, value] = await Promise.all([
-      this.nativeStakingMapper.mapValidatorsExitInfo({
+    const validatorsExitInfo =
+      await this.nativeStakingMapper.mapValidatorsExitInfo({
         chainId: args.chainId,
         safeAddress: args.safeAddress,
         to: args.to,
         transaction: null,
         dataDecoded,
-      }),
-      this.kilnNativeStakingHelper.getValueFromDataDecoded({
-        dataDecoded,
-        chainId: args.chainId,
-        safeAddress: args.safeAddress,
-      }),
-    ]);
+      });
 
     return new NativeStakingValidatorsExitConfirmationView({
       method: dataDecoded.method,
       parameters: dataDecoded.parameters,
-      // Kiln's API only has a value until stake has been withdrawn
-      value: getNumberString(value),
       ...validatorsExitInfo,
     });
   }


### PR DESCRIPTION
## Summary

The `value` of a validator exit request is always a multiple of 32, the entry stake amount. This adjusts the relevant value to return a multiple of 32, depending on the number of validators requesting exit.

Note: this also fixes the CI issue regarding milliseconds.

## Changes

- Add `value` to `NativeStakingValidatorsExitTransactionInfo`.
- Map `value` as multiple of 32 depending on validators.
- Update tests accordingly.