### PR TITLE
Disable not used queues/database modules on E2E tests

### DIFF
--- a/src/datasources/queues/queues-api.shutdown.hook.ts
+++ b/src/datasources/queues/queues-api.shutdown.hook.ts
@@ -1,5 +1,6 @@
 import { QueueConsumer } from '@/datasources/queues/queues-api.module';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 
 @Injectable()
@@ -11,7 +12,13 @@ export class QueuesApiShutdownHook implements OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     this.loggingService.info('Closing connection to queues');
-    await this.queueConsumer.channel.close();
-    this.loggingService.info('Connection to queues closed');
+    try {
+      await this.queueConsumer.channel.close();
+      this.loggingService.info('Connection to queues closed');
+    } catch (err) {
+      this.loggingService.error(
+        `Failed to close connection to queues: ${asError(err)}`,
+      );
+    }
   }
 }

--- a/src/routes/about/__tests__/get-about.e2e-spec.ts
+++ b/src/routes/about/__tests__/get-about.e2e-spec.ts
@@ -8,6 +8,10 @@ import type { Server } from 'net';
 import request from 'supertest';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Get about e2e test', () => {
   let app: INestApplication<Server>;
@@ -19,8 +23,12 @@ describe('Get about e2e test', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
 
     app = moduleRef.createNestApplication();

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -9,6 +9,10 @@ import { CacheKeyPrefix } from '@/datasources/cache/constants';
 import type { Server } from 'net';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Get contract e2e test', () => {
   let app: INestApplication<Server>;
@@ -22,8 +26,12 @@ describe('Get contract e2e test', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
 
     app = await new TestAppProvider().provide(moduleRef);

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -10,6 +10,10 @@ import { CacheKeyPrefix } from '@/datasources/cache/constants';
 import type { Server } from 'net';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Data decode e2e tests', () => {
   let app: INestApplication<Server>;
@@ -22,8 +26,12 @@ describe('Data decode e2e tests', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
 
     app = await new TestAppProvider().provide(moduleRef);

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -7,6 +7,10 @@ import { CacheKeyPrefix } from '@/datasources/cache/constants';
 import type { Server } from 'net';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Get health e2e test', () => {
   let app: INestApplication<Server>;
@@ -18,8 +22,12 @@ describe('Get health e2e test', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
     app = await new TestAppProvider().provide(moduleRef);
     await app.init();

--- a/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -17,6 +17,8 @@ import { TEST_SAFE } from '@/routes/common/__tests__/constants';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
 
 describe('Events queue processing e2e tests', () => {
   let app: INestApplication<Server>;
@@ -41,6 +43,8 @@ describe('Events queue processing e2e tests', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
       .compile();

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -9,6 +9,10 @@ import type { Server } from 'net';
 import { TEST_SAFE } from '@/routes/common/__tests__/constants';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Get safes by owner e2e test', () => {
   let app: INestApplication<Server>;
@@ -21,8 +25,12 @@ describe('Get safes by owner e2e test', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
 
     app = moduleRef.createNestApplication();

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -10,6 +10,10 @@ import type { SafeApp } from '@/routes/safe-apps/entities/safe-app.entity';
 import type { Server } from 'net';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Get Safe Apps e2e test', () => {
   let app: INestApplication<Server>;
@@ -23,8 +27,12 @@ describe('Get Safe Apps e2e test', () => {
     })
       .overrideProvider(CacheKeyPrefix)
       .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
       .overrideModule(PostgresDatabaseModuleV2)
       .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
       .compile();
 
     app = await new TestAppProvider().provide(moduleRef);


### PR DESCRIPTION
## Summary
This PR aims to fix the following CI error while running E2E tests:
```
  ● Test suite failed to run

    Unhandled error. (Error: Channel ended, no reply will be forthcoming

      at rej (node_modules/amqplib/lib/channel.js:181:9)
      at ConfirmChannel._rejectPending (node_modules/amqplib/lib/channel.js:184:7)
      at ConfirmChannel.toClosed (node_modules/amqplib/lib/channel.js:150:10)
     ...
```

While the root cause is not fully clear, chances are a race condition between the tests causes the shutdown hook to try to close an amqp channel that is already closed. This PR does two related things: 

- It wraps the `QueuesApiShutdownHook.onModuleDestroy` code into a `try-catch` block, so the possible error is handled (and therefore it shouldn't cause a test execution failure),
- It disables the infrastructure that is not involved in the E2E tests (by overriding `PostgresDatabaseModule` and  `QueuesApiModule`).

## Changes
- Add a `try-catch` block to `QueuesApiShutdownHook.onModuleDestroy` so possible errors are handled.
- Disable `PostgresDatabaseModule` and `QueuesApiModule` where they are not required.
