### PR TITLE
Fix `Page` Swagger definitions

### DIFF
--- a/src/routes/collectibles/entities/collectible.page.entity.ts
+++ b/src/routes/collectibles/entities/collectible.page.entity.ts
@@ -3,6 +3,6 @@ import { Collectible } from '@/routes/collectibles/entities/collectible.entity';
 import { Page } from '@/routes/common/entities/page.entity';
 
 export class CollectiblePage extends Page<Collectible> {
-  @ApiProperty({ type: Collectible })
+  @ApiProperty({ type: Collectible, isArray: true })
   results!: Collectible[];
 }

--- a/src/routes/community/entities/campaign-rank.page.entity.ts
+++ b/src/routes/community/entities/campaign-rank.page.entity.ts
@@ -3,6 +3,6 @@ import { CampaignRank } from '@/routes/community/entities/campaign-rank.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CampaignRankPage extends Page<CampaignRank> {
-  @ApiProperty({ type: CampaignRank })
+  @ApiProperty({ type: CampaignRank, isArray: true })
   results!: Array<CampaignRank>;
 }

--- a/src/routes/community/entities/locking-rank.page.entity.ts
+++ b/src/routes/community/entities/locking-rank.page.entity.ts
@@ -3,6 +3,6 @@ import { Page } from '@/routes/common/entities/page.entity';
 import { LockingRank } from '@/routes/community/entities/locking-rank.entity';
 
 export class LockingRankPage extends Page<LockingRank> {
-  @ApiProperty({ type: LockingRank })
+  @ApiProperty({ type: LockingRank, isArray: true })
   results!: Array<LockingRank>;
 }

--- a/src/routes/transactions/entities/incoming-transfer-page.entity.ts
+++ b/src/routes/transactions/entities/incoming-transfer-page.entity.ts
@@ -3,6 +3,6 @@ import { Page } from '@/routes/common/entities/page.entity';
 import { IncomingTransfer } from '@/routes/transactions/entities/incoming-transfer.entity';
 
 export class IncomingTransferPage extends Page<IncomingTransfer> {
-  @ApiProperty({ type: IncomingTransfer })
+  @ApiProperty({ type: IncomingTransfer, isArray: true })
   results!: IncomingTransfer[];
 }

--- a/src/routes/transactions/entities/module-transaction-page.entity.ts
+++ b/src/routes/transactions/entities/module-transaction-page.entity.ts
@@ -3,6 +3,6 @@ import { Page } from '@/routes/common/entities/page.entity';
 import { ModuleTransaction } from '@/routes/transactions/entities/module-transaction.entity';
 
 export class ModuleTransactionPage extends Page<ModuleTransaction> {
-  @ApiProperty({ type: ModuleTransaction })
+  @ApiProperty({ type: ModuleTransaction, isArray: true })
   results!: ModuleTransaction[];
 }

--- a/src/routes/transactions/entities/multisig-transaction-page.entity.ts
+++ b/src/routes/transactions/entities/multisig-transaction-page.entity.ts
@@ -3,6 +3,6 @@ import { Page } from '@/routes/common/entities/page.entity';
 import { MultisigTransaction } from '@/routes/transactions/entities/multisig-transaction.entity';
 
 export class MultisigTransactionPage extends Page<MultisigTransaction> {
-  @ApiProperty({ type: MultisigTransaction })
+  @ApiProperty({ type: MultisigTransaction, isArray: true })
   results!: MultisigTransaction[];
 }


### PR DESCRIPTION
## Summary

`Page<T>['results']` are is an `Array<T>`. Many of the `ApiProperty` Swagger definitions, however, are missing the respective `isArray` flag.

This updates incorrect entities accordingly.

## Changes

- Add `isArray` flag to:
  - `CollectiblePage`
  - `CampaignRankPage`
  - `LockingRankPage`
  - `IncomingTransferPage`
  - `ModuleTransactionPage`
  - `MultisigTransactionPage`