### PR TITLE
Only test one relay chain

### DIFF
--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -52,7 +52,10 @@ import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import type { Server } from 'net';
 
-const supportedChainIds = Object.keys(configuration().relay.apiKey);
+const supportedChainIds = faker.helpers.arrayElements(
+  Object.keys(configuration().relay.apiKey),
+  1,
+);
 
 const SAFE_VERSIONS = getDeploymentVersionsByChainIds(
   'Safe',


### PR DESCRIPTION
## Summary

Now that we support 11 chains for relaying, this increases the number of tests as we test deployments for _every_ supported chain.

This reduces the test coverage to a randomised chain. It sufficiently covers all edge cases.

## Changes

- Only test one relay chain.