### PR TITLE
Support relaying of recovery proposals/executions

### DIFF
--- a/src/domain/alerts/alerts.repository.ts
+++ b/src/domain/alerts/alerts.repository.ts
@@ -75,6 +75,7 @@ export class AlertsRepository implements IAlertsRepository {
     }
   }
 
+  // TODO: Refactor to use getSafeBeingRecovered from relay address limiter
   private _decodeTransactionAdded(
     data: Hex,
   ): Array<ReturnType<typeof this._decodeRecoveryTransaction>> {

--- a/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
+++ b/src/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder.ts
@@ -4,13 +4,14 @@ import type { Hex } from 'viem';
 import {
   encodeAbiParameters,
   encodeEventTopics,
+  encodeFunctionData,
   getAbiItem,
   getAddress,
   keccak256,
   toBytes,
 } from 'viem';
 import { Builder } from '@/__tests__/builder';
-import { TRANSACTION_ADDED_ABI } from '@/domain/alerts/contracts/decoders/delay-modifier-decoder.helper';
+import { DelayModifierAbi } from '@/domain/alerts/contracts/decoders/delay-modifier-decoder.helper';
 
 // TransactionAdded
 
@@ -33,7 +34,7 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
   implements IEncoder<TransactionAddedEvent>
 {
   private readonly item = getAbiItem({
-    abi: TRANSACTION_ADDED_ABI,
+    abi: DelayModifierAbi,
     name: 'TransactionAdded',
   });
 
@@ -49,7 +50,7 @@ class TransactionAddedEventBuilder<T extends TransactionAddedEventArgs>
     );
 
     const topics = encodeEventTopics({
-      abi: TRANSACTION_ADDED_ABI,
+      abi: DelayModifierAbi,
       eventName: 'TransactionAdded',
       args: {
         // Only indexed params
@@ -76,4 +77,68 @@ export function transactionAddedEventBuilder(): TransactionAddedEventBuilder<Tra
     .with('value', BigInt(0))
     .with('data', '0x')
     .with('operation', 0);
+}
+
+// execTransactionFromModule
+
+type ExecTransactionFromModuleArgs = {
+  to: `0x${string}`;
+  value: bigint;
+  data: `0x${string}`;
+  operation: 0 | 1;
+};
+
+class ExecTransactionFromModuleEncoder<T extends ExecTransactionFromModuleArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): `0x${string}` {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: DelayModifierAbi,
+      functionName: 'execTransactionFromModule',
+      args: [args.to, args.value, args.data, args.operation],
+    });
+  }
+}
+
+export function execTransactionFromModuleEncoder(): ExecTransactionFromModuleEncoder<ExecTransactionFromModuleArgs> {
+  return new ExecTransactionFromModuleEncoder()
+    .with('to', getAddress(faker.finance.ethereumAddress()))
+    .with('value', faker.number.bigInt())
+    .with('data', faker.string.hexadecimal() as `0x${string}`)
+    .with('operation', faker.helpers.arrayElement([0, 1]));
+}
+
+// executeNextTx
+
+type ExecNextTxArgs = {
+  to: `0x${string}`;
+  value: bigint;
+  data: `0x${string}`;
+  operation: 0 | 1;
+};
+
+class ExecNextTxEncoder<T extends ExecNextTxArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): `0x${string}` {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: DelayModifierAbi,
+      functionName: 'executeNextTx',
+      args: [args.to, args.value, args.data, args.operation],
+    });
+  }
+}
+
+export function executeNextTxEncoder(): ExecNextTxEncoder<ExecNextTxArgs> {
+  return new ExecNextTxEncoder()
+    .with('to', getAddress(faker.finance.ethereumAddress()))
+    .with('value', faker.number.bigInt())
+    .with('data', faker.string.hexadecimal() as `0x${string}`)
+    .with('operation', faker.helpers.arrayElement([0, 1]));
 }

--- a/src/domain/alerts/contracts/decoders/delay-modifier-decoder.helper.ts
+++ b/src/domain/alerts/contracts/decoders/delay-modifier-decoder.helper.ts
@@ -2,15 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { parseAbi } from 'viem';
 import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
 
-export const TRANSACTION_ADDED_ABI = parseAbi([
+export const DelayModifierAbi = parseAbi([
   'event TransactionAdded(uint256 indexed queueNonce, bytes32 indexed txHash, address to, uint256 value, bytes data, uint8 operation)',
+  'function execTransactionFromModule(address to, uint256 value, bytes calldata data, uint8 operation)',
+  'function executeNextTx(address to, uint256 value, bytes calldata data, uint8 operation)',
 ]);
 
 @Injectable()
-export class DelayModifierDecoder extends AbiDecoder<
-  typeof TRANSACTION_ADDED_ABI
-> {
+export class DelayModifierDecoder extends AbiDecoder<typeof DelayModifierAbi> {
   constructor() {
-    super(TRANSACTION_ADDED_ABI);
+    super(DelayModifierAbi);
   }
 }

--- a/src/domain/relay/relay.domain.module.ts
+++ b/src/domain/relay/relay.domain.module.ts
@@ -4,10 +4,11 @@ import { RelayRepository } from '@/domain/relay/relay.repository';
 import { RelayApiModule } from '@/datasources/relay-api/relay-api.module';
 import { RelayDecodersModule } from '@/domain/relay/relay-decoders.module';
 import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
+import { DelayModifierDecoder } from '@/domain/alerts/contracts/decoders/delay-modifier-decoder.helper';
 
 @Module({
   imports: [RelayApiModule, RelayDecodersModule, SafeRepositoryModule],
-  providers: [LimitAddressesMapper, RelayRepository],
+  providers: [LimitAddressesMapper, RelayRepository, DelayModifierDecoder],
   exports: [RelayRepository],
 })
 export class RelayDomainModule {}


### PR DESCRIPTION
## Summary

Resolves #1638

We only allow relaying of Safe interactions and transfers. For recoverers, the process of transacting may be confusing and facilitating the relaying of recovery proposals/executions would simplify this.

This adds support relaying of "valid" recovery proposals/executions:

- DelayModifier proposal (`execTransactionFromModule`) or execution (`executeNextTx`)
- (Batch) transaction(s) to add/remove/swap owners or change threshold on _a_ Safe
- Via an enabled module on said Safe

## Changes

- Update encoder/decoder to support proposal/execution methods of DelayModifiers
- Add support for valid relaying proposals/executions, limiting the address of the Safe being recovered
- Add relevant test coverage