### PR TITLE
Remove `beaconChainExplorerUriTemplate` and `contractAddresses` defaults

### DIFF
--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -619,8 +619,8 @@ describe('Chain schemas', () => {
       ['safeAppsRpcUri' as const],
       ['publicRpcUri' as const],
       ['blockExplorerUriTemplate' as const],
-      // TODO: Include after `beaconChainExplorerUriTemplate` field is deployed on Config Service
-      // ['beaconChainExplorerUriTemplate' as const],
+      ['beaconChainExplorerUriTemplate' as const],
+      ['contractAddresses' as const],
       ['nativeCurrency' as const],
       ['pricesProvider' as const],
       ['balancesProvider' as const],

--- a/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/domain/chains/entities/schemas/__tests__/chain.schema.spec.ts
@@ -168,21 +168,6 @@ describe('Chain schemas', () => {
 
       expect(result.success && result.data.publicKey).toBe(null);
     });
-
-    // TODO: Remove after `beaconChainExplorerUriTemplate` field is deployed on Config Service
-    it('should default beaconChainExplorerUriTemplate to have null publicKey', () => {
-      const chain = chainBuilder().build();
-      // @ts-expect-error - inferred types don't allow optional fields
-      delete chain.beaconChainExplorerUriTemplate;
-
-      const result = ChainSchema.safeParse(chain);
-
-      expect(
-        result.success && result.data.beaconChainExplorerUriTemplate,
-      ).toStrictEqual({
-        publicKey: null,
-      });
-    });
   });
 
   describe('ThemeSchema', () => {
@@ -553,47 +538,6 @@ describe('Chain schemas', () => {
         const result = ContractAddressesSchema.safeParse(contractAddresses);
 
         expect(result.success && result.data[field]).toBe(null);
-      });
-    });
-
-    // TODO: Remove after deployed and all chain caches include the `contractAddresses` field
-    describe('should default all contract addresses to null if the chain cache does not contain contractAddresses', () => {
-      it('on a ContractAddresses level', () => {
-        const contractAddresses = undefined;
-
-        const result = ContractAddressesSchema.safeParse(contractAddresses);
-
-        expect(result.success && result.data).toStrictEqual({
-          safeSingletonAddress: null,
-          safeProxyFactoryAddress: null,
-          multiSendAddress: null,
-          multiSendCallOnlyAddress: null,
-          fallbackHandlerAddress: null,
-          signMessageLibAddress: null,
-          createCallAddress: null,
-          simulateTxAccessorAddress: null,
-          safeWebAuthnSignerFactoryAddress: null,
-        });
-      });
-
-      it('on a Chain level', () => {
-        const chain = chainBuilder().build();
-        // @ts-expect-error - pre-inclusion of `contractAddresses` field
-        delete chain.contractAddresses;
-
-        const result = ChainSchema.safeParse(chain);
-
-        expect(result.success && result.data.contractAddresses).toStrictEqual({
-          safeSingletonAddress: null,
-          safeProxyFactoryAddress: null,
-          multiSendAddress: null,
-          multiSendCallOnlyAddress: null,
-          fallbackHandlerAddress: null,
-          signMessageLibAddress: null,
-          createCallAddress: null,
-          simulateTxAccessorAddress: null,
-          safeWebAuthnSignerFactoryAddress: null,
-        });
       });
     });
   });

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -23,14 +23,9 @@ export const BlockExplorerUriTemplateSchema = z.object({
   api: z.string(),
 });
 
-export const BeaconChainExplorerUriTemplateSchema = z
-  .object({
-    publicKey: z.string().nullish().default(null),
-  })
-  // TODO: Remove after `beaconChainExplorerUriTemplate` field is deployed on Config Service
-  .catch({
-    publicKey: null,
-  });
+export const BeaconChainExplorerUriTemplateSchema = z.object({
+  publicKey: z.string().nullish().default(null),
+});
 
 export const ThemeSchema = z.object({
   textColor: z.string(),
@@ -73,30 +68,17 @@ export const BalancesProviderSchema = z.object({
   enabled: z.boolean(),
 });
 
-export const ContractAddressesSchema = z
-  .object({
-    safeSingletonAddress: AddressSchema.nullish().default(null),
-    safeProxyFactoryAddress: AddressSchema.nullish().default(null),
-    multiSendAddress: AddressSchema.nullish().default(null),
-    multiSendCallOnlyAddress: AddressSchema.nullish().default(null),
-    fallbackHandlerAddress: AddressSchema.nullish().default(null),
-    signMessageLibAddress: AddressSchema.nullish().default(null),
-    createCallAddress: AddressSchema.nullish().default(null),
-    simulateTxAccessorAddress: AddressSchema.nullish().default(null),
-    safeWebAuthnSignerFactoryAddress: AddressSchema.nullish().default(null),
-  })
-  // TODO: Remove catch after deployed and all chain caches include the `contractAddresses` field
-  .catch({
-    safeSingletonAddress: null,
-    safeProxyFactoryAddress: null,
-    multiSendAddress: null,
-    multiSendCallOnlyAddress: null,
-    fallbackHandlerAddress: null,
-    signMessageLibAddress: null,
-    createCallAddress: null,
-    simulateTxAccessorAddress: null,
-    safeWebAuthnSignerFactoryAddress: null,
-  });
+export const ContractAddressesSchema = z.object({
+  safeSingletonAddress: AddressSchema.nullish().default(null),
+  safeProxyFactoryAddress: AddressSchema.nullish().default(null),
+  multiSendAddress: AddressSchema.nullish().default(null),
+  multiSendCallOnlyAddress: AddressSchema.nullish().default(null),
+  fallbackHandlerAddress: AddressSchema.nullish().default(null),
+  signMessageLibAddress: AddressSchema.nullish().default(null),
+  createCallAddress: AddressSchema.nullish().default(null),
+  simulateTxAccessorAddress: AddressSchema.nullish().default(null),
+  safeWebAuthnSignerFactoryAddress: AddressSchema.nullish().default(null),
+});
 
 function removeTrailingSlash(url: string): string {
   return url.replace(/\/$/, '');


### PR DESCRIPTION
## Summary

New properties of the Config Service may only be present on staging and, as we don't always release it alongside the Client Gateway, we often add fallback values.

This removes two such instances for `Chain['beaconChainExplorerUriTemplate']` and `Chain['contractAddresses']` as they are both now live on prod.

## Changes

- Remove default value for `Chain['beaconChainExplorerUriTemplate']`
- Remove default value for `Chain['contractAddresses']`
- Update tests accordingly