### PR TITLE
Remove `skip` on otherwise working creation test

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -97,8 +97,7 @@ describe('Get creation transaction', () => {
       });
   });
 
-  // TODO: Review why the response status code is 503 instead of 404
-  it.skip('should forward Transaction Service errors', async () => {
+  it('should forward Transaction Service errors', async () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;


### PR DESCRIPTION
## Summary

A `/creation`-focused test is skipped for review. However, it works as expected.

This removes the TODO comment and "unskips" the test.

## Changes

- "Unskip" working test, removing TODO