### PR TITLE
Enable `no-nested-ternary` lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,7 @@ export default tseslint.config(
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
+      'no-nested-ternary': 'error',
       'no-restricted-imports': [
         'error',
         {

--- a/src/routes/transactions/mappers/common/twap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.ts
@@ -91,18 +91,20 @@ export class TwapOrderMapper {
     // to avoid requesting too many orders
     const hasAbundantParts = twapParts.length > this.maxNumberOfParts;
 
-    // Fetch no parts if transaction isn't executed, otherwise only those up to max
-    const partsToFetch = ((): Array<GPv2OrderParameters> => {
-      if (!transaction.executionDate) {
-        return [];
-      }
+    let partsToFetch: Array<GPv2OrderParameters>;
+
+    // If the transaction is not executed, there are no parts to fetch
+    if (!transaction.executionDate) {
+      partsToFetch = [];
+    } else {
+      // Otherwise, fetch parts to get amounts/fees of order/token info
       if (!hasAbundantParts) {
-        return twapParts;
+        partsToFetch = twapParts;
+      } else {
+        // Can use the last part to get the amounts/fees for entire order
+        partsToFetch = twapParts.slice(-1);
       }
-      // We use the last part (and only one) to get the amounts/fees of the entire
-      // order and we only need one to get the token info
-      return twapParts.slice(-1);
-    })();
+    }
 
     const activePart = this.getActivePart({
       twapParts,

--- a/src/routes/transactions/mappers/common/twap-order.mapper.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.ts
@@ -91,14 +91,18 @@ export class TwapOrderMapper {
     // to avoid requesting too many orders
     const hasAbundantParts = twapParts.length > this.maxNumberOfParts;
 
-    // Fetch all order parts if the transaction has been executed, otherwise none
-    const partsToFetch = transaction.executionDate
-      ? hasAbundantParts
-        ? // We use the last part (and only one) to get the amounts/fees of the entire
-          // order and we only need one to get the token info
-          twapParts.slice(-1)
-        : twapParts
-      : [];
+    // Fetch no parts if transaction isn't executed, otherwise only those up to max
+    const partsToFetch = ((): Array<GPv2OrderParameters> => {
+      if (!transaction.executionDate) {
+        return [];
+      }
+      if (!hasAbundantParts) {
+        return twapParts;
+      }
+      // We use the last part (and only one) to get the amounts/fees of the entire
+      // order and we only need one to get the token info
+      return twapParts.slice(-1);
+    })();
 
     const activePart = this.getActivePart({
       twapParts,


### PR DESCRIPTION
## Summary

Nested ternaries are hard to follow. As such, this enabled the [`no-nested-ternary` lint rule](https://eslint.org/docs/latest/rules/no-nested-ternary) and solves the only flouting occurance.

## Changes

- Enable `no-nested-ternary` lint tule.
- Change nested ternary to use `if` clauses.