### PR TITLE
Don't assume all RPC responses are strings

### DIFF
--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -1,4 +1,3 @@
-import { fakeJson } from '@/__tests__/faker';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { BlockchainApiManager } from '@/datasources/blockchain/blockchain-api.manager';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
@@ -8,7 +7,7 @@ import { rpcUriBuilder } from '@/domain/chains/entities/__tests__/rpc-uri.builde
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { faker } from '@faker-js/faker';
-import { hexToBigInt, hexToNumber, toHex } from 'viem';
+import { hexToNumber, toHex } from 'viem';
 
 const configApiMock = jest.mocked({
   getChain: jest.fn(),
@@ -157,7 +156,14 @@ describe('BlockchainApiManager', () => {
       const chain = chainBuilder().build();
       const client = target._createCachedRpcClient(chain);
       const fetchSpy = jest.spyOn(global, 'fetch');
-      const blockByNumber = fakeJson();
+      const blockByNumber = {
+        baseFeePerGas: null,
+        hash: null,
+        logsBloom: null,
+        nonce: null,
+        number: null,
+        totalDifficulty: null,
+      };
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       fetchSpy.mockImplementation((_: unknown) => {
         return Promise.resolve({
@@ -185,7 +191,7 @@ describe('BlockchainApiManager', () => {
 
       await expect(client.getBlock()).resolves.toStrictEqual(
         // Object containing in order not to mock entire return type
-        expect.objectContaining(JSON.parse(blockByNumber)),
+        expect.objectContaining(blockByNumber),
       );
 
       // Should be cached
@@ -203,7 +209,7 @@ describe('BlockchainApiManager', () => {
       });
       expect(fakeCacheService.keyCount()).toBe(1);
       const cached = await fakeCacheService.hGet(cacheDir);
-      expect(JSON.parse(cached!)).toBe(blockByNumber);
+      expect(JSON.parse(cached!)).toStrictEqual(blockByNumber);
 
       fetchSpy.mockRestore();
     });

--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -173,7 +173,7 @@ describe('BlockchainApiManager', () => {
       });
       const body = {
         jsonrpc: '2.0',
-        id: 0,
+        id: 1,
         method: 'eth_getBlockByNumber',
         params: ['latest', false],
       };
@@ -199,7 +199,7 @@ describe('BlockchainApiManager', () => {
       });
       expect(fakeCacheService.keyCount()).toBe(1);
       await expect(fakeCacheService.hGet(cacheDir)).resolves.toBe(
-        JSON.stringify(blockByNumber),
+        blockByNumber,
       );
 
       fetchSpy.mockRestore();

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -93,7 +93,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
       const cache = await this.cacheService.hGet(cacheDir);
 
       if (cache != null) {
-        return cache;
+        return JSON.parse(cache);
       }
 
       const { error, result } = await rpcClient.request({
@@ -110,11 +110,11 @@ export class BlockchainApiManager implements IBlockchainApiManager {
 
       await this.cacheService.hSet(
         cacheDir,
-        typeof result === 'string' ? result : JSON.stringify(result),
+        JSON.stringify(result),
         this.rpcExpirationTimeInSeconds,
       );
 
-      return result;
+      return JSON.parse(result);
     };
 
     return createPublicClient({

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -100,11 +100,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
         body,
       });
 
-      if (
-        error ||
-        // Result will always be a string, but we need to check for the type
-        typeof result !== 'string'
-      ) {
+      if (error) {
         throw new RpcRequestError({
           body,
           error,
@@ -114,7 +110,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
 
       await this.cacheService.hSet(
         cacheDir,
-        result,
+        JSON.stringify(result),
         this.rpcExpirationTimeInSeconds,
       );
 

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -114,7 +114,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
         this.rpcExpirationTimeInSeconds,
       );
 
-      return JSON.parse(result);
+      return result;
     };
 
     return createPublicClient({

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -110,7 +110,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
 
       await this.cacheService.hSet(
         cacheDir,
-        JSON.stringify(result),
+        typeof result === 'string' ? result : JSON.stringify(result),
         this.rpcExpirationTimeInSeconds,
       );
 


### PR DESCRIPTION
## Summary

We temporarily cache RPC requests. Currently, RPC responses are assumed to be strings (`eth_chainId`) and this is not the case, e.g. `eth_getBlockByNumber`

This adjusts the error handling logic to only throw if an error was returned by the RPC, not if the response if a string.

## Changes

- Don't throw if RPC result is not a string.
- Add test coverage