### PR TITLE
fix: swagger factory type can’t be null

### DIFF
--- a/src/routes/transactions/entities/creation-transaction-info.entity.ts
+++ b/src/routes/transactions/entities/creation-transaction-info.entity.ts
@@ -12,8 +12,8 @@ export class CreationTransactionInfo extends TransactionInfo {
   transactionHash: string;
   @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   implementation: AddressInfo | null;
-  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
-  factory: AddressInfo | null;
+  @ApiPropertyOptional({ type: AddressInfo })
+  factory: AddressInfo;
   @ApiPropertyOptional({ type: String, nullable: true })
   saltNonce: string | null;
 
@@ -21,7 +21,7 @@ export class CreationTransactionInfo extends TransactionInfo {
     creator: AddressInfo,
     transactionHash: string,
     implementation: AddressInfo | null,
-    factory: AddressInfo | null,
+    factory: AddressInfo,
     saltNonce: string | null,
   ) {
     super(TransactionInfoType.Creation, null);


### PR DESCRIPTION
The factory address is being set as AddressInfo | null. I think that it in practice it is impossible for the factory to be null.

If we look at the transaction mapping in
src/routes/transactions/entities/transfer-transaction-info.entity.ts

We can see that the factory is set to
await this.addressInfoHelper.getOrDefault(…). The getOrDefault function always returns an Address. More, the mapTransaction sets the transaction as a CreationTransaction type. If we look at the zod schema: export const CreationTransactionSchema = z.object({ …
  factoryAddress: AddressSchema,
…
});

So the zod defintion to the CreationTransaction is also an address.

Because of this I’ve changed the tx type generated by Swagger to be only AddressInfo.
