### PR TITLE
Return indexing timestamp from Transaction Service

### DIFF
--- a/src/domain/chains/entities/__tests__/indexing-status.builder.ts
+++ b/src/domain/chains/entities/__tests__/indexing-status.builder.ts
@@ -6,9 +6,12 @@ import { faker } from '@faker-js/faker';
 export function indexingStatusBuilder(): IBuilder<IndexingStatus> {
   return new Builder<IndexingStatus>()
     .with('currentBlockNumber', faker.number.int())
+    .with('currentBlockTimestamp', faker.date.recent())
     .with('erc20BlockNumber', faker.number.int())
+    .with('erc20BlockTimestamp', faker.date.recent())
     .with('erc20Synced', faker.datatype.boolean())
     .with('masterCopiesBlockNumber', faker.number.int())
+    .with('masterCopiesBlockTimestamp', faker.date.recent())
     .with('masterCopiesSynced', faker.datatype.boolean())
     .with('synced', faker.datatype.boolean());
 }

--- a/src/domain/indexing/entities/indexing-status.entity.spec.ts
+++ b/src/domain/indexing/entities/indexing-status.entity.spec.ts
@@ -13,8 +13,11 @@ describe('IndexingStatusSchema', () => {
 
   it.each([
     'currentBlockNumber' as const,
+    'currentBlockTimestamp' as const,
     'erc20BlockNumber' as const,
+    'erc20BlockTimestamp' as const,
     'masterCopiesBlockNumber' as const,
+    'masterCopiesBlockTimestamp' as const,
     'erc20Synced' as const,
     'masterCopiesSynced' as const,
     'synced' as const,
@@ -49,6 +52,23 @@ describe('IndexingStatusSchema', () => {
     ]);
   });
 
+  it.each([
+    'currentBlockTimestamp' as const,
+    'erc20BlockTimestamp' as const,
+    'masterCopiesBlockTimestamp' as const,
+  ])('should coerce %s to a date', (key) => {
+    const date = faker.date.recent();
+    const indexingStatus = indexingStatusBuilder()
+      .with(key, date.toString() as unknown as Date)
+      .build();
+
+    const result = IndexingStatusSchema.safeParse(indexingStatus);
+
+    // zod does not coerce milliseconds
+    date.setMilliseconds(0);
+    expect(result.success && result.data[key]).toStrictEqual(date);
+  });
+
   it('should not allow an invalid IndexingStatus', () => {
     const indexingStatus = {
       invalid: 'indexingStatus',
@@ -65,11 +85,21 @@ describe('IndexingStatusSchema', () => {
         received: 'undefined',
       },
       {
+        code: 'invalid_date',
+        message: 'Invalid date',
+        path: ['currentBlockTimestamp'],
+      },
+      {
         code: 'invalid_type',
         expected: 'number',
         message: 'Required',
         path: ['erc20BlockNumber'],
         received: 'undefined',
+      },
+      {
+        code: 'invalid_date',
+        message: 'Invalid date',
+        path: ['erc20BlockTimestamp'],
       },
       {
         code: 'invalid_type',
@@ -84,6 +114,11 @@ describe('IndexingStatusSchema', () => {
         message: 'Required',
         path: ['masterCopiesBlockNumber'],
         received: 'undefined',
+      },
+      {
+        code: 'invalid_date',
+        message: 'Invalid date',
+        path: ['masterCopiesBlockTimestamp'],
       },
       {
         code: 'invalid_type',

--- a/src/domain/indexing/entities/indexing-status.entity.ts
+++ b/src/domain/indexing/entities/indexing-status.entity.ts
@@ -2,9 +2,12 @@ import { z } from 'zod';
 
 export const IndexingStatusSchema = z.object({
   currentBlockNumber: z.number(),
+  currentBlockTimestamp: z.coerce.date(),
   erc20BlockNumber: z.number(),
+  erc20BlockTimestamp: z.coerce.date(),
   erc20Synced: z.boolean(),
   masterCopiesBlockNumber: z.number(),
+  masterCopiesBlockTimestamp: z.coerce.date(),
   masterCopiesSynced: z.boolean(),
   synced: z.boolean(),
 });

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -25,20 +25,12 @@ import type { Page } from '@/domain/entities/page.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
-import type { GetBlockReturnType } from 'viem';
-import { getAddress, HttpRequestError } from 'viem';
+import { getAddress } from 'viem';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import type { Server } from 'net';
 import { indexingStatusBuilder } from '@/domain/chains/entities/__tests__/indexing-status.builder';
-import {
-  BlockchainApiManagerModule,
-  IBlockchainApiManager,
-} from '@/domain/interfaces/blockchain-api.manager.interface';
-import { TestBlockchainApiManagerModule } from '@/datasources/blockchain/__tests__/test.blockchain-api.manager';
-import type { FakeBlockchainApiManager } from '@/datasources/blockchain/__tests__/fake.blockchain-api.manager';
 
-const mockGetBlock = jest.fn();
 describe('Chains Controller (Unit)', () => {
   let app: INestApplication<Server>;
 
@@ -47,7 +39,6 @@ describe('Chains Controller (Unit)', () => {
   let version: string;
   let buildNumber: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
-  let blockchainApiManager: FakeBlockchainApiManager;
 
   const chainsResponse: Page<Chain> = {
     count: 2,
@@ -73,8 +64,6 @@ describe('Chains Controller (Unit)', () => {
       .useModule(TestNetworkModule)
       .overrideModule(QueuesApiModule)
       .useModule(TestQueuesApiModule)
-      .overrideModule(BlockchainApiManagerModule)
-      .useModule(TestBlockchainApiManagerModule)
       .compile();
 
     const configurationService = moduleFixture.get<IConfigurationService>(
@@ -85,10 +74,6 @@ describe('Chains Controller (Unit)', () => {
     version = configurationService.getOrThrow('about.version');
     buildNumber = configurationService.getOrThrow('about.buildNumber');
     networkService = moduleFixture.get(NetworkService);
-    blockchainApiManager = moduleFixture.get(IBlockchainApiManager);
-    blockchainApiManager.getApi.mockImplementation(() => ({
-      getBlock: mockGetBlock,
-    }));
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -641,31 +626,40 @@ describe('Chains Controller (Unit)', () => {
 
   describe('GET /:chainId/about/indexing', () => {
     it('Success', async () => {
-      networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
-        status: 200,
-      });
       const indexingStatus = indexingStatusBuilder().build();
-      networkService.get.mockResolvedValueOnce({
-        data: indexingStatus,
-        status: 200,
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`) {
+          return Promise.resolve({
+            data: chainResponse,
+            status: 200,
+          });
+        }
+        if (
+          url === `${chainResponse.transactionService}/api/v1/about/indexing/`
+        ) {
+          return Promise.resolve({
+            data: indexingStatus,
+            status: 200,
+          });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
       });
-      const block: Partial<GetBlockReturnType> = {
-        timestamp: faker.number.bigInt(),
-      };
-      mockGetBlock.mockResolvedValue(block);
 
       await request(app.getHttpServer())
-        .get('/v1/chains/1/about/indexing')
+        .get(`/v1/chains/${chainResponse.chainId}/about/indexing`)
         .expect(200)
         .expect({
-          lastSync: Number(block.timestamp),
+          lastSync:
+            indexingStatus.erc20BlockTimestamp >
+            indexingStatus.masterCopiesBlockTimestamp
+              ? indexingStatus.masterCopiesBlockTimestamp.getTime()
+              : indexingStatus.erc20BlockTimestamp.getTime(),
           synced: indexingStatus.synced,
         });
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
       expect(networkService.get.mock.calls[0][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/1`,
+        `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about/indexing/`,
@@ -673,16 +667,6 @@ describe('Chains Controller (Unit)', () => {
       expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
         undefined,
       );
-      expect(mockGetBlock).toHaveBeenCalledTimes(1);
-      expect(mockGetBlock).toHaveBeenCalledWith({
-        blockNumber: BigInt(
-          // The oldest block number synced
-          Math.min(
-            indexingStatus.erc20BlockNumber,
-            indexingStatus.masterCopiesBlockNumber,
-          ),
-        ),
-      });
     });
 
     it('Failure getting the chain', async () => {
@@ -695,7 +679,7 @@ describe('Chains Controller (Unit)', () => {
       networkService.get.mockRejectedValueOnce(error);
 
       await request(app.getHttpServer())
-        .get('/v1/chains/1/about/indexing')
+        .get(`/v1/chains/${chainResponse.chainId}/about/indexing`)
         .expect(400)
         .expect({
           message: 'An error occurred',
@@ -704,7 +688,7 @@ describe('Chains Controller (Unit)', () => {
 
       expect(networkService.get).toHaveBeenCalledTimes(1);
       expect(networkService.get).toHaveBeenCalledWith({
-        url: `${safeConfigUrl}/api/v1/chains/1`,
+        url: `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`,
       });
     });
 
@@ -715,18 +699,23 @@ describe('Chains Controller (Unit)', () => {
           status: 502,
         } as Response,
       );
-      networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
-        status: 200,
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`) {
+          return Promise.resolve({
+            data: chainResponse,
+            status: 200,
+          });
+        }
+        if (
+          url === `${chainResponse.transactionService}/api/v1/about/indexing/`
+        ) {
+          return Promise.reject(error);
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
       });
-      networkService.get.mockRejectedValueOnce(error);
-      const block: Partial<GetBlockReturnType> = {
-        timestamp: faker.number.bigInt(),
-      };
-      mockGetBlock.mockResolvedValue(block);
 
       await request(app.getHttpServer())
-        .get('/v1/chains/1/about/indexing')
+        .get(`/v1/chains/${chainResponse.chainId}/about/indexing`)
         .expect(502)
         .expect({
           message: 'An error occurred',
@@ -735,7 +724,7 @@ describe('Chains Controller (Unit)', () => {
 
       expect(networkService.get).toHaveBeenCalledTimes(2);
       expect(networkService.get.mock.calls[0][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/1`,
+        `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`,
       );
       expect(networkService.get.mock.calls[1][0].url).toBe(
         `${chainResponse.transactionService}/api/v1/about/indexing/`,
@@ -743,52 +732,6 @@ describe('Chains Controller (Unit)', () => {
       expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
         undefined,
       );
-    });
-
-    it('Should fail getting the block', async () => {
-      networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
-        status: 200,
-      });
-      const indexingStatus = indexingStatusBuilder().build();
-      networkService.get.mockResolvedValueOnce({
-        data: indexingStatus,
-        status: 200,
-      });
-      mockGetBlock.mockRejectedValue(
-        new HttpRequestError({
-          url: faker.internet.url(),
-        }),
-      );
-
-      await request(app.getHttpServer())
-        .get('/v1/chains/1/about/indexing')
-        .expect(500)
-        .expect({
-          message: 'Internal server error',
-          code: 500,
-        });
-
-      expect(networkService.get).toHaveBeenCalledTimes(2);
-      expect(networkService.get.mock.calls[0][0].url).toBe(
-        `${safeConfigUrl}/api/v1/chains/1`,
-      );
-      expect(networkService.get.mock.calls[1][0].url).toBe(
-        `${chainResponse.transactionService}/api/v1/about/indexing/`,
-      );
-      expect(networkService.get.mock.calls[1][0].networkRequest).toBe(
-        undefined,
-      );
-      expect(mockGetBlock).toHaveBeenCalledTimes(1);
-      expect(mockGetBlock).toHaveBeenCalledWith({
-        blockNumber: BigInt(
-          // The oldest block number synced
-          Math.min(
-            indexingStatus.erc20BlockNumber,
-            indexingStatus.masterCopiesBlockNumber,
-          ),
-        ),
-      });
     });
 
     it('Should return validation error', async () => {
@@ -805,7 +748,7 @@ describe('Chains Controller (Unit)', () => {
       });
 
       await request(app.getHttpServer())
-        .get('/v1/chains/1/about/indexing')
+        .get(`/v1/chains/${chainResponse.chainId}/about/indexing`)
         .expect(500)
         .expect({
           statusCode: 500,

--- a/src/routes/chains/chains.module.ts
+++ b/src/routes/chains/chains.module.ts
@@ -3,14 +3,9 @@ import { ChainsController } from '@/routes/chains/chains.controller';
 import { ChainsService } from '@/routes/chains/chains.service';
 import { BackboneRepositoryModule } from '@/domain/backbone/backbone.repository.interface';
 import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
-import { BlockchainApiManagerModule } from '@/domain/interfaces/blockchain-api.manager.interface';
 
 @Module({
-  imports: [
-    BackboneRepositoryModule,
-    BlockchainApiManagerModule,
-    ChainsRepositoryModule,
-  ],
+  imports: [BackboneRepositoryModule, ChainsRepositoryModule],
   controllers: [ChainsController],
   providers: [ChainsService],
 })


### PR DESCRIPTION
## Summary

We calculate the `lastSync` timestamp of the `/v1/chains/:chainId/about/indexing` endpoint based on the block timestamp. Currently, we request the block timestamp on chain.

The Transaction Service now returns the timestamp of the indexed block alongside the current, ERC-20 and singleton indexed block numbers. This removes reliance on the blockchain call, instead using the returned timestamp instead.

## Changes

- Add new properties to `IndexingStatusSchema`, thus inferring them
- Use timestamps from Transaction Service directly
- Extend builder
- Update test coverage appropriately