### PR TITLE
Iterate all chains when fetching all Safes

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -196,7 +196,6 @@ export default (): ReturnType<typeof configuration> => ({
   safeConfig: {
     baseUri: faker.internet.url({ appendSlash: false }),
     chains: {
-      maxLimit: faker.number.int(),
       maxSequentialPages: faker.number.int(),
     },
   },

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -195,6 +195,10 @@ export default (): ReturnType<typeof configuration> => ({
   },
   safeConfig: {
     baseUri: faker.internet.url({ appendSlash: false }),
+    chains: {
+      maxLimit: faker.number.int(),
+      maxSequentialPages: faker.number.int(),
+    },
   },
   safeTransaction: {
     useVpcUrl: false,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -299,6 +299,8 @@ export default () => ({
     baseUri:
       process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.safe.global/',
     chains: {
+      // According to the limits of the Config Service
+      // @see https://github.com/safe-global/safe-config-service/blob/main/src/chains/views.py#L14-L16
       maxLimit: parseInt(process.env.SAFE_CONFIG_CHAINS_MAX_LIMIT ?? `${40}`),
       maxSequentialPages: parseInt(
         process.env.SAFE_CONFIG_CHAINS_MAX_SEQUENTIAL_PAGES ?? `${3}`,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -299,9 +299,6 @@ export default () => ({
     baseUri:
       process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.safe.global/',
     chains: {
-      // According to the limits of the Config Service
-      // @see https://github.com/safe-global/safe-config-service/blob/main/src/chains/views.py#L14-L16
-      maxLimit: parseInt(process.env.SAFE_CONFIG_CHAINS_MAX_LIMIT ?? `${40}`),
       maxSequentialPages: parseInt(
         process.env.SAFE_CONFIG_CHAINS_MAX_SEQUENTIAL_PAGES ?? `${3}`,
       ),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -298,6 +298,12 @@ export default () => ({
   safeConfig: {
     baseUri:
       process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.safe.global/',
+    chains: {
+      maxLimit: parseInt(process.env.SAFE_CONFIG_CHAINS_MAX_LIMIT ?? `${40}`),
+      maxSequentialPages: parseInt(
+        process.env.SAFE_CONFIG_CHAINS_MAX_SEQUENTIAL_PAGES ?? `${3}`,
+      ),
+    },
   },
   safeTransaction: {
     useVpcUrl: process.env.USE_TX_SERVICE_VPC_URL?.toLowerCase() === 'true',

--- a/src/domain/chains/chains.repository.interface.ts
+++ b/src/domain/chains/chains.repository.interface.ts
@@ -19,6 +19,11 @@ export interface IChainsRepository {
   getChains(limit?: number, offset?: number): Promise<Page<Chain>>;
 
   /**
+   * Gets all the {@link Chain} available across pages
+   */
+  getAllChains(): Promise<Array<Chain>>;
+
+  /**
    * Gets the {@link Chain} associated with {@link chainId}
    *
    * @param chainId

--- a/src/domain/chains/chains.repository.spec.ts
+++ b/src/domain/chains/chains.repository.spec.ts
@@ -35,6 +35,7 @@ describe('ChainsRepository', () => {
   // According to the limits of the Config Service
   // @see https://github.com/safe-global/safe-config-service/blob/main/src/chains/views.py#L14-L16
   const OFFSET = 40;
+  const MAX_LIMIT = 40;
 
   let target: ChainsRepository;
   const maxSequentialPages = 3;
@@ -101,10 +102,10 @@ describe('ChainsRepository', () => {
         if (offset === 0) {
           return Promise.resolve(pages[0]);
         }
-        if (offset === 40) {
+        if (offset === OFFSET) {
           return Promise.resolve(pages[1]);
         }
-        if (offset === 80) {
+        if (offset === OFFSET * 2) {
           return Promise.resolve(pages[2]);
         }
         return Promise.reject(new Error('Invalid offset'));
@@ -123,12 +124,12 @@ describe('ChainsRepository', () => {
     );
     expect(mockConfigApi.getChains).toHaveBeenCalledTimes(2);
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(1, {
-      limit: 40,
+      limit: MAX_LIMIT,
       offset: 0,
     });
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(2, {
-      limit: 40,
-      offset: 40,
+      limit: MAX_LIMIT,
+      offset: OFFSET,
     });
   });
 
@@ -178,10 +179,10 @@ describe('ChainsRepository', () => {
         if (offset === 0) {
           return Promise.resolve(pages[0]);
         }
-        if (offset === 40) {
+        if (offset === OFFSET) {
           return Promise.resolve(pages[1]);
         }
-        if (offset === 80) {
+        if (offset === OFFSET * 2) {
           return Promise.resolve(pages[2]);
         }
         return Promise.reject(new Error('Invalid offset'));
@@ -200,16 +201,16 @@ describe('ChainsRepository', () => {
     );
     expect(mockConfigApi.getChains).toHaveBeenCalledTimes(3);
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(1, {
-      limit: 40,
+      limit: MAX_LIMIT,
       offset: 0,
     });
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(2, {
-      limit: 40,
-      offset: 40,
+      limit: MAX_LIMIT,
+      offset: OFFSET,
     });
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(3, {
-      limit: 40,
-      offset: 80,
+      limit: MAX_LIMIT,
+      offset: OFFSET * 2,
     });
   });
 
@@ -259,10 +260,10 @@ describe('ChainsRepository', () => {
         if (offset === 0) {
           return Promise.resolve(pages[0]);
         }
-        if (offset === 40) {
+        if (offset === OFFSET) {
           return Promise.resolve(pages[1]);
         }
-        if (offset === 80) {
+        if (offset === OFFSET * 2) {
           return Promise.resolve(pages[2]);
         }
         return Promise.reject(new Error('Invalid offset'));
@@ -282,16 +283,16 @@ describe('ChainsRepository', () => {
         }),
     );
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(1, {
-      limit: 40,
+      limit: MAX_LIMIT,
       offset: 0,
     });
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(2, {
-      limit: 40,
-      offset: 40,
+      limit: MAX_LIMIT,
+      offset: OFFSET,
     });
     expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(3, {
-      limit: 40,
-      offset: 80,
+      limit: MAX_LIMIT,
+      offset: OFFSET * 2,
     });
     expect(mockLoggingService.error).toHaveBeenCalledTimes(1);
     expect(mockLoggingService.error).toHaveBeenNthCalledWith(

--- a/src/domain/chains/chains.repository.spec.ts
+++ b/src/domain/chains/chains.repository.spec.ts
@@ -1,0 +1,272 @@
+import { faker } from '@faker-js/faker/.';
+import { chunk } from 'lodash';
+import { getAddress } from 'viem';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import {
+  limitAndOffsetUrlFactory,
+  pageBuilder,
+} from '@/domain/entities/__tests__/page.builder';
+import { ChainsRepository } from '@/domain/chains/chains.repository';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { Chain } from '@/domain/chains/entities/chain.entity';
+import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import type { Page } from '@/domain/entities/page.entity';
+import type { ILoggingService } from '@/logging/logging.interface';
+
+const mockLoggingService = {
+  error: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+const mockConfigApi = {
+  getChains: jest.fn(),
+} as jest.MockedObjectDeep<IConfigApi>;
+const mockTransactionApiManager =
+  {} as jest.MockedObjectDeep<ITransactionApiManager>;
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+/**
+ * Note: all other methods of the repository are tested in situ.
+ * Whilst `getAllChains` is to some extent as well, the following
+ * tests are required to cover all edge cases.
+ */
+describe('ChainsRepository', () => {
+  let target: ChainsRepository;
+
+  const maxLimit = 40;
+  const maxSequentialPages = 3;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'safeConfig.chains.maxLimit') return maxLimit;
+      if (key === 'safeConfig.chains.maxSequentialPages')
+        return maxSequentialPages;
+    });
+
+    target = new ChainsRepository(
+      mockLoggingService,
+      mockConfigApi,
+      mockTransactionApiManager,
+      mockConfigurationService,
+    );
+  });
+
+  it('should return all chains across pages below request limit', async () => {
+    const offset = 40;
+    const url = faker.internet.url({ appendSlash: true });
+    const chains = Array.from(
+      {
+        length: maxLimit * (maxSequentialPages - 1), // One page less than request limit
+      },
+      (_, i) => chainBuilder().with('chainId', i.toString()).build(),
+    );
+    const pages = chunk(chains, maxLimit).map((results, i, arr) => {
+      const pageOffset = (i + 1) * offset;
+
+      const previous = ((): string | null => {
+        if (i === 0) {
+          return null;
+        }
+        return limitAndOffsetUrlFactory(maxLimit, pageOffset, url);
+      })();
+      const next = ((): string | null => {
+        if (i === arr.length - 1) {
+          return null;
+        }
+        return limitAndOffsetUrlFactory(maxLimit, pageOffset, url);
+      })();
+
+      return pageBuilder<Chain>()
+        .with('results', results)
+        .with('count', chains.length)
+        .with('previous', previous)
+        .with('next', next)
+        .build();
+    });
+    mockConfigApi.getChains.mockImplementation(
+      ({ offset }): Promise<Page<Chain>> => {
+        if (offset === 0) {
+          return Promise.resolve(pages[0]);
+        }
+        if (offset === 40) {
+          return Promise.resolve(pages[1]);
+        }
+        if (offset === 80) {
+          return Promise.resolve(pages[2]);
+        }
+        return Promise.reject(new Error('Invalid offset'));
+      },
+    );
+
+    const result = await target.getAllChains();
+
+    expect(result).toStrictEqual(
+      chains.map((chain) => {
+        return {
+          ...chain,
+          ensRegistryAddress: getAddress(chain.ensRegistryAddress!),
+        };
+      }),
+    );
+    expect(mockConfigApi.getChains).toHaveBeenCalledTimes(2);
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(1, {
+      limit: 40,
+      offset: 0,
+    });
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(2, {
+      limit: 40,
+      offset: 40,
+    });
+  });
+
+  it('should return all chains across pages up request limit', async () => {
+    const offset = 40;
+    const url = faker.internet.url({ appendSlash: true });
+    const chains = Array.from(
+      {
+        length: maxLimit * maxSequentialPages, // Exactly request limit
+      },
+      (_, i) => chainBuilder().with('chainId', i.toString()).build(),
+    );
+    const pages = chunk(chains, maxLimit).map((results, i, arr) => {
+      const pageOffset = (i + 1) * offset;
+
+      const previous = ((): string | null => {
+        if (i === 0) {
+          return null;
+        }
+        return limitAndOffsetUrlFactory(maxLimit, pageOffset, url);
+      })();
+      const next = ((): string | null => {
+        if (i === arr.length - 1) {
+          return null;
+        }
+        return limitAndOffsetUrlFactory(maxLimit, pageOffset, url);
+      })();
+
+      return pageBuilder<Chain>()
+        .with('results', results)
+        .with('count', chains.length)
+        .with('previous', previous)
+        .with('next', next)
+        .build();
+    });
+    mockConfigApi.getChains.mockImplementation(
+      ({ offset }): Promise<Page<Chain>> => {
+        if (offset === 0) {
+          return Promise.resolve(pages[0]);
+        }
+        if (offset === 40) {
+          return Promise.resolve(pages[1]);
+        }
+        if (offset === 80) {
+          return Promise.resolve(pages[2]);
+        }
+        return Promise.reject(new Error('Invalid offset'));
+      },
+    );
+
+    const result = await target.getAllChains();
+
+    expect(result).toStrictEqual(
+      chains.map((chain) => {
+        return {
+          ...chain,
+          ensRegistryAddress: getAddress(chain.ensRegistryAddress!),
+        };
+      }),
+    );
+    expect(mockConfigApi.getChains).toHaveBeenCalledTimes(3);
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(1, {
+      limit: 40,
+      offset: 0,
+    });
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(2, {
+      limit: 40,
+      offset: 40,
+    });
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(3, {
+      limit: 40,
+      offset: 80,
+    });
+  });
+
+  it('should return all chains across pages up to request limit and notify if there are more', async () => {
+    const offset = 40;
+    const url = faker.internet.url({ appendSlash: true });
+    const chains = Array.from(
+      {
+        length: maxLimit * (maxSequentialPages + 1), // One page more than request limit
+      },
+      (_, i) => chainBuilder().with('chainId', i.toString()).build(),
+    );
+    const pages = chunk(chains, maxLimit).map((results, i, arr) => {
+      const pageOffset = (i + 1) * offset;
+
+      const previous = ((): string | null => {
+        if (i === 0) {
+          return null;
+        }
+        return limitAndOffsetUrlFactory(maxLimit, pageOffset, url);
+      })();
+      const next = ((): string | null => {
+        if (i === arr.length - 1) {
+          return null;
+        }
+        return limitAndOffsetUrlFactory(maxLimit, pageOffset, url);
+      })();
+
+      return pageBuilder<Chain>()
+        .with('results', results)
+        .with('count', chains.length)
+        .with('previous', previous)
+        .with('next', next)
+        .build();
+    });
+    mockConfigApi.getChains.mockImplementation(
+      ({ offset }): Promise<Page<Chain>> => {
+        if (offset === 0) {
+          return Promise.resolve(pages[0]);
+        }
+        if (offset === 40) {
+          return Promise.resolve(pages[1]);
+        }
+        if (offset === 80) {
+          return Promise.resolve(pages[2]);
+        }
+        return Promise.reject(new Error('Invalid offset'));
+      },
+    );
+
+    const result = await target.getAllChains();
+
+    expect(result).toStrictEqual(
+      chains.slice(0, maxLimit * maxSequentialPages).map((chain) => {
+        return {
+          ...chain,
+          ensRegistryAddress: getAddress(chain.ensRegistryAddress!),
+        };
+      }),
+    );
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(1, {
+      limit: 40,
+      offset: 0,
+    });
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(2, {
+      limit: 40,
+      offset: 40,
+    });
+    expect(mockConfigApi.getChains).toHaveBeenNthCalledWith(3, {
+      limit: 40,
+      offset: 80,
+    });
+    expect(mockLoggingService.error).toHaveBeenCalledTimes(1);
+    expect(mockLoggingService.error).toHaveBeenNthCalledWith(
+      1,
+      'More chains available despite request limit reached',
+    );
+  });
+});

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -21,7 +21,10 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 
 @Injectable()
 export class ChainsRepository implements IChainsRepository {
-  private readonly maxLimit: number;
+  // According to the limits of the Config Service
+  // @see https://github.com/safe-global/safe-config-service/blob/main/src/chains/views.py#L14-L16
+  static readonly MAX_LIMIT = 40;
+
   private readonly maxSequentialPages: number;
 
   constructor(
@@ -32,9 +35,6 @@ export class ChainsRepository implements IChainsRepository {
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
   ) {
-    this.maxLimit = this.configurationService.getOrThrow<number>(
-      'safeConfig.chains.maxLimit',
-    );
     this.maxSequentialPages = this.configurationService.getOrThrow<number>(
       'safeConfig.chains.maxSequentialPages',
     );
@@ -68,7 +68,7 @@ export class ChainsRepository implements IChainsRepository {
     let next = null;
 
     for (let i = 0; i < this.maxSequentialPages; i++) {
-      const result = await this.getChains(this.maxLimit, offset);
+      const result = await this.getChains(ChainsRepository.MAX_LIMIT, offset);
 
       next = result.next;
       chains.push(...result.results);

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -63,8 +63,7 @@ export class ChainsRepository implements IChainsRepository {
 
       const url = new URL(result.next);
       const paginationData = PaginationData.fromLimitAndOffset(url);
-      offset ??= 0;
-      offset += paginationData.offset;
+      offset = paginationData.offset;
     }
 
     return chains;

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -16,6 +16,7 @@ import {
 } from '@/domain/indexing/entities/indexing-status.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { differenceBy } from 'lodash';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
 
 @Injectable()
 export class ChainsRepository implements IChainsRepository {
@@ -45,6 +46,28 @@ export class ChainsRepository implements IChainsRepository {
       });
     }
     return valid;
+  }
+
+  async getAllChains(): Promise<Array<Chain>> {
+    const chains: Array<Chain> = [];
+
+    let offset: number | undefined;
+
+    while (true) {
+      const result = await this.getChains(undefined, offset);
+      chains.push(...result.results);
+
+      if (!result.next) {
+        break;
+      }
+
+      const url = new URL(result.next);
+      const paginationData = PaginationData.fromLimitAndOffset(url);
+      offset ??= 0;
+      offset += paginationData.offset;
+    }
+
+    return chains;
   }
 
   async getSingletons(chainId: string): Promise<Singleton[]> {

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -428,11 +428,9 @@ export class SafeRepository implements ISafeRepository {
   async getAllSafesByOwner(args: {
     ownerAddress: `0x${string}`;
   }): Promise<{ [chainId: string]: Array<string> }> {
-    // Note: does not take pagination into account but we do not support
-    // enough chains for it to be an issue
-    const { results } = await this.chainsRepository.getChains();
+    const chains = await this.chainsRepository.getAllChains();
     const allSafeLists = await Promise.all(
-      results.map(async ({ chainId }) => {
+      chains.map(async ({ chainId }) => {
         const safeList = await this.getSafesByOwner({
           chainId,
           ownerAddress: args.ownerAddress,

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -29,6 +29,7 @@ import type { Server } from 'net';
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
+  let maxLimit: number;
   let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
@@ -51,6 +52,7 @@ describe('Owners Controller (Unit)', () => {
       IConfigurationService,
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    maxLimit = configurationService.getOrThrow('safeConfig.chains.maxLimit');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -384,7 +386,7 @@ describe('Owners Controller (Unit)', () => {
       expect(networkService.get).toHaveBeenCalledTimes(1);
       expect(networkService.get).toHaveBeenCalledWith({
         url: `${safeConfigUrl}/api/v1/chains`,
-        networkRequest: { params: { limit: undefined, offset: undefined } },
+        networkRequest: { params: { limit: maxLimit, offset: 0 } },
       });
     });
 

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -25,11 +25,11 @@ import {
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import type { Server } from 'net';
+import { ChainsRepository } from '@/domain/chains/chains.repository';
 
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
-  let maxLimit: number;
   let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
@@ -52,7 +52,6 @@ describe('Owners Controller (Unit)', () => {
       IConfigurationService,
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
-    maxLimit = configurationService.getOrThrow('safeConfig.chains.maxLimit');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -386,7 +385,9 @@ describe('Owners Controller (Unit)', () => {
       expect(networkService.get).toHaveBeenCalledTimes(1);
       expect(networkService.get).toHaveBeenCalledWith({
         url: `${safeConfigUrl}/api/v1/chains`,
-        networkRequest: { params: { limit: maxLimit, offset: 0 } },
+        networkRequest: {
+          params: { limit: ChainsRepository.MAX_LIMIT, offset: 0 },
+        },
       });
     });
 


### PR DESCRIPTION
## Summary

Resolves #2001 

When getting all Safes by owner address, we fetch the chain configurations. We don't, however, take into account pagination.

This adds a new `IChainsRepository['getAllChains']` method that fetches subsequent `next` pages and concatenates `results`, called in the `getAllSafesByOwner` method.

## Changes

- Add `IChainsRepository['getAllChains']` implementation
- Call `getAllChains` instead of `getChains` in `getAllSafesByOwner`
- Add appropriate test coverage