### PR TITLE
Strictly type all addresses in `ITransactionApi`

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -923,7 +923,7 @@ describe('TransactionApi', () => {
 
   describe('getTransfers', () => {
     it('should return the transfers retrieved', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const onlyErc20 = faker.datatype.boolean();
       const onlyErc721 = faker.datatype.boolean();
       const limit = faker.number.int();
@@ -971,7 +971,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const onlyErc20 = faker.datatype.boolean();
       const onlyErc721 = faker.datatype.boolean();
       const limit = faker.number.int();
@@ -1025,7 +1025,7 @@ describe('TransactionApi', () => {
 
   describe('clearTransfers', () => {
     it('should clear the transfers cache', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearTransfers(safeAddress);
 
@@ -1038,12 +1038,12 @@ describe('TransactionApi', () => {
 
   describe('getIncomingTransfers', () => {
     it('should return the incoming transfers retrieved', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const executionDateGte = faker.date.recent().toISOString();
       const executionDateLte = faker.date.recent().toISOString();
-      const to = faker.finance.ethereumAddress();
+      const to = getAddress(faker.finance.ethereumAddress());
       const value = faker.string.numeric();
-      const tokenAddress = faker.finance.ethereumAddress();
+      const tokenAddress = getAddress(faker.finance.ethereumAddress());
       const txHash = faker.string.hexadecimal();
       const limit = faker.number.int();
       const offset = faker.number.int();
@@ -1102,12 +1102,12 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const executionDateGte = faker.date.recent().toISOString();
       const executionDateLte = faker.date.recent().toISOString();
-      const to = faker.finance.ethereumAddress();
+      const to = getAddress(faker.finance.ethereumAddress());
       const value = faker.string.numeric();
-      const tokenAddress = faker.finance.ethereumAddress();
+      const tokenAddress = getAddress(faker.finance.ethereumAddress());
       const txHash = faker.string.hexadecimal();
       const limit = faker.number.int();
       const offset = faker.number.int();
@@ -1168,7 +1168,7 @@ describe('TransactionApi', () => {
 
   describe('clearIncomingTransfers', () => {
     it('should clear the incoming transfers cache', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearIncomingTransfers(safeAddress);
 
@@ -1244,7 +1244,7 @@ describe('TransactionApi', () => {
 
   describe('getSafesByModules', () => {
     it('should return Safes with module enabled', async () => {
-      const moduleAddress = faker.finance.ethereumAddress();
+      const moduleAddress = getAddress(faker.finance.ethereumAddress());
       const safesByModule = {
         safes: [
           faker.finance.ethereumAddress(),
@@ -1271,7 +1271,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const moduleAddress = faker.finance.ethereumAddress();
+      const moduleAddress = getAddress(faker.finance.ethereumAddress());
       const getSafesByModuleUrl = `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
       const statusCode = faker.internet.httpStatusCode({
         types: ['clientError', 'serverError'],
@@ -1607,7 +1607,7 @@ describe('TransactionApi', () => {
 
   describe('clearMultisigTransactions', () => {
     it('should clear the multisig transactions cache', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
 
       await service.clearMultisigTransactions(safeAddress);
 
@@ -2535,7 +2535,7 @@ describe('TransactionApi', () => {
 
   describe('postMultisigTransaction', () => {
     it('should post multisig transaction', async () => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const proposeTransactionDto = proposeTransactionDtoBuilder().build();
       const postMultisigTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       networkService.post.mockResolvedValueOnce({
@@ -2564,7 +2564,7 @@ describe('TransactionApi', () => {
       ['Transaction Service', { nonFieldErrors: [errorMessage] }],
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
-      const safeAddress = faker.finance.ethereumAddress();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
       const proposeTransactionDto = proposeTransactionDtoBuilder().build();
       const postMultisigTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const statusCode = faker.internet.httpStatusCode({

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -466,7 +466,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getTransfers(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     onlyErc20: boolean;
     onlyErc721: boolean;
     limit?: number;
@@ -497,7 +497,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearTransfers(safeAddress: string): Promise<void> {
+  async clearTransfers(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getTransfersCacheKey({
       chainId: this.chainId,
       safeAddress,
@@ -506,12 +506,12 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getIncomingTransfers(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
-    tokenAddress?: string;
+    tokenAddress?: `0x${string}`;
     txHash?: string;
     limit?: number;
     offset?: number;
@@ -545,7 +545,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearIncomingTransfers(safeAddress: string): Promise<void> {
+  async clearIncomingTransfers(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getIncomingTransfersCacheKey({
       chainId: this.chainId,
       safeAddress,
@@ -570,7 +570,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getSafesByModule(moduleAddress: string): Promise<SafeList> {
+  async getSafesByModule(moduleAddress: `0x${string}`): Promise<SafeList> {
     try {
       const url = `${this.baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
       const { data } = await this.networkService.get<SafeList>({ url });
@@ -645,14 +645,13 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async getMultisigTransactions(args: {
-    // TODO: safeAddress and to should be `0x${string}`
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     ordering?: string;
     executed?: boolean;
     trusted?: boolean;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
     nonce?: string;
     nonceGte?: number;
@@ -692,7 +691,7 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async clearMultisigTransactions(safeAddress: string): Promise<void> {
+  async clearMultisigTransactions(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getMultisigTransactionsCacheKey({
       chainId: this.chainId,
       safeAddress,
@@ -812,7 +811,7 @@ export class TransactionApi implements ITransactionApi {
 
   // Important: there is no hook which invalidates this endpoint,
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
-  async getToken(address: string): Promise<Token> {
+  async getToken(address: `0x${string}`): Promise<Token> {
     try {
       const cacheDir = CacheRouter.getTokenCacheDir({
         chainId: this.chainId,
@@ -994,7 +993,7 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async postMultisigTransaction(args: {
-    address: string;
+    address: `0x${string}`;
     data: ProposeTransactionDto;
   }): Promise<unknown> {
     try {

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -98,35 +98,35 @@ export interface ITransactionApi {
   getTransfer(transferId: string): Promise<Transfer>;
 
   getTransfers(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     onlyErc20?: boolean;
     onlyErc721?: boolean;
     limit?: number;
     offset?: number;
   }): Promise<Page<Transfer>>;
 
-  clearTransfers(safeAddress: string): Promise<void>;
+  clearTransfers(safeAddress: `0x${string}`): Promise<void>;
 
   getIncomingTransfers(args: {
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
-    tokenAddress?: string;
+    tokenAddress?: `0x${string}`;
     txHash?: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<Transfer>>;
 
-  clearIncomingTransfers(safeAddress: string): Promise<void>;
+  clearIncomingTransfers(safeAddress: `0x${string}`): Promise<void>;
 
   postConfirmation(args: {
     safeTxHash: string;
     addConfirmationDto: AddConfirmationDto;
   }): Promise<unknown>;
 
-  getSafesByModule(moduleAddress: string): Promise<SafeList>;
+  getSafesByModule(moduleAddress: `0x${string}`): Promise<SafeList>;
 
   getModuleTransaction(moduleTransactionId: string): Promise<ModuleTransaction>;
 
@@ -159,7 +159,7 @@ export interface ITransactionApi {
     trusted?: boolean;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
     nonce?: string;
     nonceGte?: number;
@@ -167,7 +167,7 @@ export interface ITransactionApi {
     offset?: number;
   }): Promise<Page<MultisigTransaction>>;
 
-  clearMultisigTransactions(safeAddress: string): Promise<void>;
+  clearMultisigTransactions(safeAddress: `0x${string}`): Promise<void>;
 
   getCreationTransaction(
     safeAddress: `0x${string}`,
@@ -184,7 +184,7 @@ export interface ITransactionApi {
 
   clearAllTransactions(safeAddress: `0x${string}`): Promise<void>;
 
-  getToken(address: string): Promise<Token>;
+  getToken(address: `0x${string}`): Promise<Token>;
 
   getTokens(args: { limit?: number; offset?: number }): Promise<Page<Token>>;
 
@@ -217,7 +217,7 @@ export interface ITransactionApi {
   }): Promise<Page<Message>>;
 
   postMultisigTransaction(args: {
-    address: string;
+    address: `0x${string}`;
     data: ProposeTransactionDto;
   }): Promise<unknown>;
 

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -37,16 +37,19 @@ export interface ISafeRepository {
     offset?: number;
   }): Promise<Page<Transfer>>;
 
-  clearTransfers(args: { chainId: string; safeAddress: string }): Promise<void>;
+  clearTransfers(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<void>;
 
   getIncomingTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
-    tokenAddress?: string;
+    tokenAddress?: `0x${string}`;
     txHash?: string;
     limit?: number;
     offset?: number;
@@ -54,7 +57,7 @@ export interface ISafeRepository {
 
   clearIncomingTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 
   addConfirmation(args: {
@@ -137,7 +140,7 @@ export interface ISafeRepository {
 
   clearMultisigTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void>;
 
   getMultisigTransactions(args: {
@@ -183,7 +186,7 @@ export interface ISafeRepository {
 
   proposeTransaction(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     proposeTransactionDto: ProposeTransactionDto;
   }): Promise<unknown>;
 
@@ -204,7 +207,7 @@ export interface ISafeRepository {
 
   getSafesByModule(args: {
     chainId: string;
-    moduleAddress: string;
+    moduleAddress: `0x${string}`;
   }): Promise<SafeList>;
 }
 

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -98,7 +98,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getCollectibleTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number;
     offset?: number;
   }): Promise<Page<Transfer>> {
@@ -115,7 +115,7 @@ export class SafeRepository implements ISafeRepository {
 
   async clearTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
@@ -126,12 +126,12 @@ export class SafeRepository implements ISafeRepository {
 
   async getIncomingTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
-    tokenAddress?: string;
+    tokenAddress?: `0x${string}`;
     txHash?: string;
     limit?: number;
     offset?: number;
@@ -145,7 +145,7 @@ export class SafeRepository implements ISafeRepository {
 
   async clearIncomingTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
@@ -356,7 +356,7 @@ export class SafeRepository implements ISafeRepository {
 
   async clearMultisigTransactions(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
   }): Promise<void> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
@@ -370,7 +370,7 @@ export class SafeRepository implements ISafeRepository {
     executed?: boolean;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
     nonce?: string;
     nonceGte?: number;
@@ -401,7 +401,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getTransfers(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     limit?: number | undefined;
   }): Promise<Page<Transfer>> {
     const transactionService = await this.transactionApiManager.getApi(
@@ -473,7 +473,7 @@ export class SafeRepository implements ISafeRepository {
 
   async proposeTransaction(args: {
     chainId: string;
-    safeAddress: string;
+    safeAddress: `0x${string}`;
     proposeTransactionDto: ProposeTransactionDto;
   }): Promise<unknown> {
     const transactionService = await this.transactionApiManager.getApi(
@@ -512,7 +512,7 @@ export class SafeRepository implements ISafeRepository {
 
   async getSafesByModule(args: {
     chainId: string;
-    moduleAddress: string;
+    moduleAddress: `0x${string}`;
   }): Promise<SafeList> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,

--- a/src/domain/tokens/token.repository.interface.ts
+++ b/src/domain/tokens/token.repository.interface.ts
@@ -7,7 +7,7 @@ import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api
 export const ITokenRepository = Symbol('ITokenRepository');
 
 export interface ITokenRepository {
-  getToken(args: { chainId: string; address: string }): Promise<Token>;
+  getToken(args: { chainId: string; address: `0x${string}` }): Promise<Token>;
 
   getTokens(args: {
     chainId: string;

--- a/src/domain/tokens/token.repository.ts
+++ b/src/domain/tokens/token.repository.ts
@@ -15,7 +15,10 @@ export class TokenRepository implements ITokenRepository {
     private readonly transactionApiManager: ITransactionApiManager,
   ) {}
 
-  async getToken(args: { chainId: string; address: string }): Promise<Token> {
+  async getToken(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<Token> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -138,7 +138,7 @@ export class TransferInfoMapper {
 
   private getToken(
     chainId: string,
-    tokenAddress: string | null,
+    tokenAddress: `0x${string}` | null,
   ): Promise<Token> {
     if (!tokenAddress) {
       throw Error('Invalid token address for transfer');

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -79,7 +79,8 @@ export class TransactionsController {
     safeAddress: `0x${string}`,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
-    @Query('to') to?: string,
+    @Query('to', new ValidationPipe(AddressSchema.optional()))
+    to?: `0x${string}`,
     @Query('value') value?: string,
     @Query('nonce') nonce?: string,
     @Query('executed', new ParseBoolPipe({ optional: true }))
@@ -175,9 +176,11 @@ export class TransactionsController {
     trusted: boolean,
     @Query('execution_date__gte') executionDateGte?: string,
     @Query('execution_date__lte') executionDateLte?: string,
-    @Query('to') to?: string,
+    @Query('to', new ValidationPipe(AddressSchema.optional()))
+    to?: `0x${string}`,
     @Query('value') value?: string,
-    @Query('token_address') tokenAddress?: string,
+    @Query('token_address', new ValidationPipe(AddressSchema.optional()))
+    tokenAddress?: `0x${string}`,
   ): Promise<Partial<Page<IncomingTransfer>>> {
     return this.transactionsService.getIncomingTransfers({
       chainId,

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -142,7 +142,7 @@ export class TransactionsService {
     safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
     nonce?: string;
     executed?: boolean;
@@ -266,9 +266,9 @@ export class TransactionsService {
     safeAddress: `0x${string}`;
     executionDateGte?: string;
     executionDateLte?: string;
-    to?: string;
+    to?: `0x${string}`;
     value?: string;
-    tokenAddress?: string;
+    tokenAddress?: `0x${string}`;
     paginationData?: PaginationData;
     onlyTrusted: boolean;
   }): Promise<Partial<Page<IncomingTransfer>>> {


### PR DESCRIPTION
## Summary

We validate (and checksum) all addresses in the project. There are, however, some instances we missed when implementing this.

This ensures all addresses within the `ITransactionApi` are strictly typed as `0x${string` and propagates these types through the domain, adding the relevant validating to the transaction controller.

## Changes

- Increase type strictness and propagate it through layers
- Add address validation (and checksumming) to:
  - `to` query of `chains/:chainId/safes/:safeAddress/multisig-transactions` (optional field)
  - `to` and `token_address` queries of `chains/:chainId/safes/:safeAddress/incoming-transfers` (optional fields)
- Update tests accordingly