### PR TITLE
add more postgres mock

### DIFF
--- a/src/datasources/db/v2/__tests__/entity-manager.mock.ts
+++ b/src/datasources/db/v2/__tests__/entity-manager.mock.ts
@@ -1,0 +1,9 @@
+import { mockQueryBuilder } from '@/datasources/db/v2/__tests__/querybuilder.mock';
+import type { EntityManager } from 'typeorm';
+
+export const mockEntityManager = {
+  find: jest.fn(),
+  query: jest.fn(),
+  upsert: jest.fn(),
+  createQueryBuilder: jest.fn().mockImplementation(() => mockQueryBuilder),
+} as jest.MockedObjectDeep<EntityManager>;

--- a/src/datasources/db/v2/__tests__/postgresql-database.service.mock.ts
+++ b/src/datasources/db/v2/__tests__/postgresql-database.service.mock.ts
@@ -1,0 +1,22 @@
+import { mockEntityManager } from '@/datasources/db/v2/__tests__/entity-manager.mock';
+import { mockPostgresDataSource } from '@/datasources/db/v2/__tests__/postgresql-datasource.mock';
+import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import type { EntityManager } from 'typeorm';
+
+export const mockPostgresDatabaseService = {
+  getDataSource: jest.fn().mockImplementation(() => mockPostgresDataSource),
+  isInitialized: jest.fn(),
+  initializeDatabaseConnection: jest
+    .fn()
+    .mockImplementation(() => mockPostgresDataSource),
+  destroyDatabaseConnection: jest.fn(),
+  getRepository: jest.fn(),
+  transaction: jest
+    .fn()
+    .mockImplementation(
+      (callback: (mockEntityManager: EntityManager) => EntityManager) => {
+        return callback(mockEntityManager);
+      },
+    ),
+  getTransactionRunner: jest.fn().mockReturnValue(mockEntityManager),
+} as jest.MockedObjectDeep<PostgresDatabaseService>;

--- a/src/datasources/db/v2/__tests__/postgresql-datasource.mock.ts
+++ b/src/datasources/db/v2/__tests__/postgresql-datasource.mock.ts
@@ -1,0 +1,7 @@
+import type { DataSource } from 'typeorm';
+
+export const mockPostgresDataSource = {
+  query: jest.fn(),
+  runMigrations: jest.fn(),
+  initialize: jest.fn(),
+} as jest.MockedObjectDeep<DataSource>;

--- a/src/datasources/db/v2/__tests__/querybuilder.mock.ts
+++ b/src/datasources/db/v2/__tests__/querybuilder.mock.ts
@@ -1,6 +1,8 @@
+import type { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+
 export const mockQueryBuilder = {
   delete: jest.fn().mockReturnThis(),
   from: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
   execute: jest.fn(),
-};
+} as jest.MockedObjectDeep<SelectQueryBuilder<ObjectLiteral>>;

--- a/src/datasources/db/v2/__tests__/querybuilder.mock.ts
+++ b/src/datasources/db/v2/__tests__/querybuilder.mock.ts
@@ -1,0 +1,6 @@
+export const mockQueryBuilder = {
+  delete: jest.fn().mockReturnThis(),
+  from: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  execute: jest.fn(),
+};

--- a/src/datasources/db/v2/__tests__/repository.mock.ts
+++ b/src/datasources/db/v2/__tests__/repository.mock.ts
@@ -1,0 +1,9 @@
+import type { ObjectLiteral, Repository } from 'typeorm';
+
+export const mockRepository = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  upsert: jest.fn(),
+  remove: jest.fn(),
+  delete: jest.fn(),
+} as jest.MockedObjectDeep<Repository<ObjectLiteral>>;

--- a/src/datasources/db/v2/database-migrator.service.spec.ts
+++ b/src/datasources/db/v2/database-migrator.service.spec.ts
@@ -22,11 +22,11 @@ const mockLoggingService = {
 describe('PostgresDatabaseService', () => {
   let moduleRef: TestingModule;
   let databaseMigratorService: DatabaseMigrator;
-  let connection: jest.MockedObjectDeep<DataSource>;
   let postgresDatabaseService: PostgresDatabaseService;
   const NUMBER_OF_RETRIES = 2;
   const LOCK_TABLE_NAME = '_lock';
   const truncateLockQuery = `TRUNCATE TABLE "${LOCK_TABLE_NAME}";`;
+  const connection: jest.MockedObjectDeep<DataSource> = mockPostgresDataSource;
   const insertLockQuery = `INSERT INTO "${LOCK_TABLE_NAME}" (status) VALUES ($1);`;
 
   beforeAll(async () => {
@@ -66,7 +66,6 @@ describe('PostgresDatabaseService', () => {
       providers: [DatabaseMigrator],
     }).compile();
 
-    connection = mockPostgresDataSource;
     const configService = moduleRef.get<ConfigService>(ConfigService);
     postgresDatabaseService = new PostgresDatabaseService(
       mockLoggingService,

--- a/src/datasources/db/v2/database-migrator.service.spec.ts
+++ b/src/datasources/db/v2/database-migrator.service.spec.ts
@@ -9,10 +9,8 @@ import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.s
 import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
 import { type ILoggingService } from '@/logging/logging.interface';
 import type { DataSource } from 'typeorm';
-import {
-  postgresDataSourceMock,
-  TestPostgresDatabaseModuleV2,
-} from '@/datasources/db/v2/test.postgres-database.module';
+import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { mockPostgresDataSource } from '@/datasources/db/v2/__tests__/postgresql-datasource.mock';
 
 const mockLoggingService = {
   debug: jest.fn(),
@@ -68,7 +66,7 @@ describe('PostgresDatabaseService', () => {
       providers: [DatabaseMigrator],
     }).compile();
 
-    connection = postgresDataSourceMock;
+    connection = mockPostgresDataSource;
     const configService = moduleRef.get<ConfigService>(ConfigService);
     postgresDatabaseService = new PostgresDatabaseService(
       mockLoggingService,

--- a/src/datasources/db/v2/test.postgres-database.module.ts
+++ b/src/datasources/db/v2/test.postgres-database.module.ts
@@ -1,31 +1,13 @@
 import { Module } from '@nestjs/common';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
-import type { DataSource } from 'typeorm';
-
-export const postgresDataSourceMock = {
-  query: jest.fn(),
-  runMigrations: jest.fn(),
-  initialize: jest.fn(),
-} as jest.MockedObjectDeep<DataSource>;
-
-export const postgresDatabaseServiceMock = {
-  getDataSource: jest.fn().mockImplementation(() => postgresDataSourceMock),
-  isInitialized: jest.fn(),
-  initializeDatabaseConnection: jest
-    .fn()
-    .mockImplementation(() => postgresDataSourceMock),
-  destroyDatabaseConnection: jest.fn(),
-  getRepository: jest.fn(),
-  transaction: jest.fn(),
-  getTransactionRunner: jest.fn(),
-} as jest.MockedObjectDeep<PostgresDatabaseService>;
+import { mockPostgresDatabaseService } from '@/datasources/db/v2/__tests__/postgresql-database.service.mock';
 
 @Module({
   providers: [
     {
       provide: PostgresDatabaseService,
       useFactory: (): jest.MockedObjectDeep<PostgresDatabaseService> => {
-        return jest.mocked(postgresDatabaseServiceMock);
+        return jest.mocked(mockPostgresDatabaseService);
       },
     },
   ],


### PR DESCRIPTION
## Summary
This PR introduces additional mocks to simulate PostgreSQL interactions more flexibly in our Jest test suite

## Changes
entity-manager.mock.ts
postgresql-database.service.mock.ts
postgresql-datasource.mock.ts
querybuilder.mock.ts
repository.mock.ts

