### PR TITLE
Map `saltNonce` of creation transactions

### DIFF
--- a/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
@@ -13,6 +13,7 @@ export function creationTransactionBuilder(): IBuilder<CreationTransaction> {
     .with('factoryAddress', getAddress(faker.finance.ethereumAddress()))
     .with('masterCopy', getAddress(faker.finance.ethereumAddress()))
     .with('setupData', faker.string.hexadecimal() as `0x${string}`)
+    .with('saltNonce', faker.string.numeric())
     .with('dataDecoded', dataDecodedBuilder().build());
 }
 

--- a/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
@@ -101,6 +101,7 @@ describe('CreationTransactionSchema', () => {
     'creator' as const,
     'transactionHash' as const,
     'factoryAddress' as const,
+    'saltNonce' as const,
   ])('should not allow an undefined %s', (field) => {
     const creationTransaction = creationTransactionBuilder().build();
     delete creationTransaction[field];

--- a/src/domain/safe/entities/schemas/creation-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/creation-transaction.schema.ts
@@ -10,5 +10,6 @@ export const CreationTransactionSchema = z.object({
   factoryAddress: AddressSchema,
   masterCopy: AddressSchema.nullish().default(null),
   setupData: HexSchema.nullish().default(null),
+  saltNonce: z.string(),
   dataDecoded: DataDecodedSchema.nullish().default(null),
 });

--- a/src/routes/transactions/entities/creation-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction-info.entity.ts
@@ -14,17 +14,21 @@ export class CreationTransactionInfo extends TransactionInfo {
   implementation: AddressInfo | null;
   @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   factory: AddressInfo | null;
+  @ApiProperty()
+  saltNonce: string;
 
   constructor(
     creator: AddressInfo,
     transactionHash: string,
     implementation: AddressInfo | null,
     factory: AddressInfo | null,
+    saltNonce: string,
   ) {
     super(TransactionInfoType.Creation, null, null);
     this.creator = creator;
     this.transactionHash = transactionHash;
     this.implementation = implementation;
     this.factory = factory;
+    this.saltNonce = saltNonce;
   }
 }

--- a/src/routes/transactions/entities/creation-transaction.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction.entity.ts
@@ -15,6 +15,8 @@ export class CreationTransaction implements DomainCreationTransaction {
   masterCopy: `0x${string}` | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   setupData: `0x${string}` | null;
+  @ApiProperty()
+  saltNonce: string;
   @ApiPropertyOptional({ type: DataDecoded, nullable: true })
   dataDecoded: DataDecoded | null;
 
@@ -25,6 +27,7 @@ export class CreationTransaction implements DomainCreationTransaction {
     factoryAddress: `0x${string}`,
     masterCopy: `0x${string}` | null,
     setupData: `0x${string}` | null,
+    saltNonce: string,
     dataDecoded: DataDecoded | null,
   ) {
     this.created = created;
@@ -33,6 +36,7 @@ export class CreationTransaction implements DomainCreationTransaction {
     this.factoryAddress = factoryAddress;
     this.masterCopy = masterCopy;
     this.setupData = setupData;
+    this.saltNonce = saltNonce;
     this.dataDecoded = dataDecoded;
   }
 }

--- a/src/routes/transactions/mappers/creation-transaction/creation-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/creation-transaction/creation-transaction.mapper.ts
@@ -39,6 +39,7 @@ export class CreationTransactionMapper {
       transaction.transactionHash,
       implementation,
       factory,
+      transaction.saltNonce,
     );
 
     return new Transaction(


### PR DESCRIPTION
## Summary

The `saltNonce` of creation transactions is now returned by the Transaction Service. This adds the appropriate logic for validating and mapping it across all layers accordingly.

## Changes

- Add property to domain schema, therefore extending type
- Add property to `CreationTransaction` entity
- Add property to `CreationTransactionInfo` entity
- Extend builder and associated test