### PR TITLE
Return value from the TypeOrm transaction callback

### DIFF
--- a/src/datasources/db/v2/postgres-database.service.ts
+++ b/src/datasources/db/v2/postgres-database.service.ts
@@ -84,13 +84,13 @@ export class PostgresDatabaseService {
     return this.dataSource.getRepository<T>(entity);
   }
 
-  public async transaction(
-    callback: (transactionManager: EntityManager) => Promise<void>,
-  ): Promise<void> {
+  public async transaction<T>(
+    callback: (transactionManager: EntityManager) => Promise<T>,
+  ): Promise<T> {
     return this.dataSource.transaction(
-      async (transactionalEntityManager): Promise<void> => {
+      async (transactionalEntityManager): Promise<T> => {
         this.transactionManager = transactionalEntityManager;
-        await callback(this.transactionManager);
+        return await callback(this.transactionManager);
       },
     );
   }


### PR DESCRIPTION
## Summary
This PR enables returning the value from the TypeOrm transaction callback handler.

## Changes
- Returns a generic instead of void from the TypeOrm transaction callback handler