### PR TITLE
Add validation for `SafeApp['socialProfiles'][number]['platform']`

### DIFF
--- a/src/domain/safe-apps/entities/__tests__/safe-app-social-profile.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-social-profile.builder.ts
@@ -1,10 +1,11 @@
 import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
+import { SafeAppSocialProfilePlatforms } from '@/domain/safe-apps/entities/schemas/safe-app.schema';
 import type { SafeAppSocialProfile } from '@/domain/safe-apps/entities/safe-app-social-profile.entity';
 
 export function safeAppSocialProfileBuilder(): IBuilder<SafeAppSocialProfile> {
   return new Builder<SafeAppSocialProfile>()
-    .with('platform', faker.word.sample())
+    .with('platform', faker.helpers.objectValue(SafeAppSocialProfilePlatforms))
     .with('url', faker.internet.url({ appendSlash: false }));
 }

--- a/src/domain/safe-apps/entities/safe-app-social-profile.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app-social-profile.entity.ts
@@ -1,4 +1,11 @@
-export interface SafeAppSocialProfile {
-  platform: string;
+import type { z } from 'zod';
+import type {
+  SafeAppSocialProfilePlatforms,
+  SafeAppSocialProfileSchema,
+} from '@/domain/safe-apps/entities/schemas/safe-app.schema';
+
+export interface SafeAppSocialProfile
+  extends z.infer<typeof SafeAppSocialProfileSchema> {
+  platform: SafeAppSocialProfilePlatforms;
   url: string;
 }

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -14,8 +14,17 @@ export const SafeAppAccessControlSchema = z.discriminatedUnion('type', [
   }),
 ]);
 
+export enum SafeAppSocialProfilePlatforms {
+  Discord = 'DISCORD',
+  GitHub = 'GITHUB',
+  Twitter = 'TWITTER',
+  Unknown = 'UNKNOWN',
+}
+
 export const SafeAppSocialProfileSchema = z.object({
-  platform: z.string(),
+  platform: z
+    .nativeEnum(SafeAppSocialProfilePlatforms)
+    .catch(SafeAppSocialProfilePlatforms.Unknown),
   url: z.string().url(),
 });
 

--- a/src/routes/safe-apps/entities/safe-app-social-profile.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-social-profile.entity.ts
@@ -1,9 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { SafeAppSocialProfile as DomainSafeAppSocialProfile } from '@/domain/safe-apps/entities/safe-app-social-profile.entity';
+import { SafeAppSocialProfilePlatforms } from '@/domain/safe-apps/entities/schemas/safe-app.schema';
 
 export class SafeAppSocialProfile implements DomainSafeAppSocialProfile {
-  @ApiProperty()
-  platform!: string;
+  @ApiProperty({ enum: SafeAppSocialProfilePlatforms })
+  platform!: SafeAppSocialProfilePlatforms;
   @ApiProperty()
   url!: string;
 }


### PR DESCRIPTION
## Summary

We validate `SafeApp['socialProfiles'][number]['platform']` as a string. However, they can only be `DISCORD`, `GITHUB` or `TWITTER`.

This adds the relevant validation for the above values, falling back to `UNKNOWN` if it does not match.

## Changes

- Add `SafeAppSocialProfilePlatforms` enum
- Propagate enum to relevant types
- Update tests accordingly