### PR TITLE
Add Targeted Messaging Datasource

### DIFF
--- a/migrations/00006_targeted_messaging/index.sql
+++ b/migrations/00006_targeted_messaging/index.sql
@@ -1,0 +1,45 @@
+CREATE TABLE outreaches (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    start_date TIMESTAMP WITH TIME ZONE NOT NULL,
+    end_date TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT unique_outreach_name UNIQUE (name)
+);
+
+CREATE OR REPLACE TRIGGER update_outreaches_updated_at
+BEFORE UPDATE ON outreaches
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE targeted_safes (
+    id SERIAL PRIMARY KEY,
+    address VARCHAR(42) NOT NULL,
+    outreach_id INT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (outreach_id) REFERENCES outreaches(id) ON DELETE CASCADE,
+    CONSTRAINT unique_targeted_safe UNIQUE (address, outreach_id)
+);
+
+CREATE OR REPLACE TRIGGER update_targeted_safes_updated_at
+BEFORE UPDATE ON targeted_safes
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE submissions (
+    id SERIAL PRIMARY KEY,
+    targeted_safe_id INT NOT NULL,
+    signer_address VARCHAR(42) NOT NULL,
+    completion_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (targeted_safe_id) REFERENCES targeted_safes(id) ON DELETE CASCADE,
+    CONSTRAINT unique_submission UNIQUE (targeted_safe_id, signer_address)
+);
+
+CREATE OR REPLACE TRIGGER update_submissions_updated_at
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();

--- a/migrations/__tests__/00006_targeted_messaging.spec.ts
+++ b/migrations/__tests__/00006_targeted_messaging.spec.ts
@@ -1,0 +1,316 @@
+import { TestDbFactory } from '@/__tests__/db.factory';
+import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { Outreach } from '@/domain/targeted-messaging/entities/outreach.entity';
+import { Submission } from '@/domain/targeted-messaging/entities/submission.entity';
+import { TargetedSafe } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+import { faker } from '@faker-js/faker';
+import postgres, { Sql } from 'postgres';
+
+describe('Migration 00006_targeted_messaging', () => {
+  let sql: postgres.Sql;
+  let migrator: PostgresDatabaseMigrator;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
+  });
+
+  afterAll(async () => {
+    await testDbFactory.destroyTestDatabase(sql);
+  });
+
+  it('runs successfully', async () => {
+    await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+    const result = await migrator.test({
+      migration: '00006_targeted_messaging',
+      after: async (sql: Sql) => {
+        return {
+          outreaches: {
+            columns:
+              await sql`SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'outreaches'`,
+            rows: await sql`SELECT * FROM outreaches`,
+          },
+          targeted_safes: {
+            columns:
+              await sql`SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'targeted_safes'`,
+            rows: await sql`SELECT * FROM targeted_safes`,
+          },
+          submissions: {
+            columns:
+              await sql`SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'submissions'`,
+            rows: await sql`SELECT * FROM submissions`,
+          },
+        };
+      },
+    });
+
+    expect(result.after).toStrictEqual({
+      outreaches: {
+        columns: expect.arrayContaining([
+          { column_name: 'id' },
+          { column_name: 'name' },
+          { column_name: 'start_date' },
+          { column_name: 'end_date' },
+        ]),
+        rows: [],
+      },
+      targeted_safes: {
+        columns: expect.arrayContaining([
+          { column_name: 'id' },
+          { column_name: 'address' },
+          { column_name: 'outreach_id' },
+          { column_name: 'created_at' },
+          { column_name: 'updated_at' },
+        ]),
+        rows: [],
+      },
+      submissions: {
+        columns: expect.arrayContaining([
+          { column_name: 'id' },
+          { column_name: 'targeted_safe_id' },
+          { column_name: 'signer_address' },
+          { column_name: 'completion_date' },
+        ]),
+        rows: [],
+      },
+    });
+  });
+
+  describe('Outreaches', () => {
+    it('should upsert the updated_at timestamp when updating an outreach', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      const result: {
+        before: unknown;
+        after: Outreach[];
+      } = await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql): Promise<Outreach[]> => {
+          const startDate = faker.date.recent();
+          const endDate = faker.date.future({ refDate: startDate });
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${startDate}, ${endDate})
+            RETURNING *`;
+          return [outreach];
+        },
+      });
+
+      // created_at and updated_at should be the same after the row is created
+      const createdAt = new Date(result.after[0].created_at);
+      const updatedAt = new Date(result.after[0].updated_at);
+      expect(createdAt).toStrictEqual(updatedAt);
+
+      // only updated_at should be updated after the row is updated
+      await sql`UPDATE outreaches set name = ${faker.string.alphanumeric()} WHERE id = 1;`;
+      const afterUpdate = await sql<Outreach[]>`SELECT * FROM outreaches`;
+      const updatedAtAfterUpdate = new Date(afterUpdate[0].updated_at);
+      const createdAtAfterUpdate = new Date(afterUpdate[0].created_at);
+
+      expect(createdAtAfterUpdate).toStrictEqual(createdAt);
+      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThanOrEqual(
+        createdAt.getTime(),
+      );
+    });
+
+    it('should throw an error if the unique(name) constraint is violated', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql) => {
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${faker.date.recent()}, ${faker.date.future()})
+            RETURNING *`;
+          await expect(
+            sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${outreach.name}, ${faker.date.recent()}, ${faker.date.future()})
+            RETURNING *`,
+          ).rejects.toThrow('duplicate key value violates unique constraint');
+        },
+      });
+    });
+  });
+
+  describe('TargetedSafes', () => {
+    it('should upsert the updated_at timestamp when updating a targeted_safe', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      const result: {
+        before: unknown;
+        after: TargetedSafe[];
+      } = await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql): Promise<TargetedSafe[]> => {
+          const startDate = faker.date.recent();
+          const endDate = faker.date.future({ refDate: startDate });
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${startDate}, ${endDate})
+            RETURNING *`;
+          const [targetedSafe] = await sql<[TargetedSafe]>`
+          INSERT INTO targeted_safes (address, outreach_id)
+          VALUES (${faker.finance.ethereumAddress()}, ${outreach.id})
+          RETURNING *`;
+          return [targetedSafe];
+        },
+      });
+
+      // created_at and updated_at should be the same after the row is created
+      const createdAt = new Date(result.after[0].created_at);
+      const updatedAt = new Date(result.after[0].updated_at);
+      expect(createdAt).toStrictEqual(updatedAt);
+
+      // only updated_at should be updated after the row is updated
+      await sql`UPDATE targeted_safes set address = ${faker.finance.ethereumAddress()} WHERE id = 1;`;
+      const afterUpdate = await sql<
+        TargetedSafe[]
+      >`SELECT * FROM targeted_safes`;
+      const updatedAtAfterUpdate = new Date(afterUpdate[0].updated_at);
+      const createdAtAfterUpdate = new Date(afterUpdate[0].created_at);
+
+      expect(createdAtAfterUpdate).toStrictEqual(createdAt);
+      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThanOrEqual(
+        createdAt.getTime(),
+      );
+    });
+
+    it('should throw an error if the unique(address, outreach_id) constraint is violated', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql) => {
+          const startDate = faker.date.recent();
+          const endDate = faker.date.future({ refDate: startDate });
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${startDate}, ${endDate})
+            RETURNING *`;
+          const [targetedSafe] = await sql<[TargetedSafe]>`
+            INSERT INTO targeted_safes (address, outreach_id)
+            VALUES (${faker.finance.ethereumAddress()}, ${outreach.id})
+            RETURNING *`;
+          await expect(
+            sql<[TargetedSafe]>`
+            INSERT INTO targeted_safes (address, outreach_id)
+            VALUES (${targetedSafe.address}, ${outreach.id})
+            RETURNING *`,
+          ).rejects.toThrow('duplicate key value violates unique constraint');
+        },
+      });
+    });
+  });
+
+  describe('Submissions', () => {
+    it('should upsert the updated_at timestamp when updating a submission', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      const result: {
+        before: unknown;
+        after: Submission[];
+      } = await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql): Promise<Submission[]> => {
+          const startDate = faker.date.recent();
+          const endDate = faker.date.future({ refDate: startDate });
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${startDate}, ${endDate})
+            RETURNING *`;
+          const [targetedSafe] = await sql<[TargetedSafe]>`
+            INSERT INTO targeted_safes (address, outreach_id)
+            VALUES (${faker.finance.ethereumAddress()}, ${outreach.id})
+            RETURNING *`;
+          const [submission] = await sql<[Submission]>`
+            INSERT INTO submissions (targeted_safe_id, signer_address, completion_date)
+            VALUES (${targetedSafe.id}, ${faker.finance.ethereumAddress()}, ${faker.date.recent()})
+            RETURNING *`;
+          return [submission];
+        },
+      });
+
+      // created_at and updated_at should be the same after the row is created
+      const createdAt = new Date(result.after[0].created_at);
+      const updatedAt = new Date(result.after[0].updated_at);
+      expect(createdAt).toStrictEqual(updatedAt);
+
+      // only updated_at should be updated after the row is updated
+      await sql`UPDATE submissions set completion_date = ${new Date()} WHERE id = 1;`;
+      const afterUpdate = await sql<Submission[]>`SELECT * FROM submissions`;
+      const updatedAtAfterUpdate = new Date(afterUpdate[0].updated_at);
+      const createdAtAfterUpdate = new Date(afterUpdate[0].created_at);
+
+      expect(createdAtAfterUpdate).toStrictEqual(createdAt);
+      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThanOrEqual(
+        createdAt.getTime(),
+      );
+    });
+
+    it('should trigger a cascade delete when the referenced target_safe is deleted', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      const result: {
+        before: unknown;
+        after: Submission[];
+      } = await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql): Promise<Submission[]> => {
+          const startDate = faker.date.recent();
+          const endDate = faker.date.future({ refDate: startDate });
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${startDate}, ${endDate})
+            RETURNING *`;
+          const [targetedSafe] = await sql<[TargetedSafe]>`
+            INSERT INTO targeted_safes (address, outreach_id)
+            VALUES (${faker.finance.ethereumAddress()}, ${outreach.id})
+            RETURNING *`;
+          await sql<[Submission]>`
+            INSERT INTO submissions (targeted_safe_id, signer_address, completion_date)
+            VALUES (${targetedSafe.id}, ${faker.finance.ethereumAddress()}, ${faker.date.recent()})
+            RETURNING *`;
+          await sql`DELETE FROM targeted_safes WHERE id = ${targetedSafe.id};`;
+          return await sql<Submission[]>`SELECT * FROM submissions`;
+        },
+      });
+
+      expect(result.after).toStrictEqual([]);
+    });
+
+    it('should throw an error if the unique(targeted_safe_id, signer_address) constraint is violated', async () => {
+      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
+
+      await migrator.test({
+        migration: '00006_targeted_messaging',
+        after: async (sql: Sql) => {
+          const startDate = faker.date.recent();
+          const endDate = faker.date.future({ refDate: startDate });
+          const [outreach] = await sql<[Outreach]>`
+            INSERT INTO outreaches (name, start_date, end_date)
+            VALUES (${faker.string.alphanumeric()}, ${startDate}, ${endDate})
+            RETURNING *`;
+          const [targetedSafe] = await sql<[TargetedSafe]>`
+            INSERT INTO targeted_safes (address, outreach_id)
+            VALUES (${faker.finance.ethereumAddress()}, ${outreach.id})
+            RETURNING *`;
+          const signerAddress = faker.finance.ethereumAddress();
+          await sql<[Submission]>`
+          INSERT INTO submissions (targeted_safe_id, signer_address, completion_date)
+          VALUES (${targetedSafe.id}, ${signerAddress}, ${faker.date.recent()})
+            RETURNING *`;
+          await expect(
+            sql<[Submission]>`
+            INSERT INTO submissions (targeted_safe_id, signer_address, completion_date)
+            VALUES (${targetedSafe.id}, ${signerAddress}, ${faker.date.recent()})
+            RETURNING *`,
+          ).rejects.toThrow('duplicate key value violates unique constraint');
+        },
+      });
+    });
+  });
+});

--- a/src/datasources/targeted-messaging/targeted-messaging.datasource.spec.ts
+++ b/src/datasources/targeted-messaging/targeted-messaging.datasource.spec.ts
@@ -1,0 +1,318 @@
+import { TestDbFactory } from '@/__tests__/db.factory';
+import { PostgresDatabaseMigrator } from '@/datasources/db/postgres-database.migrator';
+import { TargetedMessagingDatasource } from '@/datasources/targeted-messaging/targeted-messaging.datasource';
+import { createOutreachDtoBuilder } from '@/domain/targeted-messaging/entities/tests/create-outreach.dto.builder';
+import { createTargetedSafesDtoBuilder } from '@/domain/targeted-messaging/entities/tests/create-target-safes.dto.builder';
+import { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker/.';
+import { NotFoundException } from '@nestjs/common';
+import postgres from 'postgres';
+import { getAddress } from 'viem';
+
+const mockLoggingService = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+describe('TargetedMessagingDataSource tests', () => {
+  let sql: postgres.Sql;
+  let migrator: PostgresDatabaseMigrator;
+  let target: TargetedMessagingDatasource;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
+    await migrator.migrate();
+
+    target = new TargetedMessagingDatasource(sql, mockLoggingService);
+  });
+
+  afterEach(async () => {
+    await sql`TRUNCATE TABLE submissions, targeted_safes, outreaches CASCADE`;
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await testDbFactory.destroyTestDatabase(sql);
+  });
+
+  describe('createOutreach', () => {
+    it('creates an outreach successfully', async () => {
+      const dto = createOutreachDtoBuilder().build();
+
+      const result = await target.createOutreach(dto);
+
+      expect(result).toStrictEqual({
+        id: expect.any(Number),
+        name: dto.name,
+        startDate: dto.startDate,
+        endDate: dto.endDate,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      });
+    });
+
+    it('throws if the creation fails', async () => {
+      const dto = createOutreachDtoBuilder().build();
+
+      await target.createOutreach(dto);
+
+      // An outreach with the same name already exists
+      await expect(target.createOutreach(dto)).rejects.toThrow(
+        'Error creating outreach',
+      );
+    });
+  });
+
+  describe('createTargetedSafes', () => {
+    it('adds targetedSafes successfully', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+
+      const result = await target.createTargetedSafes(createTargetedSafesDto);
+
+      expect(result).toStrictEqual([
+        {
+          id: expect.any(Number),
+          outreachId: createTargetedSafesDto.outreachId,
+          address: createTargetedSafesDto.addresses[0],
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+        },
+        {
+          id: expect.any(Number),
+          outreachId: createTargetedSafesDto.outreachId,
+          address: createTargetedSafesDto.addresses[1],
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+        },
+      ]);
+    });
+
+    it('fails if the outreach does not exist', async () => {
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+
+      await expect(
+        target.createTargetedSafes(createTargetedSafesDto),
+      ).rejects.toThrow('Error adding targeted Safes');
+    });
+
+    it('fails if the Safe was already targeted in the same outreach', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const address = getAddress(faker.finance.ethereumAddress());
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [address, address])
+        .build();
+
+      await expect(
+        target.createTargetedSafes(createTargetedSafesDto),
+      ).rejects.toThrow('Error adding targeted Safes');
+    });
+
+    it('fails if the Safe was already targeted in the same outreach (2)', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const address = getAddress(faker.finance.ethereumAddress());
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [address])
+        .build();
+
+      // Create the targeted safe
+      const created = await target.createTargetedSafes(createTargetedSafesDto);
+      expect(created).toHaveLength(1);
+
+      // Fails when trying to create the same targeted safe
+      await expect(
+        target.createTargetedSafes(createTargetedSafesDto),
+      ).rejects.toThrow('Error adding targeted Safes');
+    });
+  });
+
+  describe('getTargetedSafe', () => {
+    it('gets a targetedSafe successfully', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+      const targetedSafes = await target.createTargetedSafes(
+        createTargetedSafesDto,
+      );
+
+      const result = await target.getTargetedSafe({
+        outreachId: outreach.id,
+        safeAddress: createTargetedSafesDto.addresses[0],
+      });
+
+      expect(result).toStrictEqual({
+        id: targetedSafes[0].id,
+        address: targetedSafes[0].address,
+        outreachId: outreach.id,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      });
+    });
+
+    it('throws if the targetedSafe does not exist', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+      await target.createTargetedSafes(createTargetedSafesDto);
+
+      await expect(
+        target.getTargetedSafe({
+          outreachId: outreach.id,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getSubmission', () => {
+    it('creates a submission successfully', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+      const targetedSafes = await target.createTargetedSafes(
+        createTargetedSafesDto,
+      );
+
+      const result = await target.createSubmission({
+        targetedSafe: targetedSafes[0],
+        signerAddress: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      expect(result).toStrictEqual({
+        id: expect.any(Number),
+        outreachId: outreach.id,
+        targetedSafeId: targetedSafes[0].id,
+        signerAddress: expect.any(String),
+        completionDate: expect.any(Date),
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      });
+    });
+
+    it('gets a submission successfully', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+      const targetedSafes = await target.createTargetedSafes(
+        createTargetedSafesDto,
+      );
+      const signerAddress = getAddress(faker.finance.ethereumAddress());
+
+      await target.createSubmission({
+        targetedSafe: targetedSafes[0],
+        signerAddress,
+      });
+
+      const result = await target.getSubmission({
+        targetedSafe: targetedSafes[0],
+        signerAddress,
+      });
+
+      expect(result).toStrictEqual({
+        id: expect.any(Number),
+        outreachId: outreach.id,
+        targetedSafeId: targetedSafes[0].id,
+        signerAddress: expect.any(String),
+        completionDate: expect.any(Date),
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      });
+    });
+
+    it('throws if the submission does not exist', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+      const targetedSafes = await target.createTargetedSafes(
+        createTargetedSafesDto,
+      );
+
+      await expect(
+        target.getSubmission({
+          targetedSafe: targetedSafes[0],
+          signerAddress: getAddress(faker.finance.ethereumAddress()),
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws if trying to create a submission for the same targetedSafe and signerAddress', async () => {
+      const createOutreachDto = createOutreachDtoBuilder().build();
+      const outreach = await target.createOutreach(createOutreachDto);
+      const createTargetedSafesDto = createTargetedSafesDtoBuilder()
+        .with('outreachId', outreach.id)
+        .with('addresses', [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ])
+        .build();
+      const targetedSafes = await target.createTargetedSafes(
+        createTargetedSafesDto,
+      );
+      const signerAddress = getAddress(faker.finance.ethereumAddress());
+
+      // First submission
+      await target.createSubmission({
+        targetedSafe: targetedSafes[0],
+        signerAddress,
+      });
+
+      // Second submission - same targetedSafe and signerAddress
+      await expect(
+        target.createSubmission({
+          targetedSafe: targetedSafes[0],
+          signerAddress,
+        }),
+      ).rejects.toThrow('Error creating submission');
+    });
+  });
+});

--- a/src/datasources/targeted-messaging/targeted-messaging.datasource.spec.ts
+++ b/src/datasources/targeted-messaging/targeted-messaging.datasource.spec.ts
@@ -207,20 +207,21 @@ describe('TargetedMessagingDataSource tests', () => {
           getAddress(faker.finance.ethereumAddress()),
         ])
         .build();
+      const signerAddress = getAddress(faker.finance.ethereumAddress());
       const targetedSafes = await target.createTargetedSafes(
         createTargetedSafesDto,
       );
 
       const result = await target.createSubmission({
         targetedSafe: targetedSafes[0],
-        signerAddress: getAddress(faker.finance.ethereumAddress()),
+        signerAddress,
       });
 
       expect(result).toStrictEqual({
         id: expect.any(Number),
         outreachId: outreach.id,
         targetedSafeId: targetedSafes[0].id,
-        signerAddress: expect.any(String),
+        signerAddress,
         completionDate: expect.any(Date),
         created_at: expect.any(Date),
         updated_at: expect.any(Date),

--- a/src/datasources/targeted-messaging/targeted-messaging.datasource.spec.ts
+++ b/src/datasources/targeted-messaging/targeted-messaging.datasource.spec.ts
@@ -256,7 +256,7 @@ describe('TargetedMessagingDataSource tests', () => {
         id: expect.any(Number),
         outreachId: outreach.id,
         targetedSafeId: targetedSafes[0].id,
-        signerAddress: expect.any(String),
+        signerAddress,
         completionDate: expect.any(Date),
         created_at: expect.any(Date),
         updated_at: expect.any(Date),

--- a/src/datasources/targeted-messaging/targeted-messaging.datasource.ts
+++ b/src/datasources/targeted-messaging/targeted-messaging.datasource.ts
@@ -1,0 +1,147 @@
+import { ITargetedMessagingDatasource } from '@/domain/interfaces/targeted-messaging.datasource.interface';
+import { CreateOutreachDto } from '@/domain/targeted-messaging/entities/create-outreach.dto.entity';
+import { CreateTargetedSafesDto } from '@/domain/targeted-messaging/entities/create-targeted-safes.dto.entity';
+import { Outreach } from '@/domain/targeted-messaging/entities/outreach.entity';
+import { Submission } from '@/domain/targeted-messaging/entities/submission.entity';
+import { TargetedSafe } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
+import {
+  Inject,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import postgres from 'postgres';
+
+export class TargetedMessagingDatasource
+  implements ITargetedMessagingDatasource
+{
+  constructor(
+    @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async createOutreach(
+    createOutreachDto: CreateOutreachDto,
+  ): Promise<Outreach> {
+    const [outreach] = await this.sql`
+      INSERT INTO outreaches (name, start_date, end_date)
+      VALUES (${createOutreachDto.name}, ${createOutreachDto.startDate}, ${createOutreachDto.endDate})
+      RETURNING *`.catch((err) => {
+      this.loggingService.warn(
+        `Error creating outreach: ${asError(err).message}`,
+      );
+      throw new UnprocessableEntityException('Error creating outreach');
+    });
+
+    return {
+      id: outreach.id,
+      name: outreach.name,
+      startDate: outreach.start_date,
+      endDate: outreach.end_date,
+      created_at: outreach.created_at,
+      updated_at: outreach.updated_at,
+    };
+  }
+
+  async createTargetedSafes(
+    createTargetedSafesDto: CreateTargetedSafesDto,
+  ): Promise<Array<TargetedSafe>> {
+    return await this.sql.begin(async (sql) => {
+      const inserted = await sql<[{ id: number }]>`
+        INSERT INTO targeted_safes
+        ${sql(
+          createTargetedSafesDto.addresses.map((address) => ({
+            outreach_id: createTargetedSafesDto.outreachId,
+            address,
+          })),
+        )}
+        RETURNING id`.catch((err) => {
+        this.loggingService.warn(
+          `Error adding targeted Safes: ${asError(err).message}`,
+        );
+        throw new UnprocessableEntityException('Error adding targeted Safes');
+      });
+
+      const targetedSafes =
+        await sql`SELECT * FROM targeted_safes WHERE id = ANY(${inserted.map((i) => i.id)})`;
+
+      return targetedSafes.map((targetedSafe) => ({
+        id: targetedSafe.id,
+        outreachId: targetedSafe.outreach_id,
+        address: targetedSafe.address,
+        created_at: targetedSafe.created_at,
+        updated_at: targetedSafe.updated_at,
+      }));
+    });
+  }
+
+  async getTargetedSafe(args: {
+    outreachId: number;
+    safeAddress: `0x${string}`;
+  }): Promise<TargetedSafe> {
+    const [targetedSafe] = await this.sql`
+      SELECT * FROM targeted_safes
+      WHERE outreach_id = ${args.outreachId} AND address = ${args.safeAddress}`;
+
+    if (!targetedSafe) {
+      throw new NotFoundException();
+    }
+
+    return {
+      id: targetedSafe.id,
+      address: targetedSafe.address,
+      outreachId: targetedSafe.outreach_id,
+      created_at: targetedSafe.created_at,
+      updated_at: targetedSafe.updated_at,
+    };
+  }
+
+  async createSubmission(args: {
+    targetedSafe: TargetedSafe;
+    signerAddress: `0x${string}`;
+  }): Promise<Submission> {
+    const [submission] = await this.sql`
+      INSERT INTO submissions (targeted_safe_id, signer_address, completion_date)
+      VALUES (${args.targetedSafe.id}, ${args.signerAddress}, ${new Date()})
+      RETURNING *`.catch((err) => {
+      this.loggingService.warn(
+        `Error creating submission: ${asError(err).message}`,
+      );
+      throw new UnprocessableEntityException('Error creating submission');
+    });
+
+    return {
+      id: submission.id,
+      outreachId: args.targetedSafe.outreachId,
+      targetedSafeId: submission.targeted_safe_id,
+      signerAddress: submission.signer_address,
+      completionDate: submission.completion_date,
+      created_at: submission.created_at,
+      updated_at: submission.updated_at,
+    };
+  }
+
+  async getSubmission(args: {
+    targetedSafe: TargetedSafe;
+    signerAddress: `0x${string}`;
+  }): Promise<Submission> {
+    const [submission] = await this.sql`
+      SELECT * FROM submissions
+      WHERE targeted_safe_id = ${args.targetedSafe.id} AND signer_address = ${args.signerAddress}`;
+
+    if (!submission) {
+      throw new NotFoundException();
+    }
+
+    return {
+      id: submission.id,
+      outreachId: args.targetedSafe.outreachId,
+      targetedSafeId: submission.targeted_safe_id,
+      signerAddress: submission.signer_address,
+      completionDate: submission.completion_date,
+      created_at: submission.created_at,
+      updated_at: submission.updated_at,
+    };
+  }
+}

--- a/src/domain/interfaces/targeted-messaging.datasource.interface.ts
+++ b/src/domain/interfaces/targeted-messaging.datasource.interface.ts
@@ -1,0 +1,28 @@
+import { CreateOutreachDto } from '@/domain/targeted-messaging/entities/create-outreach.dto.entity';
+import { CreateTargetedSafesDto } from '@/domain/targeted-messaging/entities/create-targeted-safes.dto.entity';
+import { Outreach } from '@/domain/targeted-messaging/entities/outreach.entity';
+import { Submission } from '@/domain/targeted-messaging/entities/submission.entity';
+import { TargetedSafe } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+
+export interface ITargetedMessagingDatasource {
+  createOutreach(createOutreachDto: CreateOutreachDto): Promise<Outreach>;
+
+  createTargetedSafes(
+    createTargetedSafesDto: CreateTargetedSafesDto,
+  ): Promise<Array<TargetedSafe>>;
+
+  getTargetedSafe(args: {
+    outreachId: number;
+    safeAddress: `0x${string}`;
+  }): Promise<TargetedSafe>;
+
+  createSubmission(args: {
+    targetedSafe: TargetedSafe;
+    signerAddress: `0x${string}`;
+  }): Promise<Submission>;
+
+  getSubmission(args: {
+    targetedSafe: TargetedSafe;
+    signerAddress: `0x${string}`;
+  }): Promise<Submission>;
+}

--- a/src/domain/targeted-messaging/entities/create-outreach.dto.entity.ts
+++ b/src/domain/targeted-messaging/entities/create-outreach.dto.entity.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const CreateOutreachDtoSchema = z.object({
+  name: z.string(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+});
+
+export class CreateOutreachDto
+  implements z.infer<typeof CreateOutreachDtoSchema>
+{
+  name: string;
+  startDate: Date;
+  endDate: Date;
+
+  constructor(props: CreateOutreachDto) {
+    this.name = props.name;
+    this.startDate = props.startDate;
+    this.endDate = props.endDate;
+  }
+}

--- a/src/domain/targeted-messaging/entities/create-targeted-safes.dto.entity.ts
+++ b/src/domain/targeted-messaging/entities/create-targeted-safes.dto.entity.ts
@@ -1,0 +1,19 @@
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { z } from 'zod';
+
+export const CreateTargetedSafesDtoSchema = z.object({
+  outreachId: z.number(),
+  addresses: z.array(AddressSchema),
+});
+
+export class CreateTargetedSafesDto
+  implements z.infer<typeof CreateTargetedSafesDtoSchema>
+{
+  outreachId: number;
+  addresses: Array<`0x${string}`>;
+
+  constructor(props: CreateTargetedSafesDto) {
+    this.outreachId = props.outreachId;
+    this.addresses = props.addresses;
+  }
+}

--- a/src/domain/targeted-messaging/entities/outreach.entity.ts
+++ b/src/domain/targeted-messaging/entities/outreach.entity.ts
@@ -1,0 +1,10 @@
+import { RowSchema } from '@/datasources/db/entities/row.entity';
+import { z } from 'zod';
+
+export type Outreach = z.infer<typeof OutreachSchema>;
+
+export const OutreachSchema = RowSchema.extend({
+  name: z.string(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+});

--- a/src/domain/targeted-messaging/entities/submission.entity.ts
+++ b/src/domain/targeted-messaging/entities/submission.entity.ts
@@ -1,0 +1,14 @@
+import { RowSchema } from '@/datasources/db/entities/row.entity';
+import { OutreachSchema } from '@/domain/targeted-messaging/entities/outreach.entity';
+import { TargetedSafeSchema } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { z } from 'zod';
+
+export type Submission = z.infer<typeof SubmissionSchema>;
+
+export const SubmissionSchema = RowSchema.extend({
+  outreachId: OutreachSchema.shape.id,
+  targetedSafeId: TargetedSafeSchema.shape.id,
+  signerAddress: AddressSchema,
+  completionDate: z.coerce.date(),
+});

--- a/src/domain/targeted-messaging/entities/targeted-safe.entity.ts
+++ b/src/domain/targeted-messaging/entities/targeted-safe.entity.ts
@@ -1,0 +1,10 @@
+import { RowSchema } from '@/datasources/db/entities/row.entity';
+import { OutreachSchema } from '@/domain/targeted-messaging/entities/outreach.entity';
+import { z } from 'zod';
+
+export type TargetedSafe = z.infer<typeof TargetedSafeSchema>;
+
+export const TargetedSafeSchema = RowSchema.extend({
+  address: z.string(),
+  outreachId: OutreachSchema.shape.id,
+});

--- a/src/domain/targeted-messaging/entities/tests/create-outreach.dto.builder.ts
+++ b/src/domain/targeted-messaging/entities/tests/create-outreach.dto.builder.ts
@@ -1,0 +1,12 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { CreateOutreachDto } from '@/domain/targeted-messaging/entities/create-outreach.dto.entity';
+import { faker } from '@faker-js/faker/.';
+
+export function createOutreachDtoBuilder(): IBuilder<CreateOutreachDto> {
+  const startDate = faker.date.recent();
+
+  return new Builder<CreateOutreachDto>()
+    .with('name', faker.string.alphanumeric(5))
+    .with('startDate', startDate)
+    .with('endDate', faker.date.future({ refDate: startDate }));
+}

--- a/src/domain/targeted-messaging/entities/tests/create-target-safes.dto.builder.ts
+++ b/src/domain/targeted-messaging/entities/tests/create-target-safes.dto.builder.ts
@@ -1,0 +1,16 @@
+import { Builder, IBuilder } from '@/__tests__/builder';
+import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
+import { CreateTargetedSafesDto } from '@/domain/targeted-messaging/entities/create-targeted-safes.dto.entity';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+export function createTargetedSafesDtoBuilder(): IBuilder<CreateTargetedSafesDto> {
+  return new Builder<CreateTargetedSafesDto>()
+    .with('outreachId', faker.number.int({ max: DB_MAX_SAFE_INTEGER }))
+    .with(
+      'addresses',
+      Array.from({ length: faker.number.int({ min: 1, max: 5 }) }, () =>
+        getAddress(faker.finance.ethereumAddress()),
+      ),
+    );
+}


### PR DESCRIPTION
## Summary
This adds a new datasource for the Targeted Messaging feature, consisting of the following persistence entities.

- `Outreach`: a messaging campaign with `name`, `start date`, and `end date`.
- `Targeted Safe`: an entity representing a Safe address targeted for a given `Outreach`.
- `Submission`: a response to a given `Outreach`, given by a **signer address** of the `Targeted Safe`.

## Changes
- Adds a database migration to initialize the tables for each entity.
- Adds a `TargetedMessagingDatasource` containing methods to interact with `Outreaches`, `Targeted Safes`, and `Submissions`.
