### PR TITLE
Mark the `Delegate` `results` as array

### DIFF
--- a/src/routes/delegates/entities/delegate.page.entity.ts
+++ b/src/routes/delegates/entities/delegate.page.entity.ts
@@ -3,6 +3,6 @@ import { Page } from '@/routes/common/entities/page.entity';
 import { Delegate } from '@/routes/delegates/entities/delegate.entity';
 
 export class DelegatePage extends Page<Delegate> {
-  @ApiProperty({ type: Delegate })
+  @ApiProperty({ type: Delegate, isArray: true })
   results!: Delegate[];
 }


### PR DESCRIPTION
## Summary

All `results` of a `Page` in the project are an array of entities. The `DelegatePage` correctly extends the interface responsible for this but does not mark the `results` array as one.

This adds the `isArray` flag to the `ApiProperty` of the respective Swagger decorator.

## Changes

- Add `isArray` flag to `ApiProperty` decorator of `DelegatePage['results`]