### PR TITLE
Type `IConfigApi` responses as "raw"

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -12,6 +12,7 @@ import { getAddress } from 'viem';
 import { sample } from 'lodash';
 import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import type { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
+import { rawify } from '@/validation/entities/raw.entity';
 
 const configurationService = {
   getOrThrow: jest.fn(),
@@ -155,7 +156,7 @@ describe('Balances API Manager Tests', () => {
         else if (key === 'features.counterfactualBalances') return true;
         throw new Error(`Unexpected key: ${key}`);
       });
-      configApiMock.getChain.mockResolvedValue(chain);
+      configApiMock.getChain.mockResolvedValue(rawify(chain));
       dataSourceMock.get.mockResolvedValue([]);
       const balancesApiManager = new BalancesApiManager(
         configurationService,

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -14,6 +14,7 @@ import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
 import { Inject, Injectable } from '@nestjs/common';
 import { intersection } from 'lodash';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
 
 @Injectable()
 export class BalancesApiManager implements IBalancesApiManager {
@@ -83,7 +84,9 @@ export class BalancesApiManager implements IBalancesApiManager {
     const safeBalancesApi = this.safeBalancesApiMap[chainId];
     if (safeBalancesApi !== undefined) return safeBalancesApi;
 
-    const chain = await this.configApi.getChain(chainId);
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
     this.safeBalancesApiMap[chainId] = new SafeBalancesApi(
       chainId,
       this.useVpcUrl ? chain.vpcTransactionService : chain.transactionService,

--- a/src/datasources/blockchain/blockchain-api.manager.spec.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.spec.ts
@@ -6,6 +6,7 @@ import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { rpcUriBuilder } from '@/domain/chains/entities/__tests__/rpc-uri.builder';
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
 import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import { hexToNumber, toHex } from 'viem';
 
@@ -39,7 +40,7 @@ describe('BlockchainApiManager', () => {
   describe('getApi', () => {
     it('caches the API', async () => {
       const chain = chainBuilder().build();
-      configApiMock.getChain.mockResolvedValue(chain);
+      configApiMock.getChain.mockResolvedValue(rawify(chain));
 
       const api = await target.getApi(chain.chainId);
       const cachedApi = await target.getApi(chain.chainId);
@@ -58,7 +59,7 @@ describe('BlockchainApiManager', () => {
             .build(),
         )
         .build();
-      configApiMock.getChain.mockResolvedValue(chain);
+      configApiMock.getChain.mockResolvedValue(rawify(chain));
 
       const api = await target.getApi(chain.chainId);
 
@@ -70,7 +71,7 @@ describe('BlockchainApiManager', () => {
       const chain = chainBuilder()
         .with('rpcUri', rpcUriBuilder().with('value', rpcUriValue).build())
         .build();
-      configApiMock.getChain.mockResolvedValue(chain);
+      configApiMock.getChain.mockResolvedValue(rawify(chain));
 
       const api = await target.getApi(chain.chainId);
 
@@ -79,7 +80,7 @@ describe('BlockchainApiManager', () => {
 
     it('should not include the INFURA_API_KEY in the RPC URI for a RPC provider different from Infura', async () => {
       const chain = chainBuilder().build();
-      configApiMock.getChain.mockResolvedValue(chain);
+      configApiMock.getChain.mockResolvedValue(rawify(chain));
 
       const api = await target.getApi(chain.chainId);
 
@@ -90,7 +91,7 @@ describe('BlockchainApiManager', () => {
   describe('destroyApi', () => {
     it('clears the API', async () => {
       const chain = chainBuilder().build();
-      configApiMock.getChain.mockResolvedValue(chain);
+      configApiMock.getChain.mockResolvedValue(rawify(chain));
 
       const api = await target.getApi(chain.chainId);
       target.destroyApi(chain.chainId);

--- a/src/datasources/blockchain/blockchain-api.manager.ts
+++ b/src/datasources/blockchain/blockchain-api.manager.ts
@@ -6,6 +6,7 @@ import {
 } from '@/datasources/cache/cache.service.interface';
 import { Chain as DomainChain } from '@/domain/chains/entities/chain.entity';
 import { RpcUriAuthentication } from '@/domain/chains/entities/rpc-uri-authentication.entity';
+import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
 import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { Inject, Injectable } from '@nestjs/common';
@@ -46,7 +47,9 @@ export class BlockchainApiManager implements IBlockchainApiManager {
       return blockchainApi;
     }
 
-    const chain = await this.configApi.getChain(chainId);
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
     this.blockchainApiMap[chainId] = this._createCachedRpcClient(chain);
 
     return this.blockchainApiMap[chainId];

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -11,8 +11,13 @@ import { Page } from '@/domain/entities/page.entity';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { SafeApp } from '@/domain/safe-apps/entities/safe-app.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { Raw } from '@/validation/entities/raw.entity';
 import { Inject, Injectable } from '@nestjs/common';
 
+/**
+ * TODO: Move all usage of Raw to CacheFirstDataSource after fully migrated
+ * to "Raw" type implementation.
+ */
 @Injectable()
 export class ConfigApi implements IConfigApi {
   private readonly baseUri: string;
@@ -47,12 +52,12 @@ export class ConfigApi implements IConfigApi {
   async getChains(args: {
     limit?: number;
     offset?: number;
-  }): Promise<Page<Chain>> {
+  }): Promise<Raw<Page<Chain>>> {
     try {
       const url = `${this.baseUri}/api/v1/chains`;
       const params = { limit: args.limit, offset: args.offset };
       const cacheDir = CacheRouter.getChainsCacheDir(args);
-      return await this.dataSource.get({
+      return await this.dataSource.get<Raw<Chain>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -64,11 +69,11 @@ export class ConfigApi implements IConfigApi {
     }
   }
 
-  async getChain(chainId: string): Promise<Chain> {
+  async getChain(chainId: string): Promise<Raw<Chain>> {
     try {
       const url = `${this.baseUri}/api/v1/chains/${chainId}`;
       const cacheDir = CacheRouter.getChainCacheDir(chainId);
-      return await this.dataSource.get({
+      return await this.dataSource.get<Raw<Chain>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -98,7 +103,7 @@ export class ConfigApi implements IConfigApi {
     clientUrl?: string;
     onlyListed?: boolean;
     url?: string;
-  }): Promise<SafeApp[]> {
+  }): Promise<Raw<SafeApp[]>> {
     try {
       const providerUrl = `${this.baseUri}/api/v1/safe-apps/`;
       const params = {

--- a/src/datasources/staking-api/staking-api.manager.ts
+++ b/src/datasources/staking-api/staking-api.manager.ts
@@ -6,6 +6,7 @@ import {
 } from '@/datasources/cache/cache.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
+import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { IStakingApi } from '@/domain/interfaces/staking-api.interface';
 import { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
@@ -30,7 +31,9 @@ export class StakingApiManager implements IStakingApiManager {
       return Promise.resolve(this.apis[chainId]);
     }
 
-    const chain = await this.configApi.getChain(chainId);
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
 
     const baseUrl = this.configurationService.getOrThrow<string>(
       chain.isTestnet ? 'staking.testnet.baseUri' : 'staking.mainnet.baseUri',

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -7,6 +7,7 @@ import { TransactionApiManager } from '@/datasources/transaction-api/transaction
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import type { ILoggingService } from '@/logging/logging.interface';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 
 const configurationService = {
@@ -77,7 +78,7 @@ describe('Transaction API Manager Tests', () => {
 
       throw new Error(`Unexpected key: ${key}`);
     });
-    configApiMock.getChain.mockResolvedValue(chain);
+    configApiMock.getChain.mockResolvedValue(rawify(chain));
     const target = new TransactionApiManager(
       configurationServiceMock,
       configApiMock,

--- a/src/datasources/transaction-api/transaction-api.manager.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.ts
@@ -11,7 +11,7 @@ import {
   NetworkService,
 } from '@/datasources/network/network.service.interface';
 import { TransactionApi } from '@/datasources/transaction-api/transaction-api.service';
-import { Chain } from '@/domain/chains/entities/chain.entity';
+import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
@@ -41,7 +41,9 @@ export class TransactionApiManager implements ITransactionApiManager {
     const transactionApi = this.transactionApiMap[chainId];
     if (transactionApi !== undefined) return transactionApi;
 
-    const chain: Chain = await this.configApi.getChain(chainId);
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
     this.transactionApiMap[chainId] = new TransactionApi(
       chainId,
       this.useVpcUrl ? chain.vpcTransactionService : chain.transactionService,

--- a/src/domain/chains/chains.repository.spec.ts
+++ b/src/domain/chains/chains.repository.spec.ts
@@ -13,6 +13,7 @@ import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import type { Page } from '@/domain/entities/page.entity';
 import type { ILoggingService } from '@/logging/logging.interface';
+import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 const mockLoggingService = {
   error: jest.fn(),
@@ -89,16 +90,18 @@ describe('ChainsRepository', () => {
           );
         })();
 
-        return pageBuilder<Chain>()
-          .with('results', results)
-          .with('count', chains.length)
-          .with('previous', previous)
-          .with('next', next)
-          .build();
+        return rawify(
+          pageBuilder<Chain>()
+            .with('results', results)
+            .with('count', chains.length)
+            .with('previous', previous)
+            .with('next', next)
+            .build(),
+        );
       },
     );
     mockConfigApi.getChains.mockImplementation(
-      ({ offset }): Promise<Page<Chain>> => {
+      ({ offset }): Promise<Raw<Page<Chain>>> => {
         if (offset === 0) {
           return Promise.resolve(pages[0]);
         }
@@ -166,16 +169,18 @@ describe('ChainsRepository', () => {
           );
         })();
 
-        return pageBuilder<Chain>()
-          .with('results', results)
-          .with('count', chains.length)
-          .with('previous', previous)
-          .with('next', next)
-          .build();
+        return rawify(
+          pageBuilder<Chain>()
+            .with('results', results)
+            .with('count', chains.length)
+            .with('previous', previous)
+            .with('next', next)
+            .build(),
+        );
       },
     );
     mockConfigApi.getChains.mockImplementation(
-      ({ offset }): Promise<Page<Chain>> => {
+      ({ offset }): Promise<Raw<Page<Chain>>> => {
         if (offset === 0) {
           return Promise.resolve(pages[0]);
         }
@@ -247,16 +252,18 @@ describe('ChainsRepository', () => {
           );
         })();
 
-        return pageBuilder<Chain>()
-          .with('results', results)
-          .with('count', chains.length)
-          .with('previous', previous)
-          .with('next', next)
-          .build();
+        return rawify(
+          pageBuilder<Chain>()
+            .with('results', results)
+            .with('count', chains.length)
+            .with('previous', previous)
+            .with('next', next)
+            .build(),
+        );
       },
     );
     mockConfigApi.getChains.mockImplementation(
-      ({ offset }): Promise<Page<Chain>> => {
+      ({ offset }): Promise<Raw<Page<Chain>>> => {
         if (offset === 0) {
           return Promise.resolve(pages[0]);
         }

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -18,6 +18,7 @@ import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { differenceBy } from 'lodash';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { LenientBasePageSchema } from '@/domain/entities/schemas/page.schema.factory';
 
 @Injectable()
 export class ChainsRepository implements IChainsRepository {
@@ -50,7 +51,9 @@ export class ChainsRepository implements IChainsRepository {
   }
 
   async getChains(limit?: number, offset?: number): Promise<Page<Chain>> {
-    const page = await this.configApi.getChains({ limit, offset });
+    const page = await this.configApi
+      .getChains({ limit, offset })
+      .then(LenientBasePageSchema.parse);
     const valid = ChainLenientPageSchema.parse(page);
     if (valid.results.length < page.results.length) {
       this.loggingService.error({

--- a/src/domain/entities/schemas/page.schema.factory.ts
+++ b/src/domain/entities/schemas/page.schema.factory.ts
@@ -13,6 +13,10 @@ export function buildPageSchema<T extends z.ZodTypeAny>(
   return BasePageSchema.extend({ results: z.array(itemSchema) });
 }
 
+export const LenientBasePageSchema = BasePageSchema.extend({
+  results: z.array(z.any()),
+});
+
 /**
  * Builds a lenient page schema that filters out invalid items from
  * the results array, setting the length of which as the count.
@@ -20,9 +24,7 @@ export function buildPageSchema<T extends z.ZodTypeAny>(
 export function buildLenientPageSchema<T extends z.ZodTypeAny>(
   itemSchema: T,
 ): z.ZodType<Page<z.infer<T>>> {
-  return BasePageSchema.extend({
-    results: z.array(z.any()),
-  }).transform((data) => {
+  return LenientBasePageSchema.transform((data) => {
     const results = data.results.flatMap((item) => {
       const result = itemSchema.safeParse(item);
       return result.success ? [result.data] : [];

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -1,13 +1,17 @@
 import type { Chain } from '@/domain/chains/entities/chain.entity';
 import type { Page } from '@/domain/entities/page.entity';
 import type { SafeApp } from '@/domain/safe-apps/entities/safe-app.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
 
 export const IConfigApi = Symbol('IConfigApi');
 
 export interface IConfigApi {
-  getChains(args: { limit?: number; offset?: number }): Promise<Page<Chain>>;
+  getChains(args: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<Chain>>>;
 
-  getChain(chainId: string): Promise<Chain>;
+  getChain(chainId: string): Promise<Raw<Chain>>;
 
   clearChain(chainId: string): Promise<void>;
 
@@ -16,7 +20,7 @@ export interface IConfigApi {
     clientUrl?: string;
     onlyListed?: boolean;
     url?: string;
-  }): Promise<SafeApp[]>;
+  }): Promise<Raw<SafeApp[]>>;
 
   clearSafeApps(chainId: string): Promise<void>;
 }

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -48,3 +48,5 @@ export const SafeAppSchema = z.object({
   developerWebsite: z.string().url().nullish().default(null),
   featured: z.boolean(),
 });
+
+export const SafeAppsSchema = z.array(SafeAppSchema);

--- a/src/domain/safe-apps/safe-apps.repository.ts
+++ b/src/domain/safe-apps/safe-apps.repository.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { SafeApp } from '@/domain/safe-apps/entities/safe-app.entity';
 import { ISafeAppsRepository } from '@/domain/safe-apps/safe-apps.repository.interface';
-import { SafeAppSchema } from '@/domain/safe-apps/entities/schemas/safe-app.schema';
+import { SafeAppsSchema } from '@/domain/safe-apps/entities/schemas/safe-app.schema';
 
 @Injectable()
 export class SafeAppsRepository implements ISafeAppsRepository {
@@ -18,7 +18,7 @@ export class SafeAppsRepository implements ISafeAppsRepository {
     url?: string;
   }): Promise<SafeApp[]> {
     const safeApps = await this.configApi.getSafeApps(args);
-    return safeApps.map((safeApp) => SafeAppSchema.parse(safeApp));
+    return SafeAppsSchema.parse(safeApps);
   }
 
   async clearSafeApps(chainId: string): Promise<void> {
@@ -26,8 +26,10 @@ export class SafeAppsRepository implements ISafeAppsRepository {
   }
 
   async getSafeAppById(chainId: string, id: number): Promise<SafeApp | null> {
-    const safeApps = await this.configApi.getSafeApps({ chainId });
+    const safeApps = await this.configApi
+      .getSafeApps({ chainId })
+      .then(SafeAppsSchema.parse);
     const safeApp = safeApps.find((safeApp) => safeApp.id === id);
-    return safeApp ? SafeAppSchema.parse(safeApp) : null;
+    return safeApp ?? null;
   }
 }

--- a/src/validation/entities/raw.entity.ts
+++ b/src/validation/entities/raw.entity.ts
@@ -17,3 +17,7 @@
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Raw<_> = symbol;
+
+export function rawify<T>(value: T): Raw<T> {
+  return value as Raw<T>;
+}


### PR DESCRIPTION
Partial implementation of #1731

## Summary

We validate API responses on the domain layer, but directly assign the type in the datasources. This means that the response types are not necessarily correct.

This types all request responses of `IConfigApi` as "raw". These responses are therefore not be used directly unless they are validated.

## Changes

- Add `Raw` utility type to `IConfigApi`
- Update validation where appropriate
- Update tests accordingly