### PR TITLE
Fix DB initialization on E2E tests

### DIFF
--- a/src/routes/about/__tests__/get-about.e2e-spec.ts
+++ b/src/routes/about/__tests__/get-about.e2e-spec.ts
@@ -1,8 +1,6 @@
 import '@/__tests__/matchers/to-be-string-or-null';
 import { AppModule } from '@/app.module';
 import { CacheKeyPrefix } from '@/datasources/cache/constants';
-import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
-import { PostgresDatabaseModule } from '@/datasources/db/postgres-database.module';
 import { expect } from '@jest/globals';
 import type { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
@@ -17,8 +15,6 @@ describe('Get about e2e test', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.register()],
     })
-      .overrideModule(PostgresDatabaseModule)
-      .useModule(TestPostgresDatabaseModule)
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
       .compile();

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -16,6 +16,8 @@ process.env.POSTGRES_PORT = '5433';
 process.env.POSTGRES_DB = 'test-db';
 process.env.POSTGRES_USER = 'postgres';
 process.env.POSTGRES_PASSWORD = 'postgres';
+process.env.POSTGRES_SSL_ENABLED = 'true';
+process.env.POSTGRES_SSL_CA_PATH = 'db_config/test/server.crt';
 
 // For E2E tests, connect to the test cache
 process.env.REDIS_HOST = '127.0.0.1';


### PR DESCRIPTION
## Summary
This PR adds the SSL certificate path to the e2e tests. Otherwise, these tests would fail as they don't mock the database. As `PostgresDatabaseModule` is now part of the `AppModule`, the actual Postgres container needs to be available on the e2e test execution context.

## Changes
- Adds `POSTGRES_SSL_ENABLED` and `POSTGRES_SSL_CA_PATH` to the `e2e-setup.ts` configuration.
