### PR TITLE
Catch unhandled TargetedMessagingDatasource errors

### DIFF
--- a/src/datasources/targeted-messaging/outreach-file-processor.ts
+++ b/src/datasources/targeted-messaging/outreach-file-processor.ts
@@ -53,6 +53,10 @@ export class OutreachFileProcessor implements OnModuleInit, OnModuleDestroy {
         await this.cacheService.hSet(lockCacheDir, 'true', MAX_TTL);
         await this.processOutreachFiles();
       }
+    } catch (err) {
+      this.loggingService.error(
+        `Error processing outreach files: ${asError(err).message}`,
+      );
     } finally {
       await this.cacheService.deleteByKey(
         CacheRouter.getOutreachFileProcessorCacheKey(),

--- a/src/datasources/targeted-messaging/targeted-messaging.datasource.ts
+++ b/src/datasources/targeted-messaging/targeted-messaging.datasource.ts
@@ -99,7 +99,16 @@ export class TargetedMessagingDatasource
   async getUnprocessedOutreaches(): Promise<Outreach[]> {
     const dbOutreaches = await this.sql<
       DbOutreach[]
-    >`SELECT * FROM outreaches WHERE source_file_processed_date IS NULL`;
+    >`SELECT * FROM outreaches WHERE source_file_processed_date IS NULL`.catch(
+      (err) => {
+        this.loggingService.warn(
+          `Error getting unprocessed outreaches: ${asError(err).message}`,
+        );
+        throw new UnprocessableEntityException(
+          'Error getting unprocessed outreaches',
+        );
+      },
+    );
 
     return dbOutreaches.map((dbOutreach) =>
       this.outreachDbMapper.map(dbOutreach),


### PR DESCRIPTION
## Changes
- Adds a `catch` block to the `TargetedMessagingDatasource.getUnprocessedOutreaches` to manage db errors.
