### PR TITLE
Type relay-related responses as "raw"

### DIFF
--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -11,7 +11,13 @@ import {
   CacheService,
   ICacheService,
 } from '@/datasources/cache/cache.service.interface';
+import type { Relay } from '@/domain/relay/entities/relay.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
 
+/**
+ * TODO: Move all usage of Raw to NetworkService after fully migrated
+ * to "Raw" type implementation.
+ */
 @Injectable()
 export class GelatoApi implements IRelayApi {
   /**
@@ -43,14 +49,14 @@ export class GelatoApi implements IRelayApi {
     to: `0x${string}`;
     data: string;
     gasLimit: bigint | null;
-  }): Promise<{ taskId: string }> {
+  }): Promise<Raw<Relay>> {
     const sponsorApiKey = this.configurationService.getOrThrow<string>(
       `relay.apiKey.${args.chainId}`,
     );
 
     try {
       const url = `${this.baseUri}/relays/v2/sponsored-call`;
-      const { data } = await this.networkService.post<{ taskId: string }>({
+      const { data } = await this.networkService.post<Raw<Relay>>({
         url,
         data: {
           sponsorApiKey,
@@ -75,6 +81,7 @@ export class GelatoApi implements IRelayApi {
   async getRelayCount(args: {
     chainId: string;
     address: `0x${string}`;
+    // TODO: Change to Raw when cache service is migrated
   }): Promise<number> {
     const cacheDir = CacheRouter.getRelayCacheDir(args);
     const count = await this.cacheService.hGet(cacheDir);

--- a/src/domain/interfaces/relay-api.interface.ts
+++ b/src/domain/interfaces/relay-api.interface.ts
@@ -1,3 +1,6 @@
+import type { Relay } from '@/domain/relay/entities/relay.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
+
 export const IRelayApi = Symbol('IRelayApi');
 
 export interface IRelayApi {
@@ -6,7 +9,7 @@ export interface IRelayApi {
     to: `0x${string}`;
     data: string;
     gasLimit: bigint | null;
-  }): Promise<{ taskId: string }>;
+  }): Promise<Raw<Relay>>;
 
   getRelayCount(args: {
     chainId: string;

--- a/src/domain/relay/entities/relay.entity.spec.ts
+++ b/src/domain/relay/entities/relay.entity.spec.ts
@@ -1,0 +1,64 @@
+import { RelaySchema } from '@/domain/relay/entities/relay.entity';
+import { faker } from '@faker-js/faker';
+
+// Note: no builder exists for Relay as it is only tested here
+describe('RelaySchema', () => {
+  it('should validate a Relay', () => {
+    const relay = {
+      taskId: faker.string.alphanumeric(),
+    };
+
+    const result = RelaySchema.safeParse(relay);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not validate a Relay with missing taskId', () => {
+    const relay = {};
+
+    const result = RelaySchema.safeParse(relay);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'invalid_type',
+      expected: 'string',
+      message: 'Required',
+      path: ['taskId'],
+      received: 'undefined',
+    });
+  });
+
+  it('should not validate a Relay with invalid taskId', () => {
+    const relay = {
+      taskId: faker.number.int(),
+    };
+
+    const result = RelaySchema.safeParse(relay);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'invalid_type',
+      expected: 'string',
+      message: 'Expected string, received number',
+      path: ['taskId'],
+      received: 'number',
+    });
+  });
+
+  it('should not validate an invalid Relay', () => {
+    const relay = {
+      invalid: 'relay',
+    };
+
+    const result = RelaySchema.safeParse(relay);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(!result.success && result.error.issues[0]).toStrictEqual({
+      code: 'invalid_type',
+      expected: 'string',
+      message: 'Required',
+      path: ['taskId'],
+      received: 'undefined',
+    });
+  });
+});

--- a/src/domain/relay/entities/relay.entity.ts
+++ b/src/domain/relay/entities/relay.entity.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const RelaySchema = z.object({
+  taskId: z.string(),
+});
+
+export type Relay = z.infer<typeof RelaySchema>;

--- a/src/domain/relay/relay.repository.ts
+++ b/src/domain/relay/relay.repository.ts
@@ -4,6 +4,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { IRelayApi } from '@/domain/interfaces/relay-api.interface';
 import { LimitAddressesMapper } from '@/domain/relay/limit-addresses.mapper';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { Relay, RelaySchema } from '@/domain/relay/entities/relay.entity';
 
 @Injectable()
 export class RelayRepository {
@@ -26,7 +27,7 @@ export class RelayRepository {
     to: `0x${string}`;
     data: `0x${string}`;
     gasLimit: bigint | null;
-  }): Promise<{ taskId: string }> {
+  }): Promise<Relay> {
     const relayAddresses =
       await this.limitAddressesMapper.getLimitAddresses(args);
 
@@ -46,7 +47,9 @@ export class RelayRepository {
       }
     }
 
-    const relayResponse = await this.relayApi.relay(args);
+    const relayResponse = await this.relayApi
+      .relay(args)
+      .then(RelaySchema.parse);
 
     // If we fail to increment count, we should not fail the relay
     for (const address of relayAddresses) {

--- a/src/routes/relay/entities/relay.entity.ts
+++ b/src/routes/relay/entities/relay.entity.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Relay as DomainRelay } from '@/domain/relay/entities/relay.entity';
+
+export class Relay implements DomainRelay {
+  @ApiProperty()
+  taskId: string;
+
+  constructor(relay: DomainRelay) {
+    this.taskId = relay.taskId;
+  }
+}

--- a/src/routes/relay/entities/relays-remaining.entity.ts
+++ b/src/routes/relay/entities/relays-remaining.entity.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RelaysRemaining {
+  @ApiProperty()
+  remaining: number;
+
+  @ApiProperty()
+  limit: number;
+
+  constructor({ remaining, limit }: { remaining: number; limit: number }) {
+    this.remaining = remaining;
+    this.limit = limit;
+  }
+}

--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -11,6 +11,8 @@ import { UnofficialMultiSendExceptionFilter } from '@/domain/relay/exception-fil
 import { UnofficialProxyFactoryExceptionFilter } from '@/domain/relay/exception-filters/unofficial-proxy-factory.exception-filter';
 import { RelayDtoSchema } from '@/routes/relay/entities/schemas/relay.dto.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import type { Relay } from '@/routes/relay/entities/relay.entity';
+import type { RelaysRemaining } from '@/routes/relay/entities/relays-remaining.entity';
 
 @ApiTags('relay')
 @Controller({
@@ -33,7 +35,7 @@ export class RelayController {
     @Param('chainId') chainId: string,
     @Body(new ValidationPipe(RelayDtoSchema))
     relayDto: RelayDto,
-  ): Promise<{ taskId: string }> {
+  ): Promise<Relay> {
     return this.relayService.relay({ chainId, relayDto });
   }
 
@@ -42,10 +44,7 @@ export class RelayController {
     @Param('chainId') chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: `0x${string}`,
-  ): Promise<{
-    remaining: number;
-    limit: number;
-  }> {
+  ): Promise<RelaysRemaining> {
     return this.relayService.getRelaysRemaining({ chainId, safeAddress });
   }
 }

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { RelayRepository } from '@/domain/relay/relay.repository';
 import { RelayDto } from '@/routes/relay/entities/relay.dto.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { Relay } from '@/routes/relay/entities/relay.entity';
+import { RelaysRemaining } from '@/routes/relay/entities/relays-remaining.entity';
 
 @Injectable()
 export class RelayService {
@@ -15,17 +17,16 @@ export class RelayService {
     this.limit = configurationService.getOrThrow('relay.limit');
   }
 
-  async relay(args: {
-    chainId: string;
-    relayDto: RelayDto;
-  }): Promise<{ taskId: string }> {
-    return this.relayRepository.relay({
+  async relay(args: { chainId: string; relayDto: RelayDto }): Promise<Relay> {
+    const relay = await this.relayRepository.relay({
       version: args.relayDto.version,
       chainId: args.chainId,
       to: args.relayDto.to,
       data: args.relayDto.data,
       gasLimit: args.relayDto.gasLimit,
     });
+
+    return new Relay(relay);
   }
 
   async getRelaysRemaining(args: {
@@ -37,9 +38,9 @@ export class RelayService {
       address: args.safeAddress,
     });
 
-    return {
+    return new RelaysRemaining({
       remaining: Math.max(this.limit - currentCount, 0),
       limit: this.limit,
-    };
+    });
   }
 }


### PR DESCRIPTION
Partial implementation of #1731

## Summary

We validate API responses on the domain layer, but directly assign the type in the datasources. This means that the response types are not necessarily correct.

This types all the relay-related responses as "raw". These responses can therefore not be used directly unless they are validated.

## Changes

- Add `Raw` utility type to `IRelayApi`
- Update domain/route entities accordingly