### PR TITLE
Add `proposedByDelegate` to multisig mapping

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -13,6 +13,7 @@ import { getAddress } from 'viem';
 const HASH_LENGTH = 10;
 
 export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
+  const delegate = getAddress(faker.finance.ethereumAddress());
   return new Builder<MultisigTransaction>()
     .with('baseGas', faker.number.int())
     .with('blockNumber', faker.number.int())
@@ -43,7 +44,8 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
         appendSlash: false,
       })}", "name": "${faker.word.words()}"}`,
     )
-    .with('proposer', getAddress(faker.finance.ethereumAddress()))
+    .with('proposer', delegate)
+    .with('proposedByDelegate', delegate)
     .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
     .with('safe', getAddress(faker.finance.ethereumAddress()))
     .with('safeTxGas', faker.number.int())

--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -13,55 +13,57 @@ import { getAddress } from 'viem';
 const HASH_LENGTH = 10;
 
 export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
-  const delegate = getAddress(faker.finance.ethereumAddress());
-  return new Builder<MultisigTransaction>()
-    .with('baseGas', faker.number.int())
-    .with('blockNumber', faker.number.int())
-    .with(
-      'confirmations',
-      faker.helpers.multiple(() => confirmationBuilder().build(), {
-        count: { min: 0, max: 5 },
-      }),
-    )
-    .with('confirmationsRequired', faker.number.int())
-    .with('data', faker.string.hexadecimal() as `0x${string}`)
-    .with('dataDecoded', dataDecodedBuilder().build())
-    .with('ethGasPrice', faker.string.hexadecimal())
-    .with('executor', getAddress(faker.finance.ethereumAddress()))
-    .with('executionDate', faker.date.recent())
-    .with('fee', faker.string.hexadecimal())
-    .with('gasPrice', faker.string.hexadecimal())
-    .with('gasToken', getAddress(faker.finance.ethereumAddress()))
-    .with('gasUsed', faker.number.int())
-    .with('isExecuted', faker.datatype.boolean())
-    .with('isSuccessful', faker.datatype.boolean())
-    .with('modified', faker.date.recent())
-    .with('nonce', faker.number.int())
-    .with('operation', faker.helpers.arrayElement([0, 1]) as Operation)
-    .with(
-      'origin',
-      `{"url": "${faker.internet.url({
-        appendSlash: false,
-      })}", "name": "${faker.word.words()}"}`,
-    )
-    .with('proposer', delegate)
-    .with('proposedByDelegate', delegate)
-    .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
-    .with('safe', getAddress(faker.finance.ethereumAddress()))
-    .with('safeTxGas', faker.number.int())
-    .with(
-      'safeTxHash',
-      faker.string.hexadecimal({ length: HASH_LENGTH }) as `0x${string}`,
-    )
-    .with('signatures', faker.string.hexadecimal() as `0x${string}`)
-    .with('submissionDate', faker.date.recent())
-    .with('to', getAddress(faker.finance.ethereumAddress()))
-    .with(
-      'transactionHash',
-      faker.string.hexadecimal({ length: HASH_LENGTH }) as `0x${string}`,
-    )
-    .with('trusted', faker.datatype.boolean())
-    .with('value', faker.string.numeric());
+  return (
+    new Builder<MultisigTransaction>()
+      .with('baseGas', faker.number.int())
+      .with('blockNumber', faker.number.int())
+      .with(
+        'confirmations',
+        faker.helpers.multiple(() => confirmationBuilder().build(), {
+          count: { min: 0, max: 5 },
+        }),
+      )
+      .with('confirmationsRequired', faker.number.int())
+      .with('data', faker.string.hexadecimal() as `0x${string}`)
+      .with('dataDecoded', dataDecodedBuilder().build())
+      .with('ethGasPrice', faker.string.hexadecimal())
+      .with('executor', getAddress(faker.finance.ethereumAddress()))
+      .with('executionDate', faker.date.recent())
+      .with('fee', faker.string.hexadecimal())
+      .with('gasPrice', faker.string.hexadecimal())
+      .with('gasToken', getAddress(faker.finance.ethereumAddress()))
+      .with('gasUsed', faker.number.int())
+      .with('isExecuted', faker.datatype.boolean())
+      .with('isSuccessful', faker.datatype.boolean())
+      .with('modified', faker.date.recent())
+      .with('nonce', faker.number.int())
+      .with('operation', faker.helpers.arrayElement([0, 1]) as Operation)
+      .with(
+        'origin',
+        `{"url": "${faker.internet.url({
+          appendSlash: false,
+        })}", "name": "${faker.word.words()}"}`,
+      )
+      .with('proposer', getAddress(faker.finance.ethereumAddress()))
+      // Not proposed by delegate
+      .with('proposedByDelegate', null)
+      .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
+      .with('safe', getAddress(faker.finance.ethereumAddress()))
+      .with('safeTxGas', faker.number.int())
+      .with(
+        'safeTxHash',
+        faker.string.hexadecimal({ length: HASH_LENGTH }) as `0x${string}`,
+      )
+      .with('signatures', faker.string.hexadecimal() as `0x${string}`)
+      .with('submissionDate', faker.date.recent())
+      .with('to', getAddress(faker.finance.ethereumAddress()))
+      .with(
+        'transactionHash',
+        faker.string.hexadecimal({ length: HASH_LENGTH }) as `0x${string}`,
+      )
+      .with('trusted', faker.datatype.boolean())
+      .with('value', faker.string.numeric())
+  );
 }
 
 export function toJson(multisigTransaction: MultisigTransaction): unknown {

--- a/src/domain/safe/entities/__tests__/multisig-transaction.entity.spec.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.entity.spec.ts
@@ -1,0 +1,459 @@
+import { confirmationBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
+import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import {
+  ConfirmationSchema,
+  MultisigTransactionPageSchema,
+  MultisigTransactionSchema,
+  MultisigTransactionTypeSchema,
+} from '@/domain/safe/entities/multisig-transaction.entity';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+describe('MultisigTransaction', () => {
+  describe('ConfirmationSchema', () => {
+    it('should validate a Confirmation', () => {
+      const confirmation = confirmationBuilder().build();
+
+      const result = ConfirmationSchema.safeParse(confirmation);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not validate and invalid Confirmation', () => {
+      const confirmation = {
+        invalid: 'confirmation',
+      };
+
+      const result = ConfirmationSchema.safeParse(confirmation);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['owner'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_date',
+          message: 'Invalid date',
+          path: ['submissionDate'],
+        },
+        {
+          code: 'invalid_type',
+          expected:
+            "'CONTRACT_SIGNATURE' | 'APPROVED_HASH' | 'EOA' | 'ETH_SIGN'",
+          message: 'Required',
+          path: ['signatureType'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('MultisigTransactionSchema', () => {
+    it('should validate a MultisigTransaction', () => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(result.success).toBe(true);
+    });
+
+    it.each([
+      'safe' as const,
+      'to' as const,
+      'value' as const,
+      'operation' as const,
+      'nonce' as const,
+      'submissionDate' as const,
+      'safeTxHash' as const,
+      'isExecuted' as const,
+      'confirmationsRequired' as const,
+      'trusted' as const,
+    ])('should require %s', (key) => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+      delete multisigTransaction[key];
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(!result.success && result.error.issues.length).toBe(1);
+      expect(!result.success && result.error.issues[0].path).toStrictEqual([
+        key,
+      ]);
+    });
+
+    it.each([
+      'safe' as const,
+      'to' as const,
+      'gasToken' as const,
+      'proposer' as const,
+      'proposedByDelegate' as const,
+      'refundReceiver' as const,
+      'executor' as const,
+    ])('should checksum %s', (key) => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase();
+      const multisigTransaction = multisigTransactionBuilder()
+        .with(key, nonChecksummedAddress as `0x${string}`)
+        .build();
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(result.success && result.data[key]).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    });
+
+    it.each([
+      'value' as const,
+      'gasPrice' as const,
+      'ethGasPrice' as const,
+      'fee' as const,
+    ])('should require %s to be a numeric string', (key) => {
+      const multisigTransaction = multisigTransactionBuilder()
+        .with(key, faker.string.alpha())
+        .build();
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'custom',
+          message: 'Invalid base-10 numeric string',
+          path: [key],
+        },
+      ]);
+    });
+
+    it.each([
+      'data' as const,
+      'transactionHash' as const,
+      'safeTxHash' as const,
+    ])('should require %s to be a hex string', (key) => {
+      const multisigTransaction = multisigTransactionBuilder()
+        .with(key, faker.string.numeric() as `0x${string}`)
+        .build();
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'custom',
+          message: 'Invalid "0x" notated hex string',
+          path: [key],
+        },
+      ]);
+    });
+
+    it.each([
+      'data' as const,
+      'dataDecoded' as const,
+      'gasToken' as const,
+      'safeTxGas' as const,
+      'baseGas' as const,
+      'gasPrice' as const,
+      'proposer' as const,
+      'proposedByDelegate' as const,
+      'refundReceiver' as const,
+      'executionDate' as const,
+      'modified' as const,
+      'blockNumber' as const,
+      'transactionHash' as const,
+      'executor' as const,
+      'isSuccessful' as const,
+      'ethGasPrice' as const,
+      'gasUsed' as const,
+      'fee' as const,
+      'origin' as const,
+      'confirmations' as const,
+      'signatures' as const,
+    ])('should default %s to null', (key) => {
+      const multisigTransaction = multisigTransactionBuilder().build();
+      delete multisigTransaction[key];
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(result.success && result.data[key]).toBe(null);
+    });
+
+    it('should require operation to be 0 or 1', () => {
+      const multisigTransaction = multisigTransactionBuilder()
+        .with('operation', faker.number.int({ min: 2 }))
+        .build();
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_enum_value',
+          message: `Invalid enum value. Expected 0 | 1, received '${multisigTransaction.operation}'`,
+          options: [0, 1],
+          path: ['operation'],
+          received: multisigTransaction.operation,
+        },
+      ]);
+    });
+
+    it.each([
+      'executionDate' as const,
+      'submissionDate' as const,
+      'modified' as const,
+    ])('should coerce %s to be a Date', (key) => {
+      const date = faker.date.recent();
+      const multisigTransaction = multisigTransactionBuilder()
+        .with(key, date.toString() as unknown as Date)
+        .build();
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      // zod coerces to nearest millisecond
+      date.setMilliseconds(0);
+      expect(result.success && result.data[key]).toStrictEqual(date);
+    });
+
+    it('should not validate an invalid MultisigTransaction', () => {
+      const multisigTransaction = {
+        invalid: 'multisigTransaction',
+      };
+
+      const result = MultisigTransactionSchema.safeParse(multisigTransaction);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['safe'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['to'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['value'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: '0 | 1',
+          message: 'Required',
+          path: ['operation'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['nonce'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_date',
+          message: 'Invalid date',
+          path: ['submissionDate'],
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['safeTxHash'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          message: 'Required',
+          path: ['isExecuted'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['confirmationsRequired'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          message: 'Required',
+          path: ['trusted'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('MultisigTransactionTypeSchema', () => {
+    it('should validate a MultisigTransactionType', () => {
+      const multisigTransactionType = {
+        ...multisigTransactionBuilder().build(),
+        txType: 'MULTISIG_TRANSACTION',
+      };
+
+      const result = MultisigTransactionTypeSchema.safeParse(
+        multisigTransactionType,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not validate an invalid MultisigTransactionType', () => {
+      const multisigTransactionType = {
+        invalid: 'multisigTransactionType',
+      };
+
+      const result = MultisigTransactionTypeSchema.safeParse(
+        multisigTransactionType,
+      );
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['safe'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['to'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['value'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: '0 | 1',
+          message: 'Required',
+          path: ['operation'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['nonce'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_date',
+          message: 'Invalid date',
+          path: ['submissionDate'],
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['safeTxHash'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          message: 'Required',
+          path: ['isExecuted'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['confirmationsRequired'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          message: 'Required',
+          path: ['trusted'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_literal',
+          expected: 'MULTISIG_TRANSACTION',
+          message: 'Invalid literal value, expected "MULTISIG_TRANSACTION"',
+          path: ['txType'],
+          received: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe('MultisigTransactionPageSchema', () => {
+    it('should validate a MultisigTransactionPage', () => {
+      const multisigTransactionType = {
+        ...multisigTransactionBuilder().build(),
+        type: 'MULTISIG_TRANSACTION',
+      };
+      const multisigTransactionPage = pageBuilder()
+        .with('count', 1)
+        .with('results', [multisigTransactionType])
+        .build();
+
+      const result = MultisigTransactionPageSchema.safeParse(
+        multisigTransactionPage,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not validate an invalid MultisigTransactionPage', () => {
+      const multisigTransactionPage = {
+        invalid: 'multisigTransactionPage',
+      };
+
+      const result = MultisigTransactionPageSchema.safeParse(
+        multisigTransactionPage,
+      );
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Required',
+          path: ['count'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['next'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['previous'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['results'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+});

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -11,7 +11,7 @@ export type Confirmation = z.infer<typeof ConfirmationSchema>;
 
 export type MultisigTransaction = z.infer<typeof MultisigTransactionSchema>;
 
-const ConfirmationSchema = z.object({
+export const ConfirmationSchema = z.object({
   owner: AddressSchema,
   submissionDate: z.coerce.date(),
   transactionHash: HexSchema.nullish().default(null),
@@ -31,6 +31,7 @@ export const MultisigTransactionSchema = z.object({
   baseGas: z.number().nullish().default(null),
   gasPrice: NumericStringSchema.nullish().default(null),
   proposer: AddressSchema.nullish().default(null),
+  proposedByDelegate: AddressSchema.nullish().default(null),
   refundReceiver: AddressSchema.nullish().default(null),
   nonce: z.number(),
   executionDate: z.coerce.date().nullish().default(null),

--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -58,6 +58,8 @@ export class MultisigExecutionDetails extends ExecutionDetails {
   trusted: boolean;
   @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   proposer!: AddressInfo | null;
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
+  proposedByDelegate!: AddressInfo | null;
 
   constructor(
     submittedAt: number,
@@ -76,6 +78,7 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     gasTokenInfo: Token | null,
     trusted: boolean,
     proposer: AddressInfo | null,
+    proposedByDelegate: AddressInfo | null,
   ) {
     super(ExecutionDetailsType.Multisig);
     this.submittedAt = submittedAt;
@@ -94,5 +97,6 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     this.gasTokenInfo = gasTokenInfo;
     this.trusted = trusted;
     this.proposer = proposer;
+    this.proposedByDelegate = proposedByDelegate;
   }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -149,6 +149,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         gasTokenInfo: null,
         trusted: transaction.trusted,
         proposer: new AddressInfo(transaction.proposer!),
+        proposedByDelegate: new AddressInfo(transaction.proposedByDelegate!),
       }),
     );
   });
@@ -215,6 +216,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         gasTokenInfo: null,
         trusted: transaction.trusted,
         proposer: new AddressInfo(transaction.proposer!),
+        proposedByDelegate: new AddressInfo(transaction.proposedByDelegate!),
       }),
     );
   });
@@ -244,6 +246,34 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
       expect.objectContaining({
         type: 'MULTISIG',
         proposer: null,
+      }),
+    );
+  });
+  it('should return a MultisigExecutionDetails object with no proposedByDelegate if not present', async () => {
+    const chainId = faker.string.numeric();
+    const safe = safeBuilder().build();
+    const transaction = multisigTransactionBuilder()
+      .with('safe', safe.address)
+      .with('proposedByDelegate', null)
+      .build();
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    safeRepository.getMultisigTransactions.mockResolvedValue(
+      pageBuilder<MultisigTransaction>().with('results', []).build(),
+    );
+    const gasTokenInfo = tokenBuilder().build();
+    tokenRepository.getToken.mockResolvedValue(gasTokenInfo);
+
+    const actual = await mapper.mapMultisigExecutionDetails(
+      chainId,
+      transaction,
+      safe,
+    );
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        type: 'MULTISIG',
+        proposedByDelegate: null,
       }),
     );
   });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -249,6 +249,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
       }),
     );
   });
+
   it('should return a MultisigExecutionDetails object with no proposedByDelegate if not present', async () => {
     const chainId = faker.string.numeric();
     const safe = safeBuilder().build();

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -84,6 +84,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         gasTokenInfo,
         trusted: transaction.trusted,
         proposer: new AddressInfo(transaction.proposer!),
+        proposedByDelegate: new AddressInfo(transaction.proposedByDelegate!),
       }),
     );
   });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -14,6 +14,7 @@ import { NULL_ADDRESS } from '@/routes/common/constants';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { MultisigConfirmationDetails } from '@/routes/transactions/entities/transaction-details/multisig-execution-details.entity';
 import { MultisigTransactionExecutionDetailsMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper';
+import { getAddress } from 'viem';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -84,7 +85,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         gasTokenInfo,
         trusted: transaction.trusted,
         proposer: new AddressInfo(transaction.proposer!),
-        proposedByDelegate: new AddressInfo(transaction.proposedByDelegate!),
+        proposedByDelegate: null,
       }),
     );
   });
@@ -149,7 +150,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         gasTokenInfo: null,
         trusted: transaction.trusted,
         proposer: new AddressInfo(transaction.proposer!),
-        proposedByDelegate: new AddressInfo(transaction.proposedByDelegate!),
+        proposedByDelegate: null,
       }),
     );
   });
@@ -216,7 +217,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         gasTokenInfo: null,
         trusted: transaction.trusted,
         proposer: new AddressInfo(transaction.proposer!),
-        proposedByDelegate: new AddressInfo(transaction.proposedByDelegate!),
+        proposedByDelegate: null,
       }),
     );
   });
@@ -250,12 +251,14 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
     );
   });
 
-  it('should return a MultisigExecutionDetails object with no proposedByDelegate if not present', async () => {
+  it('should return a MultisigExecutionDetails object proposedByDelegate if not present', async () => {
     const chainId = faker.string.numeric();
     const safe = safeBuilder().build();
+    const delegate = getAddress(faker.finance.ethereumAddress());
     const transaction = multisigTransactionBuilder()
       .with('safe', safe.address)
-      .with('proposedByDelegate', null)
+      .with('proposer', delegate)
+      .with('proposedByDelegate', delegate)
       .build();
     const addressInfo = addressInfoBuilder().build();
     addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
@@ -274,7 +277,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
     expect(actual).toEqual(
       expect.objectContaining({
         type: 'MULTISIG',
-        proposedByDelegate: null,
+        proposedByDelegate: new AddressInfo(delegate),
       }),
     );
   });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -43,6 +43,9 @@ export class MultisigTransactionExecutionDetailsMapper {
     const proposer = transaction.proposer
       ? new AddressInfo(transaction.proposer)
       : null;
+    const proposedByDelegate = transaction.proposedByDelegate
+      ? new AddressInfo(transaction.proposedByDelegate)
+      : null;
 
     const [gasTokenInfo, executor, refundReceiver, rejectors] =
       await Promise.all([
@@ -79,6 +82,7 @@ export class MultisigTransactionExecutionDetailsMapper {
       gasTokenInfo,
       transaction.trusted,
       proposer,
+      proposedByDelegate,
     );
   }
 


### PR DESCRIPTION
## Summary

A new `proposedByDelegate` field has been [added to multisig transactions](https://github.com/safe-global/safe-transaction-service/issues/2275) on the Transaction Service. This is also [needed by the client](https://github.com/safe-global/safe-platform-requests/issues/8) for delegate integration.

This adds the new field to the relevant validation schema and maps it accordingly.

## Changes

- Add property to relevant schemas/builder
- Propagate property to mappings
- Add/update tests accordingly