### PR TITLE
Map `SafeApp['featured']` flag

### DIFF
--- a/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
@@ -24,5 +24,6 @@ export function safeAppBuilder(): IBuilder<SafeApp> {
       faker.helpers.multiple(() => safeAppSocialProfileBuilder().build(), {
         count: { min: 0, max: 5 },
       }),
-    );
+    )
+    .with('featured', faker.datatype.boolean());
 }

--- a/src/domain/safe-apps/entities/schemas/__tests__/safe-app.schema.spec.ts
+++ b/src/domain/safe-apps/entities/schemas/__tests__/safe-app.schema.spec.ts
@@ -243,6 +243,13 @@ describe('SafeAppSchema', () => {
           path: ['socialProfiles'],
           message: 'Required',
         },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          received: 'undefined',
+          path: ['featured'],
+          message: 'Required',
+        },
       ]),
     );
   });

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -37,4 +37,5 @@ export const SafeAppSchema = z.object({
   iconUrl: z.string().url().nullish().default(null),
   provider: SafeAppProviderSchema.nullish().default(null),
   developerWebsite: z.string().url().nullish().default(null),
+  featured: z.boolean(),
 });

--- a/src/routes/safe-apps/entities/safe-app.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app.entity.ts
@@ -28,6 +28,8 @@ export class SafeApp {
   developerWebsite: string | null;
   @ApiProperty({ type: SafeAppSocialProfile })
   socialProfiles: SafeAppSocialProfile[];
+  @ApiProperty()
+  featured: boolean;
 
   constructor(
     id: number,
@@ -42,6 +44,7 @@ export class SafeApp {
     features: string[],
     developerWebsite: string | null,
     socialProfiles: SafeAppSocialProfile[],
+    featured: boolean,
   ) {
     this.id = id;
     this.url = url;
@@ -55,5 +58,6 @@ export class SafeApp {
     this.features = features;
     this.developerWebsite = developerWebsite;
     this.socialProfiles = socialProfiles;
+    this.featured = featured;
   }
 }

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -120,6 +120,7 @@ describe('Safe Apps Controller (Unit)', () => {
             features: safeAppsResponse[0].features,
             developerWebsite: safeAppsResponse[0].developerWebsite,
             socialProfiles: safeAppsResponse[0].socialProfiles,
+            featured: safeAppsResponse[0].featured,
           },
           {
             id: safeAppsResponse[1].id,
@@ -137,6 +138,7 @@ describe('Safe Apps Controller (Unit)', () => {
             features: safeAppsResponse[1].features,
             developerWebsite: safeAppsResponse[1].developerWebsite,
             socialProfiles: safeAppsResponse[1].socialProfiles,
+            featured: safeAppsResponse[1].featured,
           },
         ]);
     });
@@ -183,6 +185,7 @@ describe('Safe Apps Controller (Unit)', () => {
             features: safeAppsResponse[0].features,
             developerWebsite: safeAppsResponse[0].developerWebsite,
             socialProfiles: safeAppsResponse[0].socialProfiles,
+            featured: safeAppsResponse[0].featured,
           },
         ]);
     });

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -38,6 +38,7 @@ export class SafeAppsService {
           safeApp.features,
           safeApp.developerWebsite,
           safeApp.socialProfiles,
+          safeApp.featured,
         ),
     );
   }


### PR DESCRIPTION
## Summary

A featured` flag has been [added to the `SafeApp` model](https://github.com/safe-global/safe-config-service/pull/1272) of the Config Service.

This maps the new `featured` flag to the appropriate `SafeApp` entity, under the `featured` property.

## Changes

- Add `featured` to the `SafeAppsSchema`
- Map flag to `SafeApp['featured']`
- Update tests accordingly