### PR TITLE
Ignore blame for consistent type imports

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
 # Change import statement paths to path aliases
 4729440761cfe608ab8935d782238ae7fe55343b
+# Enfore consistent usage of type imports
+9804ceef5bcaa08feebc5ca412834fa04e023d7a


### PR DESCRIPTION
## Summary

Adds commit hash for https://github.com/safe-global/safe-client-gateway/pull/1987 to the `.git-blame-ignore-revs`.
