### PR TITLE
Remove log from TWAP test

### DIFF
--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -1478,7 +1478,6 @@ describe('TwapOrderMapper', () => {
           if (order) {
             return Promise.resolve(order);
           }
-          console.log('Order not found', orderUid);
           return Promise.reject(new NotFoundException());
         },
       );


### PR DESCRIPTION
## Summary

There is an unnecessary log in the TWAP mapper test suite. This removes it.