### PR TITLE
Put address poisoning detection improvements behind a feature flag

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -152,6 +152,7 @@ export default (): ReturnType<typeof configuration> => ({
     nativeStaking: false,
     nativeStakingDecoding: false,
     targetedMessaging: false,
+    improvedAddressPoisoning: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -235,6 +235,8 @@ export default () => ({
       process.env.FF_NATIVE_STAKING_DECODING?.toLowerCase() === 'true',
     targetedMessaging:
       process.env.FF_TARGETED_MESSAGING?.toLowerCase() === 'true',
+    improvedAddressPoisoning:
+      process.env.FF_IMPROVED_ADDRESS_POISONING?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/transactions/mappers/transfers/transfer-imitation.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-imitation.mapper.ts
@@ -161,7 +161,7 @@ export class TransferImitationMapper {
       ? // Value can differ by +/- tolerance
         value <= prevValue + this.valueTolerance &&
         value >= prevValue - this.valueTolerance
-      : // Value must differ
+      : // Value must be equal
         value === prevValue;
     if (!isSpoofedValue) {
       return false;

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -81,6 +81,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
       features: {
         ...configuration().features,
         imitationMapping: true,
+        improvedAddressPoisoning: true,
       },
     });
 


### PR DESCRIPTION
## Summary

This puts the new address poisoning detection (value threshold/marking of "echo" transaction" behind a feature flag: `FF_IMPROVED_ADDRESS_POISONING`.

## Changes

- Add new `features.improvedAddressPoisoning` configuration
- If set, only filter spoofed events of same value