### PR TITLE
Remove FF_EVENTS_QUEUE

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -141,7 +141,6 @@ export default (): ReturnType<typeof configuration> => ({
     configHooksDebugLogs: false,
     imitationMapping: false,
     auth: false,
-    eventsQueue: false,
     delegatesV2: false,
     counterfactualBalances: false,
     accounts: false,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -219,7 +219,6 @@ export default () => ({
     imitationMapping:
       process.env.FF_IMITATION_MAPPING?.toLowerCase() === 'true',
     auth: process.env.FF_AUTH?.toLowerCase() === 'true',
-    eventsQueue: process.env.FF_EVENTS_QUEUE?.toLowerCase() === 'true',
     delegatesV2: process.env.FF_DELEGATES_V2?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',

--- a/src/datasources/queues/queues-api.service.spec.ts
+++ b/src/datasources/queues/queues-api.service.spec.ts
@@ -1,4 +1,3 @@
-import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import type { QueueConsumer } from '@/datasources/queues/queues-api.module';
 import { QueueApiService } from '@/datasources/queues/queues-api.service';
 import type { ILoggingService } from '@/logging/logging.interface';
@@ -21,88 +20,30 @@ const mockLoggingService = {
 
 describe('QueuesApi', () => {
   let service: QueueApiService;
-  const fakeConfigurationService: FakeConfigurationService =
-    new FakeConfigurationService();
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   describe('isReady', () => {
-    it('should return true if FF is not active and the consumer connection is not available', () => {
-      fakeConfigurationService.set('features.eventsQueue', false);
-      mockQueueConsumer.connection.isConnected.mockReturnValue(false);
-      service = new QueueApiService(
-        mockQueueConsumer,
-        mockLoggingService,
-        fakeConfigurationService,
-      );
-
-      expect(service.isReady()).toBe(true);
-    });
-
-    it('should return true if FF is not active and the consumer connection is available', () => {
-      fakeConfigurationService.set('features.eventsQueue', false);
+    it('should return true if the consumer connection is available', () => {
       mockQueueConsumer.connection.isConnected.mockReturnValue(true);
-      service = new QueueApiService(
-        mockQueueConsumer,
-        mockLoggingService,
-        fakeConfigurationService,
-      );
+      service = new QueueApiService(mockQueueConsumer, mockLoggingService);
 
       expect(service.isReady()).toBe(true);
     });
 
-    it('should return true if FF is active and the consumer connection is available', () => {
-      fakeConfigurationService.set('features.eventsQueue', true);
-      mockQueueConsumer.connection.isConnected.mockReturnValue(true);
-      service = new QueueApiService(
-        mockQueueConsumer,
-        mockLoggingService,
-        fakeConfigurationService,
-      );
-
-      expect(service.isReady()).toBe(true);
-    });
-
-    it('should return false if FF is active and the consumer connection is not available', () => {
-      fakeConfigurationService.set('features.eventsQueue', true);
+    it('should return false if the consumer connection is not available', () => {
       mockQueueConsumer.connection.isConnected.mockReturnValue(false);
-      service = new QueueApiService(
-        mockQueueConsumer,
-        mockLoggingService,
-        fakeConfigurationService,
-      );
+      service = new QueueApiService(mockQueueConsumer, mockLoggingService);
 
       expect(service.isReady()).toBe(false);
     });
   });
 
   describe('subscribe', () => {
-    it('should not subscribe to the queue if the FF is not active', async () => {
-      fakeConfigurationService.set('features.eventsQueue', false);
-      service = new QueueApiService(
-        mockQueueConsumer,
-        mockLoggingService,
-        fakeConfigurationService,
-      );
-      const fn = jest.fn();
-
-      await service.subscribe(faker.string.sample(), fn);
-
-      expect(mockQueueConsumer.channel.consume).not.toHaveBeenCalled();
-      expect(mockQueueConsumer.channel.ack).not.toHaveBeenCalled();
-      expect(fn).not.toHaveBeenCalled();
-      expect(mockLoggingService.warn).toHaveBeenCalledTimes(1);
-    });
-
-    it('should subscribe to the queue if the FF is active', async () => {
-      fakeConfigurationService.set('features.eventsQueue', true);
-      service = new QueueApiService(
-        mockQueueConsumer,
-        mockLoggingService,
-        fakeConfigurationService,
-      );
+    it('should subscribe to the queue', async () => {
+      service = new QueueApiService(mockQueueConsumer, mockLoggingService);
       const fn = jest.fn();
 
       await service.subscribe(faker.string.sample(), fn);

--- a/src/datasources/queues/queues-api.service.ts
+++ b/src/datasources/queues/queues-api.service.ts
@@ -1,4 +1,3 @@
-import { IConfigurationService } from '@/config/configuration.service.interface';
 import { QueueConsumer } from '@/datasources/queues/queues-api.module';
 import { IQueuesApiService } from '@/datasources/queues/queues-api.service.interface';
 import { IQueueReadiness } from '@/domain/interfaces/queue-readiness.interface';
@@ -7,35 +6,19 @@ import { Inject } from '@nestjs/common';
 import { ConsumeMessage } from 'amqplib';
 
 export class QueueApiService implements IQueuesApiService, IQueueReadiness {
-  private readonly isEventsQueueEnabled: boolean;
-
   constructor(
     @Inject('QueueConsumer') private readonly consumer: QueueConsumer,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
-    @Inject(IConfigurationService)
-    private readonly configurationService: IConfigurationService,
-  ) {
-    this.isEventsQueueEnabled = this.configurationService.getOrThrow<boolean>(
-      'features.eventsQueue',
-    );
-  }
+  ) {}
 
   isReady(): boolean {
-    if (this.isEventsQueueEnabled) {
-      return this.consumer.connection.isConnected();
-    }
-    return true;
+    return this.consumer.connection.isConnected();
   }
 
   async subscribe(
     queueName: string,
     fn: (msg: ConsumeMessage) => Promise<void>,
   ): Promise<void> {
-    if (!this.isEventsQueueEnabled) {
-      return this.loggingService.warn(
-        `Cannot subscribe to queue: ${queueName}. AMQP consumer is disabled`,
-      );
-    }
     await this.consumer.channel.consume(queueName, (msg: ConsumeMessage) => {
       // Note: each message is explicitly acknowledged at this point, regardless the callback execution result.
       // The callback is expected to handle any errors and/or retries. Messages are not re-enqueued on error.

--- a/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -34,10 +34,6 @@ describe('Events queue processing e2e tests', () => {
         ...defaultConfiguration.amqp,
         queue,
       },
-      features: {
-        ...defaultConfiguration.features,
-        eventsQueue: true,
-      },
     });
 
     const moduleRef = await Test.createTestingModule({

--- a/src/routes/hooks/hooks-notifications.spec.ts
+++ b/src/routes/hooks/hooks-notifications.spec.ts
@@ -58,7 +58,8 @@ import jwtConfiguration from '@/datasources/jwt/configuration/__tests__/jwt.conf
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 
-describe('Post Hook Events for Notifications (Unit)', () => {
+// TODO: Migrate to E2E tests as TransactionEventType events are already being received via queue.
+describe.skip('Post Hook Events for Notifications (Unit)', () => {
   let app: INestApplication<Server>;
   let pushNotificationsApi: jest.MockedObjectDeep<IPushNotificationsApi>;
   let notificationsDatasource: jest.MockedObjectDeep<INotificationsDatasource>;

--- a/src/routes/hooks/hooks.controller.spec.ts
+++ b/src/routes/hooks/hooks.controller.spec.ts
@@ -63,18 +63,7 @@ describe('Post Hook Events (Unit)', () => {
     await app.close();
   });
 
-  it('should return 410 if the eventsQueue FF is active and the hook is not CHAIN_UPDATE or SAFE_APPS_UPDATE', async () => {
-    const defaultConfiguration = configuration();
-    const testConfiguration = (): typeof defaultConfiguration => ({
-      ...defaultConfiguration,
-      features: {
-        ...defaultConfiguration.features,
-        eventsQueue: true,
-      },
-    });
-
-    await initApp(testConfiguration);
-
+  it('should return 410 if the hook is not CHAIN_UPDATE or SAFE_APPS_UPDATE', async () => {
     const payload = {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),

--- a/src/routes/hooks/hooks.controller.ts
+++ b/src/routes/hooks/hooks.controller.ts
@@ -14,7 +14,6 @@ import { BasicAuthGuard } from '@/routes/common/auth/basic-auth.guard';
 import { Event } from '@/routes/hooks/entities/event.entity';
 import { EventSchema } from '@/routes/hooks/entities/schemas/event.schema';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { IConfigurationService } from '@/config/configuration.service.interface';
 import { EventProtocolChangedError } from '@/routes/hooks/errors/event-protocol-changed.error';
 import { EventProtocolChangedFilter } from '@/routes/hooks/filters/event-protocol-changed.filter';
 import { ConfigEventType } from '@/routes/hooks/entities/event-type.entity';
@@ -25,25 +24,17 @@ import { ConfigEventType } from '@/routes/hooks/entities/event-type.entity';
 })
 @ApiExcludeController()
 export class HooksController {
-  private readonly isEventsQueueEnabled: boolean;
-
   constructor(
     private readonly hooksService: HooksService,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
-    @Inject(IConfigurationService)
-    private readonly configurationService: IConfigurationService,
-  ) {
-    this.isEventsQueueEnabled = this.configurationService.getOrThrow<boolean>(
-      'features.eventsQueue',
-    );
-  }
+  ) {}
 
   @UseGuards(BasicAuthGuard)
   @Post('/hooks/events')
   @UseFilters(EventProtocolChangedFilter)
   @HttpCode(202)
   postEvent(@Body(new ValidationPipe(EventSchema)) event: Event): void {
-    if (!this.isEventsQueueEnabled || this.isHttpEvent(event)) {
+    if (this.isConfigEvent(event)) {
       this.hooksService.onEvent(event).catch((error) => {
         this.loggingService.error(error);
       });
@@ -52,7 +43,7 @@ export class HooksController {
     }
   }
 
-  private isHttpEvent(event: Event): boolean {
+  private isConfigEvent(event: Event): boolean {
     return Object.values(ConfigEventType).includes(
       event.type as ConfigEventType,
     );


### PR DESCRIPTION
## Summary
This PR removes the `FF_EVENTS_QUEUE` feature flag, and its related logic. 

## Changes
- Removes `FF_EVENTS_QUEUE` from the configuration/sample environment file.
- Removes `features.eventsQueue` configuration key and its associated logic.
- 
