### PR TITLE
Fix jwt algorithm

### DIFF
--- a/src/datasources/jwt/jwt.module.ts
+++ b/src/datasources/jwt/jwt.module.ts
@@ -30,7 +30,7 @@ function jwtClientFactory() {
           ...rest,
         },
         options.secretOrPrivateKey,
-        { algorithm: options.algorithm ?? 'HS256' },
+        { algorithm: options.algorithm },
       );
     },
     verify: <T extends object>(

--- a/src/datasources/jwt/jwt.module.ts
+++ b/src/datasources/jwt/jwt.module.ts
@@ -1,4 +1,4 @@
-import jwt, { type Algorithm } from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import { Module } from '@nestjs/common';
 import { JwtService } from '@/datasources/jwt/jwt.service';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
@@ -38,7 +38,7 @@ function jwtClientFactory() {
       options: {
         issuer: string;
         secretOrPrivateKey: string;
-        algorithms?: Array<Algorithm>;
+        algorithms?: Array<jwt.Algorithm>;
       },
     ): T => {
       return jwt.verify(token, options.secretOrPrivateKey, {
@@ -53,7 +53,7 @@ function jwtClientFactory() {
       options: {
         issuer: string;
         secretOrPrivateKey: string;
-        algorithms?: Array<Algorithm>;
+        algorithms?: Array<jwt.Algorithm>;
       },
     ): JwtPayloadWithClaims<T> => {
       // Client has `decode` method but we also want to verify the signature

--- a/src/datasources/jwt/jwt.service.interface.ts
+++ b/src/datasources/jwt/jwt.service.interface.ts
@@ -1,4 +1,5 @@
 import type { JwtPayloadWithClaims } from '@/datasources/jwt/jwt-claims.entity';
+import type { Algorithm } from 'jsonwebtoken';
 
 export const IJwtService = Symbol('IJwtService');
 
@@ -13,6 +14,7 @@ export interface IJwtService {
     payload: T,
     options?: {
       secretOrPrivateKey: string;
+      algorithm?: Algorithm;
     },
   ): string;
 

--- a/src/datasources/jwt/jwt.service.spec.ts
+++ b/src/datasources/jwt/jwt.service.spec.ts
@@ -65,6 +65,24 @@ describe('JwtService', () => {
         secretOrPrivateKey: customSecret,
       });
     });
+
+    it('should sign a payload with RS256 algorithm', () => {
+      const payload = JSON.parse(fakeJson()) as object;
+
+      service.sign(payload, {
+        secretOrPrivateKey: configSecret,
+        algorithm: 'RS256',
+      });
+
+      expect(jwtClientMock.sign).toHaveBeenCalledTimes(1);
+      expect(jwtClientMock.sign).toHaveBeenCalledWith(
+        { iss: configIssuer, ...payload },
+        {
+          secretOrPrivateKey: configSecret,
+          algorithm: 'RS256',
+        },
+      );
+    });
   });
 
   describe('verify', () => {
@@ -96,6 +114,25 @@ describe('JwtService', () => {
         secretOrPrivateKey: customSecret,
       });
     });
+
+    it('should verify a token with RS256 algorithm', () => {
+      const token = faker.string.alphanumeric();
+      const customIssuer = faker.word.noun();
+      const customSecret = faker.string.alphanumeric();
+
+      service.verify(token, {
+        issuer: customIssuer,
+        secretOrPrivateKey: customSecret,
+        algorithms: ['RS256'],
+      });
+
+      expect(jwtClientMock.verify).toHaveBeenCalledTimes(1);
+      expect(jwtClientMock.verify).toHaveBeenCalledWith(token, {
+        issuer: customIssuer,
+        secretOrPrivateKey: customSecret,
+        algorithms: ['RS256'],
+      });
+    });
   });
 
   describe('decode', () => {
@@ -125,6 +162,25 @@ describe('JwtService', () => {
       expect(jwtClientMock.decode).toHaveBeenCalledWith(token, {
         issuer: customIssuer,
         secretOrPrivateKey: customSecret,
+      });
+    });
+
+    it('should decode a token with RS256 Algorithm', () => {
+      const token = faker.string.alphanumeric();
+      const customIssuer = faker.word.noun();
+      const customSecret = faker.string.alphanumeric();
+
+      service.decode(token, {
+        issuer: customIssuer,
+        secretOrPrivateKey: customSecret,
+        algorithms: ['RS256'],
+      });
+
+      expect(jwtClientMock.decode).toHaveBeenCalledTimes(1);
+      expect(jwtClientMock.decode).toHaveBeenCalledWith(token, {
+        issuer: customIssuer,
+        secretOrPrivateKey: customSecret,
+        algorithms: ['RS256'],
       });
     });
   });

--- a/src/datasources/jwt/jwt.service.spec.ts
+++ b/src/datasources/jwt/jwt.service.spec.ts
@@ -44,6 +44,7 @@ describe('JwtService', () => {
         { iss: configIssuer, ...payload },
         {
           secretOrPrivateKey: configSecret,
+          algorithm: 'HS256',
         },
       );
     });
@@ -63,6 +64,7 @@ describe('JwtService', () => {
       expect(jwtClientMock.sign).toHaveBeenCalledTimes(1);
       expect(jwtClientMock.sign).toHaveBeenCalledWith(payload, {
         secretOrPrivateKey: customSecret,
+        algorithm: 'HS256',
       });
     });
 

--- a/src/datasources/jwt/jwt.service.ts
+++ b/src/datasources/jwt/jwt.service.ts
@@ -3,6 +3,7 @@ import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import { JwtPayloadWithClaims } from '@/datasources/jwt/jwt-claims.entity';
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import type { Algorithm } from 'jsonwebtoken';
 
 @Injectable()
 export class JwtService implements IJwtService {
@@ -27,7 +28,7 @@ export class JwtService implements IJwtService {
     },
   >(
     payload: T,
-    options: { secretOrPrivateKey: string } = {
+    options: { secretOrPrivateKey: string; algorithm?: Algorithm } = {
       secretOrPrivateKey: this.secret,
     },
   ): string {
@@ -42,7 +43,11 @@ export class JwtService implements IJwtService {
 
   verify<T extends object>(
     token: string,
-    options: { issuer: string; secretOrPrivateKey: string } = {
+    options: {
+      issuer: string;
+      secretOrPrivateKey: string;
+      algorithms?: Array<Algorithm>;
+    } = {
       issuer: this.issuer,
       secretOrPrivateKey: this.secret,
     },
@@ -52,7 +57,11 @@ export class JwtService implements IJwtService {
 
   decode<T extends object>(
     token: string,
-    options: { issuer: string; secretOrPrivateKey: string } = {
+    options: {
+      issuer: string;
+      secretOrPrivateKey: string;
+      algorithms?: Array<Algorithm>;
+    } = {
       issuer: this.issuer,
       secretOrPrivateKey: this.secret,
     },

--- a/src/datasources/jwt/jwt.service.ts
+++ b/src/datasources/jwt/jwt.service.ts
@@ -7,6 +7,8 @@ import type { Algorithm } from 'jsonwebtoken';
 
 @Injectable()
 export class JwtService implements IJwtService {
+  private static readonly ALGORITHM: Algorithm = 'HS256';
+
   issuer: string;
   secret: string;
 
@@ -37,7 +39,7 @@ export class JwtService implements IJwtService {
         iss: 'iss' in payload ? payload.iss : this.issuer,
         ...payload,
       },
-      options,
+      { ...options, algorithm: options.algorithm ?? JwtService.ALGORITHM },
     );
   }
 


### PR DESCRIPTION
## Summary
This PR fixes an issue where the JWT algorithm was incorrectly passed in the payload when signing and decoding. The algorithm is now correctly placed in the third parameter as an option, ensuring proper signing/decoding of tokens with the desired algorithms.

## Changes
- Moved the JWT algorithm from the payload to the options parameter in the sign/verify/decode method
- Verified that tokens are now signed/verified/decoded and validated with the specified algorithm