### PR TITLE
`close` app `afterEach` test

### DIFF
--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -89,12 +89,9 @@ describe('AccountsController', () => {
     jest.useFakeTimers();
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
+    jest.useRealTimers();
   });
 
   describe('AuthGuard', () => {

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.spec.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.spec.ts
@@ -91,7 +91,7 @@ describe('CounterfactualSafesController', () => {
     jest.resetAllMocks();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/alerts/alerts.controller.spec.ts
+++ b/src/routes/alerts/alerts.controller.spec.ts
@@ -128,7 +128,7 @@ describe('Alerts (Unit)', () => {
       await app.init();
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
@@ -908,7 +908,7 @@ describe('Alerts (Unit)', () => {
         await app.init();
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await app.close();
       });
 

--- a/src/routes/auth/auth.controller.spec.ts
+++ b/src/routes/auth/auth.controller.spec.ts
@@ -102,11 +102,8 @@ describe('AuthController', () => {
     await initApp(testConfiguration);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
-  });
-
-  afterEach(() => {
     jest.useRealTimers();
   });
 

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -97,7 +97,7 @@ describe('Balances Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -71,7 +71,7 @@ describe('Balances Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -67,7 +67,7 @@ describe('Zerion Collectibles Controller', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -73,7 +73,7 @@ describe('Collectibles Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -73,7 +73,7 @@ describe('Community (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -52,7 +52,7 @@ describe('Contracts controller', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -60,7 +60,7 @@ describe('Estimations Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -83,7 +83,7 @@ describe('Post Hook Events for Cache (Unit)', () => {
     await initApp(configuration);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/hooks/hooks.controller.spec.ts
+++ b/src/routes/hooks/hooks.controller.spec.ts
@@ -51,7 +51,7 @@ describe('Post Hook Events (Unit)', () => {
     await initApp(configuration);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -54,7 +54,7 @@ describe('Owners Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/recovery/recovery.controller.spec.ts
+++ b/src/routes/recovery/recovery.controller.spec.ts
@@ -100,11 +100,8 @@ describe('Recovery (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
-  });
-
-  afterEach(() => {
     jest.useRealTimers();
   });
 

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -119,7 +119,7 @@ describe('Relay controller', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -54,7 +54,7 @@ describe('Safe Apps Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -58,7 +58,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -62,7 +62,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -56,7 +56,7 @@ describe('Get creation transaction', () => {
 
   beforeEach(() => jest.resetAllMocks());
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -72,7 +72,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
   it('Failure: Config API fails', async () => {

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -69,7 +69,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -58,7 +58,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -68,7 +68,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -56,7 +56,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
@@ -87,7 +87,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -87,7 +87,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -60,7 +60,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -62,7 +62,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -101,7 +101,7 @@ describe('Transactions History Controller (Unit)', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -96,7 +96,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -92,7 +92,7 @@ describe('TransactionsViewController tests', () => {
     await app.init();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 


### PR DESCRIPTION
## Summary

Resolves #2020

In every controller test, we `init` the app `beforeEach` to have a "clean" instances for testing. Theoretically, we should `close` these before initialising a new one.

Many tests `close` the current instance only `afterAll` tests have run, calling `init` before every test. This moves all `close` calls to `afterEach`.

## Changes

- Move all calls to `close` the app from `afterAll` to `afterEach`