### PR TITLE
Use correct type for campaign activities

### DIFF
--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -7,6 +7,7 @@ import {
 import { Page } from '@/domain/entities/page.entity';
 import { ILockingApi } from '@/domain/interfaces/locking-api.interface';
 import { Campaign } from '@/domain/community/entities/campaign.entity';
+import { CampaignActivity } from '@/domain/community/entities/campaign-activity.entity';
 import { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { LockingEvent } from '@/domain/community/entities/locking-event.entity';
 import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
@@ -62,10 +63,10 @@ export class LockingApi implements ILockingApi {
     holder?: `0x${string}`;
     limit?: number;
     offset?: number;
-  }): Promise<number> {
+  }): Promise<CampaignActivity> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/activities`;
-      const { data } = await this.networkService.get<number>({
+      const { data } = await this.networkService.get<CampaignActivity>({
         url,
         networkRequest: {
           params: {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@/domain/entities/page.entity';
 import type { Campaign } from '@/domain/community/entities/campaign.entity';
+import type { CampaignActivity } from '@/domain/community/entities/campaign-activity.entity';
 import type { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import type { LockingEvent } from '@/domain/community/entities/locking-event.entity';
 import type { LockingRank } from '@/domain/community/entities/locking-rank.entity';
@@ -19,7 +20,7 @@ export interface ILockingApi {
     holder?: `0x${string}`;
     limit?: number;
     offset?: number;
-  }): Promise<number>;
+  }): Promise<CampaignActivity>;
 
   getLockingRank(safeAddress: `0x${string}`): Promise<LockingRank>;
 


### PR DESCRIPTION
## Summary

We have a type defined for `CampaignActivity` but it is not used on the datasource layer. It's not been noticed as we are correctly validating the response at runtime.

This uses the correct type.

## Changes

- Use correct type