### PR TITLE
Remove TargetedMessaging file processor unlocking at shutdown

### DIFF
--- a/src/datasources/targeted-messaging/outreach-file-processor.ts
+++ b/src/datasources/targeted-messaging/outreach-file-processor.ts
@@ -12,18 +12,13 @@ import { ITargetedMessagingDatasource } from '@/domain/interfaces/targeted-messa
 import { Outreach } from '@/domain/targeted-messaging/entities/outreach.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
-import {
-  Inject,
-  Injectable,
-  OnModuleDestroy,
-  type OnModuleInit,
-} from '@nestjs/common';
+import { Inject, Injectable, type OnModuleInit } from '@nestjs/common';
 import { createHash } from 'crypto';
 import { readFile } from 'fs/promises';
 import path from 'path';
 
 @Injectable()
-export class OutreachFileProcessor implements OnModuleInit, OnModuleDestroy {
+export class OutreachFileProcessor implements OnModuleInit {
   private readonly storageType: FileStorageType;
   private readonly localBaseDir: string;
 
@@ -58,12 +53,6 @@ export class OutreachFileProcessor implements OnModuleInit, OnModuleDestroy {
         CacheRouter.getOutreachFileProcessorCacheKey(),
       );
     }
-  }
-
-  async onModuleDestroy(): Promise<void> {
-    await this.cacheService.deleteByKey(
-      CacheRouter.getOutreachFileProcessorCacheKey(),
-    );
   }
 
   private async processOutreachFiles(): Promise<void> {


### PR DESCRIPTION
## Summary
This PR removes the `cacheService.deleteByKey` call to remove the lock at the application shutdown. This was introduced to ensure the lock gets released, but when `onModuleDestroy` is executed, the `redis` connection is unavailable, causing an error during the shutdown process.

Also, given the lock gets released on `onModuleInit`, this shouldn't be a problem since new service instances would release the lock during the startup phase.

## Changes
- Prevents the lock cache key from being deleted in `onModuleDestroy`.
