### PR TITLE
Add job to build SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,14 @@ jobs:
           AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
           AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
           TARGET_ENV: 'staging'
+
+  sdk:
+    runs-on: ubuntu-latest
+    needs: [autodeploy]
+    steps:
+      - run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GH_ACCESS_TOKEN_CGW_SDK }}" \
+            https://api.github.com/repos/safe-global/safe-client-gateway-sdk/dispatches \
+            -d '{"event_type":"Dispatched by safe-client-gateway"}'


### PR DESCRIPTION
## Summary

It is possible to dispatch events, triggering workflows in other repos. This adds a new `autodeploy`-dependant job to the CI, triggering the workflow responsible for building/releasing the SDK.

## Changes

- Add new `sdk` CI job, triggering SDK repo. workflow