### PR TITLE
Validate staking API keys

### DIFF
--- a/src/config/configuration.module.ts
+++ b/src/config/configuration.module.ts
@@ -62,4 +62,6 @@ export const RootConfigurationSchema = z.object({
   RELAY_PROVIDER_API_KEY_LINEA: z.string(),
   RELAY_PROVIDER_API_KEY_BLAST: z.string(),
   RELAY_PROVIDER_API_KEY_SEPOLIA: z.string(),
+  STAKING_API_KEY: z.string(),
+  STAKING_TESTNET_API_KEY: z.string(),
 });

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -34,6 +34,8 @@ describe('Configuration validator', () => {
     RELAY_PROVIDER_API_KEY_LINEA: faker.string.uuid(),
     RELAY_PROVIDER_API_KEY_BLAST: faker.string.uuid(),
     RELAY_PROVIDER_API_KEY_SEPOLIA: faker.string.uuid(),
+    STAKING_API_KEY: faker.string.uuid(),
+    STAKING_TESTNET_API_KEY: faker.string.uuid(),
   };
 
   it('should bypass this validation on test environment', () => {
@@ -75,6 +77,8 @@ describe('Configuration validator', () => {
     { key: 'RELAY_PROVIDER_API_KEY_LINEA' },
     { key: 'RELAY_PROVIDER_API_KEY_BLAST' },
     { key: 'RELAY_PROVIDER_API_KEY_SEPOLIA' },
+    { key: 'STAKING_API_KEY' },
+    { key: 'STAKING_TESTNET_API_KEY' },
   ])(
     'should detect that $key is missing in the configuration in production environment',
     ({ key }) => {
@@ -121,6 +125,8 @@ describe('Configuration validator', () => {
       RELAY_PROVIDER_API_KEY_LINEA: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_BLAST: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_SEPOLIA: faker.string.uuid(),
+      STAKING_API_KEY: faker.string.uuid(),
+      STAKING_TESTNET_API_KEY: faker.string.uuid(),
     };
     expect(() =>
       configurationValidator(invalidConfiguration, RootConfigurationSchema),


### PR DESCRIPTION
## Summary

The `STAKING_API_KEY` and `STAKING_TESTNET_API_KEY` values are required by the project. We have, however, no validation for them.

This appropriately adds the two keys to the `RootConfigurationSchema`.

## Changes

- Add `STAKING_API_KEY` and `STAKING_TESTNET_API_KEY` to the `RootConfigurationSchema`.
- Update test coverage accordingly.