### PR TITLE
Fix flaky GET Creation Transaction controller test

### DIFF
--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -48,7 +48,9 @@ describe('AccountsController', () => {
   let jwtService: IJwtService;
   let accountDataSource: jest.MockedObjectDeep<IAccountsDatasource>;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    jest.useFakeTimers();
     const defaultConfiguration = configuration();
     const testConfiguration = (): typeof defaultConfiguration => ({
       ...defaultConfiguration,
@@ -84,11 +86,6 @@ describe('AccountsController', () => {
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
-  });
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-    jest.useFakeTimers();
   });
 
   afterEach(() => {

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.spec.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.spec.ts
@@ -47,7 +47,8 @@ describe('CounterfactualSafesController', () => {
   let accountsRepository: jest.MockedObjectDeep<IAccountsRepository>;
   let counterfactualSafesDataSource: jest.MockedObjectDeep<ICounterfactualSafesDatasource>;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
     const defaultConfiguration = configuration();
     const testConfiguration = (): typeof defaultConfiguration => ({
       ...defaultConfiguration,
@@ -86,10 +87,6 @@ describe('CounterfactualSafesController', () => {
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
-  });
-
-  beforeEach(() => {
-    jest.resetAllMocks();
   });
 
   afterAll(async () => {

--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -116,9 +116,6 @@ describe('Get creation transaction', () => {
             } as Response),
           );
         default:
-          console.log('************');
-          console.log(url, getChainUrl, chain, getCreationTransactionUrl);
-          console.log('************');
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });

--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -34,7 +34,8 @@ describe('Get creation transaction', () => {
   let safeConfigUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule.register(configuration)],
     })
@@ -61,8 +62,6 @@ describe('Get creation transaction', () => {
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
   });
-
-  beforeEach(() => jest.resetAllMocks());
 
   afterAll(async () => {
     await app.close();
@@ -117,6 +116,9 @@ describe('Get creation transaction', () => {
             } as Response),
           );
         default:
+          console.log('************');
+          console.log(url, getChainUrl, chain, getCreationTransactionUrl);
+          console.log('************');
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });


### PR DESCRIPTION
## Summary
This PR fixes a flaky test affecting `get-creation-transaction.transactions.controller.spec`.

An example of an error in this test can be seen in the following CI run: https://github.com/safe-global/safe-client-gateway/actions/runs/11724359558/job/32658109820

The problem was the `app` initialization was called inside a Jest's `beforeAll` hook, instead of a `beforeEach` one. As tests run in parallel, the mocked `networkService` instance was shared among all the tests, and even though `jest.resetAllMocks()` was called on the `beforeEach` hook, the `networkService` mock behaviour was sometimes unexpected due to race conditions between tests' executions.

## Changes
- Ensures the `app` initialization is called inside a Jest's `beforeEach` hook, instead of a `beforeAll` one.
