### PR TITLE
Fix Swagger definitions

### DIFF
--- a/src/routes/chains/entities/backbone.entity.ts
+++ b/src/routes/chains/entities/backbone.entity.ts
@@ -1,10 +1,10 @@
 import { Backbone as DomainBackbone } from '@/domain/backbone/entities/backbone.entity';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class Backbone implements DomainBackbone {
   @ApiProperty()
   api_version!: string;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   headers!: string[] | null;
   @ApiProperty()
   host!: string;
@@ -12,7 +12,7 @@ export class Backbone implements DomainBackbone {
   name!: string;
   @ApiProperty()
   secure!: boolean;
-  @ApiProperty()
+  @ApiProperty({ type: Object, nullable: true })
   settings!: Record<string, unknown> | null;
   @ApiProperty()
   version!: string;

--- a/src/routes/chains/entities/chain-page.entity.ts
+++ b/src/routes/chains/entities/chain-page.entity.ts
@@ -3,6 +3,6 @@ import { Chain } from '@/routes/chains/entities/chain.entity';
 import { Page } from '@/routes/common/entities/page.entity';
 
 export class ChainPage extends Page<Chain> {
-  @ApiProperty({ type: Chain })
+  @ApiProperty({ type: Chain, isArray: true })
   results!: Chain[];
 }

--- a/src/routes/community/entities/campaign-activity.page.entity.ts
+++ b/src/routes/community/entities/campaign-activity.page.entity.ts
@@ -3,6 +3,6 @@ import { CampaignActivity } from '@/routes/community/entities/campaign-activity.
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CampaignActivityPage extends Page<CampaignActivity> {
-  @ApiProperty({ type: [CampaignActivity] })
+  @ApiProperty({ type: CampaignActivity, isArray: true })
   results!: Array<CampaignActivity>;
 }

--- a/src/routes/community/entities/campaign.entity.ts
+++ b/src/routes/community/entities/campaign.entity.ts
@@ -15,7 +15,11 @@ export class Campaign implements DomainCampaign {
   endDate!: Date;
   @ApiPropertyOptional({ type: String, nullable: true })
   lastUpdated!: Date | null;
-  @ApiPropertyOptional({ type: [ActivityMetadata], nullable: true })
+  @ApiPropertyOptional({
+    type: ActivityMetadata,
+    isArray: true,
+    nullable: true,
+  })
   activitiesMetadata!: ActivityMetadata[] | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   rewardValue!: string | null;

--- a/src/routes/community/entities/campaign.page.entity.ts
+++ b/src/routes/community/entities/campaign.page.entity.ts
@@ -3,6 +3,6 @@ import { Campaign } from '@/routes/community/entities/campaign.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CampaignPage extends Page<Campaign> {
-  @ApiProperty({ type: [Campaign] })
+  @ApiProperty({ type: Campaign, isArray: true })
   results!: Array<Campaign>;
 }

--- a/src/routes/data-decode/entities/data-decoded-parameter.entity.ts
+++ b/src/routes/data-decode/entities/data-decoded-parameter.entity.ts
@@ -1,5 +1,5 @@
 import { DataDecodedParameter as DomainDataDecodedParameter } from '@/domain/data-decoder/entities/data-decoded.entity';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class DataDecodedParameter implements DomainDataDecodedParameter {
   @ApiProperty()
@@ -8,7 +8,10 @@ export class DataDecodedParameter implements DomainDataDecodedParameter {
   type: string;
   @ApiProperty()
   value: Required<unknown>;
-  @ApiProperty()
+  @ApiPropertyOptional({
+    oneOf: [{ type: 'object' }, { type: 'array', items: { type: 'object' } }],
+    nullable: true,
+  })
   valueDecoded: Record<string, unknown> | Record<string, unknown>[] | null;
 
   constructor(

--- a/src/routes/data-decode/entities/data-decoded.entity.ts
+++ b/src/routes/data-decode/entities/data-decoded.entity.ts
@@ -5,7 +5,11 @@ import { DataDecoded as DomainDataDecoded } from '@/domain/data-decoder/entities
 export class DataDecoded implements DomainDataDecoded {
   @ApiProperty()
   method: string;
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   constructor(method: string, parameters: DataDecodedParameter[] | null) {

--- a/src/routes/delegates/entities/create-delegate.dto.entity.ts
+++ b/src/routes/delegates/entities/create-delegate.dto.entity.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 export class CreateDelegateDto
   implements z.infer<typeof CreateDelegateDtoSchema>
 {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   safe!: `0x${string}` | null;
   @ApiProperty()
   delegate!: `0x${string}`;

--- a/src/routes/delegates/v2/entities/delete-delegate.v2.dto.entity.ts
+++ b/src/routes/delegates/v2/entities/delete-delegate.v2.dto.entity.ts
@@ -5,9 +5,9 @@ import { z } from 'zod';
 export class DeleteDelegateV2Dto
   implements z.infer<typeof DeleteDelegateV2DtoSchema>
 {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   delegator!: `0x${string}` | null;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   safe!: `0x${string}` | null;
   @ApiProperty()
   signature!: string;

--- a/src/routes/safe-apps/entities/safe-app.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app.entity.ts
@@ -10,7 +10,7 @@ export class SafeApp {
   url: string;
   @ApiProperty()
   name: string;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   iconUrl: string | null;
   @ApiProperty()
   description: string;

--- a/src/routes/safes/entities/safe-info.entity.ts
+++ b/src/routes/safes/entities/safe-info.entity.ts
@@ -30,13 +30,13 @@ export class SafeState {
   readonly version: string | null;
   @ApiProperty({ enum: Object.values(MasterCopyVersionState) })
   readonly implementationVersionState: MasterCopyVersionState;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   readonly collectiblesTag: string | null;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   readonly txQueuedTag: string | null;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   readonly txHistoryTag: string | null;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   readonly messagesTag: string | null;
 
   constructor(

--- a/src/routes/safes/entities/safe-overview.entity.ts
+++ b/src/routes/safes/entities/safe-overview.entity.ts
@@ -1,5 +1,5 @@
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SafeOverview {
   @ApiProperty()
@@ -14,7 +14,7 @@ export class SafeOverview {
   readonly fiatTotal: string;
   @ApiProperty()
   readonly queued: number;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: Number, nullable: true })
   readonly awaitingConfirmation: number | null;
 
   constructor(

--- a/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/confirmation-view/confirmation-view.entity.ts
@@ -35,7 +35,11 @@ export class BaselineConfirmationView implements Baseline {
   @ApiProperty()
   method: string;
 
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   constructor(args: {

--- a/src/routes/transactions/entities/custom-transaction.entity.ts
+++ b/src/routes/transactions/entities/custom-transaction.entity.ts
@@ -11,7 +11,7 @@ export class CustomTransactionInfo extends TransactionInfo {
   to: AddressInfo;
   @ApiProperty()
   dataSize: string;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   value: string | null;
   @ApiProperty()
   isCancellation: boolean;

--- a/src/routes/transactions/entities/settings-change-transaction.entity.ts
+++ b/src/routes/transactions/entities/settings-change-transaction.entity.ts
@@ -10,7 +10,7 @@ import {
 export class SettingsChangeTransaction extends TransactionInfo {
   @ApiProperty()
   dataDecoded: DataDecoded;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: SettingsChange, nullable: true })
   settingsInfo: SettingsChange | null;
 
   constructor(

--- a/src/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-confirmation-view.entity.ts
@@ -24,7 +24,11 @@ export class NativeStakingDepositConfirmationView
   @ApiProperty()
   method: string;
 
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   @ApiProperty()

--- a/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-deposit-info.entity.ts
@@ -8,7 +8,7 @@ import {
   TransactionInfo,
   TransactionInfoType,
 } from '@/routes/transactions/entities/transaction-info.entity';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export type NativeStakingDepositInfo = StakingTimeInfo & StakingFinancialInfo;
 
@@ -61,7 +61,10 @@ export class NativeStakingDepositTransactionInfo
   @ApiProperty()
   tokenInfo: TokenInfo;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
+    type: String,
+    isArray: true,
+    nullable: true,
     description: 'Populated after transaction has been executed',
   })
   validators: Array<`0x${string}`> | null;

--- a/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-validators-exit-confirmation-view.entity.ts
@@ -21,7 +21,11 @@ export class NativeStakingValidatorsExitConfirmationView implements Baseline {
   @ApiProperty()
   method: string;
 
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   @ApiProperty()

--- a/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/staking/native-staking-withdraw-confirmation-view.entity.ts
@@ -15,7 +15,11 @@ export class NativeStakingWithdrawConfirmationView implements Baseline {
   @ApiProperty()
   method: string;
 
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   @ApiProperty()

--- a/src/routes/transactions/entities/swaps/swap-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/swaps/swap-confirmation-view.entity.ts
@@ -20,7 +20,11 @@ export class CowSwapConfirmationView implements Baseline, OrderInfo {
   @ApiProperty()
   method: string;
 
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   // OrderInfo implementation

--- a/src/routes/transactions/entities/swaps/twap-confirmation-view.entity.ts
+++ b/src/routes/transactions/entities/swaps/twap-confirmation-view.entity.ts
@@ -24,7 +24,11 @@ export class CowSwapTwapConfirmationView implements Baseline, TwapOrderInfo {
   @ApiProperty()
   method: string;
 
-  @ApiPropertyOptional({ type: [DataDecodedParameter], nullable: true })
+  @ApiPropertyOptional({
+    type: DataDecodedParameter,
+    isArray: true,
+    nullable: true,
+  })
   parameters: DataDecodedParameter[] | null;
 
   // TwapOrderInfo implementation
@@ -62,6 +66,7 @@ export class CowSwapTwapConfirmationView implements Baseline, TwapOrderInfo {
   buyAmount: string;
 
   @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description:
       'The executed sell token raw amount (no decimals), or null if there are too many parts',
@@ -69,6 +74,7 @@ export class CowSwapTwapConfirmationView implements Baseline, TwapOrderInfo {
   executedSellAmount: string | null;
 
   @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description:
       'The executed surplus fee raw amount (no decimals), or null if there are too many parts',
@@ -76,6 +82,7 @@ export class CowSwapTwapConfirmationView implements Baseline, TwapOrderInfo {
   executedSurplusFee: string | null;
 
   @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description:
       'The executed buy token raw amount (no decimals), or null if there are too many parts',

--- a/src/routes/transactions/entities/swaps/twap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/twap-order-info.entity.ts
@@ -75,7 +75,8 @@ export class TwapOrderTransactionInfo
   @ApiPropertyOptional({ enum: OrderClass })
   class: OrderClass.Limit;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description: 'The order UID of the active order, or null if none is active',
   })
@@ -95,6 +96,7 @@ export class TwapOrderTransactionInfo
   buyAmount: string;
 
   @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description:
       'The executed sell token raw amount (no decimals), or null if there are too many parts',
@@ -102,6 +104,7 @@ export class TwapOrderTransactionInfo
   executedSellAmount: string | null;
 
   @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description:
       'The executed buy token raw amount (no decimals), or null if there are too many parts',
@@ -109,6 +112,7 @@ export class TwapOrderTransactionInfo
   executedBuyAmount: string | null;
 
   @ApiPropertyOptional({
+    type: String,
     nullable: true,
     description:
       'The executed surplus fee raw amount (no decimals), or null if there are too many parts',

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -37,9 +37,9 @@ import { NativeStakingWithdrawTransactionInfo } from '@/routes/transactions/enti
 export class Transaction {
   @ApiProperty()
   id: string;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   txHash: `0x${string}` | null;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: Number, nullable: true })
   timestamp: number | null;
   @ApiProperty()
   txStatus: string;

--- a/src/routes/transactions/entities/transfers/native-coin-transfer.entity.ts
+++ b/src/routes/transactions/entities/transfers/native-coin-transfer.entity.ts
@@ -1,11 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import {
   Transfer,
   TransferType,
 } from '@/routes/transactions/entities/transfers/transfer.entity';
 
 export class NativeCoinTransfer extends Transfer {
-  @ApiProperty()
+  @ApiPropertyOptional({ type: String, nullable: true })
   value: string | null;
 
   constructor(value: string | null) {


### PR DESCRIPTION
## Summary

We are observing inconsistencies between our TypeScript types and Swagger schema in our automatically generated SDK. This fixes some of those encountered issues.

## Changes

- All nullable values are defined in `ApiOptionalProperty` decorators, flagged as `nullable` with the correct `type`
- All array-expected values leverage the `isArray` property instead of TypeScript annotations