### PR TITLE
Make `CreationTransaction['saltNonce']` nullable

### DIFF
--- a/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
@@ -48,6 +48,7 @@ describe('CreationTransactionSchema', () => {
     'masterCopy' as const,
     'setupData' as const,
     'dataDecoded' as const,
+    'saltNonce' as const,
   ])('should allow an optional %s', (field) => {
     const creationTransaction = creationTransactionBuilder().build();
     delete creationTransaction[field];
@@ -101,7 +102,6 @@ describe('CreationTransactionSchema', () => {
     'creator' as const,
     'transactionHash' as const,
     'factoryAddress' as const,
-    'saltNonce' as const,
   ])('should not allow an undefined %s', (field) => {
     const creationTransaction = creationTransactionBuilder().build();
     delete creationTransaction[field];

--- a/src/domain/safe/entities/schemas/creation-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/creation-transaction.schema.ts
@@ -10,6 +10,6 @@ export const CreationTransactionSchema = z.object({
   factoryAddress: AddressSchema,
   masterCopy: AddressSchema.nullish().default(null),
   setupData: HexSchema.nullish().default(null),
-  saltNonce: z.string(),
+  saltNonce: z.string().nullish().default(null),
   dataDecoded: DataDecodedSchema.nullish().default(null),
 });


### PR DESCRIPTION
## Summary

The `saltNonce` of a Safe creation may not be decodable, or not deployed with one. This means that the value returned by the Transaction Service can be `null`.

This changes the validation from expecting a string to also accept `null`.

## Changes

- Allow `null` as a value for `saltNonce`