### PR TITLE
Flag spoof events with varied value

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -150,6 +150,7 @@ export default (): ReturnType<typeof configuration> => ({
   mappings: {
     imitation: {
       lookupDistance: faker.number.int(),
+      valueTolerance: faker.number.bigInt(),
       prefixLength: faker.number.int(),
       suffixLength: faker.number.int(),
     },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -235,6 +235,9 @@ export default () => ({
   mappings: {
     imitation: {
       lookupDistance: parseInt(process.env.IMITATION_LOOKUP_DISTANCE ?? `${3}`),
+      // Note: due to high value formatted token values, we use bigint
+      // This means the value tolerance can only be an integer
+      valueTolerance: BigInt(process.env.IMITATION_VALUE_TOLERANCE ?? 1),
       prefixLength: parseInt(process.env.IMITATION_PREFIX_LENGTH ?? `${3}`),
       suffixLength: parseInt(process.env.IMITATION_SUFFIX_LENGTH ?? `${4}`),
     },

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -27,10 +27,7 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import type {
-  ERC20Transfer,
-  Transfer,
-} from '@/domain/safe/entities/transfer.entity';
+import type { Transfer } from '@/domain/safe/entities/transfer.entity';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { NetworkService } from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
@@ -105,2528 +102,1222 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
     await app.close();
   });
 
-  describe('Event spoofing', () => {
-    function parseUnits(value: bigint, decimals: number): bigint {
-      return value * BigInt(10 ** decimals);
-    }
+  function parseUnits(value: bigint, decimals: number): bigint {
+    return value * BigInt(10 ** decimals);
+  }
 
-    function getImitationAddress(address: `0x${string}`): `0x${string}` {
-      // + 2 is to account for the '0x' prefix
-      const prefix = address.slice(0, prefixLength + 2);
-      const suffix = address.slice(-suffixLength);
-      const imitator = `${prefix}${faker.finance.ethereumAddress().slice(prefixLength + 2, -suffixLength)}${suffix}`;
-      return getAddress(imitator);
-    }
-    const chain = chainBuilder().build();
-    const safe = safeBuilder().build();
+  function getImitationAddress(address: `0x${string}`): `0x${string}` {
+    // + 2 is to account for the '0x' prefix
+    const prefix = address.slice(0, prefixLength + 2);
+    const suffix = address.slice(-suffixLength);
+    const imitator = `${prefix}${faker.finance.ethereumAddress().slice(prefixLength + 2, -suffixLength)}${suffix}`;
+    return getAddress(imitator);
+  }
+  const chain = chainBuilder().build();
+  const safe = safeBuilder().build();
 
-    const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
-    const multisigToken = tokenBuilder()
-      .with('type', TokenType.Erc20)
-      .with('decimals', faker.number.int({ min: 8, max: 18 }))
-      .build();
-    const multisigTransfer = {
-      ...erc20TransferBuilder()
+  const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
+  const multisigToken = tokenBuilder().with('type', TokenType.Erc20).build();
+  // Use value higher than BigInt(1) as we use tolerance +/- BigInt(1) to signify outside tolerance
+  // later in tests, and values of 0 are not mapped
+  const testValueBuffer = valueTolerance * faker.number.bigInt({ min: 2 });
+  const multisigTransferValue = parseUnits(
+    faker.number.bigInt({
+      min: testValueBuffer,
+      max: testValueBuffer + valueTolerance,
+    }),
+    multisigToken.decimals!,
+  );
+  const multisigTransfer = {
+    ...erc20TransferBuilder()
+      .with('executionDate', multisigExecutionDate)
+      .with('from', safe.address)
+      .with('tokenAddress', multisigToken.address)
+      .with('value', multisigTransferValue.toString())
+      .build(),
+    tokenInfo: multisigToken,
+  };
+  const multisigTransaction = {
+    ...(multisigTransactionToJson(
+      multisigTransactionBuilder()
         .with('executionDate', multisigExecutionDate)
-        .with('from', safe.address)
-        .with('tokenAddress', multisigToken.address)
+        .with('safe', safe.address)
+        .with('to', multisigToken.address)
+        .with('value', '0')
+        .with('operation', 0)
+        .with('gasToken', zeroAddress)
+        .with('safeTxGas', 0)
+        .with('baseGas', 0)
+        .with('gasPrice', '0')
+        .with('refundReceiver', zeroAddress)
+        .with('proposer', safe.owners[0])
+        .with('executor', safe.owners[0])
+        .with('isExecuted', true)
+        .with('isSuccessful', true)
+        .with('origin', null)
         .with(
-          'value',
-          parseUnits(
-            faker.number.bigInt({
-              // Must be above value tolerance as we hide any transfers with a value of 0
-              // and any value between 0 and tolerance would result in <= 0
-              min: valueTolerance * faker.number.bigInt({ min: 2 }),
-            }),
-            multisigToken.decimals!,
-          ).toString(),
-        )
-        .build(),
-      tokenInfo: multisigToken,
-    };
-    const multisigTransaction = {
-      ...(multisigTransactionToJson(
-        multisigTransactionBuilder()
-          .with('executionDate', multisigExecutionDate)
-          .with('safe', safe.address)
-          .with('to', multisigToken.address)
-          .with('value', '0')
-          .with('operation', 0)
-          .with('gasToken', zeroAddress)
-          .with('safeTxGas', 0)
-          .with('baseGas', 0)
-          .with('gasPrice', '0')
-          .with('refundReceiver', zeroAddress)
-          .with('proposer', safe.owners[0])
-          .with('executor', safe.owners[0])
-          .with('isExecuted', true)
-          .with('isSuccessful', true)
-          .with('origin', null)
-          .with(
-            'dataDecoded',
-            dataDecodedBuilder()
-              .with('method', 'transfer')
-              .with('parameters', [
-                dataDecodedParameterBuilder()
-                  .with('name', 'to')
-                  .with('type', 'address')
-                  .with('value', multisigTransfer.to)
-                  .build(),
-                dataDecodedParameterBuilder()
-                  .with('name', 'value')
-                  .with('type', 'uint256')
-                  .with('value', multisigTransfer.value)
-                  .build(),
-              ])
-              .build(),
-          )
-          .with('confirmationsRequired', 1)
-          .with('confirmations', [
-            confirmationBuilder().with('owner', safe.owners[0]).build(),
-          ])
-          .with('trusted', true)
-          .build(),
-      ) as MultisigTransaction),
-      // TODO: Update type to include transfers - only on all-transactions endpoint
-      transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
-    } as MultisigTransaction;
-
-    const notImitatedMultisigToken = tokenBuilder()
-      .with('type', TokenType.Erc20)
-      .with('decimals', faker.number.int({ min: 6, max: 18 }))
-      .build();
-    const notImitatedMultisigTransfer = {
-      ...erc20TransferBuilder()
-        .with('executionDate', multisigExecutionDate)
-        .with('from', safe.address)
-        .with('tokenAddress', notImitatedMultisigToken.address)
-        .with(
-          'value',
-          parseUnits(
-            faker.number.bigInt({
-              // Must be above value tolerance as we hide any transfers with a value of 0
-              // and any value between 0 and tolerance would result in <= 0
-              min: valueTolerance * faker.number.bigInt({ min: 2 }),
-            }),
-            notImitatedMultisigToken.decimals!,
-          ).toString(),
-        )
-        .build(),
-      tokenInfo: multisigToken,
-    };
-    const notImitatedMultisigTransaction = {
-      ...(multisigTransactionToJson(
-        multisigTransactionBuilder()
-          .with('executionDate', multisigExecutionDate)
-          .with('safe', safe.address)
-          .with('to', notImitatedMultisigToken.address)
-          .with('value', '0')
-          .with('operation', 0)
-          .with('gasToken', zeroAddress)
-          .with('safeTxGas', 0)
-          .with('baseGas', 0)
-          .with('gasPrice', '0')
-          .with('refundReceiver', zeroAddress)
-          .with('proposer', safe.owners[0])
-          .with('executor', safe.owners[0])
-          .with('isExecuted', true)
-          .with('isSuccessful', true)
-          .with('origin', null)
-          .with(
-            'dataDecoded',
-            dataDecodedBuilder()
-              .with('method', 'transfer')
-              .with('parameters', [
-                dataDecodedParameterBuilder()
-                  .with('name', 'to')
-                  .with('type', 'address')
-                  .with('value', notImitatedMultisigTransfer.to)
-                  .build(),
-                dataDecodedParameterBuilder()
-                  .with('name', 'value')
-                  .with('type', 'uint256')
-                  .with('value', notImitatedMultisigTransfer.value)
-                  .build(),
-              ])
-              .build(),
-          )
-          .with('confirmationsRequired', 1)
-          .with('confirmations', [
-            confirmationBuilder().with('owner', safe.owners[0]).build(),
-          ])
-          .with('trusted', true)
-          .build(),
-      ) as MultisigTransaction),
-      // TODO: Update type to include transfers - only on all-transactions endpoint
-      transfers: [erc20TransferToJson(notImitatedMultisigTransfer) as Transfer],
-    } as MultisigTransaction;
-
-    const imitationAddress = getImitationAddress(multisigTransfer.to);
-    const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
-    const imitationToken = tokenBuilder()
-      .with('type', TokenType.Erc20)
-      .with('decimals', multisigToken.decimals)
-      .build();
-
-    const imitationIncomingTransfer = {
-      ...erc20TransferBuilder()
-        .with('from', imitationAddress)
-        .with('to', safe.address)
-        .with('tokenAddress', imitationToken.address)
-        .with('value', multisigTransfer.value)
-        .with('executionDate', imitationExecutionDate)
-        .build(),
-      // TODO: Update type to include tokenInfo - only on all-transactions endpoint
-      tokenInfo: imitationToken,
-    };
-    const imitationIncomingErc20Transfer = erc20TransferEncoder()
-      .with('to', safe.address)
-      .with('value', BigInt(multisigTransfer.value));
-    const imitationIncomingTransaction = ethereumTransactionToJson(
-      ethereumTransactionBuilder()
-        .with('executionDate', imitationIncomingTransfer.executionDate)
-        .with('data', imitationIncomingErc20Transfer.encode())
-        .with('transfers', [
-          erc20TransferToJson(imitationIncomingTransfer) as Transfer,
-        ])
-        .build(),
-    ) as EthereumTransaction;
-
-    const imitationOutgoingTransfer = {
-      ...erc20TransferBuilder()
-        .with('from', safe.address)
-        .with('to', imitationAddress)
-        .with('tokenAddress', imitationToken.address)
-        .with('value', multisigTransfer.value)
-        .with('executionDate', imitationExecutionDate)
-        .build(),
-      // TODO: Update type to include tokenInfo - only on all-transactions endpoint
-      tokenInfo: imitationToken,
-    };
-    const imitationOutgoingErc20Transfer = erc20TransferEncoder()
-      .with('to', imitationAddress)
-      .with('value', BigInt(multisigTransfer.value));
-    const imitationOutgoingTransaction = ethereumTransactionToJson(
-      ethereumTransactionBuilder()
-        .with('executionDate', imitationOutgoingTransfer.executionDate)
-        .with('data', imitationOutgoingErc20Transfer.encode())
-        .with('transfers', [
-          erc20TransferToJson(imitationOutgoingTransfer) as Transfer,
-        ])
-        .build(),
-    ) as EthereumTransaction;
-
-    const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${multisigToken.address}`;
-    const getNotImitatedTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${notImitatedMultisigToken.address}`;
-    const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${imitationToken.address}`;
-
-    describe('Same value', () => {
-      it('should flag imitation incoming/outgoing transfers of the same value within the lookup distance', async () => {
-        const results = [
-          imitationIncomingTransaction,
-          multisigTransaction,
-          imitationOutgoingTransaction,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927778000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'INCOMING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: true,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationIncomingTransaction.transfers![0].transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: true,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationOutgoingTransaction.transfers![0].transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-
-      it('should filter out imitation incoming/outgoing transfers of the same value outside the lookup distance', async () => {
-        const results = [
-          imitationIncomingTransaction,
-          imitationOutgoingTransaction,
-          notImitatedMultisigTransaction,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927778000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'INCOMING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false, // Not flagged
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationIncomingTransaction.transfers![0].transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false, // Not flagged
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationOutgoingTransaction.transfers![0].transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-
-      it('should filter out imitation incoming/outgoing transfers of the same value within the lookup distance if parameter is false - example #1', async () => {
-        const results = [
-          imitationIncomingTransaction,
-          multisigTransaction,
-          imitationOutgoingTransaction,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927685000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                  txStatus: 'SUCCESS',
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-
-      // TODO: Discern the difference between this and the test above
-      it('should not flag imitation incoming/outgoing transfers of the same value within the lookup distance if parameter is false - example #2', async () => {
-        const results = [
-          imitationIncomingTransaction,
-          imitationOutgoingTransaction,
-          notImitatedMultisigTransaction,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927778000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'INCOMING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false, // Not flagged
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationIncomingTransaction.transfers![0].transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false, // Not flagged
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationOutgoingTransaction.transfers![0].transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-    });
-
-    describe('Value difference', () => {
-      const highTolerantValue =
-        BigInt(multisigTransfer.value) +
-        parseUnits(valueTolerance, multisigToken.decimals!);
-      const lowTolerantValue =
-        BigInt(multisigTransfer.value) -
-        parseUnits(valueTolerance, multisigToken.decimals!);
-
-      const imitationTransactionWithHighTolerantValue =
-        ((): EthereumTransaction => {
-          const transaction = structuredClone(imitationIncomingTransaction);
-          (transaction.transfers![0] as ERC20Transfer).value =
-            highTolerantValue.toString();
-          return transaction;
-        })();
-      const imitationTransactionWithLowTolerantValue =
-        ((): EthereumTransaction => {
-          const transaction = structuredClone(imitationOutgoingTransaction);
-          (transaction.transfers![0] as ERC20Transfer).value =
-            lowTolerantValue.toString();
-          return transaction;
-        })();
-
-      const highIntolerantValue =
-        BigInt(multisigTransfer.value) +
-        parseUnits(valueTolerance + BigInt(1), multisigToken.decimals!);
-      const lowIntolerantValue =
-        BigInt(multisigTransfer.value) -
-        parseUnits(valueTolerance + BigInt(1), multisigToken.decimals!);
-
-      const imitationTransactionWithHighIntolerantValue =
-        ((): EthereumTransaction => {
-          const transaction = structuredClone(imitationIncomingTransaction);
-          (transaction.transfers![0] as ERC20Transfer).value =
-            highIntolerantValue.toString();
-          return transaction;
-        })();
-      const imitationTransactionWithLowIntolerantValue =
-        ((): EthereumTransaction => {
-          const transaction = structuredClone(imitationOutgoingTransaction);
-          (transaction.transfers![0] as ERC20Transfer).value =
-            lowIntolerantValue.toString();
-          return transaction;
-        })();
-
-      it('should flag imitation incoming/outgoing transfers with a tolerant value difference within the lookup distance', async () => {
-        const results = [
-          imitationTransactionWithHighTolerantValue,
-          multisigTransaction,
-          imitationTransactionWithLowTolerantValue,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927778000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'INCOMING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: true,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: (
-                        imitationTransactionWithHighTolerantValue
-                          .transfers![0] as ERC20Transfer
-                      ).value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationTransactionWithHighTolerantValue.transfers![0]
-                      .transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: new Date(
-                    imitationTransactionWithLowTolerantValue.executionDate,
-                  ).getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: true,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: (
-                        imitationTransactionWithLowTolerantValue
-                          .transfers![0] as ERC20Transfer
-                      ).value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationTransactionWithLowTolerantValue.transfers![0]
-                      .transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-
-      it('should not flag imitation incoming/outgoing transfers with an intolerant value difference within the lookup distance', async () => {
-        const results = [
-          imitationTransactionWithHighIntolerantValue,
-          multisigTransaction,
-          imitationTransactionWithLowIntolerantValue,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927778000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'INCOMING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: (
-                        imitationTransactionWithHighIntolerantValue
-                          .transfers![0] as ERC20Transfer
-                      ).value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationTransactionWithHighIntolerantValue.transfers![0]
-                      .transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: new Date(
-                    imitationTransactionWithLowIntolerantValue.executionDate,
-                  ).getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: (
-                        imitationTransactionWithLowIntolerantValue
-                          .transfers![0] as ERC20Transfer
-                      ).value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationTransactionWithLowIntolerantValue.transfers![0]
-                      .transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-
-      it('should not flag imitation incoming/outgoing transfers with an intolerant value difference outside the lookup distance', async () => {
-        const results = [
-          imitationTransactionWithHighTolerantValue,
-          imitationTransactionWithLowTolerantValue,
-          notImitatedMultisigTransaction,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927778000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927778000,
-                  txInfo: {
-                    direction: 'INCOMING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: (
-                        imitationTransactionWithHighTolerantValue
-                          .transfers![0] as ERC20Transfer
-                      ).value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationTransactionWithHighTolerantValue.transfers![0]
-                      .transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: null,
-                  // @ts-expect-error - Type does not contain transfers
-                  id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
-                  safeAppInfo: null,
-                  timestamp: new Date(
-                    imitationTransactionWithLowTolerantValue.executionDate,
-                  ).getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: imitationAddress,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: imitationToken.decimals,
-                      imitation: false,
-                      logoUri: imitationToken.logoUri,
-                      tokenAddress: imitationToken.address,
-                      tokenName: imitationToken.name,
-                      tokenSymbol: imitationToken.symbol,
-                      trusted: imitationToken.trusted,
-                      type: 'ERC20',
-                      value: (
-                        imitationTransactionWithLowTolerantValue
-                          .transfers![0] as ERC20Transfer
-                      ).value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash:
-                    imitationTransactionWithLowIntolerantValue.transfers![0]
-                      .transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp:
-                    notImitatedMultisigTransfer.executionDate.getTime(),
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-
-      it('should filter out imitation incoming/outgoing transfers with a tolerant value difference if the parameter is false', async () => {
-        const results = [
-          imitationTransactionWithHighTolerantValue,
-          multisigTransaction,
-          imitationTransactionWithLowTolerantValue,
-          notImitatedMultisigTransaction,
-          multisigTransaction,
-        ];
-        networkService.get.mockImplementation(({ url }) => {
-          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
-          }
-          if (url === getAllTransactionsUrl) {
-            return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
-              status: 200,
-            });
-          }
-          if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
-          }
-          if (url === getTokenAddressUrl) {
-            return Promise.resolve({
-              data: multisigToken,
-              status: 200,
-            });
-          }
-          if (url === getNotImitatedTokenAddressUrl) {
-            return Promise.resolve({
-              data: notImitatedMultisigToken,
-              status: 200,
-            });
-          }
-          if (url === getImitationTokenAddressUrl) {
-            return Promise.resolve({
-              data: imitationToken,
-              status: 200,
-            });
-          }
-          return Promise.reject(new Error(`Could not match ${url}`));
-        });
-
-        await request(app.getHttpServer())
-          .get(
-            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
-          )
-          .expect(200)
-          .then(({ body }) => {
-            expect(body.results).toStrictEqual([
-              {
-                timestamp: 1710927685000,
-                type: 'DATE_LABEL',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: notImitatedMultisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: notImitatedMultisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: notImitatedMultisigToken.decimals,
-                      imitation: false,
-                      logoUri: notImitatedMultisigToken.logoUri,
-                      tokenAddress: notImitatedMultisigToken.address,
-                      tokenName: notImitatedMultisigToken.name,
-                      tokenSymbol: notImitatedMultisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: notImitatedMultisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: notImitatedMultisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-              {
-                conflictType: 'None',
-                transaction: {
-                  executionInfo: {
-                    confirmationsRequired: 1,
-                    confirmationsSubmitted: 1,
-                    missingSigners: null,
-                    nonce: multisigTransaction.nonce,
-                    type: 'MULTISIG',
-                  },
-                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                  safeAppInfo: null,
-                  timestamp: 1710927685000,
-                  txInfo: {
-                    direction: 'OUTGOING',
-                    humanDescription: null,
-                    recipient: {
-                      logoUri: null,
-                      name: null,
-                      value: multisigTransfer.to,
-                    },
-                    richDecodedInfo: null,
-                    sender: {
-                      logoUri: null,
-                      name: null,
-                      value: safe.address,
-                    },
-                    transferInfo: {
-                      decimals: multisigToken.decimals,
-                      imitation: false,
-                      logoUri: multisigToken.logoUri,
-                      tokenAddress: multisigToken.address,
-                      tokenName: multisigToken.name,
-                      tokenSymbol: multisigToken.symbol,
-                      trusted: null,
-                      type: 'ERC20',
-                      value: multisigTransfer.value,
-                    },
-                    type: 'Transfer',
-                  },
-                  txStatus: 'SUCCESS',
-                  txHash: multisigTransaction.transactionHash,
-                },
-                type: 'TRANSACTION',
-              },
-            ]);
-          });
-      });
-    });
-
-    it('should flag imitation tokens using differing decimals', async () => {
-      const differentDecimals = multisigToken.decimals! + 1;
-      const differentValue = multisigTransfer.value + '0';
-      const imitationWithDifferentDecimalsAddress = getImitationAddress(
-        multisigTransfer.to,
-      );
-      const imitationWithDifferentDecimalsExecutionDate = new Date(
-        '2024-03-20T09:42:58Z',
-      );
-      const imitationWithDifferentDecimalsToken = tokenBuilder()
-        .with('type', TokenType.Erc20)
-        .with('decimals', differentDecimals)
-        .build();
-
-      const imitationWithDifferentDecimalsIncomingTransfer = {
-        ...erc20TransferBuilder()
-          .with('from', imitationWithDifferentDecimalsAddress)
-          .with('to', safe.address)
-          .with('tokenAddress', imitationWithDifferentDecimalsToken.address)
-          .with('value', differentValue)
-          .with('executionDate', imitationWithDifferentDecimalsExecutionDate)
-          .build(),
-        // TODO: Update type to include tokenInfo - only on all-transactions endpoint
-        tokenInfo: imitationWithDifferentDecimalsToken,
-      };
-      const imitationWithDifferentDecimalsIncomingErc20Transfer =
-        erc20TransferEncoder()
-          .with('to', safe.address)
-          .with('value', BigInt(differentValue));
-      const imitationWithDifferentDecimalsIncomingTransaction =
-        ethereumTransactionToJson(
-          ethereumTransactionBuilder()
-            .with(
-              'executionDate',
-              imitationWithDifferentDecimalsIncomingTransfer.executionDate,
-            )
-            .with(
-              'data',
-              imitationWithDifferentDecimalsIncomingErc20Transfer.encode(),
-            )
-            .with('transfers', [
-              erc20TransferToJson(
-                imitationWithDifferentDecimalsIncomingTransfer,
-              ) as Transfer,
+          'dataDecoded',
+          dataDecodedBuilder()
+            .with('method', 'transfer')
+            .with('parameters', [
+              dataDecodedParameterBuilder()
+                .with('name', 'to')
+                .with('type', 'address')
+                .with('value', multisigTransfer.to)
+                .build(),
+              dataDecodedParameterBuilder()
+                .with('name', 'value')
+                .with('type', 'uint256')
+                .with('value', multisigTransfer.value)
+                .build(),
             ])
             .build(),
-        ) as EthereumTransaction;
-
-      const results = [
-        imitationWithDifferentDecimalsIncomingTransaction,
-        multisigTransaction,
-      ];
-      networkService.get.mockImplementation(({ url }) => {
-        if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
-        }
-        if (url === getAllTransactionsUrl) {
-          return Promise.resolve({
-            data: pageBuilder().with('results', results).build(),
-            status: 200,
-          });
-        }
-        if (url === getSafeUrl) {
-          return Promise.resolve({ data: safe, status: 200 });
-        }
-        if (url === getTokenAddressUrl) {
-          return Promise.resolve({
-            data: multisigToken,
-            status: 200,
-          });
-        }
-        if (
-          url ===
-          `${chain.transactionService}/api/v1/tokens/${imitationWithDifferentDecimalsToken.address}`
-        ) {
-          return Promise.resolve({
-            data: imitationWithDifferentDecimalsToken,
-            status: 200,
-          });
-        }
-        return Promise.reject(new Error(`Could not match ${url}`));
-      });
-
-      await request(app.getHttpServer())
-        .get(
-          `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
         )
-        .expect(200)
-        .then(({ body }) => {
-          expect(body.results).toStrictEqual([
-            {
-              timestamp: 1710927778000,
-              type: 'DATE_LABEL',
-            },
-            {
-              conflictType: 'None',
-              transaction: {
-                executionInfo: null,
-                // @ts-expect-error - Type does not contain transfers
-                id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-                safeAppInfo: null,
-                timestamp: 1710927778000,
-                txInfo: {
-                  direction: 'INCOMING',
-                  humanDescription: null,
-                  recipient: {
-                    logoUri: null,
-                    name: null,
-                    value: safe.address,
-                  },
-                  richDecodedInfo: null,
-                  sender: {
-                    logoUri: null,
-                    name: null,
-                    value: imitationWithDifferentDecimalsAddress,
-                  },
-                  transferInfo: {
-                    decimals: imitationWithDifferentDecimalsToken.decimals,
-                    imitation: true,
-                    logoUri: imitationWithDifferentDecimalsToken.logoUri,
-                    tokenAddress: imitationWithDifferentDecimalsToken.address,
-                    tokenName: imitationWithDifferentDecimalsToken.name,
-                    tokenSymbol: imitationWithDifferentDecimalsToken.symbol,
-                    trusted: imitationWithDifferentDecimalsToken.trusted,
-                    type: 'ERC20',
-                    value: imitationWithDifferentDecimalsIncomingTransfer.value,
-                  },
-                  type: 'Transfer',
-                },
-                txStatus: 'SUCCESS',
-                txHash:
-                  imitationWithDifferentDecimalsIncomingTransaction
-                    .transfers![0].transactionHash,
-              },
-              type: 'TRANSACTION',
-            },
-            {
-              conflictType: 'None',
-              transaction: {
-                executionInfo: {
-                  confirmationsRequired: 1,
-                  confirmationsSubmitted: 1,
-                  missingSigners: null,
-                  nonce: multisigTransaction.nonce,
-                  type: 'MULTISIG',
-                },
-                id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-                safeAppInfo: null,
-                timestamp: 1710927685000,
-                txInfo: {
-                  direction: 'OUTGOING',
-                  humanDescription: null,
-                  recipient: {
-                    logoUri: null,
-                    name: null,
-                    value: multisigTransfer.to,
-                  },
-                  richDecodedInfo: null,
-                  sender: {
-                    logoUri: null,
-                    name: null,
-                    value: safe.address,
-                  },
-                  transferInfo: {
-                    decimals: multisigToken.decimals,
-                    imitation: false,
-                    logoUri: multisigToken.logoUri,
-                    tokenAddress: multisigToken.address,
-                    tokenName: multisigToken.name,
-                    tokenSymbol: multisigToken.symbol,
-                    trusted: null,
-                    type: 'ERC20',
-                    value: multisigTransfer.value,
-                  },
-                  type: 'Transfer',
-                },
-                txStatus: 'SUCCESS',
-                txHash: multisigTransaction.transactionHash,
-              },
-              type: 'TRANSACTION',
-            },
-          ]);
+        .with('confirmationsRequired', 1)
+        .with('confirmations', [
+          confirmationBuilder().with('owner', safe.owners[0]).build(),
+        ])
+        .with('trusted', true)
+        .build(),
+    ) as MultisigTransaction),
+    // TODO: Update type to include transfers
+    transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
+  } as MultisigTransaction;
+
+  const notImitatedMultisigToken = tokenBuilder()
+    .with('type', TokenType.Erc20)
+    .build();
+  const notImitatedMultisigTransfer = {
+    ...erc20TransferBuilder()
+      .with('executionDate', multisigExecutionDate)
+      .with('from', safe.address)
+      .with('tokenAddress', notImitatedMultisigToken.address)
+      .with('value', multisigTransfer.value)
+      .build(),
+    tokenInfo: multisigToken,
+  };
+  const notImitatedMultisigTransaction = {
+    ...(multisigTransactionToJson(
+      multisigTransactionBuilder()
+        .with('executionDate', multisigExecutionDate)
+        .with('safe', safe.address)
+        .with('to', notImitatedMultisigToken.address)
+        .with('value', '0')
+        .with('operation', 0)
+        .with('gasToken', zeroAddress)
+        .with('safeTxGas', 0)
+        .with('baseGas', 0)
+        .with('gasPrice', '0')
+        .with('refundReceiver', zeroAddress)
+        .with('proposer', safe.owners[0])
+        .with('executor', safe.owners[0])
+        .with('isExecuted', true)
+        .with('isSuccessful', true)
+        .with('origin', null)
+        .with(
+          'dataDecoded',
+          dataDecodedBuilder()
+            .with('method', 'transfer')
+            .with('parameters', [
+              dataDecodedParameterBuilder()
+                .with('name', 'to')
+                .with('type', 'address')
+                .with('value', notImitatedMultisigTransfer.to)
+                .build(),
+              dataDecodedParameterBuilder()
+                .with('name', 'value')
+                .with('type', 'uint256')
+                .with('value', notImitatedMultisigTransfer.value)
+                .build(),
+            ])
+            .build(),
+        )
+        .with('confirmationsRequired', 1)
+        .with('confirmations', [
+          confirmationBuilder().with('owner', safe.owners[0]).build(),
+        ])
+        .with('trusted', true)
+        .build(),
+    ) as MultisigTransaction),
+    // TODO: Update type to include transfers
+    transfers: [erc20TransferToJson(notImitatedMultisigTransfer) as Transfer],
+  } as MultisigTransaction;
+
+  const imitationAddress = getImitationAddress(multisigTransfer.to);
+  const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
+  const imitationToken = tokenBuilder()
+    .with('type', TokenType.Erc20)
+    .with('decimals', multisigToken.decimals)
+    .build();
+
+  const imitationIncomingTransfer = {
+    ...erc20TransferBuilder()
+      .with('from', imitationAddress)
+      .with('to', safe.address)
+      .with('tokenAddress', imitationToken.address)
+      .with('value', multisigTransfer.value)
+      .with('executionDate', imitationExecutionDate)
+      .build(),
+    // TODO: Update type to include tokenInfo
+    tokenInfo: imitationToken,
+  };
+  const imitationIncomingErc20Transfer = erc20TransferEncoder()
+    .with('to', safe.address)
+    .with('value', BigInt(multisigTransfer.value));
+  const imitationIncomingTransaction = ethereumTransactionToJson(
+    ethereumTransactionBuilder()
+      .with('executionDate', imitationIncomingTransfer.executionDate)
+      .with('data', imitationIncomingErc20Transfer.encode())
+      .with('transfers', [
+        erc20TransferToJson(imitationIncomingTransfer) as Transfer,
+      ])
+      .build(),
+  ) as EthereumTransaction;
+
+  const imitationOutgoingTransfer = {
+    ...erc20TransferBuilder()
+      .with('from', safe.address)
+      .with('to', imitationAddress)
+      .with('tokenAddress', imitationToken.address)
+      .with('value', multisigTransfer.value)
+      .with('executionDate', imitationExecutionDate)
+      .build(),
+    // TODO: Update type to include tokenInfo
+    tokenInfo: imitationToken,
+  };
+  const imitationOutgoingErc20Transfer = erc20TransferEncoder()
+    .with('to', imitationAddress)
+    .with('value', BigInt(multisigTransfer.value));
+  const imitationOutgoingTransaction = ethereumTransactionToJson(
+    ethereumTransactionBuilder()
+      .with('executionDate', imitationOutgoingTransfer.executionDate)
+      .with('data', imitationOutgoingErc20Transfer.encode())
+      .with('transfers', [
+        erc20TransferToJson(imitationOutgoingTransfer) as Transfer,
+      ])
+      .build(),
+  ) as EthereumTransaction;
+
+  const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
+  const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+  const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${multisigToken.address}`;
+  const getNotImitatedTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${notImitatedMultisigToken.address}`;
+  const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${imitationToken.address}`;
+
+  it('should flag imitation incoming/outgoing transfers within the lookup distance', async () => {
+    const results = [
+      imitationIncomingTransaction,
+      multisigTransaction,
+      imitationOutgoingTransaction,
+      notImitatedMultisigTransaction,
+      multisigTransaction,
+    ];
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: chain, status: 200 });
+      }
+      if (url === getAllTransactionsUrl) {
+        return Promise.resolve({
+          data: pageBuilder().with('results', results).build(),
+          status: 200,
         });
+      }
+      if (url === getSafeUrl) {
+        return Promise.resolve({ data: safe, status: 200 });
+      }
+      if (url === getTokenAddressUrl) {
+        return Promise.resolve({
+          data: multisigToken,
+          status: 200,
+        });
+      }
+      if (url === getNotImitatedTokenAddressUrl) {
+        return Promise.resolve({
+          data: notImitatedMultisigToken,
+          status: 200,
+        });
+      }
+      if (url === getImitationTokenAddressUrl) {
+        return Promise.resolve({
+          data: imitationToken,
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
     });
 
-    it.todo('Incoming transfer "echo"');
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+      )
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.results).toStrictEqual([
+          {
+            timestamp: 1710927778000,
+            type: 'DATE_LABEL',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: null,
+              // @ts-expect-error - Type does not contain transfers
+              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+              safeAppInfo: null,
+              timestamp: 1710927778000,
+              txInfo: {
+                direction: 'INCOMING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: imitationAddress,
+                },
+                transferInfo: {
+                  decimals: imitationToken.decimals,
+                  imitation: true,
+                  logoUri: imitationToken.logoUri,
+                  tokenAddress: imitationToken.address,
+                  tokenName: imitationToken.name,
+                  tokenSymbol: imitationToken.symbol,
+                  trusted: imitationToken.trusted,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash:
+                imitationIncomingTransaction.transfers![0].transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: multisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: 1710927685000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: multisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: multisigToken.decimals,
+                  imitation: false,
+                  logoUri: multisigToken.logoUri,
+                  tokenAddress: multisigToken.address,
+                  tokenName: multisigToken.name,
+                  tokenSymbol: multisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: multisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: null,
+              // @ts-expect-error - Type does not contain transfers
+              id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
+              safeAppInfo: null,
+              timestamp: 1710927778000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: imitationAddress,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: imitationToken.decimals,
+                  imitation: true,
+                  logoUri: imitationToken.logoUri,
+                  tokenAddress: imitationToken.address,
+                  tokenName: imitationToken.name,
+                  tokenSymbol: imitationToken.symbol,
+                  trusted: imitationToken.trusted,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash:
+                imitationOutgoingTransaction.transfers![0].transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: notImitatedMultisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: notImitatedMultisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: notImitatedMultisigToken.decimals,
+                  imitation: false,
+                  logoUri: notImitatedMultisigToken.logoUri,
+                  tokenAddress: notImitatedMultisigToken.address,
+                  tokenName: notImitatedMultisigToken.name,
+                  tokenSymbol: notImitatedMultisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: notImitatedMultisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: notImitatedMultisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: multisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: 1710927685000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: multisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: multisigToken.decimals,
+                  imitation: false,
+                  logoUri: multisigToken.logoUri,
+                  tokenAddress: multisigToken.address,
+                  tokenName: multisigToken.name,
+                  tokenSymbol: multisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: multisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+        ]);
+      });
+  });
+
+  it('should not flag imitation incoming/outgoing transfers outside the lookup distance', async () => {
+    const results = [
+      imitationIncomingTransaction,
+      imitationOutgoingTransaction,
+      notImitatedMultisigTransaction,
+      notImitatedMultisigTransaction,
+      multisigTransaction,
+    ];
+
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: chain, status: 200 });
+      }
+      if (url === getAllTransactionsUrl) {
+        return Promise.resolve({
+          data: pageBuilder().with('results', results).build(),
+          status: 200,
+        });
+      }
+      if (url === getSafeUrl) {
+        return Promise.resolve({ data: safe, status: 200 });
+      }
+      if (url === getTokenAddressUrl) {
+        return Promise.resolve({
+          data: multisigToken,
+          status: 200,
+        });
+      }
+      if (url === getNotImitatedTokenAddressUrl) {
+        return Promise.resolve({
+          data: notImitatedMultisigToken,
+          status: 200,
+        });
+      }
+      if (url === getImitationTokenAddressUrl) {
+        return Promise.resolve({
+          data: imitationToken,
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+      )
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.results).toStrictEqual([
+          {
+            timestamp: 1710927778000,
+            type: 'DATE_LABEL',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: null,
+              // @ts-expect-error - Type does not contain transfers
+              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+              safeAppInfo: null,
+              timestamp: 1710927778000,
+              txInfo: {
+                direction: 'INCOMING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: imitationAddress,
+                },
+                transferInfo: {
+                  decimals: imitationToken.decimals,
+                  imitation: false, // Not flagged
+                  logoUri: imitationToken.logoUri,
+                  tokenAddress: imitationToken.address,
+                  tokenName: imitationToken.name,
+                  tokenSymbol: imitationToken.symbol,
+                  trusted: imitationToken.trusted,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash:
+                imitationIncomingTransaction.transfers![0].transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: null,
+              // @ts-expect-error - Type does not contain transfers
+              id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
+              safeAppInfo: null,
+              timestamp: 1710927778000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: imitationAddress,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: imitationToken.decimals,
+                  imitation: false, // Not flagged
+                  logoUri: imitationToken.logoUri,
+                  tokenAddress: imitationToken.address,
+                  tokenName: imitationToken.name,
+                  tokenSymbol: imitationToken.symbol,
+                  trusted: imitationToken.trusted,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash:
+                imitationOutgoingTransaction.transfers![0].transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: notImitatedMultisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: notImitatedMultisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: notImitatedMultisigToken.decimals,
+                  imitation: false,
+                  logoUri: notImitatedMultisigToken.logoUri,
+                  tokenAddress: notImitatedMultisigToken.address,
+                  tokenName: notImitatedMultisigToken.name,
+                  tokenSymbol: notImitatedMultisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: notImitatedMultisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: notImitatedMultisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: notImitatedMultisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: notImitatedMultisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: notImitatedMultisigToken.decimals,
+                  imitation: false,
+                  logoUri: notImitatedMultisigToken.logoUri,
+                  tokenAddress: notImitatedMultisigToken.address,
+                  tokenName: notImitatedMultisigToken.name,
+                  tokenSymbol: notImitatedMultisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: notImitatedMultisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: notImitatedMultisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: multisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: 1710927685000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: multisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: multisigToken.decimals,
+                  imitation: false,
+                  logoUri: multisigToken.logoUri,
+                  tokenAddress: multisigToken.address,
+                  tokenName: multisigToken.name,
+                  tokenSymbol: multisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: multisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+        ]);
+      });
+  });
+
+  it('should filter out imitation incoming/outgoing transfers within the lookup distance', async () => {
+    const results = [
+      imitationIncomingTransaction,
+      multisigTransaction,
+      imitationOutgoingTransaction,
+      notImitatedMultisigTransaction,
+      multisigTransaction,
+    ];
+
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: chain, status: 200 });
+      }
+      if (url === getAllTransactionsUrl) {
+        return Promise.resolve({
+          data: pageBuilder().with('results', results).build(),
+          status: 200,
+        });
+      }
+      if (url === getSafeUrl) {
+        return Promise.resolve({ data: safe, status: 200 });
+      }
+      if (url === getTokenAddressUrl) {
+        return Promise.resolve({
+          data: multisigToken,
+          status: 200,
+        });
+      }
+      if (url === getNotImitatedTokenAddressUrl) {
+        return Promise.resolve({
+          data: notImitatedMultisigToken,
+          status: 200,
+        });
+      }
+      if (url === getImitationTokenAddressUrl) {
+        return Promise.resolve({
+          data: imitationToken,
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
+      )
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.results).toStrictEqual([
+          {
+            timestamp: 1710927685000,
+            type: 'DATE_LABEL',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: multisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: 1710927685000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: multisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: multisigToken.decimals,
+                  imitation: false,
+                  logoUri: multisigToken.logoUri,
+                  tokenAddress: multisigToken.address,
+                  tokenName: multisigToken.name,
+                  tokenSymbol: multisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: multisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: notImitatedMultisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: notImitatedMultisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: notImitatedMultisigToken.decimals,
+                  imitation: false,
+                  logoUri: notImitatedMultisigToken.logoUri,
+                  tokenAddress: notImitatedMultisigToken.address,
+                  tokenName: notImitatedMultisigToken.name,
+                  tokenSymbol: notImitatedMultisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: notImitatedMultisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txHash: notImitatedMultisigTransaction.transactionHash,
+              txStatus: 'SUCCESS',
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: multisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: 1710927685000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: multisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: multisigToken.decimals,
+                  imitation: false,
+                  logoUri: multisigToken.logoUri,
+                  tokenAddress: multisigToken.address,
+                  tokenName: multisigToken.name,
+                  tokenSymbol: multisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: multisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+        ]);
+      });
+  });
+
+  it('should not filter out imitation incoming/outgoing transfers within the lookup distance', async () => {
+    const results = [
+      imitationIncomingTransaction,
+      imitationOutgoingTransaction,
+      notImitatedMultisigTransaction,
+      notImitatedMultisigTransaction,
+      multisigTransaction,
+    ];
+
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: chain, status: 200 });
+      }
+      if (url === getAllTransactionsUrl) {
+        return Promise.resolve({
+          data: pageBuilder().with('results', results).build(),
+          status: 200,
+        });
+      }
+      if (url === getSafeUrl) {
+        return Promise.resolve({ data: safe, status: 200 });
+      }
+      if (url === getTokenAddressUrl) {
+        return Promise.resolve({
+          data: multisigToken,
+          status: 200,
+        });
+      }
+      if (url === getNotImitatedTokenAddressUrl) {
+        return Promise.resolve({
+          data: notImitatedMultisigToken,
+          status: 200,
+        });
+      }
+      if (url === getImitationTokenAddressUrl) {
+        return Promise.resolve({
+          data: imitationToken,
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
+      )
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.results).toStrictEqual([
+          {
+            timestamp: 1710927778000,
+            type: 'DATE_LABEL',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: null,
+              // @ts-expect-error - Type does not contain transfers
+              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+              safeAppInfo: null,
+              timestamp: 1710927778000,
+              txInfo: {
+                direction: 'INCOMING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: imitationAddress,
+                },
+                transferInfo: {
+                  decimals: imitationToken.decimals,
+                  imitation: false, // Not flagged
+                  logoUri: imitationToken.logoUri,
+                  tokenAddress: imitationToken.address,
+                  tokenName: imitationToken.name,
+                  tokenSymbol: imitationToken.symbol,
+                  trusted: imitationToken.trusted,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash:
+                imitationIncomingTransaction.transfers![0].transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: null,
+              // @ts-expect-error - Type does not contain transfers
+              id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
+              safeAppInfo: null,
+              timestamp: 1710927778000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: imitationAddress,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: imitationToken.decimals,
+                  imitation: false, // Not flagged
+                  logoUri: imitationToken.logoUri,
+                  tokenAddress: imitationToken.address,
+                  tokenName: imitationToken.name,
+                  tokenSymbol: imitationToken.symbol,
+                  trusted: imitationToken.trusted,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash:
+                imitationOutgoingTransaction.transfers![0].transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: notImitatedMultisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: notImitatedMultisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: notImitatedMultisigToken.decimals,
+                  imitation: false,
+                  logoUri: notImitatedMultisigToken.logoUri,
+                  tokenAddress: notImitatedMultisigToken.address,
+                  tokenName: notImitatedMultisigToken.name,
+                  tokenSymbol: notImitatedMultisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: notImitatedMultisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: notImitatedMultisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: notImitatedMultisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: notImitatedMultisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: notImitatedMultisigToken.decimals,
+                  imitation: false,
+                  logoUri: notImitatedMultisigToken.logoUri,
+                  tokenAddress: notImitatedMultisigToken.address,
+                  tokenName: notImitatedMultisigToken.name,
+                  tokenSymbol: notImitatedMultisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: notImitatedMultisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: notImitatedMultisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+          {
+            conflictType: 'None',
+            transaction: {
+              executionInfo: {
+                confirmationsRequired: 1,
+                confirmationsSubmitted: 1,
+                missingSigners: null,
+                nonce: multisigTransaction.nonce,
+                type: 'MULTISIG',
+              },
+              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+              safeAppInfo: null,
+              timestamp: 1710927685000,
+              txInfo: {
+                direction: 'OUTGOING',
+                humanDescription: null,
+                recipient: {
+                  logoUri: null,
+                  name: null,
+                  value: multisigTransfer.to,
+                },
+                richDecodedInfo: null,
+                sender: {
+                  logoUri: null,
+                  name: null,
+                  value: safe.address,
+                },
+                transferInfo: {
+                  decimals: multisigToken.decimals,
+                  imitation: false,
+                  logoUri: multisigToken.logoUri,
+                  tokenAddress: multisigToken.address,
+                  tokenName: multisigToken.name,
+                  tokenSymbol: multisigToken.symbol,
+                  trusted: null,
+                  type: 'ERC20',
+                  value: multisigTransfer.value,
+                },
+                type: 'Transfer',
+              },
+              txStatus: 'SUCCESS',
+              txHash: multisigTransaction.transactionHash,
+            },
+            type: 'TRANSACTION',
+          },
+        ]);
+      });
   });
 });

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -27,7 +27,10 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import type { Transfer } from '@/domain/safe/entities/transfer.entity';
+import type {
+  ERC20Transfer,
+  Transfer,
+} from '@/domain/safe/entities/transfer.entity';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { NetworkService } from '@/datasources/network/network.service.interface';
 import { AppModule } from '@/app.module';
@@ -53,6 +56,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
   const lookupDistance = 2;
   const prefixLength = 3;
   const suffixLength = 4;
+  const valueTolerance = BigInt(1);
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -63,6 +67,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ...configuration().mappings,
         imitation: {
           lookupDistance,
+          valueTolerance,
           prefixLength,
           suffixLength,
         },
@@ -100,1393 +105,2528 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
     await app.close();
   });
 
-  function getImitationAddress(address: `0x${string}`): `0x${string}` {
-    // + 2 is to account for the '0x' prefix
-    const prefix = address.slice(0, prefixLength + 2);
-    const suffix = address.slice(-suffixLength);
-    const imitator = `${prefix}${faker.finance.ethereumAddress().slice(prefixLength + 2, -suffixLength)}${suffix}`;
-    return getAddress(imitator);
-  }
-  const chain = chainBuilder().build();
-  const safe = safeBuilder().build();
+  describe('Event spoofing', () => {
+    function parseUnits(value: bigint, decimals: number): bigint {
+      return value * BigInt(10 ** decimals);
+    }
 
-  const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
-  const multisigToken = tokenBuilder().with('type', TokenType.Erc20).build();
-  const multisigTransfer = {
-    ...erc20TransferBuilder()
-      .with('executionDate', multisigExecutionDate)
-      .with('from', safe.address)
-      .with('tokenAddress', multisigToken.address)
-      .with('value', faker.string.numeric({ exclude: ['0'] }))
-      .build(),
-    tokenInfo: multisigToken,
-  };
-  const multisigTransaction = {
-    ...(multisigTransactionToJson(
-      multisigTransactionBuilder()
-        .with('executionDate', multisigExecutionDate)
-        .with('safe', safe.address)
-        .with('to', multisigToken.address)
-        .with('value', '0')
-        .with('operation', 0)
-        .with('gasToken', zeroAddress)
-        .with('safeTxGas', 0)
-        .with('baseGas', 0)
-        .with('gasPrice', '0')
-        .with('refundReceiver', zeroAddress)
-        .with('proposer', safe.owners[0])
-        .with('executor', safe.owners[0])
-        .with('isExecuted', true)
-        .with('isSuccessful', true)
-        .with('origin', null)
-        .with(
-          'dataDecoded',
-          dataDecodedBuilder()
-            .with('method', 'transfer')
-            .with('parameters', [
-              dataDecodedParameterBuilder()
-                .with('name', 'to')
-                .with('type', 'address')
-                .with('value', multisigTransfer.to)
-                .build(),
-              dataDecodedParameterBuilder()
-                .with('name', 'value')
-                .with('type', 'uint256')
-                .with('value', multisigTransfer.value)
-                .build(),
-            ])
-            .build(),
-        )
-        .with('confirmationsRequired', 1)
-        .with('confirmations', [
-          confirmationBuilder().with('owner', safe.owners[0]).build(),
-        ])
-        .with('trusted', true)
-        .build(),
-    ) as MultisigTransaction),
-    // TODO: Update type to include transfers
-    transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
-  } as MultisigTransaction;
+    function getImitationAddress(address: `0x${string}`): `0x${string}` {
+      // + 2 is to account for the '0x' prefix
+      const prefix = address.slice(0, prefixLength + 2);
+      const suffix = address.slice(-suffixLength);
+      const imitator = `${prefix}${faker.finance.ethereumAddress().slice(prefixLength + 2, -suffixLength)}${suffix}`;
+      return getAddress(imitator);
+    }
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
 
-  const notImitatedMultisigToken = tokenBuilder()
-    .with('type', TokenType.Erc20)
-    .build();
-  const notImitatedMultisigTransfer = {
-    ...erc20TransferBuilder()
-      .with('executionDate', multisigExecutionDate)
-      .with('from', safe.address)
-      .with('tokenAddress', notImitatedMultisigToken.address)
-      .with('value', faker.string.numeric({ exclude: ['0'] }))
-      .build(),
-    tokenInfo: multisigToken,
-  };
-  const notImitatedMultisigTransaction = {
-    ...(multisigTransactionToJson(
-      multisigTransactionBuilder()
-        .with('executionDate', multisigExecutionDate)
-        .with('safe', safe.address)
-        .with('to', notImitatedMultisigToken.address)
-        .with('value', '0')
-        .with('operation', 0)
-        .with('gasToken', zeroAddress)
-        .with('safeTxGas', 0)
-        .with('baseGas', 0)
-        .with('gasPrice', '0')
-        .with('refundReceiver', zeroAddress)
-        .with('proposer', safe.owners[0])
-        .with('executor', safe.owners[0])
-        .with('isExecuted', true)
-        .with('isSuccessful', true)
-        .with('origin', null)
-        .with(
-          'dataDecoded',
-          dataDecodedBuilder()
-            .with('method', 'transfer')
-            .with('parameters', [
-              dataDecodedParameterBuilder()
-                .with('name', 'to')
-                .with('type', 'address')
-                .with('value', notImitatedMultisigTransfer.to)
-                .build(),
-              dataDecodedParameterBuilder()
-                .with('name', 'value')
-                .with('type', 'uint256')
-                .with('value', notImitatedMultisigTransfer.value)
-                .build(),
-            ])
-            .build(),
-        )
-        .with('confirmationsRequired', 1)
-        .with('confirmations', [
-          confirmationBuilder().with('owner', safe.owners[0]).build(),
-        ])
-        .with('trusted', true)
-        .build(),
-    ) as MultisigTransaction),
-    // TODO: Update type to include transfers
-    transfers: [erc20TransferToJson(notImitatedMultisigTransfer) as Transfer],
-  } as MultisigTransaction;
-
-  const imitationAddress = getImitationAddress(multisigTransfer.to);
-  const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
-  const imitationToken = tokenBuilder()
-    .with('type', TokenType.Erc20)
-    .with('decimals', multisigToken.decimals)
-    .build();
-
-  const imitationIncomingTransfer = {
-    ...erc20TransferBuilder()
-      .with('from', imitationAddress)
-      .with('to', safe.address)
-      .with('tokenAddress', imitationToken.address)
-      .with('value', multisigTransfer.value)
-      .with('executionDate', imitationExecutionDate)
-      .build(),
-    // TODO: Update type to include tokenInfo
-    tokenInfo: imitationToken,
-  };
-  const imitationIncomingErc20Transfer = erc20TransferEncoder()
-    .with('to', safe.address)
-    .with('value', BigInt(multisigTransfer.value));
-  const imitationIncomingTransaction = ethereumTransactionToJson(
-    ethereumTransactionBuilder()
-      .with('executionDate', imitationIncomingTransfer.executionDate)
-      .with('data', imitationIncomingErc20Transfer.encode())
-      .with('transfers', [
-        erc20TransferToJson(imitationIncomingTransfer) as Transfer,
-      ])
-      .build(),
-  ) as EthereumTransaction;
-
-  const imitationOutgoingTransfer = {
-    ...erc20TransferBuilder()
-      .with('from', safe.address)
-      .with('to', imitationAddress)
-      .with('tokenAddress', imitationToken.address)
-      .with('value', multisigTransfer.value)
-      .with('executionDate', imitationExecutionDate)
-      .build(),
-    // TODO: Update type to include tokenInfo
-    tokenInfo: imitationToken,
-  };
-  const imitationOutgoingErc20Transfer = erc20TransferEncoder()
-    .with('to', imitationAddress)
-    .with('value', BigInt(multisigTransfer.value));
-  const imitationOutgoingTransaction = ethereumTransactionToJson(
-    ethereumTransactionBuilder()
-      .with('executionDate', imitationOutgoingTransfer.executionDate)
-      .with('data', imitationOutgoingErc20Transfer.encode())
-      .with('transfers', [
-        erc20TransferToJson(imitationOutgoingTransfer) as Transfer,
-      ])
-      .build(),
-  ) as EthereumTransaction;
-
-  const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
-  const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-  const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${multisigToken.address}`;
-  const getNotImitatedTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${notImitatedMultisigToken.address}`;
-  const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${imitationToken.address}`;
-
-  it('should flag imitation incoming/outgoing transfers within the lookup distance', async () => {
-    const results = [
-      imitationIncomingTransaction,
-      multisigTransaction,
-      imitationOutgoingTransaction,
-      notImitatedMultisigTransaction,
-      multisigTransaction,
-    ];
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
-      }
-      if (url === getAllTransactionsUrl) {
-        return Promise.resolve({
-          data: pageBuilder().with('results', results).build(),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
-      }
-      if (url === getTokenAddressUrl) {
-        return Promise.resolve({
-          data: multisigToken,
-          status: 200,
-        });
-      }
-      if (url === getNotImitatedTokenAddressUrl) {
-        return Promise.resolve({
-          data: notImitatedMultisigToken,
-          status: 200,
-        });
-      }
-      if (url === getImitationTokenAddressUrl) {
-        return Promise.resolve({
-          data: imitationToken,
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-      )
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.results).toStrictEqual([
-          {
-            timestamp: 1710927778000,
-            type: 'DATE_LABEL',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'INCOMING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationAddress,
-                },
-                transferInfo: {
-                  decimals: imitationToken.decimals,
-                  imitation: true,
-                  logoUri: imitationToken.logoUri,
-                  tokenAddress: imitationToken.address,
-                  tokenName: imitationToken.name,
-                  tokenSymbol: imitationToken.symbol,
-                  trusted: imitationToken.trusted,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationIncomingTransaction.transfers![0].transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationAddress,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: imitationToken.decimals,
-                  imitation: true,
-                  logoUri: imitationToken.logoUri,
-                  tokenAddress: imitationToken.address,
-                  tokenName: imitationToken.name,
-                  tokenSymbol: imitationToken.symbol,
-                  trusted: imitationToken.trusted,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationOutgoingTransaction.transfers![0].transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: notImitatedMultisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: notImitatedMultisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: notImitatedMultisigToken.decimals,
-                  imitation: false,
-                  logoUri: notImitatedMultisigToken.logoUri,
-                  tokenAddress: notImitatedMultisigToken.address,
-                  tokenName: notImitatedMultisigToken.name,
-                  tokenSymbol: notImitatedMultisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: notImitatedMultisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: notImitatedMultisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-        ]);
-      });
-  });
-
-  it('should not flag imitation incoming/outgoing transfers outside the lookup distance', async () => {
-    const results = [
-      imitationIncomingTransaction,
-      imitationOutgoingTransaction,
-      notImitatedMultisigTransaction,
-      notImitatedMultisigTransaction,
-      multisigTransaction,
-    ];
-
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
-      }
-      if (url === getAllTransactionsUrl) {
-        return Promise.resolve({
-          data: pageBuilder().with('results', results).build(),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
-      }
-      if (url === getTokenAddressUrl) {
-        return Promise.resolve({
-          data: multisigToken,
-          status: 200,
-        });
-      }
-      if (url === getNotImitatedTokenAddressUrl) {
-        return Promise.resolve({
-          data: notImitatedMultisigToken,
-          status: 200,
-        });
-      }
-      if (url === getImitationTokenAddressUrl) {
-        return Promise.resolve({
-          data: imitationToken,
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-      )
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.results).toStrictEqual([
-          {
-            timestamp: 1710927778000,
-            type: 'DATE_LABEL',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'INCOMING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationAddress,
-                },
-                transferInfo: {
-                  decimals: imitationToken.decimals,
-                  imitation: false, // Not flagged
-                  logoUri: imitationToken.logoUri,
-                  tokenAddress: imitationToken.address,
-                  tokenName: imitationToken.name,
-                  tokenSymbol: imitationToken.symbol,
-                  trusted: imitationToken.trusted,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationIncomingTransaction.transfers![0].transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationAddress,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: imitationToken.decimals,
-                  imitation: false, // Not flagged
-                  logoUri: imitationToken.logoUri,
-                  tokenAddress: imitationToken.address,
-                  tokenName: imitationToken.name,
-                  tokenSymbol: imitationToken.symbol,
-                  trusted: imitationToken.trusted,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationOutgoingTransaction.transfers![0].transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: notImitatedMultisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: notImitatedMultisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: notImitatedMultisigToken.decimals,
-                  imitation: false,
-                  logoUri: notImitatedMultisigToken.logoUri,
-                  tokenAddress: notImitatedMultisigToken.address,
-                  tokenName: notImitatedMultisigToken.name,
-                  tokenSymbol: notImitatedMultisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: notImitatedMultisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: notImitatedMultisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: notImitatedMultisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: notImitatedMultisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: notImitatedMultisigToken.decimals,
-                  imitation: false,
-                  logoUri: notImitatedMultisigToken.logoUri,
-                  tokenAddress: notImitatedMultisigToken.address,
-                  tokenName: notImitatedMultisigToken.name,
-                  tokenSymbol: notImitatedMultisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: notImitatedMultisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: notImitatedMultisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-        ]);
-      });
-  });
-
-  it('should filter out imitation incoming/outgoing transfers within the lookup distance', async () => {
-    const results = [
-      imitationIncomingTransaction,
-      multisigTransaction,
-      imitationOutgoingTransaction,
-      notImitatedMultisigTransaction,
-      multisigTransaction,
-    ];
-
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
-      }
-      if (url === getAllTransactionsUrl) {
-        return Promise.resolve({
-          data: pageBuilder().with('results', results).build(),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
-      }
-      if (url === getTokenAddressUrl) {
-        return Promise.resolve({
-          data: multisigToken,
-          status: 200,
-        });
-      }
-      if (url === getNotImitatedTokenAddressUrl) {
-        return Promise.resolve({
-          data: notImitatedMultisigToken,
-          status: 200,
-        });
-      }
-      if (url === getImitationTokenAddressUrl) {
-        return Promise.resolve({
-          data: imitationToken,
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
-      )
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.results).toStrictEqual([
-          {
-            timestamp: 1710927685000,
-            type: 'DATE_LABEL',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: notImitatedMultisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: notImitatedMultisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: notImitatedMultisigToken.decimals,
-                  imitation: false,
-                  logoUri: notImitatedMultisigToken.logoUri,
-                  tokenAddress: notImitatedMultisigToken.address,
-                  tokenName: notImitatedMultisigToken.name,
-                  tokenSymbol: notImitatedMultisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: notImitatedMultisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txHash: notImitatedMultisigTransaction.transactionHash,
-              txStatus: 'SUCCESS',
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-        ]);
-      });
-  });
-
-  it('should not filter out imitation incoming/outgoing transfers within the lookup distance', async () => {
-    const results = [
-      imitationIncomingTransaction,
-      imitationOutgoingTransaction,
-      notImitatedMultisigTransaction,
-      notImitatedMultisigTransaction,
-      multisigTransaction,
-    ];
-
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
-      }
-      if (url === getAllTransactionsUrl) {
-        return Promise.resolve({
-          data: pageBuilder().with('results', results).build(),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
-      }
-      if (url === getTokenAddressUrl) {
-        return Promise.resolve({
-          data: multisigToken,
-          status: 200,
-        });
-      }
-      if (url === getNotImitatedTokenAddressUrl) {
-        return Promise.resolve({
-          data: notImitatedMultisigToken,
-          status: 200,
-        });
-      }
-      if (url === getImitationTokenAddressUrl) {
-        return Promise.resolve({
-          data: imitationToken,
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
-      )
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.results).toStrictEqual([
-          {
-            timestamp: 1710927778000,
-            type: 'DATE_LABEL',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'INCOMING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationAddress,
-                },
-                transferInfo: {
-                  decimals: imitationToken.decimals,
-                  imitation: false, // Not flagged
-                  logoUri: imitationToken.logoUri,
-                  tokenAddress: imitationToken.address,
-                  tokenName: imitationToken.name,
-                  tokenSymbol: imitationToken.symbol,
-                  trusted: imitationToken.trusted,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationIncomingTransaction.transfers![0].transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationAddress,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: imitationToken.decimals,
-                  imitation: false, // Not flagged
-                  logoUri: imitationToken.logoUri,
-                  tokenAddress: imitationToken.address,
-                  tokenName: imitationToken.name,
-                  tokenSymbol: imitationToken.symbol,
-                  trusted: imitationToken.trusted,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationOutgoingTransaction.transfers![0].transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: notImitatedMultisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: notImitatedMultisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: notImitatedMultisigToken.decimals,
-                  imitation: false,
-                  logoUri: notImitatedMultisigToken.logoUri,
-                  tokenAddress: notImitatedMultisigToken.address,
-                  tokenName: notImitatedMultisigToken.name,
-                  tokenSymbol: notImitatedMultisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: notImitatedMultisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: notImitatedMultisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: notImitatedMultisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: notImitatedMultisigTransfer.executionDate.getTime(),
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: notImitatedMultisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: notImitatedMultisigToken.decimals,
-                  imitation: false,
-                  logoUri: notImitatedMultisigToken.logoUri,
-                  tokenAddress: notImitatedMultisigToken.address,
-                  tokenName: notImitatedMultisigToken.name,
-                  tokenSymbol: notImitatedMultisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: notImitatedMultisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: notImitatedMultisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
-              },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
-              },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-        ]);
-      });
-  });
-
-  it('should detect imitation tokens using differing decimals', async () => {
-    const differentDecimals = multisigToken.decimals! + 1;
-    const differentValue = multisigTransfer.value + '0';
-    const imitationWithDifferentDecimalsAddress = getImitationAddress(
-      multisigTransfer.to,
-    );
-    const imitationWithDifferentDecimalsExecutionDate = new Date(
-      '2024-03-20T09:42:58Z',
-    );
-    const imitationWithDifferentDecimalsToken = tokenBuilder()
+    const multisigExecutionDate = new Date('2024-03-20T09:41:25Z');
+    const multisigToken = tokenBuilder()
       .with('type', TokenType.Erc20)
-      .with('decimals', differentDecimals)
+      .with('decimals', faker.number.int({ min: 8, max: 18 }))
+      .build();
+    const multisigTransfer = {
+      ...erc20TransferBuilder()
+        .with('executionDate', multisigExecutionDate)
+        .with('from', safe.address)
+        .with('tokenAddress', multisigToken.address)
+        .with(
+          'value',
+          parseUnits(
+            faker.number.bigInt({
+              // Must be above value tolerance as we hide any transfers with a value of 0
+              // and any value between 0 and tolerance would result in <= 0
+              min: valueTolerance * faker.number.bigInt({ min: 2 }),
+            }),
+            multisigToken.decimals!,
+          ).toString(),
+        )
+        .build(),
+      tokenInfo: multisigToken,
+    };
+    const multisigTransaction = {
+      ...(multisigTransactionToJson(
+        multisigTransactionBuilder()
+          .with('executionDate', multisigExecutionDate)
+          .with('safe', safe.address)
+          .with('to', multisigToken.address)
+          .with('value', '0')
+          .with('operation', 0)
+          .with('gasToken', zeroAddress)
+          .with('safeTxGas', 0)
+          .with('baseGas', 0)
+          .with('gasPrice', '0')
+          .with('refundReceiver', zeroAddress)
+          .with('proposer', safe.owners[0])
+          .with('executor', safe.owners[0])
+          .with('isExecuted', true)
+          .with('isSuccessful', true)
+          .with('origin', null)
+          .with(
+            'dataDecoded',
+            dataDecodedBuilder()
+              .with('method', 'transfer')
+              .with('parameters', [
+                dataDecodedParameterBuilder()
+                  .with('name', 'to')
+                  .with('type', 'address')
+                  .with('value', multisigTransfer.to)
+                  .build(),
+                dataDecodedParameterBuilder()
+                  .with('name', 'value')
+                  .with('type', 'uint256')
+                  .with('value', multisigTransfer.value)
+                  .build(),
+              ])
+              .build(),
+          )
+          .with('confirmationsRequired', 1)
+          .with('confirmations', [
+            confirmationBuilder().with('owner', safe.owners[0]).build(),
+          ])
+          .with('trusted', true)
+          .build(),
+      ) as MultisigTransaction),
+      // TODO: Update type to include transfers - only on all-transactions endpoint
+      transfers: [erc20TransferToJson(multisigTransfer) as Transfer],
+    } as MultisigTransaction;
+
+    const notImitatedMultisigToken = tokenBuilder()
+      .with('type', TokenType.Erc20)
+      .with('decimals', faker.number.int({ min: 6, max: 18 }))
+      .build();
+    const notImitatedMultisigTransfer = {
+      ...erc20TransferBuilder()
+        .with('executionDate', multisigExecutionDate)
+        .with('from', safe.address)
+        .with('tokenAddress', notImitatedMultisigToken.address)
+        .with(
+          'value',
+          parseUnits(
+            faker.number.bigInt({
+              // Must be above value tolerance as we hide any transfers with a value of 0
+              // and any value between 0 and tolerance would result in <= 0
+              min: valueTolerance * faker.number.bigInt({ min: 2 }),
+            }),
+            notImitatedMultisigToken.decimals!,
+          ).toString(),
+        )
+        .build(),
+      tokenInfo: multisigToken,
+    };
+    const notImitatedMultisigTransaction = {
+      ...(multisigTransactionToJson(
+        multisigTransactionBuilder()
+          .with('executionDate', multisigExecutionDate)
+          .with('safe', safe.address)
+          .with('to', notImitatedMultisigToken.address)
+          .with('value', '0')
+          .with('operation', 0)
+          .with('gasToken', zeroAddress)
+          .with('safeTxGas', 0)
+          .with('baseGas', 0)
+          .with('gasPrice', '0')
+          .with('refundReceiver', zeroAddress)
+          .with('proposer', safe.owners[0])
+          .with('executor', safe.owners[0])
+          .with('isExecuted', true)
+          .with('isSuccessful', true)
+          .with('origin', null)
+          .with(
+            'dataDecoded',
+            dataDecodedBuilder()
+              .with('method', 'transfer')
+              .with('parameters', [
+                dataDecodedParameterBuilder()
+                  .with('name', 'to')
+                  .with('type', 'address')
+                  .with('value', notImitatedMultisigTransfer.to)
+                  .build(),
+                dataDecodedParameterBuilder()
+                  .with('name', 'value')
+                  .with('type', 'uint256')
+                  .with('value', notImitatedMultisigTransfer.value)
+                  .build(),
+              ])
+              .build(),
+          )
+          .with('confirmationsRequired', 1)
+          .with('confirmations', [
+            confirmationBuilder().with('owner', safe.owners[0]).build(),
+          ])
+          .with('trusted', true)
+          .build(),
+      ) as MultisigTransaction),
+      // TODO: Update type to include transfers - only on all-transactions endpoint
+      transfers: [erc20TransferToJson(notImitatedMultisigTransfer) as Transfer],
+    } as MultisigTransaction;
+
+    const imitationAddress = getImitationAddress(multisigTransfer.to);
+    const imitationExecutionDate = new Date('2024-03-20T09:42:58Z');
+    const imitationToken = tokenBuilder()
+      .with('type', TokenType.Erc20)
+      .with('decimals', multisigToken.decimals)
       .build();
 
-    const imitationWithDifferentDecimalsIncomingTransfer = {
+    const imitationIncomingTransfer = {
       ...erc20TransferBuilder()
-        .with('from', imitationWithDifferentDecimalsAddress)
+        .with('from', imitationAddress)
         .with('to', safe.address)
-        .with('tokenAddress', imitationWithDifferentDecimalsToken.address)
-        .with('value', differentValue)
-        .with('executionDate', imitationWithDifferentDecimalsExecutionDate)
+        .with('tokenAddress', imitationToken.address)
+        .with('value', multisigTransfer.value)
+        .with('executionDate', imitationExecutionDate)
         .build(),
-      // TODO: Update type to include tokenInfo
-      tokenInfo: imitationWithDifferentDecimalsToken,
+      // TODO: Update type to include tokenInfo - only on all-transactions endpoint
+      tokenInfo: imitationToken,
     };
-    const imitationWithDifferentDecimalsIncomingErc20Transfer =
-      erc20TransferEncoder()
-        .with('to', safe.address)
-        .with('value', BigInt(differentValue));
-    const imitationWithDifferentDecimalsIncomingTransaction =
-      ethereumTransactionToJson(
-        ethereumTransactionBuilder()
-          .with(
-            'executionDate',
-            imitationWithDifferentDecimalsIncomingTransfer.executionDate,
-          )
-          .with(
-            'data',
-            imitationWithDifferentDecimalsIncomingErc20Transfer.encode(),
-          )
-          .with('transfers', [
-            erc20TransferToJson(
-              imitationWithDifferentDecimalsIncomingTransfer,
-            ) as Transfer,
-          ])
-          .build(),
-      ) as EthereumTransaction;
+    const imitationIncomingErc20Transfer = erc20TransferEncoder()
+      .with('to', safe.address)
+      .with('value', BigInt(multisigTransfer.value));
+    const imitationIncomingTransaction = ethereumTransactionToJson(
+      ethereumTransactionBuilder()
+        .with('executionDate', imitationIncomingTransfer.executionDate)
+        .with('data', imitationIncomingErc20Transfer.encode())
+        .with('transfers', [
+          erc20TransferToJson(imitationIncomingTransfer) as Transfer,
+        ])
+        .build(),
+    ) as EthereumTransaction;
 
-    const results = [
-      imitationWithDifferentDecimalsIncomingTransaction,
-      multisigTransaction,
-    ];
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
-      }
-      if (url === getAllTransactionsUrl) {
-        return Promise.resolve({
-          data: pageBuilder().with('results', results).build(),
-          status: 200,
+    const imitationOutgoingTransfer = {
+      ...erc20TransferBuilder()
+        .with('from', safe.address)
+        .with('to', imitationAddress)
+        .with('tokenAddress', imitationToken.address)
+        .with('value', multisigTransfer.value)
+        .with('executionDate', imitationExecutionDate)
+        .build(),
+      // TODO: Update type to include tokenInfo - only on all-transactions endpoint
+      tokenInfo: imitationToken,
+    };
+    const imitationOutgoingErc20Transfer = erc20TransferEncoder()
+      .with('to', imitationAddress)
+      .with('value', BigInt(multisigTransfer.value));
+    const imitationOutgoingTransaction = ethereumTransactionToJson(
+      ethereumTransactionBuilder()
+        .with('executionDate', imitationOutgoingTransfer.executionDate)
+        .with('data', imitationOutgoingErc20Transfer.encode())
+        .with('transfers', [
+          erc20TransferToJson(imitationOutgoingTransfer) as Transfer,
+        ])
+        .build(),
+    ) as EthereumTransaction;
+
+    const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
+    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+    const getTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${multisigToken.address}`;
+    const getNotImitatedTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${notImitatedMultisigToken.address}`;
+    const getImitationTokenAddressUrl = `${chain.transactionService}/api/v1/tokens/${imitationToken.address}`;
+
+    describe('Same value', () => {
+      it('should flag imitation incoming/outgoing transfers of the same value within the lookup distance', async () => {
+        const results = [
+          imitationIncomingTransaction,
+          multisigTransaction,
+          imitationOutgoingTransaction,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
         });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
-      }
-      if (url === getTokenAddressUrl) {
-        return Promise.resolve({
-          data: multisigToken,
-          status: 200,
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927778000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'INCOMING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: true,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationIncomingTransaction.transfers![0].transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: true,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationOutgoingTransaction.transfers![0].transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
+
+      it('should filter out imitation incoming/outgoing transfers of the same value outside the lookup distance', async () => {
+        const results = [
+          imitationIncomingTransaction,
+          imitationOutgoingTransaction,
+          notImitatedMultisigTransaction,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
         });
-      }
-      if (
-        url ===
-        `${chain.transactionService}/api/v1/tokens/${imitationWithDifferentDecimalsToken.address}`
-      ) {
-        return Promise.resolve({
-          data: imitationWithDifferentDecimalsToken,
-          status: 200,
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927778000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'INCOMING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false, // Not flagged
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationIncomingTransaction.transfers![0].transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false, // Not flagged
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationOutgoingTransaction.transfers![0].transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
+
+      it('should filter out imitation incoming/outgoing transfers of the same value within the lookup distance if parameter is false - example #1', async () => {
+        const results = [
+          imitationIncomingTransaction,
+          multisigTransaction,
+          imitationOutgoingTransaction,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
         });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927685000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                  txStatus: 'SUCCESS',
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
+
+      // TODO: Discern the difference between this and the test above
+      it('should not flag imitation incoming/outgoing transfers of the same value within the lookup distance if parameter is false - example #2', async () => {
+        const results = [
+          imitationIncomingTransaction,
+          imitationOutgoingTransaction,
+          notImitatedMultisigTransaction,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927778000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'INCOMING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false, // Not flagged
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationIncomingTransaction.transfers![0].transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false, // Not flagged
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationOutgoingTransaction.transfers![0].transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
     });
 
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
-      )
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.results).toStrictEqual([
-          {
-            timestamp: 1710927778000,
-            type: 'DATE_LABEL',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: null,
-              // @ts-expect-error - Type does not contain transfers
-              id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
-              safeAppInfo: null,
-              timestamp: 1710927778000,
-              txInfo: {
-                direction: 'INCOMING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: imitationWithDifferentDecimalsAddress,
-                },
-                transferInfo: {
-                  decimals: imitationWithDifferentDecimalsToken.decimals,
-                  imitation: true,
-                  logoUri: imitationWithDifferentDecimalsToken.logoUri,
-                  tokenAddress: imitationWithDifferentDecimalsToken.address,
-                  tokenName: imitationWithDifferentDecimalsToken.name,
-                  tokenSymbol: imitationWithDifferentDecimalsToken.symbol,
-                  trusted: imitationWithDifferentDecimalsToken.trusted,
-                  type: 'ERC20',
-                  value: imitationWithDifferentDecimalsIncomingTransfer.value,
-                },
-                type: 'Transfer',
+    describe('Value difference', () => {
+      const highTolerantValue =
+        BigInt(multisigTransfer.value) +
+        parseUnits(valueTolerance, multisigToken.decimals!);
+      const lowTolerantValue =
+        BigInt(multisigTransfer.value) -
+        parseUnits(valueTolerance, multisigToken.decimals!);
+
+      const imitationTransactionWithHighTolerantValue =
+        ((): EthereumTransaction => {
+          const transaction = structuredClone(imitationIncomingTransaction);
+          (transaction.transfers![0] as ERC20Transfer).value =
+            highTolerantValue.toString();
+          return transaction;
+        })();
+      const imitationTransactionWithLowTolerantValue =
+        ((): EthereumTransaction => {
+          const transaction = structuredClone(imitationOutgoingTransaction);
+          (transaction.transfers![0] as ERC20Transfer).value =
+            lowTolerantValue.toString();
+          return transaction;
+        })();
+
+      const highIntolerantValue =
+        BigInt(multisigTransfer.value) +
+        parseUnits(valueTolerance + BigInt(1), multisigToken.decimals!);
+      const lowIntolerantValue =
+        BigInt(multisigTransfer.value) -
+        parseUnits(valueTolerance + BigInt(1), multisigToken.decimals!);
+
+      const imitationTransactionWithHighIntolerantValue =
+        ((): EthereumTransaction => {
+          const transaction = structuredClone(imitationIncomingTransaction);
+          (transaction.transfers![0] as ERC20Transfer).value =
+            highIntolerantValue.toString();
+          return transaction;
+        })();
+      const imitationTransactionWithLowIntolerantValue =
+        ((): EthereumTransaction => {
+          const transaction = structuredClone(imitationOutgoingTransaction);
+          (transaction.transfers![0] as ERC20Transfer).value =
+            lowIntolerantValue.toString();
+          return transaction;
+        })();
+
+      it('should flag imitation incoming/outgoing transfers with a tolerant value difference within the lookup distance', async () => {
+        const results = [
+          imitationTransactionWithHighTolerantValue,
+          multisigTransaction,
+          imitationTransactionWithLowTolerantValue,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927778000,
+                type: 'DATE_LABEL',
               },
-              txStatus: 'SUCCESS',
-              txHash:
-                imitationWithDifferentDecimalsIncomingTransaction.transfers![0]
-                  .transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-          {
-            conflictType: 'None',
-            transaction: {
-              executionInfo: {
-                confirmationsRequired: 1,
-                confirmationsSubmitted: 1,
-                missingSigners: null,
-                nonce: multisigTransaction.nonce,
-                type: 'MULTISIG',
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'INCOMING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: true,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: (
+                        imitationTransactionWithHighTolerantValue
+                          .transfers![0] as ERC20Transfer
+                      ).value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationTransactionWithHighTolerantValue.transfers![0]
+                      .transactionHash,
+                },
+                type: 'TRANSACTION',
               },
-              id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
-              safeAppInfo: null,
-              timestamp: 1710927685000,
-              txInfo: {
-                direction: 'OUTGOING',
-                humanDescription: null,
-                recipient: {
-                  logoUri: null,
-                  name: null,
-                  value: multisigTransfer.to,
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
                 },
-                richDecodedInfo: null,
-                sender: {
-                  logoUri: null,
-                  name: null,
-                  value: safe.address,
-                },
-                transferInfo: {
-                  decimals: multisigToken.decimals,
-                  imitation: false,
-                  logoUri: multisigToken.logoUri,
-                  tokenAddress: multisigToken.address,
-                  tokenName: multisigToken.name,
-                  tokenSymbol: multisigToken.symbol,
-                  trusted: null,
-                  type: 'ERC20',
-                  value: multisigTransfer.value,
-                },
-                type: 'Transfer',
+                type: 'TRANSACTION',
               },
-              txStatus: 'SUCCESS',
-              txHash: multisigTransaction.transactionHash,
-            },
-            type: 'TRANSACTION',
-          },
-        ]);
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: new Date(
+                    imitationTransactionWithLowTolerantValue.executionDate,
+                  ).getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: true,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: (
+                        imitationTransactionWithLowTolerantValue
+                          .transfers![0] as ERC20Transfer
+                      ).value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationTransactionWithLowTolerantValue.transfers![0]
+                      .transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
       });
+
+      it('should not flag imitation incoming/outgoing transfers with an intolerant value difference within the lookup distance', async () => {
+        const results = [
+          imitationTransactionWithHighIntolerantValue,
+          multisigTransaction,
+          imitationTransactionWithLowIntolerantValue,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927778000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'INCOMING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: (
+                        imitationTransactionWithHighIntolerantValue
+                          .transfers![0] as ERC20Transfer
+                      ).value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationTransactionWithHighIntolerantValue.transfers![0]
+                      .transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[2].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: new Date(
+                    imitationTransactionWithLowIntolerantValue.executionDate,
+                  ).getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: (
+                        imitationTransactionWithLowIntolerantValue
+                          .transfers![0] as ERC20Transfer
+                      ).value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationTransactionWithLowIntolerantValue.transfers![0]
+                      .transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
+
+      it('should not flag imitation incoming/outgoing transfers with an intolerant value difference outside the lookup distance', async () => {
+        const results = [
+          imitationTransactionWithHighTolerantValue,
+          imitationTransactionWithLowTolerantValue,
+          notImitatedMultisigTransaction,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927778000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927778000,
+                  txInfo: {
+                    direction: 'INCOMING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: (
+                        imitationTransactionWithHighTolerantValue
+                          .transfers![0] as ERC20Transfer
+                      ).value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationTransactionWithHighTolerantValue.transfers![0]
+                      .transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: null,
+                  // @ts-expect-error - Type does not contain transfers
+                  id: `transfer_${safe.address}_${results[1].transfers[0].transferId}`,
+                  safeAppInfo: null,
+                  timestamp: new Date(
+                    imitationTransactionWithLowTolerantValue.executionDate,
+                  ).getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: imitationAddress,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: imitationToken.decimals,
+                      imitation: false,
+                      logoUri: imitationToken.logoUri,
+                      tokenAddress: imitationToken.address,
+                      tokenName: imitationToken.name,
+                      tokenSymbol: imitationToken.symbol,
+                      trusted: imitationToken.trusted,
+                      type: 'ERC20',
+                      value: (
+                        imitationTransactionWithLowTolerantValue
+                          .transfers![0] as ERC20Transfer
+                      ).value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash:
+                    imitationTransactionWithLowIntolerantValue.transfers![0]
+                      .transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp:
+                    notImitatedMultisigTransfer.executionDate.getTime(),
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
+
+      it('should filter out imitation incoming/outgoing transfers with a tolerant value difference if the parameter is false', async () => {
+        const results = [
+          imitationTransactionWithHighTolerantValue,
+          multisigTransaction,
+          imitationTransactionWithLowTolerantValue,
+          notImitatedMultisigTransaction,
+          multisigTransaction,
+        ];
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+            return Promise.resolve({ data: chain, status: 200 });
+          }
+          if (url === getAllTransactionsUrl) {
+            return Promise.resolve({
+              data: pageBuilder().with('results', results).build(),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({ data: safe, status: 200 });
+          }
+          if (url === getTokenAddressUrl) {
+            return Promise.resolve({
+              data: multisigToken,
+              status: 200,
+            });
+          }
+          if (url === getNotImitatedTokenAddressUrl) {
+            return Promise.resolve({
+              data: notImitatedMultisigToken,
+              status: 200,
+            });
+          }
+          if (url === getImitationTokenAddressUrl) {
+            return Promise.resolve({
+              data: imitationToken,
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false&imitation=false`,
+          )
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.results).toStrictEqual([
+              {
+                timestamp: 1710927685000,
+                type: 'DATE_LABEL',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: notImitatedMultisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${notImitatedMultisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: notImitatedMultisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: notImitatedMultisigToken.decimals,
+                      imitation: false,
+                      logoUri: notImitatedMultisigToken.logoUri,
+                      tokenAddress: notImitatedMultisigToken.address,
+                      tokenName: notImitatedMultisigToken.name,
+                      tokenSymbol: notImitatedMultisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: notImitatedMultisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: notImitatedMultisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+              {
+                conflictType: 'None',
+                transaction: {
+                  executionInfo: {
+                    confirmationsRequired: 1,
+                    confirmationsSubmitted: 1,
+                    missingSigners: null,
+                    nonce: multisigTransaction.nonce,
+                    type: 'MULTISIG',
+                  },
+                  id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                  safeAppInfo: null,
+                  timestamp: 1710927685000,
+                  txInfo: {
+                    direction: 'OUTGOING',
+                    humanDescription: null,
+                    recipient: {
+                      logoUri: null,
+                      name: null,
+                      value: multisigTransfer.to,
+                    },
+                    richDecodedInfo: null,
+                    sender: {
+                      logoUri: null,
+                      name: null,
+                      value: safe.address,
+                    },
+                    transferInfo: {
+                      decimals: multisigToken.decimals,
+                      imitation: false,
+                      logoUri: multisigToken.logoUri,
+                      tokenAddress: multisigToken.address,
+                      tokenName: multisigToken.name,
+                      tokenSymbol: multisigToken.symbol,
+                      trusted: null,
+                      type: 'ERC20',
+                      value: multisigTransfer.value,
+                    },
+                    type: 'Transfer',
+                  },
+                  txStatus: 'SUCCESS',
+                  txHash: multisigTransaction.transactionHash,
+                },
+                type: 'TRANSACTION',
+              },
+            ]);
+          });
+      });
+    });
+
+    it('should flag imitation tokens using differing decimals', async () => {
+      const differentDecimals = multisigToken.decimals! + 1;
+      const differentValue = multisigTransfer.value + '0';
+      const imitationWithDifferentDecimalsAddress = getImitationAddress(
+        multisigTransfer.to,
+      );
+      const imitationWithDifferentDecimalsExecutionDate = new Date(
+        '2024-03-20T09:42:58Z',
+      );
+      const imitationWithDifferentDecimalsToken = tokenBuilder()
+        .with('type', TokenType.Erc20)
+        .with('decimals', differentDecimals)
+        .build();
+
+      const imitationWithDifferentDecimalsIncomingTransfer = {
+        ...erc20TransferBuilder()
+          .with('from', imitationWithDifferentDecimalsAddress)
+          .with('to', safe.address)
+          .with('tokenAddress', imitationWithDifferentDecimalsToken.address)
+          .with('value', differentValue)
+          .with('executionDate', imitationWithDifferentDecimalsExecutionDate)
+          .build(),
+        // TODO: Update type to include tokenInfo - only on all-transactions endpoint
+        tokenInfo: imitationWithDifferentDecimalsToken,
+      };
+      const imitationWithDifferentDecimalsIncomingErc20Transfer =
+        erc20TransferEncoder()
+          .with('to', safe.address)
+          .with('value', BigInt(differentValue));
+      const imitationWithDifferentDecimalsIncomingTransaction =
+        ethereumTransactionToJson(
+          ethereumTransactionBuilder()
+            .with(
+              'executionDate',
+              imitationWithDifferentDecimalsIncomingTransfer.executionDate,
+            )
+            .with(
+              'data',
+              imitationWithDifferentDecimalsIncomingErc20Transfer.encode(),
+            )
+            .with('transfers', [
+              erc20TransferToJson(
+                imitationWithDifferentDecimalsIncomingTransfer,
+              ) as Transfer,
+            ])
+            .build(),
+        ) as EthereumTransaction;
+
+      const results = [
+        imitationWithDifferentDecimalsIncomingTransaction,
+        multisigTransaction,
+      ];
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+          return Promise.resolve({ data: chain, status: 200 });
+        }
+        if (url === getAllTransactionsUrl) {
+          return Promise.resolve({
+            data: pageBuilder().with('results', results).build(),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({ data: safe, status: 200 });
+        }
+        if (url === getTokenAddressUrl) {
+          return Promise.resolve({
+            data: multisigToken,
+            status: 200,
+          });
+        }
+        if (
+          url ===
+          `${chain.transactionService}/api/v1/tokens/${imitationWithDifferentDecimalsToken.address}`
+        ) {
+          return Promise.resolve({
+            data: imitationWithDifferentDecimalsToken,
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/history?trusted=false`,
+        )
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.results).toStrictEqual([
+            {
+              timestamp: 1710927778000,
+              type: 'DATE_LABEL',
+            },
+            {
+              conflictType: 'None',
+              transaction: {
+                executionInfo: null,
+                // @ts-expect-error - Type does not contain transfers
+                id: `transfer_${safe.address}_${results[0].transfers[0].transferId}`,
+                safeAppInfo: null,
+                timestamp: 1710927778000,
+                txInfo: {
+                  direction: 'INCOMING',
+                  humanDescription: null,
+                  recipient: {
+                    logoUri: null,
+                    name: null,
+                    value: safe.address,
+                  },
+                  richDecodedInfo: null,
+                  sender: {
+                    logoUri: null,
+                    name: null,
+                    value: imitationWithDifferentDecimalsAddress,
+                  },
+                  transferInfo: {
+                    decimals: imitationWithDifferentDecimalsToken.decimals,
+                    imitation: true,
+                    logoUri: imitationWithDifferentDecimalsToken.logoUri,
+                    tokenAddress: imitationWithDifferentDecimalsToken.address,
+                    tokenName: imitationWithDifferentDecimalsToken.name,
+                    tokenSymbol: imitationWithDifferentDecimalsToken.symbol,
+                    trusted: imitationWithDifferentDecimalsToken.trusted,
+                    type: 'ERC20',
+                    value: imitationWithDifferentDecimalsIncomingTransfer.value,
+                  },
+                  type: 'Transfer',
+                },
+                txStatus: 'SUCCESS',
+                txHash:
+                  imitationWithDifferentDecimalsIncomingTransaction
+                    .transfers![0].transactionHash,
+              },
+              type: 'TRANSACTION',
+            },
+            {
+              conflictType: 'None',
+              transaction: {
+                executionInfo: {
+                  confirmationsRequired: 1,
+                  confirmationsSubmitted: 1,
+                  missingSigners: null,
+                  nonce: multisigTransaction.nonce,
+                  type: 'MULTISIG',
+                },
+                id: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+                safeAppInfo: null,
+                timestamp: 1710927685000,
+                txInfo: {
+                  direction: 'OUTGOING',
+                  humanDescription: null,
+                  recipient: {
+                    logoUri: null,
+                    name: null,
+                    value: multisigTransfer.to,
+                  },
+                  richDecodedInfo: null,
+                  sender: {
+                    logoUri: null,
+                    name: null,
+                    value: safe.address,
+                  },
+                  transferInfo: {
+                    decimals: multisigToken.decimals,
+                    imitation: false,
+                    logoUri: multisigToken.logoUri,
+                    tokenAddress: multisigToken.address,
+                    tokenName: multisigToken.name,
+                    tokenSymbol: multisigToken.symbol,
+                    trusted: null,
+                    type: 'ERC20',
+                    value: multisigTransfer.value,
+                  },
+                  type: 'Transfer',
+                },
+                txStatus: 'SUCCESS',
+                txHash: multisigTransaction.transactionHash,
+              },
+              type: 'TRANSACTION',
+            },
+          ]);
+        });
+    });
+
+    it.todo('Incoming transfer "echo"');
   });
 });


### PR DESCRIPTION
## Summary

Resolves #2023

We flag imitation transactions (spoof events) based on certain criteria, of which a matching value being one of them. This comparison is becoming redundant as the values are beginning to vary compared to the transaction being imitated.

This adjusts the current check, adding a new tolerance. A transaction is now marked as an imitation if the value is +/- value + tolerance of the transaction being imitated. 

## Changes

- Add new tolerance env. var. with default value.
- Include tolerance in value check for flagging spoof events.
- Add/update tests accordingly.