### PR TITLE
Add Blob Encryption

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -17,6 +17,7 @@ export default (): ReturnType<typeof configuration> => ({
     encryption: {
       type: faker.string.sample(),
       awsKms: {
+        algorithm: faker.string.alphanumeric(),
         keyId: faker.string.uuid(),
       },
       local: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -30,6 +30,7 @@ export default () => ({
       type: process.env.ACCOUNTS_ENCRYPTION_TYPE || 'local',
       awsKms: {
         keyId: process.env.AWS_KMS_ENCRYPTION_KEY_ID,
+        algorithm: process.env.AWS_KMS_ENCRYPTION_ALGORITHM || 'aes-256-gcm',
       },
       local: {
         algorithm: process.env.LOCAL_ENCRYPTION_ALGORITHM || 'aes-256-cbc',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -30,7 +30,7 @@ export default () => ({
       type: process.env.ACCOUNTS_ENCRYPTION_TYPE || 'local',
       awsKms: {
         keyId: process.env.AWS_KMS_ENCRYPTION_KEY_ID,
-        algorithm: process.env.AWS_KMS_ENCRYPTION_ALGORITHM || 'aes-256-gcm',
+        algorithm: process.env.AWS_KMS_ENCRYPTION_ALGORITHM || 'aes-256-cbc',
       },
       local: {
         algorithm: process.env.LOCAL_ENCRYPTION_ALGORITHM || 'aes-256-cbc',

--- a/src/datasources/accounts/encryption/aws-encryption-api.service.spec.ts
+++ b/src/datasources/accounts/encryption/aws-encryption-api.service.spec.ts
@@ -1,8 +1,16 @@
+import { fakeJson } from '@/__tests__/faker';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import { AwsEncryptionApiService } from '@/datasources/accounts/encryption/aws-encryption-api.service';
-import { DecryptCommand, EncryptCommand, KMSClient } from '@aws-sdk/client-kms';
+import { encryptedBlobBuilder } from '@/datasources/accounts/encryption/entities/__tests__/encrypted-blob.builder';
+import {
+  DecryptCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+  KMSClient,
+} from '@aws-sdk/client-kms';
 import { faker } from '@faker-js/faker/.';
 import { mockClient } from 'aws-sdk-client-mock';
+import * as crypto from 'crypto';
 
 const mockConfigurationService = {
   get: jest.fn(),
@@ -18,47 +26,141 @@ describe('AwsEncryptionApiService', () => {
     jest.resetAllMocks();
     mockConfigurationService.get.mockImplementation((key) => {
       if (key === 'accounts.encryption.awsKms.keyId') return awsKmsKeyId;
+      throw new Error(`Unexpected key: ${key}`);
+    });
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-cbc';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new AwsEncryptionApiService(mockConfigurationService);
   });
 
-  it('should encrypt and decrypt data correctly', async () => {
-    const data = 'test data';
-    kmsMock.on(EncryptCommand).resolves({
-      CiphertextBlob: Buffer.from(data),
-    });
-    kmsMock.on(DecryptCommand).resolves({
-      Plaintext: Buffer.from(data),
-    });
-    const encrypted = await target.encrypt(data);
-    const decrypted = await target.decrypt(encrypted);
-
-    expect(decrypted).toBe(data);
-    expect(
-      kmsMock.commandCalls(EncryptCommand, {
-        KeyId: awsKmsKeyId,
+  describe('encrypt/decrypt', () => {
+    it('should encrypt and decrypt data correctly', async () => {
+      const data = faker.string.alphanumeric();
+      kmsMock.on(EncryptCommand).resolves({
+        CiphertextBlob: Buffer.from(data),
+      });
+      kmsMock.on(DecryptCommand).resolves({
         Plaintext: Buffer.from(data),
-      }),
-    ).toHaveLength(1);
-    expect(
-      kmsMock.commandCalls(DecryptCommand, {
-        CiphertextBlob: Buffer.from(encrypted, 'base64'),
-      }),
-    ).toHaveLength(1);
+      });
+      const encrypted = await target.encrypt(data);
+      const decrypted = await target.decrypt(encrypted);
+
+      expect(decrypted).toBe(data);
+      expect(
+        kmsMock.commandCalls(EncryptCommand, {
+          KeyId: awsKmsKeyId,
+          Plaintext: Buffer.from(data),
+        }),
+      ).toHaveLength(1);
+      expect(
+        kmsMock.commandCalls(DecryptCommand, {
+          CiphertextBlob: Buffer.from(encrypted, 'base64'),
+        }),
+      ).toHaveLength(1);
+    });
+
+    it('should fail to encrypt when the KMS client fails', async () => {
+      const data = faker.string.alphanumeric();
+      kmsMock.on(EncryptCommand).rejects(new Error('Test error'));
+      await expect(target.encrypt(data)).rejects.toThrow('Test error');
+    });
+
+    it('should fail to decrypt when the KMS client fails', async () => {
+      const data = faker.string.alphanumeric();
+      kmsMock.on(DecryptCommand).rejects(new Error('Test error'));
+      await expect(target.decrypt(data)).rejects.toThrow('Test error');
+    });
+
+    it('should fail to encrypt when the KMS client does not return a CiphertextBlob', async () => {
+      const data = faker.string.alphanumeric();
+      kmsMock.on(EncryptCommand).resolves({});
+      await expect(target.encrypt(data)).rejects.toThrow(
+        'Failed to encrypt data',
+      );
+    });
+
+    it('should fail to decrypt when the KMS client does not return a Plaintext', async () => {
+      const data = faker.string.alphanumeric();
+      kmsMock.on(DecryptCommand).resolves({});
+      await expect(target.decrypt(data)).rejects.toThrow(
+        'Failed to decrypt data',
+      );
+    });
   });
 
-  it.todo('should fail to encrypt when the KMS client fails');
-  it.todo('should fail to decrypt when the KMS client fails');
-  it.todo(
-    'should fail to encrypt when the KMS client does not return a CiphertextBlob',
-  );
-  it.todo(
-    'should fail to decrypt when the KMS client does not return a Plaintext',
-  );
-  it.todo('should encrypt and decrypt arrays of objects correctly');
-  it.todo('should fail to encrypt non-object data');
-  it.todo('should fail to encrypt null data');
-  it.todo('should fail to encrypt undefined data');
+  describe('encryptBlob/decryptBlob', () => {
+    it('should encrypt and decrypt arrays of objects correctly', async () => {
+      const data = [JSON.parse(fakeJson()), JSON.parse(fakeJson())];
+      const key = new Uint8Array(crypto.randomBytes(32).buffer);
+      const encryptedBlob = encryptedBlobBuilder().build();
+      kmsMock.on(GenerateDataKeyCommand).resolves({
+        Plaintext: Buffer.from(key),
+        CiphertextBlob: Buffer.from(encryptedBlob.encryptedDataKey),
+      });
+      kmsMock.on(EncryptCommand).resolves({
+        CiphertextBlob: encryptedBlob.encryptedDataKey,
+      });
+      kmsMock.on(DecryptCommand).resolves({
+        Plaintext: Buffer.from(key),
+      });
+      const encrypted = await target.encryptBlob(data);
+      const decrypted = await target.decryptBlob(encrypted);
+
+      expect(decrypted).toStrictEqual(data);
+    });
+
+    it('should fail to encrypt when the KMS client fails to generate the key', async () => {
+      const data = [JSON.parse(fakeJson()), JSON.parse(fakeJson())];
+      kmsMock.on(GenerateDataKeyCommand).rejects(new Error('Test error'));
+      await expect(target.encryptBlob(data)).rejects.toThrow('Test error');
+    });
+
+    it('should fail to encrypt when the KMS client does not return a CiphertextBlob key', async () => {
+      const data = [JSON.parse(fakeJson()), JSON.parse(fakeJson())];
+      kmsMock
+        .on(GenerateDataKeyCommand)
+        .resolves({ Plaintext: Buffer.from([]) });
+      await expect(target.encryptBlob(data)).rejects.toThrow(
+        'Failed to generate data key',
+      );
+    });
+
+    it('should fail to encrypt when the KMS client does not return a Plaintext key', async () => {
+      const data = [JSON.parse(fakeJson()), JSON.parse(fakeJson())];
+      kmsMock
+        .on(GenerateDataKeyCommand)
+        .resolves({ CiphertextBlob: Buffer.from([]) });
+      await expect(target.encryptBlob(data)).rejects.toThrow(
+        'Failed to generate data key',
+      );
+    });
+
+    it('should fail to encrypt non-object data', async () => {
+      await expect(
+        target.encryptBlob(faker.string.alphanumeric()),
+      ).rejects.toThrow('Data must be an object or array');
+    });
+
+    it('should fail to encrypt null data', async () => {
+      await expect(target.encryptBlob(null)).rejects.toThrow(
+        'Data must be an object or array',
+      );
+    });
+
+    it('should fail to encrypt undefined data', async () => {
+      await expect(target.encryptBlob(undefined)).rejects.toThrow(
+        'Data must be an object or array',
+      );
+    });
+
+    it('should fail to decrypt when the KMS client fails while decrypting the key', async () => {
+      const encryptedBlob = encryptedBlobBuilder().build();
+      kmsMock.on(DecryptCommand).rejects(new Error('Test error'));
+      await expect(target.decryptBlob(encryptedBlob)).rejects.toThrow(
+        'Test error',
+      );
+    });
+  });
 });

--- a/src/datasources/accounts/encryption/aws-encryption-api.service.spec.ts
+++ b/src/datasources/accounts/encryption/aws-encryption-api.service.spec.ts
@@ -17,9 +17,8 @@ describe('AwsEncryptionApiService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockConfigurationService.get.mockImplementation((key) => {
-      if (key === 'accounts.encryption.awsKms.keyId') {
-        return awsKmsKeyId;
-      }
+      if (key === 'accounts.encryption.awsKms.keyId') return awsKmsKeyId;
+      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new AwsEncryptionApiService(mockConfigurationService);
@@ -49,4 +48,17 @@ describe('AwsEncryptionApiService', () => {
       }),
     ).toHaveLength(1);
   });
+
+  it.todo('should fail to encrypt when the KMS client fails');
+  it.todo('should fail to decrypt when the KMS client fails');
+  it.todo(
+    'should fail to encrypt when the KMS client does not return a CiphertextBlob',
+  );
+  it.todo(
+    'should fail to decrypt when the KMS client does not return a Plaintext',
+  );
+  it.todo('should encrypt and decrypt arrays of objects correctly');
+  it.todo('should fail to encrypt non-object data');
+  it.todo('should fail to encrypt null data');
+  it.todo('should fail to encrypt undefined data');
 });

--- a/src/datasources/accounts/encryption/aws-encryption-api.service.spec.ts
+++ b/src/datasources/accounts/encryption/aws-encryption-api.service.spec.ts
@@ -18,7 +18,7 @@ describe('AwsEncryptionApiService', () => {
     jest.resetAllMocks();
     mockConfigurationService.get.mockImplementation((key) => {
       if (key === 'accounts.encryption.awsKms.keyId') return awsKmsKeyId;
-      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
+      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-cbc';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new AwsEncryptionApiService(mockConfigurationService);

--- a/src/datasources/accounts/encryption/aws-encryption-api.service.ts
+++ b/src/datasources/accounts/encryption/aws-encryption-api.service.ts
@@ -1,21 +1,19 @@
-import { fakeJson } from '@/__tests__/faker';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { EncryptedBlob } from '@/datasources/accounts/encryption/entities/encrypted-blob.entity';
 import type { IEncryptionApi } from '@/domain/interfaces/encryption-api.interface';
 import {
-  CreateKeyCommand,
   DecryptCommand,
   EncryptCommand,
   GenerateDataKeyCommand,
   KMSClient,
 } from '@aws-sdk/client-kms';
-import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import * as crypto from 'crypto';
 
 @Injectable()
-export class AwsEncryptionApiService implements IEncryptionApi, OnModuleInit {
+export class AwsEncryptionApiService implements IEncryptionApi {
   private readonly kmsClient: KMSClient;
-  private awsKmsKeyId: string | undefined; // TODO: make readonly
+  private readonly awsKmsKeyId: string | undefined;
   private readonly algorithm: string;
 
   constructor(
@@ -28,33 +26,7 @@ export class AwsEncryptionApiService implements IEncryptionApi, OnModuleInit {
     this.algorithm = this.configurationService.getOrThrow<string>(
       'accounts.encryption.awsKms.algorithm',
     );
-    // TODO: LocalStack testing
-    this.kmsClient = new KMSClient({
-      region: 'us-east-1',
-      endpoint: 'http://localhost:4566', // LocalStack
-      credentials: {
-        accessKeyId: 'test', // Dummy credentials for LocalStack
-        secretAccessKey: 'test',
-      },
-    });
-  }
-
-  // TODO: LocalStack testing
-  async onModuleInit(): Promise<void> {
-    const data = JSON.parse(fakeJson());
-    console.log('Data:', data);
-    const key = await this.kmsClient.send(
-      new CreateKeyCommand({
-        Description: 'Test KMS Key for LocalStack',
-        KeyUsage: 'ENCRYPT_DECRYPT', // Key can encrypt and decrypt
-        CustomerMasterKeySpec: 'SYMMETRIC_DEFAULT', // Default symmetric key
-      }),
-    );
-    this.awsKmsKeyId = key.KeyMetadata?.KeyId;
-    const encrypted = await this.encryptBlob(data);
-    console.log('Encrypted Data:', encrypted);
-    const decrypted = await this.decryptBlob(encrypted);
-    console.log('Decrypted Data:', decrypted);
+    this.kmsClient = new KMSClient({});
   }
 
   async encrypt(data: string): Promise<string> {

--- a/src/datasources/accounts/encryption/aws-encryption-api.service.ts
+++ b/src/datasources/accounts/encryption/aws-encryption-api.service.ts
@@ -81,6 +81,9 @@ export class AwsEncryptionApiService implements IEncryptionApi, OnModuleInit {
   }
 
   async encryptBlob(data: unknown): Promise<EncryptedBlob> {
+    if ((typeof data !== 'object' && !Array.isArray(data)) || data === null) {
+      throw new Error('Data must be an object or array');
+    }
     const { Plaintext, CiphertextBlob } = await this.kmsClient.send(
       new GenerateDataKeyCommand({
         KeyId: this.awsKmsKeyId,

--- a/src/datasources/accounts/encryption/aws-encryption-api.service.ts
+++ b/src/datasources/accounts/encryption/aws-encryption-api.service.ts
@@ -1,12 +1,19 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { IEncryptionApi } from '@/domain/interfaces/encryption-api.interface';
-import { DecryptCommand, EncryptCommand, KMSClient } from '@aws-sdk/client-kms';
+import {
+  DecryptCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+  KMSClient,
+} from '@aws-sdk/client-kms';
 import { Inject, Injectable } from '@nestjs/common';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class AwsEncryptionApiService implements IEncryptionApi {
   private readonly kmsClient: KMSClient;
   private readonly awsKmsKeyId: string | undefined;
+  private readonly algorithm: string;
 
   constructor(
     @Inject(IConfigurationService)
@@ -14,6 +21,9 @@ export class AwsEncryptionApiService implements IEncryptionApi {
   ) {
     this.awsKmsKeyId = this.configurationService.get<string>(
       'accounts.encryption.awsKms.keyId',
+    );
+    this.algorithm = this.configurationService.getOrThrow<string>(
+      'accounts.encryption.awsKms.algorithm',
     );
     this.kmsClient = new KMSClient({});
   }
@@ -31,6 +41,37 @@ export class AwsEncryptionApiService implements IEncryptionApi {
     return Buffer.from(encryptedData.CiphertextBlob).toString('base64');
   }
 
+  async encryptBlob(data: unknown): Promise<{
+    encryptedData: Buffer;
+    encryptedDataKey: Buffer;
+    iv: Buffer;
+  }> {
+    const dataKeyResponse = await this.kmsClient.send(
+      new GenerateDataKeyCommand({
+        KeyId: this.awsKmsKeyId,
+        KeySpec: 'AES_256',
+      }),
+    );
+    if (!dataKeyResponse.Plaintext || !dataKeyResponse.CiphertextBlob) {
+      throw new Error('Failed to generate data key');
+    }
+    const iv = crypto.randomBytes(16); // Generate a new IV for each encryption
+    const cipher = crypto.createCipheriv(
+      this.algorithm,
+      dataKeyResponse.Plaintext,
+      iv,
+    );
+    const encryptedData = Buffer.concat([
+      cipher.update(JSON.stringify(data), 'utf8'),
+      cipher.final(),
+    ]);
+    return {
+      encryptedData: Buffer.from(encryptedData),
+      encryptedDataKey: Buffer.from(dataKeyResponse.CiphertextBlob),
+      iv,
+    };
+  }
+
   async decrypt(data: string): Promise<string> {
     const decryptedData = await this.kmsClient.send(
       new DecryptCommand({ CiphertextBlob: Buffer.from(data, 'base64') }),
@@ -39,5 +80,26 @@ export class AwsEncryptionApiService implements IEncryptionApi {
       throw new Error('Failed to decrypt data');
     }
     return Buffer.from(decryptedData.Plaintext).toString('utf-8');
+  }
+
+  async decryptBlob(data: {
+    encryptedData: Buffer;
+    encryptedDataKey: Buffer;
+    iv: Buffer;
+  }): Promise<unknown> {
+    const decryptedDataKey = await this.kmsClient.send(
+      new DecryptCommand({ CiphertextBlob: data.encryptedDataKey }),
+    );
+    if (!decryptedDataKey.Plaintext) {
+      throw new Error('Failed to decrypt data key');
+    }
+    const decipher = crypto.createDecipheriv(
+      this.algorithm,
+      decryptedDataKey.Plaintext,
+      data.iv,
+    );
+    let decrypted = decipher.update(data.encryptedData, 'base64', 'utf8');
+    decrypted += decipher.final('utf8');
+    return JSON.parse(decrypted);
   }
 }

--- a/src/datasources/accounts/encryption/encryption-api.manager.spec.ts
+++ b/src/datasources/accounts/encryption/encryption-api.manager.spec.ts
@@ -52,6 +52,8 @@ describe('EncryptionApiManager', () => {
   it('should get a AwsEncryptionApiService', async () => {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'accounts.encryption.type') return 'aws';
+      if (key === 'accounts.encryption.awsKms.keyId') return 'a'.repeat(64);
+      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new EncryptionApiManager(mockConfigurationService);
@@ -64,7 +66,7 @@ describe('EncryptionApiManager', () => {
   it('should return the same instance of AwsEncryptionApiService on a second call', async () => {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'accounts.encryption.type') return 'aws';
-      if (key === 'accounts.encryption.awsKms.keyId') return 'aes-256-gcm';
+      if (key === 'accounts.encryption.awsKms.keyId') return 'a'.repeat(64);
       if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
       throw new Error(`Unexpected key: ${key}`);
     });

--- a/src/datasources/accounts/encryption/encryption-api.manager.spec.ts
+++ b/src/datasources/accounts/encryption/encryption-api.manager.spec.ts
@@ -53,7 +53,7 @@ describe('EncryptionApiManager', () => {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'accounts.encryption.type') return 'aws';
       if (key === 'accounts.encryption.awsKms.keyId') return 'a'.repeat(64);
-      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
+      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-cbc';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new EncryptionApiManager(mockConfigurationService);
@@ -67,7 +67,7 @@ describe('EncryptionApiManager', () => {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'accounts.encryption.type') return 'aws';
       if (key === 'accounts.encryption.awsKms.keyId') return 'a'.repeat(64);
-      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
+      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-cbc';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new EncryptionApiManager(mockConfigurationService);

--- a/src/datasources/accounts/encryption/encryption-api.manager.spec.ts
+++ b/src/datasources/accounts/encryption/encryption-api.manager.spec.ts
@@ -64,6 +64,8 @@ describe('EncryptionApiManager', () => {
   it('should return the same instance of AwsEncryptionApiService on a second call', async () => {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'accounts.encryption.type') return 'aws';
+      if (key === 'accounts.encryption.awsKms.keyId') return 'aes-256-gcm';
+      if (key === 'accounts.encryption.awsKms.algorithm') return 'aes-256-gcm';
       throw new Error(`Unexpected key: ${key}`);
     });
     target = new EncryptionApiManager(mockConfigurationService);

--- a/src/datasources/accounts/encryption/encryption-api.manager.ts
+++ b/src/datasources/accounts/encryption/encryption-api.manager.ts
@@ -4,12 +4,10 @@ import { AwsEncryptionApiService } from '@/datasources/accounts/encryption/aws-e
 import { LocalEncryptionApiService } from '@/datasources/accounts/encryption/local-encryption-api.service';
 import { IEncryptionApi } from '@/domain/interfaces/encryption-api.interface';
 import { IEncryptionApiManager } from '@/domain/interfaces/encryption-api.manager.interface';
-import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class EncryptionApiManager
-  implements IEncryptionApiManager, OnModuleInit
-{
+export class EncryptionApiManager implements IEncryptionApiManager {
   /**
    * This is linked to the Accounts feature. It is used to determine which encryption provider to use.
    * If the encryption is needed for a different feature, this should be renamed/moved to a generic configuration.
@@ -29,11 +27,6 @@ export class EncryptionApiManager
       this.configurationService.getOrThrow<AccountsEncryptionType>(
         'accounts.encryption.type',
       );
-  }
-
-  // TODO: LocalStack testing
-  async onModuleInit(): Promise<void> {
-    await new AwsEncryptionApiService(this.configurationService).onModuleInit();
   }
 
   getApi(): Promise<IEncryptionApi> {

--- a/src/datasources/accounts/encryption/encryption-api.manager.ts
+++ b/src/datasources/accounts/encryption/encryption-api.manager.ts
@@ -4,10 +4,12 @@ import { AwsEncryptionApiService } from '@/datasources/accounts/encryption/aws-e
 import { LocalEncryptionApiService } from '@/datasources/accounts/encryption/local-encryption-api.service';
 import { IEncryptionApi } from '@/domain/interfaces/encryption-api.interface';
 import { IEncryptionApiManager } from '@/domain/interfaces/encryption-api.manager.interface';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 
 @Injectable()
-export class EncryptionApiManager implements IEncryptionApiManager {
+export class EncryptionApiManager
+  implements IEncryptionApiManager, OnModuleInit
+{
   /**
    * This is linked to the Accounts feature. It is used to determine which encryption provider to use.
    * If the encryption is needed for a different feature, this should be renamed/moved to a generic configuration.
@@ -27,6 +29,11 @@ export class EncryptionApiManager implements IEncryptionApiManager {
       this.configurationService.getOrThrow<AccountsEncryptionType>(
         'accounts.encryption.type',
       );
+  }
+
+  // TODO: LocalStack testing
+  async onModuleInit(): Promise<void> {
+    await new AwsEncryptionApiService(this.configurationService).onModuleInit();
   }
 
   getApi(): Promise<IEncryptionApi> {

--- a/src/datasources/accounts/encryption/entities/__tests__/encrypted-blob.builder.ts
+++ b/src/datasources/accounts/encryption/entities/__tests__/encrypted-blob.builder.ts
@@ -1,0 +1,18 @@
+import { Builder, type IBuilder } from '@/__tests__/builder';
+import { fakeJson } from '@/__tests__/faker';
+import type { EncryptedBlob } from '@/datasources/accounts/encryption/entities/encrypted-blob.entity';
+import { faker } from '@faker-js/faker/.';
+
+export function encryptedBlobBuilder(): IBuilder<EncryptedBlob> {
+  return new Builder<EncryptedBlob>()
+    .with(
+      'encryptedData',
+      Buffer.from(
+        faker.helpers.multiple(() => JSON.parse(fakeJson()), {
+          count: 10,
+        }),
+      ),
+    )
+    .with('encryptedDataKey', Buffer.from(faker.string.alphanumeric()))
+    .with('iv', Buffer.from(faker.string.alphanumeric()));
+}

--- a/src/datasources/accounts/encryption/entities/encrypted-blob.entity.ts
+++ b/src/datasources/accounts/encryption/entities/encrypted-blob.entity.ts
@@ -1,0 +1,5 @@
+export type EncryptedBlob = {
+  encryptedData: Buffer;
+  encryptedDataKey: Buffer;
+  iv: Buffer;
+};

--- a/src/datasources/accounts/encryption/local-encryption-api.service.spec.ts
+++ b/src/datasources/accounts/encryption/local-encryption-api.service.spec.ts
@@ -1,5 +1,9 @@
+import { fakeJson } from '@/__tests__/faker';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { encryptedBlobBuilder } from '@/datasources/accounts/encryption/entities/__tests__/encrypted-blob.builder';
 import { LocalEncryptionApiService } from '@/datasources/accounts/encryption/local-encryption-api.service';
+import { faker } from '@faker-js/faker/.';
+import * as crypto from 'crypto';
 
 const mockConfigurationService = {
   get: jest.fn(),
@@ -21,41 +25,115 @@ describe('LocalEncryptionApiService', () => {
     target = new LocalEncryptionApiService(mockConfigurationService);
   });
 
-  it('should fail to encrypt in production', async () => {
-    mockConfigurationService.getOrThrow.mockImplementation((key) => {
-      if (key === 'application.isProduction') return true;
-      if (key === 'accounts.encryption.local.algorithm') return 'aes-256-cbc';
-      if (key === 'accounts.encryption.local.key') return 'a'.repeat(64);
-      if (key === 'accounts.encryption.local.iv') return 'b'.repeat(32);
-      throw new Error(`Unexpected key: ${key}`);
-    });
-    target = new LocalEncryptionApiService(mockConfigurationService);
+  describe('encrypt/decrypt', () => {
+    it('should fail to encrypt in production', async () => {
+      mockConfigurationService.getOrThrow.mockImplementation((key) => {
+        if (key === 'application.isProduction') return true;
+        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-cbc';
+        if (key === 'accounts.encryption.local.key') return 'a'.repeat(64);
+        if (key === 'accounts.encryption.local.iv') return 'b'.repeat(32);
+        throw new Error(`Unexpected key: ${key}`);
+      });
+      target = new LocalEncryptionApiService(mockConfigurationService);
 
-    await expect(target.encrypt('data')).rejects.toThrow(
-      'Local encryption is not suitable for production usage',
-    );
+      await expect(target.encrypt(faker.string.alphanumeric())).rejects.toThrow(
+        'Local encryption is not suitable for production usage',
+      );
+    });
+
+    it('should fail to decrypt in production', async () => {
+      mockConfigurationService.getOrThrow.mockImplementation((key) => {
+        if (key === 'application.isProduction') return true;
+        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-cbc';
+        if (key === 'accounts.encryption.local.key') return 'a'.repeat(64);
+        if (key === 'accounts.encryption.local.iv') return 'b'.repeat(32);
+        throw new Error(`Unexpected key: ${key}`);
+      });
+      target = new LocalEncryptionApiService(mockConfigurationService);
+
+      await expect(target.decrypt(faker.string.alphanumeric())).rejects.toThrow(
+        'Local encryption is not suitable for production usage',
+      );
+    });
+
+    it('should encrypt and decrypt data correctly', async () => {
+      const data = faker.string.alphanumeric({ length: 100 });
+      const encrypted = await target.encrypt(data);
+      const decrypted = await target.decrypt(encrypted);
+
+      expect(decrypted).toBe(data);
+    });
+
+    it('should encrypt and decrypt objects correctly', async () => {
+      const data = JSON.parse(fakeJson());
+      const encrypted = await target.encryptBlob(data);
+      const decrypted = await target.decryptBlob(encrypted);
+
+      expect(decrypted).toStrictEqual(data);
+    });
   });
 
-  it('should fail to decrypt in production', async () => {
-    mockConfigurationService.getOrThrow.mockImplementation((key) => {
-      if (key === 'application.isProduction') return true;
-      if (key === 'accounts.encryption.local.algorithm') return 'aes-256-cbc';
-      if (key === 'accounts.encryption.local.key') return 'a'.repeat(64);
-      if (key === 'accounts.encryption.local.iv') return 'b'.repeat(32);
-      throw new Error(`Unexpected key: ${key}`);
+  describe('encryptBlob/decryptBlob', () => {
+    it('should fail to encryptBlob in production', async () => {
+      mockConfigurationService.getOrThrow.mockImplementation((key) => {
+        if (key === 'application.isProduction') return true;
+        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-gcm';
+        if (key === 'accounts.encryption.local.key')
+          return crypto.randomBytes(32);
+        throw new Error(`Unexpected key: ${key}`);
+      });
+      target = new LocalEncryptionApiService(mockConfigurationService);
+
+      await expect(
+        target.encryptBlob(faker.string.alphanumeric()),
+      ).rejects.toThrow(
+        'Local encryption is not suitable for production usage',
+      );
     });
-    target = new LocalEncryptionApiService(mockConfigurationService);
 
-    await expect(target.decrypt('data')).rejects.toThrow(
-      'Local encryption is not suitable for production usage',
-    );
-  });
+    it('should fail to decryptBlob in production', async () => {
+      mockConfigurationService.getOrThrow.mockImplementation((key) => {
+        if (key === 'application.isProduction') return true;
+        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-gcm';
+        if (key === 'accounts.encryption.local.key')
+          return crypto.randomBytes(32);
+        throw new Error(`Unexpected key: ${key}`);
+      });
+      target = new LocalEncryptionApiService(mockConfigurationService);
 
-  it('should encrypt and decrypt data correctly', async () => {
-    const data = 'test data';
-    const encrypted = await target.encrypt(data);
-    const decrypted = await target.decrypt(encrypted);
+      await expect(
+        target.decryptBlob(encryptedBlobBuilder().build()),
+      ).rejects.toThrow(
+        'Local encryption is not suitable for production usage',
+      );
+    });
 
-    expect(decrypted).toBe(data);
+    it('should encrypt and decrypt arrays of objects correctly', async () => {
+      const data = faker.helpers.multiple(() => JSON.parse(fakeJson()), {
+        count: 10,
+      });
+      const encrypted = await target.encryptBlob(data);
+      const decrypted = await target.decryptBlob(encrypted);
+
+      expect(decrypted).toStrictEqual(data);
+    });
+
+    it('should fail to encrypt non-object data', async () => {
+      await expect(
+        target.encryptBlob(faker.string.alphanumeric()),
+      ).rejects.toThrow('Data must be an object or array');
+    });
+
+    it('should fail to encrypt null or undefined data', async () => {
+      await expect(target.encryptBlob(null)).rejects.toThrow(
+        'Data must be an object or array',
+      );
+    });
+
+    it('should fail to encrypt undefined data', async () => {
+      await expect(target.encryptBlob(undefined)).rejects.toThrow(
+        'Data must be an object or array',
+      );
+    });
   });
 });

--- a/src/datasources/accounts/encryption/local-encryption-api.service.spec.ts
+++ b/src/datasources/accounts/encryption/local-encryption-api.service.spec.ts
@@ -3,7 +3,6 @@ import type { IConfigurationService } from '@/config/configuration.service.inter
 import { encryptedBlobBuilder } from '@/datasources/accounts/encryption/entities/__tests__/encrypted-blob.builder';
 import { LocalEncryptionApiService } from '@/datasources/accounts/encryption/local-encryption-api.service';
 import { faker } from '@faker-js/faker/.';
-import * as crypto from 'crypto';
 
 const mockConfigurationService = {
   get: jest.fn(),
@@ -77,9 +76,9 @@ describe('LocalEncryptionApiService', () => {
     it('should fail to encryptBlob in production', async () => {
       mockConfigurationService.getOrThrow.mockImplementation((key) => {
         if (key === 'application.isProduction') return true;
-        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-gcm';
-        if (key === 'accounts.encryption.local.key')
-          return crypto.randomBytes(32);
+        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-cbc';
+        if (key === 'accounts.encryption.local.key') return 'a'.repeat(64);
+        if (key === 'accounts.encryption.local.iv') return 'b'.repeat(32);
         throw new Error(`Unexpected key: ${key}`);
       });
       target = new LocalEncryptionApiService(mockConfigurationService);
@@ -94,9 +93,9 @@ describe('LocalEncryptionApiService', () => {
     it('should fail to decryptBlob in production', async () => {
       mockConfigurationService.getOrThrow.mockImplementation((key) => {
         if (key === 'application.isProduction') return true;
-        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-gcm';
-        if (key === 'accounts.encryption.local.key')
-          return crypto.randomBytes(32);
+        if (key === 'accounts.encryption.local.algorithm') return 'aes-256-cbc';
+        if (key === 'accounts.encryption.local.key') return 'a'.repeat(64);
+        if (key === 'accounts.encryption.local.iv') return 'b'.repeat(32);
         throw new Error(`Unexpected key: ${key}`);
       });
       target = new LocalEncryptionApiService(mockConfigurationService);
@@ -124,7 +123,7 @@ describe('LocalEncryptionApiService', () => {
       ).rejects.toThrow('Data must be an object or array');
     });
 
-    it('should fail to encrypt null or undefined data', async () => {
+    it('should fail to encrypt null data', async () => {
       await expect(target.encryptBlob(null)).rejects.toThrow(
         'Data must be an object or array',
       );

--- a/src/datasources/accounts/encryption/local-encryption-api.service.ts
+++ b/src/datasources/accounts/encryption/local-encryption-api.service.ts
@@ -1,4 +1,5 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { EncryptedBlob } from '@/datasources/accounts/encryption/entities/encrypted-blob.entity';
 import type { IEncryptionApi } from '@/domain/interfaces/encryption-api.interface';
 import { Injectable } from '@nestjs/common';
 import * as crypto from 'crypto';
@@ -49,5 +50,48 @@ export class LocalEncryptionApiService implements IEncryptionApi {
     let decrypted = decipher.update(data, 'hex', 'utf8');
     decrypted += decipher.final('utf8');
     return Promise.resolve(decrypted);
+  }
+
+  async encryptBlob(data: unknown): Promise<EncryptedBlob> {
+    if (this.isProduction) {
+      throw new Error('Local encryption is not suitable for production usage');
+    }
+    if ((typeof data !== 'object' && !Array.isArray(data)) || data === null) {
+      throw new Error('Data must be an object or array');
+    }
+    const encryptedData = Buffer.from(
+      await this.encrypt(JSON.stringify(data)),
+      'hex',
+    );
+    const encryptedDataKey = Buffer.from(
+      await this.encrypt(this.key.toString('hex')),
+      'hex',
+    );
+    return {
+      encryptedData,
+      encryptedDataKey,
+      iv: this.iv,
+    };
+  }
+
+  async decryptBlob(encryptedBlob: EncryptedBlob): Promise<unknown> {
+    if (this.isProduction) {
+      throw new Error('Local encryption is not suitable for production usage');
+    }
+    const decryptedKey = await this.decrypt(
+      encryptedBlob.encryptedDataKey.toString('hex'),
+    );
+    const decipher = crypto.createDecipheriv(
+      this.algorithm,
+      Buffer.from(decryptedKey, 'hex'),
+      encryptedBlob.iv,
+    );
+    let decrypted = decipher.update(
+      encryptedBlob.encryptedData.toString('hex'),
+      'hex',
+      'utf8',
+    );
+    decrypted += decipher.final('utf8');
+    return Promise.resolve(JSON.parse(decrypted));
   }
 }

--- a/src/domain/interfaces/encryption-api.interface.ts
+++ b/src/domain/interfaces/encryption-api.interface.ts
@@ -1,7 +1,13 @@
+import type { EncryptedBlob } from '@/datasources/accounts/encryption/entities/encrypted-blob.entity';
+
 export const IEncryptionApi = Symbol('IEncryptionApi');
 
 export interface IEncryptionApi {
   encrypt(data: string): Promise<string>;
 
+  encryptBlob(data: unknown): Promise<EncryptedBlob>;
+
   decrypt(data: string): Promise<string>;
+
+  decryptBlob(data: EncryptedBlob): Promise<unknown>;
 }

--- a/src/domain/interfaces/encryption-api.interface.ts
+++ b/src/domain/interfaces/encryption-api.interface.ts
@@ -5,9 +5,9 @@ export const IEncryptionApi = Symbol('IEncryptionApi');
 export interface IEncryptionApi {
   encrypt(data: string): Promise<string>;
 
-  encryptBlob(data: unknown): Promise<EncryptedBlob>;
-
   decrypt(data: string): Promise<string>;
+
+  encryptBlob(data: unknown): Promise<EncryptedBlob>;
 
   decryptBlob(data: EncryptedBlob): Promise<unknown>;
 }


### PR DESCRIPTION
## Summary
This PR adds JSON encryption/decryption to `IEncryptionApi`. 

It adds two functions: `encryptBlob` and `decryptBlob`. Since the key to encrypt the blob is a one-use key, the return of `encryptBlob` will be an `EncryptedBlob`, which holds:

1. The encrypted data.
2. The key used to encrypt (also encrypted).
3. The `iv` used in the process.

Also, this `EncryptedBlob` will be used as an input parameter for `decryptBlob`, which needs to decrypt the key first, and then, using that key and the `iv`, it can decrypt the data.

## Changes
- Adds JSON encryption/decryption to `LocalEncryptionApiService` using NodeJS `crypto` module exclusively.
- Adds JSON encryption/decryption to `AwsEncryptionApiService` using NodeJS `crypto` module and AWS KMS to generate and decrypt individual DEKs (Data Encryption Keys) that are used for a specific data payload.
