### PR TITLE
chore: pass algorithm to jwt sign as an option in push notifications

### DIFF
--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -100,7 +100,7 @@ describe('FirebaseCloudMessagingApiService', () => {
       data: {
         message: {
           token: fcmToken,
-          notification,
+          ...notification,
         },
       },
       networkRequest: {
@@ -138,7 +138,7 @@ describe('FirebaseCloudMessagingApiService', () => {
       data: {
         message: {
           token: fcmToken,
-          notification,
+          ...notification,
         },
       },
       networkRequest: {

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -71,7 +71,7 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
         data: {
           message: {
             token: fcmToken,
-            notification,
+            ...notification,
           },
         },
         networkRequest: {
@@ -138,7 +138,6 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
     const now = new Date();
 
     const payload = {
-      alg: 'RS256',
       iss: this.clientEmail,
       scope: FirebaseCloudMessagingApiService.Scope,
       aud: FirebaseCloudMessagingApiService.OAuth2TokenUrl,
@@ -149,6 +148,7 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
 
     return this.jwtService.sign(payload, {
       secretOrPrivateKey: this.privateKey,
+      algorithm: 'RS256',
     });
   }
 }


### PR DESCRIPTION
## Summary
This PR addresses an issue with the algorithm parameter in the JWT signing process for notifications and updates the structure of the notification payload. Previously, the algorithm was passed in an incorrect position, which caused unintended behavior in token generation. This update moves the algorithm parameter to the correct location, ensuring that tokens are signed with the intended algorithm.

## Changes
- Corrected the position of the algorithm parameter in the jwt.sign function for notifications.
- Cleaned up the notification payload to include only the necessary fields, making sure it meets the latest requirements.