### PR TITLE
Fix created_at/updated_at flaky comparison tests

### DIFF
--- a/migrations/deprecated/__tests__/00001_accounts.spec.ts
+++ b/migrations/deprecated/__tests__/00001_accounts.spec.ts
@@ -1,7 +1,9 @@
 import { TestDbFactory } from '@/__tests__/db.factory';
+import { waitMilliseconds } from '@/__tests__/util/retry';
 import { PostgresDatabaseMigrator } from '@/datasources/db/v1/postgres-database.migrator';
 import { faker } from '@faker-js/faker';
-import postgres, { Sql } from 'postgres';
+import type { Sql } from 'postgres';
+import type postgres from 'postgres';
 
 interface AccountRow {
   id: number;
@@ -119,6 +121,8 @@ describe('Migration 00001_accounts', () => {
     const updatedAt = new Date(result.after[0].updated_at);
     expect(createdAt).toStrictEqual(updatedAt);
 
+    // wait for 1 millisecond to ensure that the updated_at timestamp is different
+    await waitMilliseconds(1);
     // only updated_at should be updated after the row is updated
     await sql`UPDATE accounts set address = '0x0001' WHERE id = 1;`;
     const afterUpdate = await sql<AccountRow[]>`SELECT * FROM accounts`;

--- a/migrations/deprecated/__tests__/00002_account-data-types.spec.ts
+++ b/migrations/deprecated/__tests__/00002_account-data-types.spec.ts
@@ -1,7 +1,9 @@
 import { TestDbFactory } from '@/__tests__/db.factory';
+import { waitMilliseconds } from '@/__tests__/util/retry';
 import { PostgresDatabaseMigrator } from '@/datasources/db/v1/postgres-database.migrator';
 import { faker } from '@faker-js/faker';
-import postgres, { Sql } from 'postgres';
+import type { Sql } from 'postgres';
+import type postgres from 'postgres';
 
 interface AccountDataTypeRow {
   id: number;
@@ -106,6 +108,8 @@ describe('Migration 00002_account-data-types', () => {
     expect(createdAt).toBeInstanceOf(Date);
     expect(createdAt).toStrictEqual(updatedAt);
 
+    // wait for 1 millisecond to ensure that the updated_at timestamp is different
+    await waitMilliseconds(1);
     // only updated_at should be updated after the row is updated
     await sql`UPDATE account_data_types set name = 'updatedName' WHERE id = 1;`;
     const afterUpdate = await sql<

--- a/migrations/deprecated/__tests__/00003_account-data-settings.spec.ts
+++ b/migrations/deprecated/__tests__/00003_account-data-settings.spec.ts
@@ -1,7 +1,8 @@
 import { TestDbFactory } from '@/__tests__/db.factory';
+import { waitMilliseconds } from '@/__tests__/util/retry';
 import { PostgresDatabaseMigrator } from '@/datasources/db/v1/postgres-database.migrator';
 import { faker } from '@faker-js/faker';
-import postgres from 'postgres';
+import type postgres from 'postgres';
 import { getAddress } from 'viem';
 
 interface AccountRow {
@@ -107,6 +108,8 @@ describe('Migration 00003_account-data-settings', () => {
     expect(createdAt).toBeInstanceOf(Date);
     expect(createdAt).toStrictEqual(updatedAt);
 
+    // wait for 1 millisecond to ensure that the updated_at timestamp is different
+    await waitMilliseconds(1);
     // only updated_at should be updated after the row is updated
     const afterUpdate = await sql<
       AccountDataTypeRow[]

--- a/migrations/deprecated/__tests__/00004_counterfactual-safes.spec.ts
+++ b/migrations/deprecated/__tests__/00004_counterfactual-safes.spec.ts
@@ -1,7 +1,8 @@
 import { TestDbFactory } from '@/__tests__/db.factory';
+import { waitMilliseconds } from '@/__tests__/util/retry';
 import { PostgresDatabaseMigrator } from '@/datasources/db/v1/postgres-database.migrator';
 import { faker } from '@faker-js/faker';
-import postgres from 'postgres';
+import type postgres from 'postgres';
 import { getAddress } from 'viem';
 
 interface AccountRow {
@@ -129,6 +130,9 @@ describe('Migration 00004_counterfactual-safes', () => {
     const updatedAt = new Date(counterfactualSafesRows[0].updated_at);
     expect(createdAt).toBeInstanceOf(Date);
     expect(createdAt).toStrictEqual(updatedAt);
+
+    // wait for 1 millisecond to ensure that the updated_at timestamp is different
+    await waitMilliseconds(1);
     // only updated_at should be updated after the row is updated
     const afterUpdate = await sql<
       CounterfactualSafesRow[]

--- a/migrations/deprecated/__tests__/00006_targeted_messaging.spec.ts
+++ b/migrations/deprecated/__tests__/00006_targeted_messaging.spec.ts
@@ -1,4 +1,5 @@
 import { TestDbFactory } from '@/__tests__/db.factory';
+import { waitMilliseconds } from '@/__tests__/util/retry';
 import { PostgresDatabaseMigrator } from '@/datasources/db/v1/postgres-database.migrator';
 import type { Outreach } from '@/domain/targeted-messaging/entities/outreach.entity';
 import type { Submission } from '@/domain/targeted-messaging/entities/submission.entity';
@@ -104,6 +105,8 @@ describe('Migration 00006_targeted_messaging', () => {
       const updatedAt = new Date(result.after[0].updated_at);
       expect(createdAt).toStrictEqual(updatedAt);
 
+      // wait for 1 millisecond to ensure that the updated_at timestamp is different
+      await waitMilliseconds(1);
       // only updated_at should be updated after the row is updated
       await sql`UPDATE outreaches set name = ${faker.string.alphanumeric()} WHERE id = 1;`;
       const afterUpdate = await sql<Outreach[]>`SELECT * FROM outreaches`;
@@ -111,7 +114,7 @@ describe('Migration 00006_targeted_messaging', () => {
       const createdAtAfterUpdate = new Date(afterUpdate[0].created_at);
 
       expect(createdAtAfterUpdate).toStrictEqual(createdAt);
-      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThanOrEqual(
+      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThan(
         createdAt.getTime(),
       );
     });
@@ -166,6 +169,8 @@ describe('Migration 00006_targeted_messaging', () => {
       const updatedAt = new Date(result.after[0].updated_at);
       expect(createdAt).toStrictEqual(updatedAt);
 
+      // wait for 1 millisecond to ensure that the updated_at timestamp is different
+      await waitMilliseconds(1);
       // only updated_at should be updated after the row is updated
       await sql`UPDATE targeted_safes set address = ${faker.finance.ethereumAddress()} WHERE id = 1;`;
       const afterUpdate = await sql<
@@ -175,7 +180,7 @@ describe('Migration 00006_targeted_messaging', () => {
       const createdAtAfterUpdate = new Date(afterUpdate[0].created_at);
 
       expect(createdAtAfterUpdate).toStrictEqual(createdAt);
-      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThanOrEqual(
+      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThan(
         createdAt.getTime(),
       );
     });
@@ -240,6 +245,8 @@ describe('Migration 00006_targeted_messaging', () => {
       const updatedAt = new Date(result.after[0].updated_at);
       expect(createdAt).toStrictEqual(updatedAt);
 
+      // wait for 1 millisecond to ensure that the updated_at timestamp is different
+      await waitMilliseconds(1);
       // only updated_at should be updated after the row is updated
       await sql`UPDATE submissions set completion_date = ${new Date()} WHERE id = 1;`;
       const afterUpdate = await sql<Submission[]>`SELECT * FROM submissions`;
@@ -247,7 +254,7 @@ describe('Migration 00006_targeted_messaging', () => {
       const createdAtAfterUpdate = new Date(afterUpdate[0].created_at);
 
       expect(createdAtAfterUpdate).toStrictEqual(createdAt);
-      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThanOrEqual(
+      expect(updatedAtAfterUpdate.getTime()).toBeGreaterThan(
         createdAt.getTime(),
       );
     });


### PR DESCRIPTION
## Summary
This PR adds logic to manage the corner case where the `update_at` and `created_at` database fields have the same value after an insertion and update took place subsequently. Sometimes the operations are performed during the same millisecond so both timestamps are the same one, and the migration tests checking the `updated_at` is greater than `created_at` fail.

An example can be seen at https://github.com/safe-global/safe-client-gateway/actions/runs/11515722403/job/32056943212

```
Summary of all failing tests
FAIL migrations/deprecated/__tests__/00001_accounts.spec.ts
  ● Migration 00001_accounts › should add and update row timestamps

    expect(received).toBeGreaterThan(expected)

    Expected: > 1729849189006
    Received:   1729849189006
```

## Changes
- Adds 1 millisecond delays to `updated_at` checks during the migrations tests.
