### PR TITLE
fix: output the correct tx info type in swagger

### DIFF
--- a/src/routes/transactions/entities/creation-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction-info.entity.ts
@@ -6,6 +6,8 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 
 export class CreationTransactionInfo extends TransactionInfo {
+  @ApiProperty({ enum: [TransactionInfoType.Creation] })
+  override type = TransactionInfoType.Creation;
   @ApiProperty()
   creator: AddressInfo;
   @ApiProperty()

--- a/src/routes/transactions/entities/custom-transaction.entity.ts
+++ b/src/routes/transactions/entities/custom-transaction.entity.ts
@@ -6,6 +6,8 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 
 export class CustomTransactionInfo extends TransactionInfo {
+  @ApiProperty({ enum: [TransactionInfoType.Custom] })
+  override type = TransactionInfoType.Custom;
   @ApiProperty()
   to: AddressInfo;
   @ApiProperty()

--- a/src/routes/transactions/entities/settings-change-transaction.entity.ts
+++ b/src/routes/transactions/entities/settings-change-transaction.entity.ts
@@ -7,6 +7,8 @@ import {
 } from '@/routes/transactions/entities/transaction-info.entity';
 
 export class SettingsChangeTransaction extends TransactionInfo {
+  @ApiProperty({ enum: [TransactionInfoType.SettingsChange] })
+  override type = TransactionInfoType.SettingsChange;
   @ApiProperty()
   dataDecoded: DataDecoded;
   @ApiPropertyOptional({ type: SettingsChange, nullable: true })

--- a/src/routes/transactions/entities/transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transfer-transaction-info.entity.ts
@@ -13,6 +13,8 @@ export enum TransferDirection {
 }
 
 export class TransferTransactionInfo extends TransactionInfo {
+  @ApiProperty({ enum: [TransactionInfoType.Transfer] })
+  override type = TransactionInfoType.Transfer;
   @ApiProperty()
   sender: AddressInfo;
   @ApiProperty()

--- a/src/routes/transactions/swap-transfer-transaction-info.entity.ts
+++ b/src/routes/transactions/swap-transfer-transaction-info.entity.ts
@@ -21,6 +21,9 @@ export class SwapTransferTransactionInfo
   extends TransactionInfo
   implements TransferTransactionInfo, SwapOrderTransactionInfo
 {
+  @ApiProperty({ enum: [TransactionInfoType.SwapTransfer] })
+  override type = TransactionInfoType.SwapTransfer;
+
   // TransferTransactionInfo properties
   @ApiProperty()
   sender: AddressInfo;


### PR DESCRIPTION
I've been trying to use https://redux-toolkit.js.org/rtk-query/usage/code-generation RTK's code-generation with the output of our openAPI. It worked fine, but the generated code was making typescript complain. For example we have this here:

```
export type Transaction = {
  id: string
  txHash?: string | null
  timestamp?: number | null
  txStatus: string
  txInfo:
    | CreationTransactionInfo
    | CustomTransactionInfo
...
  executionInfo?: (MultisigExecutionInfo | ModuleExecutionInfo) | null
  safeAppInfo?: SafeAppInfo | null
}

export type CreationTransactionInfo = {
  type: string
  humanDescription?: string | null
  creator: AddressInfo
  transactionHash: string
  implementation?: AddressInfo | null
  factory?: AddressInfo | null
  saltNonce?: string | null
}
export type CustomTransactionInfo = {
  type: string
  humanDescription?: string | null
  to: AddressInfo
  dataSize: string
  value?: string | null
  isCancellation: boolean
  methodName?: string | null
  actionCount?: number | null
}

const getTxTo = ({ txInfo }: Pick<Transaction, 'txInfo'>): AddressEx | undefined => {
  switch (txInfo.type) {
    case TransactionInfoType.CREATION: {
      return txInfo.factory
    }
    case TransactionInfoType.TRANSFER: {
      return txInfo.recipient
    }
    case TransactionInfoType.SETTINGS_CHANGE: {
      return undefined
    }
    case TransactionInfoType.CUSTOM: {
      return txInfo.to
    }
  }
}
```

My Switch statement was hitting the correct case(Creation), but TS was not recognising the txInfo being a CreationTransactionInfo and was complaining that factory doesn't exist. This turned out to stem from the fact that our openAPI is setting type: string and because of this TS was not able to infer the correct type....

Swagger is very picky. Our transactionInfoType is an enum and in every TransactionInfo class we actually know the type of transactionInfo we are dealing with. It’s impossible to have CreationTransactionInfo with a “custom” type. The type is going to be “creation”. By overriding the type with the correct type and setting an ApiProperty with a single value the swagger docs manage to generate a type that is closer to what the TransactionInfo is.
![grafik](https://github.com/user-attachments/assets/736a9d88-d9d2-4a37-9d1e-dd64eade3fde)

