### PR TITLE
Add `origin` to `Messages`

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -26,6 +26,7 @@ import { DeviceType } from '@/domain/notifications/v1/entities/device.entity';
 import { getAddress } from 'viem';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { indexingStatusBuilder } from '@/domain/chains/entities/__tests__/indexing-status.builder';
+import { fakeJson } from '@/__tests__/faker';
 
 const dataSource = {
   get: jest.fn(),
@@ -3491,6 +3492,7 @@ describe('TransactionApi', () => {
       const message = faker.word.words();
       const safeAppId = faker.number.int();
       const signature = faker.string.hexadecimal();
+      const origin = fakeJson();
       const postMessageUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
@@ -3502,6 +3504,7 @@ describe('TransactionApi', () => {
         message,
         safeAppId,
         signature,
+        origin,
       });
 
       expect(networkService.post).toHaveBeenCalledTimes(1);
@@ -3511,6 +3514,7 @@ describe('TransactionApi', () => {
           message,
           safeAppId,
           signature,
+          origin,
         },
       });
     });
@@ -3524,6 +3528,7 @@ describe('TransactionApi', () => {
       const message = faker.word.words();
       const safeAppId = faker.number.int();
       const signature = faker.string.hexadecimal();
+      const origin = fakeJson();
       const postMessageUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
@@ -3545,6 +3550,7 @@ describe('TransactionApi', () => {
           message,
           safeAppId,
           signature,
+          origin,
         }),
       ).rejects.toThrow(expected);
 
@@ -3555,6 +3561,7 @@ describe('TransactionApi', () => {
           message,
           safeAppId,
           signature,
+          origin,
         },
       });
     });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -1097,6 +1097,7 @@ export class TransactionApi implements ITransactionApi {
     message: unknown;
     safeAppId: number | null;
     signature: string;
+    origin: string | null;
   }): Promise<Message> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/messages/`;
@@ -1106,6 +1107,7 @@ export class TransactionApi implements ITransactionApi {
           message: args.message,
           safeAppId: args.safeAppId,
           signature: args.signature,
+          origin: args.origin,
         },
       });
       return data;

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -226,6 +226,7 @@ export interface ITransactionApi {
     message: unknown;
     safeAppId: number | null;
     signature: string;
+    origin: string | null;
   }): Promise<Message>;
 
   postMessageSignature(args: {

--- a/src/domain/messages/entities/__tests__/message.builder.ts
+++ b/src/domain/messages/entities/__tests__/message.builder.ts
@@ -7,6 +7,7 @@ import {
   toJson as messageConfirmationToJson,
 } from '@/domain/messages/entities/__tests__/message-confirmation.builder';
 import { getAddress } from 'viem';
+import { fakeJson } from '@/__tests__/faker';
 
 export function messageBuilder(): IBuilder<Message> {
   return new Builder<Message>()
@@ -29,7 +30,8 @@ export function messageBuilder(): IBuilder<Message> {
     .with(
       'preparedSignature',
       faker.string.hexadecimal({ length: 32 }) as `0x${string}`,
-    );
+    )
+    .with('origin', fakeJson());
 }
 
 export function toJson(message: Message): unknown {

--- a/src/domain/messages/entities/__tests__/message.entity.spec.ts
+++ b/src/domain/messages/entities/__tests__/message.entity.spec.ts
@@ -1,0 +1,205 @@
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { fakeJson } from '@/__tests__/faker';
+import { messageBuilder } from '@/domain/messages/entities/__tests__/message.builder';
+import { MessageSchema } from '@/domain/messages/entities/message.entity';
+import type { Message } from '@/domain/messages/entities/message.entity';
+import { ZodError } from 'zod';
+
+describe('MessageSchema', () => {
+  it('should validate a Message', () => {
+    const message = messageBuilder().build();
+
+    const result = MessageSchema.safeParse(message);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    'created' as const,
+    'modified' as const,
+    'safe' as const,
+    'messageHash' as const,
+    'message' as const,
+    'proposedBy' as const,
+    'confirmations' as const,
+  ])('should fail when %s is missing', (key) => {
+    const message = messageBuilder().build();
+    delete message[key];
+
+    const result = MessageSchema.safeParse(message);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0].path).toStrictEqual([key]);
+  });
+
+  it.each(['created' as const, 'modified' as const])(
+    'should coerce %s to a Date',
+    (key) => {
+      const date = faker.date.recent();
+      const message = messageBuilder()
+        .with(key, date.toString() as unknown as Date)
+        .build();
+
+      const result = MessageSchema.safeParse(message);
+
+      // Zod coerces the date to the nearest millisecond
+      date.setMilliseconds(0);
+      expect(result.success && result.data[key]).toStrictEqual(date);
+    },
+  );
+
+  it.each(['safe' as const, 'proposedBy' as const])(
+    'should checksum the %s address',
+    (key) => {
+      const nonChecksummedAddress = faker.finance.ethereumAddress().toString();
+      const message = messageBuilder()
+        .with(key, nonChecksummedAddress as `0x${string}`)
+        .build();
+
+      const result = MessageSchema.safeParse(message);
+
+      expect(result.success && result.data[key]).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    },
+  );
+
+  it.each(['messageHash' as const, 'preparedSignature' as const])(
+    'should not allow a non-hex messageHash',
+    (key) => {
+      const message = messageBuilder()
+        .with(key, faker.string.alphanumeric() as `0x${string}`)
+        .build();
+
+      const result = MessageSchema.safeParse(message);
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0]).toStrictEqual({
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: [key],
+      });
+    },
+  );
+
+  it.each([
+    ['string', faker.string.alphanumeric()],
+    ['record', JSON.parse(fakeJson())],
+  ])('should accept a %s message', (_, message) => {
+    const result = MessageSchema.safeParse(
+      messageBuilder()
+        .with('message', message as Message['message'])
+        .build(),
+    );
+
+    expect(result.success && result.data.message).toStrictEqual(message);
+  });
+
+  it.each([
+    'safeAppId' as const,
+    'preparedSignature' as const,
+    'origin' as const,
+  ])('should default %s to null', (key) => {
+    const message = messageBuilder().build();
+    delete message[key];
+
+    const result = MessageSchema.safeParse(message);
+
+    expect(result.success && result.data[key]).toBe(null);
+  });
+
+  it('should not allow a non-array confirmations', () => {
+    const message = messageBuilder()
+      .with(
+        'confirmations',
+        faker.string.numeric() as unknown as Message['confirmations'],
+      )
+      .build();
+
+    const result = MessageSchema.safeParse(message);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'invalid_type',
+      expected: 'array',
+      message: 'Expected array, received string',
+      path: ['confirmations'],
+      received: 'string',
+    });
+  });
+
+  it('should not validate an invalid Message', () => {
+    const message = {
+      invalid: 'message',
+    };
+
+    const result = MessageSchema.safeParse(message);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_date',
+        message: 'Invalid date',
+        path: ['created'],
+      },
+      {
+        code: 'invalid_date',
+        message: 'Invalid date',
+        path: ['modified'],
+      },
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['safe'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['messageHash'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_union',
+        message: 'Invalid input',
+        path: ['message'],
+        unionErrors: [
+          new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              received: 'undefined',
+              path: ['message'],
+              message: 'Required',
+            },
+          ]),
+          new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'object',
+              received: 'undefined',
+              path: ['message'],
+              message: 'Required',
+            },
+          ]),
+        ],
+      },
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['proposedBy'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'array',
+        message: 'Required',
+        path: ['confirmations'],
+        received: 'undefined',
+      },
+    ]);
+  });
+});

--- a/src/domain/messages/entities/message.entity.ts
+++ b/src/domain/messages/entities/message.entity.ts
@@ -16,6 +16,7 @@ export const MessageSchema = z.object({
   safeAppId: z.number().nullish().default(null),
   confirmations: z.array(MessageConfirmationSchema),
   preparedSignature: HexSchema.nullish().default(null),
+  origin: z.string().nullish().default(null),
 });
 
 export const MessagePageSchema = buildPageSchema(MessageSchema);

--- a/src/domain/messages/messages.repository.interface.ts
+++ b/src/domain/messages/messages.repository.interface.ts
@@ -25,6 +25,7 @@ export interface IMessagesRepository {
     message: unknown;
     safeAppId: number;
     signature: string;
+    origin: string | null;
   }): Promise<unknown>;
 
   updateMessageSignature(args: {

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -50,6 +50,7 @@ export class MessagesRepository implements IMessagesRepository {
     message: unknown;
     safeAppId: number | null;
     signature: string;
+    origin: string | null;
   }): Promise<unknown> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
@@ -60,6 +61,7 @@ export class MessagesRepository implements IMessagesRepository {
       message: args.message,
       safeAppId: args.safeAppId,
       signature: args.signature,
+      origin: args.origin,
     });
   }
 

--- a/src/routes/messages/entities/__tests__/create-message.dto.builder.ts
+++ b/src/routes/messages/entities/__tests__/create-message.dto.builder.ts
@@ -2,10 +2,11 @@ import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
 import type { CreateMessageDto } from '@/routes/messages/entities/create-message.dto.entity';
+import { fakeJson } from '@/__tests__/faker';
 
 export function createMessageDtoBuilder(): IBuilder<CreateMessageDto> {
   return new Builder<CreateMessageDto>()
     .with('message', faker.word.words({ count: { min: 1, max: 5 } }))
-    .with('safeAppId', faker.number.int({ min: 0 }))
-    .with('signature', faker.string.hexadecimal({ length: 32 }));
+    .with('signature', faker.string.hexadecimal({ length: 32 }))
+    .with('origin', fakeJson());
 }

--- a/src/routes/messages/entities/create-message.dto.entity.ts
+++ b/src/routes/messages/entities/create-message.dto.entity.ts
@@ -7,8 +7,10 @@ export class CreateMessageDto
 {
   @ApiProperty()
   message!: string | Record<string, unknown>;
-  @ApiPropertyOptional({ type: Number, nullable: true })
+  @ApiPropertyOptional({ type: Number, nullable: true, deprecated: true })
   safeAppId!: number | null;
   @ApiProperty()
   signature!: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  origin!: string | null;
 }

--- a/src/routes/messages/entities/message.entity.ts
+++ b/src/routes/messages/entities/message.entity.ts
@@ -32,6 +32,8 @@ export class Message {
   confirmations: MessageConfirmation[];
   @ApiPropertyOptional({ type: String, nullable: true })
   preparedSignature: `0x${string}` | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  origin: string | null;
 
   constructor(
     messageHash: `0x${string}`,
@@ -46,6 +48,7 @@ export class Message {
     proposedBy: AddressInfo,
     confirmations: MessageConfirmation[],
     preparedSignature: `0x${string}` | null,
+    origin: string | null,
   ) {
     this.messageHash = messageHash;
     this.status = status;
@@ -59,5 +62,6 @@ export class Message {
     this.proposedBy = proposedBy;
     this.confirmations = confirmations;
     this.preparedSignature = preparedSignature;
+    this.origin = origin;
   }
 }

--- a/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
@@ -169,4 +169,28 @@ describe('CreateMessageDtoSchema', () => {
       );
     });
   });
+
+  describe('origin', () => {
+    it('should validate without origin, defaulting to null', () => {
+      const createMessageDto = createMessageDtoBuilder().build();
+      // @ts-expect-error - inferred type doesn't allow optional properties
+      delete createMessageDto.origin;
+
+      const result = CreateMessageDtoSchema.safeParse(createMessageDto);
+
+      expect(result.success && result.data.origin).toBe(null);
+    });
+
+    it('should validate a stringified origin', () => {
+      const createMessageDto = createMessageDtoBuilder()
+        .with('origin', JSON.stringify({ example: faker.internet.url() }))
+        .build();
+
+      const result = CreateMessageDtoSchema.safeParse(createMessageDto);
+
+      expect(result.success && result.data.origin).toBe(
+        createMessageDto.origin,
+      );
+    });
+  });
 });

--- a/src/routes/messages/entities/schemas/create-message.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/create-message.dto.schema.ts
@@ -4,4 +4,5 @@ export const CreateMessageDtoSchema = z.object({
   message: z.union([z.record(z.unknown()), z.string()]),
   safeAppId: z.number().int().gte(0).nullish().default(null),
   signature: z.string(),
+  origin: z.string().nullish().default(null),
 });

--- a/src/routes/messages/mappers/message-mapper.ts
+++ b/src/routes/messages/mappers/message-mapper.ts
@@ -41,6 +41,7 @@ export class MessageMapper {
           message.proposedBy,
           message.confirmations,
           message.preparedSignature,
+          message.origin,
         );
       }),
     );
@@ -85,6 +86,7 @@ export class MessageMapper {
       proposedBy,
       confirmations,
       preparedSignature,
+      message.origin,
     );
   }
 

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -134,6 +134,7 @@ describe('Messages controller', () => {
             signature: confirmation.signature,
           })),
           preparedSignature: message.preparedSignature,
+          origin: message.origin,
         });
     });
 
@@ -201,6 +202,7 @@ describe('Messages controller', () => {
             signature: confirmation.signature,
           })),
           preparedSignature: message.preparedSignature,
+          origin: message.origin,
         });
     });
 
@@ -265,6 +267,7 @@ describe('Messages controller', () => {
             signature: confirmation.signature,
           })),
           preparedSignature: null,
+          origin: message.origin,
         });
     });
 
@@ -332,6 +335,7 @@ describe('Messages controller', () => {
             signature: confirmation.signature,
           })),
           preparedSignature: null,
+          origin: message.origin,
         });
     });
 
@@ -396,6 +400,7 @@ describe('Messages controller', () => {
             signature: confirmation.signature,
           })),
           preparedSignature: null,
+          origin: message.origin,
         });
     });
 
@@ -458,6 +463,7 @@ describe('Messages controller', () => {
             signature: confirmation.signature,
           })),
           preparedSignature: null,
+          origin: message.origin,
         });
     });
   });
@@ -570,6 +576,7 @@ describe('Messages controller', () => {
                     signature: confirmation.signature,
                   })),
                   preparedSignature: null,
+                  origin: message.origin,
                 },
               ])
               .build(),

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -131,6 +131,7 @@ export class MessagesService {
       safeAddress: args.safeAddress,
       message: args.createMessageDto.message,
       safeAppId: args.createMessageDto.safeAppId,
+      origin: args.createMessageDto.origin,
       signature: args.createMessageDto.signature,
     });
   }


### PR DESCRIPTION
## Summary

In an effort to maintain consistency between transactions and `Message`s, a [new `origin` field has been added](https://github.com/safe-global/safe-transaction-service/issues/2067) to eventually replace the `safeAppId`.

This adds the respective field to both the proposal object, as well as `Message` retrieved from the Transaction Service.

## Changes

- Add `origin` to `CreateMessageDto` schema, inferring type
- Propose `origin` when posting a message
- Add `origin` to `Message` schema, inferring type and propagating field
- Add/update test coverage