### PR TITLE
Disable CronJob scheduling on tests execution

### DIFF
--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -152,7 +152,9 @@ export class EventCacheHelper {
    * Logs the number of unsupported chain events for each chain and clears the store.
    * This function is public just for testing purposes.
    */
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_MINUTE, {
+    disabled: process.env.NODE_ENV === 'test',
+  })
   public async logUnsupportedEvents(): Promise<void> {
     await Promise.all(
       this.unsupportedChains.map(async (chainId) => {


### PR DESCRIPTION
## Summary
This PR disables the scheduling of `logUnsupportedEvents` `CronJob` on test execution, which had been causing Jest open handles.

## Changes
- Modifies the `@Cron` annotation associated with `logUnsupportedEvents`, to disable it when `NODE_ENV === test`.
