### PR TITLE
Mark `SafeApp['features' | 'socialProfiles']` as arrays

### DIFF
--- a/src/routes/safe-apps/entities/safe-app.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app.entity.ts
@@ -22,11 +22,11 @@ export class SafeApp {
   accessControl: SafeAppAccessControl;
   @ApiProperty()
   tags: string[];
-  @ApiProperty()
+  @ApiProperty({ type: String, isArray: true })
   features: string[];
   @ApiPropertyOptional({ type: String, nullable: true })
   developerWebsite: string | null;
-  @ApiProperty({ type: SafeAppSocialProfile })
+  @ApiProperty({ type: SafeAppSocialProfile, isArray: true })
   socialProfiles: SafeAppSocialProfile[];
 
   constructor(


### PR DESCRIPTION
## Summary

The `SafeApp` entity has both `features` and `socialProfiles` that are arrays, but not correctly marked as such. This adds the `isArray` flag to both decorators.

## Changes

- Add `isArray` flag to relevant `ApiProperty` decorators