### PR TITLE
Add Account route entity name property

### DIFF
--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -184,6 +184,7 @@ describe('AccountsController', () => {
         id: account.id.toString(),
         groupId: null,
         address: account.address,
+        name: account.name,
       };
 
       await request(app.getHttpServer())
@@ -212,6 +213,7 @@ describe('AccountsController', () => {
         id: account.id.toString(),
         groupId: groupId.toString(),
         address: account.address,
+        name: account.name,
       };
 
       await request(app.getHttpServer())

--- a/src/routes/accounts/accounts.service.ts
+++ b/src/routes/accounts/accounts.service.ts
@@ -103,6 +103,7 @@ export class AccountsService {
       domainAccount.id.toString(),
       domainAccount.group_id?.toString() ?? null,
       domainAccount.address,
+      domainAccount.name,
     );
   }
 

--- a/src/routes/accounts/entities/account.entity.ts
+++ b/src/routes/accounts/entities/account.entity.ts
@@ -7,10 +7,18 @@ export class Account {
   groupId: string | null;
   @ApiProperty()
   address: `0x${string}`;
+  @ApiProperty()
+  name: string;
 
-  constructor(id: string, groupId: string | null, address: `0x${string}`) {
+  constructor(
+    id: string,
+    groupId: string | null,
+    address: `0x${string}`,
+    name: string,
+  ) {
     this.id = id;
     this.groupId = groupId;
     this.address = address;
+    this.name = name;
   }
 }


### PR DESCRIPTION
## Summary
This PR adds `Account['name']` property to `Account` route entity.

## Changes
- Adds `Account['name']` property to `Account` route entity
