### PR TITLE
Directly import `CowSwapTwapConfirmationView` as API model

### DIFF
--- a/src/routes/transactions/entities/swaps/twap-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/swaps/twap-confirmation-view.entity.ts
@@ -43,6 +43,8 @@ export class CowSwapTwapConfirmationView implements Baseline, TwapOrderInfo {
   @ApiProperty({
     description:
       'The order UID of the active order, null as it is not an active order',
+    // Prevent bidirectional dependency
+    type: typeof null,
   })
   activeOrderUid: null;
 

--- a/src/routes/transactions/transactions-view.controller.ts
+++ b/src/routes/transactions/transactions-view.controller.ts
@@ -65,15 +65,15 @@ export class TransactionsViewController {
   @ApiExtraModels(
     BaselineConfirmationView,
     CowSwapConfirmationView,
-    // Prevent bidirectional dependency
-    () => CowSwapTwapConfirmationView,
+    CowSwapTwapConfirmationView,
     NativeStakingDepositConfirmationView,
     NativeStakingValidatorsExitConfirmationView,
     NativeStakingWithdrawConfirmationView,
   )
   @ApiOperation({
-    summary: 'Confirm Transaction View',
-    description: 'This endpoint is experimental and may change.',
+    description:
+      'Deprecated in favour of /v1/chains/:chainId/transactions/:safeAddress/preview.',
+    deprecated: true,
   })
   @Post('chains/:chainId/safes/:safeAddress/views/transaction-confirmation')
   async getTransactionConfirmationView(


### PR DESCRIPTION
## Summary

The action to [generate the SDK](https://github.com/safe-global/safe-client-gateway-sdk
) is currently not working because of an issue with the schema. After debugging, it was isolated as the way in which we import the `CowSwapTwapConfirmationView` API model.

The currently implementation was put in place to prevent a bidirectional dependency, but it is incorrect. The lazy resolve should be on the `type` and it has therefore been moved there.

## Changes

- Directly import `CowSwapTwapConfirmationView` as API model.
- Lazily resolve the `type` within the `ApiProperty` decorator.