### PR TITLE
Type Locking Service responses as "raw"

### DIFF
--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -12,7 +12,12 @@ import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
 import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { Inject } from '@nestjs/common';
+import type { Raw } from '@/validation/entities/raw.entity';
 
+/**
+ * TODO: Move all usage of Raw to NetworkService after fully migrated
+ * to "Raw" type implementation.
+ */
 export class LockingApi implements ILockingApi {
   private readonly baseUri: string;
 
@@ -27,10 +32,10 @@ export class LockingApi implements ILockingApi {
       this.configurationService.getOrThrow<string>('locking.baseUri');
   }
 
-  async getCampaignById(resourceId: string): Promise<Campaign> {
+  async getCampaignById(resourceId: string): Promise<Raw<Campaign>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${resourceId}`;
-      const { data } = await this.networkService.get<Campaign>({ url });
+      const { data } = await this.networkService.get<Raw<Campaign>>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -40,10 +45,10 @@ export class LockingApi implements ILockingApi {
   async getCampaigns(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Campaign>> {
+  }): Promise<Raw<Page<Campaign>>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns`;
-      const { data } = await this.networkService.get<Page<Campaign>>({
+      const { data } = await this.networkService.get<Raw<Page<Campaign>>>({
         url,
         networkRequest: {
           params: {
@@ -63,10 +68,12 @@ export class LockingApi implements ILockingApi {
     holder?: `0x${string}`;
     limit?: number;
     offset?: number;
-  }): Promise<CampaignActivity> {
+  }): Promise<Raw<Page<CampaignActivity>>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/activities`;
-      const { data } = await this.networkService.get<CampaignActivity>({
+      const { data } = await this.networkService.get<
+        Raw<Page<CampaignActivity>>
+      >({
         url,
         networkRequest: {
           params: {
@@ -85,20 +92,22 @@ export class LockingApi implements ILockingApi {
   async getCampaignRank(args: {
     resourceId: string;
     safeAddress: `0x${string}`;
-  }): Promise<CampaignRank> {
+  }): Promise<Raw<CampaignRank>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard/${args.safeAddress}`;
-      const { data } = await this.networkService.get<CampaignRank>({ url });
+      const { data } = await this.networkService.get<Raw<CampaignRank>>({
+        url,
+      });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
-  async getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank> {
+  async getLockingRank(safeAddress: `0x${string}`): Promise<Raw<LockingRank>> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;
-      const { data } = await this.networkService.get<LockingRank>({ url });
+      const { data } = await this.networkService.get<Raw<LockingRank>>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -108,10 +117,10 @@ export class LockingApi implements ILockingApi {
   async getLeaderboard(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<LockingRank>> {
+  }): Promise<Raw<Page<LockingRank>>> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard`;
-      const { data } = await this.networkService.get<Page<LockingRank>>({
+      const { data } = await this.networkService.get<Raw<Page<LockingRank>>>({
         url,
         networkRequest: {
           params: {
@@ -130,10 +139,10 @@ export class LockingApi implements ILockingApi {
     resourceId: string;
     limit?: number;
     offset?: number;
-  }): Promise<Page<CampaignRank>> {
+  }): Promise<Raw<Page<CampaignRank>>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard`;
-      const { data } = await this.networkService.get<Page<CampaignRank>>({
+      const { data } = await this.networkService.get<Raw<Page<CampaignRank>>>({
         url,
         networkRequest: {
           params: {
@@ -152,10 +161,10 @@ export class LockingApi implements ILockingApi {
     safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
-  }): Promise<Page<LockingEvent>> {
+  }): Promise<Raw<Page<LockingEvent>>> {
     try {
       const url = `${this.baseUri}/api/v1/all-events/${args.safeAddress}`;
-      const { data } = await this.networkService.get<Page<LockingEvent>>({
+      const { data } = await this.networkService.get<Raw<Page<LockingEvent>>>({
         url,
         networkRequest: {
           params: {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -4,45 +4,46 @@ import type { CampaignActivity } from '@/domain/community/entities/campaign-acti
 import type { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import type { LockingEvent } from '@/domain/community/entities/locking-event.entity';
 import type { LockingRank } from '@/domain/community/entities/locking-rank.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
 
 export const ILockingApi = Symbol('ILockingApi');
 
 export interface ILockingApi {
-  getCampaignById(resourceId: string): Promise<Campaign>;
+  getCampaignById(resourceId: string): Promise<Raw<Campaign>>;
 
   getCampaigns(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Campaign>>;
+  }): Promise<Raw<Page<Campaign>>>;
 
   getCampaignActivities(args: {
     resourceId: string;
     holder?: `0x${string}`;
     limit?: number;
     offset?: number;
-  }): Promise<CampaignActivity>;
+  }): Promise<Raw<Page<CampaignActivity>>>;
 
-  getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank>;
+  getLockingRank(safeAddress: `0x${string}`): Promise<Raw<LockingRank>>;
 
   getLeaderboard(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<LockingRank>>;
+  }): Promise<Raw<Page<LockingRank>>>;
 
   getCampaignLeaderboard(args: {
     resourceId: string;
     limit?: number;
     offset?: number;
-  }): Promise<Page<CampaignRank>>;
+  }): Promise<Raw<Page<CampaignRank>>>;
 
   getCampaignRank(args: {
     resourceId: string;
     safeAddress: `0x${string}`;
-  }): Promise<CampaignRank>;
+  }): Promise<Raw<CampaignRank>>;
 
   getLockingHistory(args: {
     safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
-  }): Promise<Page<LockingEvent>>;
+  }): Promise<Raw<Page<LockingEvent>>>;
 }

--- a/src/validation/entities/raw.entity.ts
+++ b/src/validation/entities/raw.entity.ts
@@ -1,0 +1,19 @@
+/**
+ * Represents a type that has not been validated yet but should be
+ * before being used.
+ *
+ * @example
+ * ```typescript
+ * function log(value: number) {
+ *   console.log(value);
+ * }
+ *
+ * const value = 69420 as Raw<number>
+ *
+ * log(value); // errors
+ * log(z.number().parse(value)); // works
+ * ```
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Raw<_> = { readonly _: unique symbol };

--- a/src/validation/entities/raw.entity.ts
+++ b/src/validation/entities/raw.entity.ts
@@ -16,4 +16,4 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type Raw<_> = { readonly _: unique symbol };
+export type Raw<_> = symbol;


### PR DESCRIPTION
This is a sample implementation for #1731.

## Summary

We validate API responses on the domain layer, but directly assign the type in the datasources. This means that the response types are not necessarily correct.

Using the Locking Service as an example, this type all responses as "raw". These responses can therefore not be used directly unless they are validated.

By returning the API response directly in the `CommunityRepository`, you can see a type error that demonstrates this:

![image](https://github.com/user-attachments/assets/aa31f8da-bfdc-4860-b54a-02b85e34cf3b)

## Changes

- Add new `Raw` utility type
- Apply utility type to responses of Locking Service