### PR TITLE
Extract event ABI when encoding

### DIFF
--- a/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
+++ b/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
@@ -3,14 +3,14 @@ import { faker } from '@faker-js/faker';
 import {
   encodeAbiParameters,
   encodeEventTopics,
+  getAbiItem,
   getAddress,
   Hex,
   keccak256,
-  parseAbi,
-  parseAbiParameters,
   toBytes,
 } from 'viem';
 import { Builder } from '@/__tests__/builder';
+import { TRANSACTION_ADDED_ABI } from '@/domain/alerts/contracts/decoders/delay-modifier-decoder.helper';
 
 // TransactionAdded
 
@@ -32,26 +32,27 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
   extends Builder<T>
   implements IEncoder<TransactionAddedEvent>
 {
-  // TODO: Extract ABI and non-indexed params as done in Kiln's WithdrawalEventBuilder
-  static readonly NON_INDEXED_PARAMS =
-    'address to, uint256 value, bytes data, uint8 operation' as const;
-  static readonly EVENT_SIGNATURE =
-    `event TransactionAdded(uint256 indexed queueNonce, bytes32 indexed txHash, ${TransactionAddedEventBuilder.NON_INDEXED_PARAMS})` as const;
+  private readonly item = getAbiItem({
+    abi: TRANSACTION_ADDED_ABI,
+    name: 'TransactionAdded',
+  });
 
   encode(): TransactionAddedEvent {
-    const abi = parseAbi([TransactionAddedEventBuilder.EVENT_SIGNATURE]);
-
     const args = this.build();
 
     const data = encodeAbiParameters(
-      parseAbiParameters(TransactionAddedEventBuilder.NON_INDEXED_PARAMS),
+      // Only non-indexed parameters
+      this.item.inputs.filter((input) => {
+        return !('indexed' in input) || !input.indexed;
+      }),
       [args.to, args.value, args.data, args.operation],
     );
 
     const topics = encodeEventTopics({
-      abi,
+      abi: TRANSACTION_ADDED_ABI,
       eventName: 'TransactionAdded',
       args: {
+        // Only indexed params
         queueNonce: args.queueNonce,
         txHash: args.txHash,
       },

--- a/src/domain/alerts/contracts/decoders/delay-modifier-decoder.helper.ts
+++ b/src/domain/alerts/contracts/decoders/delay-modifier-decoder.helper.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { parseAbi } from 'viem';
 import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
 
-const TRANSACTION_ADDED_ABI = parseAbi([
+export const TRANSACTION_ADDED_ABI = parseAbi([
   'event TransactionAdded(uint256 indexed queueNonce, bytes32 indexed txHash, address to, uint256 value, bytes data, uint8 operation)',
 ]);
 

--- a/src/domain/staking/contracts/decoders/__tests__/encoders/kiln-encoder.builder.ts
+++ b/src/domain/staking/contracts/decoders/__tests__/encoders/kiln-encoder.builder.ts
@@ -192,14 +192,17 @@ class WithdrawalEventBuilder<T extends WithdrawalArgs>
   extends Builder<T>
   implements IEncoder<Withdrawal>
 {
-  encode(): Withdrawal {
-    const item = getAbiItem({ abi: KilnAbi, name: 'Withdrawal' });
+  private readonly item = getAbiItem({
+    abi: KilnAbi,
+    name: 'Withdrawal',
+  });
 
+  encode(): Withdrawal {
     const args = this.build();
 
     const data = encodeAbiParameters(
-      // Only indexed parameters
-      item.inputs.filter((input) => {
+      // Only non-indexed parameters
+      this.item.inputs.filter((input) => {
         return !('indexed' in input) || !input.indexed;
       }),
       [args.pubKeyRoot, args.rewards, args.nodeOperatorFee, args.treasuryFee],


### PR DESCRIPTION
## Summary

It is possible to extract a type safe item from an ABI. Currently, we duplicate the `TransactionAdded` event from the DelayModifier ABI in the relative encoder. This extracts it instead.

## Changes

- Tweak format of existing event encoder.
- Extract `TransactionAdded` from DelayModifier ABI.