### PR TITLE
Use Test modules on AppModule E2E test

### DIFF
--- a/src/app.module.e2e-spec.ts
+++ b/src/app.module.e2e-spec.ts
@@ -1,11 +1,28 @@
 import { Test } from '@nestjs/testing';
 import { AppModule } from '@/app.module';
+import { CacheKeyPrefix } from '@/datasources/cache/constants';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 
 describe('Application bootstrap', () => {
   it('should init the app', async () => {
+    const cacheKeyPrefix = crypto.randomUUID();
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.register()],
-    }).compile();
+    })
+      .overrideProvider(CacheKeyPrefix)
+      .useValue(cacheKeyPrefix)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
+      .overrideModule(PostgresDatabaseModuleV2)
+      .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
+      .compile();
 
     const app = moduleRef.createNestApplication();
     await app.init();


### PR DESCRIPTION
## Summary
This PR changes the initialization sequence for `AppModule` when testing the app startup on `app.module.e2e-spec.ts`.

## Changes
- Adds test modules to `AppModule` startup on `app.module.e2e-spec.ts`.