### PR TITLE
Remove redundant date parsing in TargetedMessagingDatasource

### DIFF
--- a/src/datasources/targeted-messaging/entities/submission.entity.ts
+++ b/src/datasources/targeted-messaging/entities/submission.entity.ts
@@ -2,17 +2,17 @@ export class Submission {
   id: number;
   targeted_safe_id: number;
   signer_address: `0x${string}`;
-  completion_date: string;
-  created_at: string;
-  updated_at: string;
+  completion_date: Date;
+  created_at: Date;
+  updated_at: Date;
 
   constructor(
     id: number,
     targeted_safe_id: number,
     signer_address: `0x${string}`,
-    completion_date: string,
-    created_at: string,
-    updated_at: string,
+    completion_date: Date,
+    created_at: Date,
+    updated_at: Date,
   ) {
     this.id = id;
     this.targeted_safe_id = targeted_safe_id;

--- a/src/datasources/targeted-messaging/entities/targeted-safe.entity.ts
+++ b/src/datasources/targeted-messaging/entities/targeted-safe.entity.ts
@@ -2,15 +2,15 @@ export class TargetedSafe {
   id: number;
   address: `0x${string}`;
   outreach_id: number;
-  created_at: string;
-  updated_at: string;
+  created_at: Date;
+  updated_at: Date;
 
   constructor(
     id: number,
     address: `0x${string}`,
     outreach_id: number,
-    created_at: string,
-    updated_at: string,
+    created_at: Date,
+    updated_at: Date,
   ) {
     this.id = id;
     this.address = address;

--- a/src/datasources/targeted-messaging/targeted-messaging.datasource.ts
+++ b/src/datasources/targeted-messaging/targeted-messaging.datasource.ts
@@ -74,10 +74,12 @@ export class TargetedMessagingDatasource
       type: outreach.type,
       teamName: outreach.team_name,
       sourceFile: outreach.source_file,
-      sourceFileProcessedDate: outreach.source_file_processed_date,
+      sourceFileProcessedDate: outreach.source_file_processed_date
+        ? this.parseDate(outreach.source_file_processed_date)
+        : null,
       sourceFileChecksum: outreach.source_file_checksum,
-      created_at: outreach.created_at,
-      updated_at: outreach.updated_at,
+      created_at: this.parseDate(outreach.created_at),
+      updated_at: this.parseDate(outreach.updated_at),
     };
   }
 
@@ -108,8 +110,8 @@ export class TargetedMessagingDatasource
         id: targetedSafe.id,
         outreachId: targetedSafe.outreach_id,
         address: targetedSafe.address,
-        created_at: new Date(targetedSafe.created_at),
-        updated_at: new Date(targetedSafe.updated_at),
+        created_at: this.parseDate(targetedSafe.created_at),
+        updated_at: this.parseDate(targetedSafe.updated_at),
       }));
     });
 
@@ -142,8 +144,8 @@ export class TargetedMessagingDatasource
       id: targetedSafe.id,
       address: targetedSafe.address,
       outreachId: targetedSafe.outreach_id,
-      created_at: new Date(targetedSafe.created_at),
-      updated_at: new Date(targetedSafe.updated_at),
+      created_at: this.parseDate(targetedSafe.created_at),
+      updated_at: this.parseDate(targetedSafe.updated_at),
     };
   }
 
@@ -169,9 +171,9 @@ export class TargetedMessagingDatasource
       outreachId: args.targetedSafe.outreachId,
       targetedSafeId: submission.targeted_safe_id,
       signerAddress: submission.signer_address,
-      completionDate: new Date(submission.completion_date),
-      created_at: new Date(submission.created_at),
-      updated_at: new Date(submission.updated_at),
+      completionDate: this.parseDate(submission.completion_date),
+      created_at: this.parseDate(submission.created_at),
+      updated_at: this.parseDate(submission.updated_at),
     };
   }
 
@@ -200,9 +202,13 @@ export class TargetedMessagingDatasource
       outreachId: args.targetedSafe.outreachId,
       targetedSafeId: args.targetedSafe.id,
       signerAddress: args.signerAddress,
-      completionDate: new Date(submission.completion_date),
-      created_at: new Date(submission.created_at),
-      updated_at: new Date(submission.updated_at),
+      completionDate: this.parseDate(submission.completion_date),
+      created_at: this.parseDate(submission.created_at),
+      updated_at: this.parseDate(submission.updated_at),
     };
+  }
+
+  private parseDate(date: Date | string): Date {
+    return date instanceof Date ? date : new Date(date);
   }
 }


### PR DESCRIPTION
## Summary
This PR addresses the conversation in https://github.com/safe-global/safe-client-gateway/pull/2010#discussion_r1802848525

## Changes
- Avoids redundant `Date` conversion on the mapping of the database entities to the domain entities in `TargetedMessagindDatasource`.
