### PR TITLE
Process CHAIN_UPDATE events for unsupported chains

### DIFF
--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -468,6 +468,10 @@ export class EventCacheHelper implements OnModuleInit, OnModuleDestroy {
     // As the chains have been updated, we need to clear the memoized function cache.
     if (this.isSupportedChainMemo.cache.clear) {
       this.isSupportedChainMemo.cache.clear();
+      // Remove the chain from the unsupported chains list
+      this.unsupportedChains = this.unsupportedChains.filter(
+        (unsupportedChain) => unsupportedChain !== event.chainId,
+      );
     }
     return [
       this.chainsRepository.clearChain(event.chainId).then(() => {

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -157,6 +157,33 @@ describe('HooksRepository (Unit)', () => {
     expect(mockSafeRepository.clearIncomingTransfers).toHaveBeenCalledTimes(3);
   });
 
+  it('should process CHAIN_UPDATE events for unsupported chains', async () => {
+    const chain = chainBuilder().build();
+    const event = chainUpdateEventBuilder()
+      .with('chainId', chain.chainId)
+      .build();
+    mockChainsRepository.isSupportedChain.mockResolvedValue(false);
+    mockChainsRepository.clearChain.mockResolvedValue();
+
+    // same event 3 times
+    await hooksRepository.onEvent(event);
+    await hooksRepository.onEvent(event);
+    await hooksRepository.onEvent(event);
+
+    // 3 calls to isSupportedChain
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledTimes(3);
+    expect(mockChainsRepository.isSupportedChain).toHaveBeenCalledWith(
+      event.chainId,
+    );
+
+    // 3 calls to repositories
+    expect(mockChainsRepository.clearChain).toHaveBeenCalledTimes(3);
+    expect(mockBlockchainRepository.clearApi).toHaveBeenCalledTimes(3);
+    expect(mockStakingRepository.clearApi).toHaveBeenCalledTimes(3);
+    expect(mockTransactionsRepository.clearApi).toHaveBeenCalledTimes(3);
+    expect(mockBalancesRepository.clearApi).toHaveBeenCalledTimes(3);
+  });
+
   it('should clear the chain lookup cache on a CHAIN_UPDATE event', async () => {
     const chain = chainBuilder().build();
     const event = incomingTokenEventBuilder()

--- a/src/domain/hooks/hooks.repository.ts
+++ b/src/domain/hooks/hooks.repository.ts
@@ -8,6 +8,7 @@ import { EventSchema } from '@/routes/hooks/entities/schemas/event.schema';
 import { IHooksRepository } from '@/domain/hooks/hooks.repository.interface';
 import { EventNotificationsHelper } from '@/domain/hooks/helpers/event-notifications.helper';
 import { EventCacheHelper } from '@/domain/hooks/helpers/event-cache.helper';
+import { ConfigEventType } from '@/routes/hooks/entities/event-type.entity';
 
 @Injectable()
 export class HooksRepositoryWithNotifications
@@ -102,7 +103,7 @@ export class HooksRepository implements IHooksRepository, OnModuleInit {
     const isSupportedChainId = await this.eventCacheHelper.isSupportedChainMemo(
       event.chainId,
     );
-    if (isSupportedChainId) {
+    if (isSupportedChainId || event.type === ConfigEventType.CHAIN_UPDATE) {
       return this.eventCacheHelper.onEventClearCache(event).finally(() => {
         this.eventCacheHelper.onEventLog(event);
       });


### PR DESCRIPTION
## Summary
Closes https://github.com/safe-global/safe-client-gateway/issues/1991

## Changes
- Process `CHAIN_UPDATE` even if the chain was previously set as unsupported.
- Clear `unsupportedChains` when a `CHAIN_UPDATE` event is processed.
