### PR TITLE
Update Kiln's mainnet API URL

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -292,8 +292,7 @@ export default () => ({
       apiKey: process.env.STAKING_TESTNET_API_KEY,
     },
     mainnet: {
-      baseUri:
-        process.env.STAKING_API_BASE_URI || 'https://api.testnet.kiln.fi',
+      baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
       apiKey: process.env.STAKING_API_KEY,
     },
   },


### PR DESCRIPTION
## Summary

We currently have the Kiln API URL for mainnet set to the testnet URL. This changes it to the correct one for mainnet.

## Changes

- Update `staking.mainnet.baseUri` to `"https://api.kiln.fi"`