### PR TITLE
Normalize Events log message keys

### DIFF
--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -513,10 +513,10 @@ export class EventCacheHelper {
   ): void {
     this.loggingService.info({
       type: EventCacheHelper.HOOK_TYPE,
-      eventType: event.type,
+      event_type: event.type,
       address: event.address,
-      chainId: event.chainId,
-      safeTxHash: event.safeTxHash,
+      chain_id: event.chainId,
+      safe_tx_hash: event.safeTxHash,
     });
   }
 
@@ -525,10 +525,10 @@ export class EventCacheHelper {
   ): void {
     this.loggingService.info({
       type: EventCacheHelper.HOOK_TYPE,
-      eventType: event.type,
+      event_type: event.type,
       address: event.address,
-      chainId: event.chainId,
-      txHash: event.txHash,
+      chain_id: event.chainId,
+      tx_hash: event.txHash,
     });
   }
 
@@ -537,18 +537,18 @@ export class EventCacheHelper {
   ): void {
     this.loggingService.info({
       type: EventCacheHelper.HOOK_TYPE,
-      eventType: event.type,
+      event_type: event.type,
       address: event.address,
-      chainId: event.chainId,
-      messageHash: event.messageHash,
+      chain_id: event.chainId,
+      message_hash: event.messageHash,
     });
   }
 
   private _logEvent(event: Event): void {
     this.loggingService.info({
       type: EventCacheHelper.HOOK_TYPE,
-      eventType: event.type,
-      chainId: event.chainId,
+      event_type: event.type,
+      chain_id: event.chainId,
     });
   }
 }


### PR DESCRIPTION
## Summary
The usage of snake_case key identifiers for logging is normalized through the service. This is not the case for events reception log lines, which use camelCase notation.

## Changes
- Use snake_case identifiers on events logging.
