### PR TITLE
Ensure recovery relay tests have addresses

### DIFF
--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -204,7 +204,7 @@ describe('Relay controller', () => {
                 .with('chainId', faker.helpers.arrayElement(supportedChainIds))
                 .build();
               const safes = Array.from(
-                { length: faker.number.int({ min: 1, max: 4 }) },
+                { length: faker.number.int({ min: 2, max: 4 }) },
                 () => getAddress(faker.finance.ethereumAddress()),
               );
               // We don't need to test all possible combinations as we only use the address
@@ -1043,7 +1043,7 @@ describe('Relay controller', () => {
                   )
                   .build();
                 const safes = Array.from(
-                  { length: faker.number.int({ min: 1, max: 4 }) },
+                  { length: faker.number.int({ min: 2, max: 4 }) },
                   () => getAddress(faker.finance.ethereumAddress()),
                 );
                 // We don't need to test all possible combinations as we only use the address
@@ -2028,7 +2028,7 @@ describe('Relay controller', () => {
                 .with('chainId', faker.helpers.arrayElement(supportedChainIds))
                 .build();
               const safes = Array.from(
-                { length: faker.number.int({ min: 1, max: 4 }) },
+                { length: faker.number.int({ min: 2, max: 4 }) },
                 () => getAddress(faker.finance.ethereumAddress()),
               );
               // We don't need to test all possible combinations as we only use the address

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -1219,7 +1219,7 @@ describe('Relay controller', () => {
                   )
                   .build();
                 const safes = Array.from(
-                  { length: faker.number.int({ min: 1, max: 4 }) },
+                  { length: faker.number.int({ min: 2, max: 4 }) },
                   () => getAddress(faker.finance.ethereumAddress()),
                 );
                 // We don't need to test all possible combinations as we only use the address


### PR DESCRIPTION
## Summary

After adding recovery relaying, our tests started to break due to [`undefined` addresses in `multiSend` calls](https://github.com/safe-global/safe-client-gateway/actions/runs/11673066742/job/32502981237?pr=2092).

When testing recovery "batches", we inherently have [>1 transaction in the mocked data](https://github.com/safe-global/safe-client-gateway/blob/relay-mock/src/routes/relay/relay.controller.spec.ts#L1323-L1333). We do not, however, have [enough mock Safe addresses to compare against](https://github.com/safe-global/safe-client-gateway/blob/relay-mock/src/routes/relay/relay.controller.spec.ts#L1311).

This adjusts the `min` length of mock addresses to match that of the number of transactions in a batch.

## Changes

- Increase the `min` values of mock Safe addresses in recovery relaying batches