### PR TITLE
Remove unnecessary table drops in migration tests

### DIFF
--- a/migrations/deprecated/00001_accounts/index.sql
+++ b/migrations/deprecated/00001_accounts/index.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS groups,
-accounts CASCADE;
+DROP TABLE IF EXISTS groups, accounts CASCADE;
 
 CREATE TABLE
     groups (

--- a/migrations/deprecated/00006_targeted_messaging/index.sql
+++ b/migrations/deprecated/00006_targeted_messaging/index.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;
+
 CREATE TABLE outreaches (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL,

--- a/migrations/deprecated/__tests__/00001_accounts.spec.ts
+++ b/migrations/deprecated/__tests__/00001_accounts.spec.ts
@@ -28,8 +28,6 @@ describe('Migration 00001_accounts', () => {
   });
 
   it('runs successfully', async () => {
-    await sql`DROP TABLE IF EXISTS groups, accounts CASCADE;`;
-
     const result = await migrator.test({
       migration: '00001_accounts',
       after: async (sql: Sql) => {
@@ -71,8 +69,6 @@ describe('Migration 00001_accounts', () => {
   });
 
   it('should add and update row timestamps', async () => {
-    await sql`DROP TABLE IF EXISTS groups, accounts CASCADE;`;
-
     const result: {
       before: unknown;
       after: AccountRow[];
@@ -102,8 +98,6 @@ describe('Migration 00001_accounts', () => {
   });
 
   it('only updated_at should be updated on row changes', async () => {
-    await sql`DROP TABLE IF EXISTS groups, accounts CASCADE;`;
-
     const result: {
       before: unknown;
       after: AccountRow[];

--- a/migrations/deprecated/__tests__/00002_account-data-types.spec.ts
+++ b/migrations/deprecated/__tests__/00002_account-data-types.spec.ts
@@ -29,8 +29,6 @@ describe('Migration 00002_account-data-types', () => {
   });
 
   it('runs successfully', async () => {
-    await sql`DROP TABLE IF EXISTS account_data_types CASCADE;`;
-
     const result = await migrator.test({
       migration: '00002_account-data-types',
       after: async (sql: Sql) => {
@@ -85,8 +83,6 @@ describe('Migration 00002_account-data-types', () => {
   });
 
   it('should add and update row timestamps', async () => {
-    await sql`DROP TABLE IF EXISTS account_data_types CASCADE;`;
-
     const result: { before: unknown; after: AccountDataTypeRow[] } =
       await migrator.test({
         migration: '00002_account-data-types',

--- a/migrations/deprecated/__tests__/00006_targeted_messaging.spec.ts
+++ b/migrations/deprecated/__tests__/00006_targeted_messaging.spec.ts
@@ -23,8 +23,6 @@ describe('Migration 00006_targeted_messaging', () => {
   });
 
   it('runs successfully', async () => {
-    await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
     const result = await migrator.test({
       migration: '00006_targeted_messaging',
       after: async (sql: Sql) => {
@@ -82,8 +80,6 @@ describe('Migration 00006_targeted_messaging', () => {
 
   describe('Outreaches', () => {
     it('should upsert the updated_at timestamp when updating an outreach', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       const result: {
         before: unknown;
         after: Outreach[];
@@ -120,8 +116,6 @@ describe('Migration 00006_targeted_messaging', () => {
     });
 
     it('should throw an error if the unique(name) constraint is violated', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       await migrator.test({
         migration: '00006_targeted_messaging',
         after: async (sql: Sql) => {
@@ -142,8 +136,6 @@ describe('Migration 00006_targeted_messaging', () => {
 
   describe('TargetedSafes', () => {
     it('should upsert the updated_at timestamp when updating a targeted_safe', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       const result: {
         before: unknown;
         after: TargetedSafe[];
@@ -186,8 +178,6 @@ describe('Migration 00006_targeted_messaging', () => {
     });
 
     it('should throw an error if the unique(address, outreach_id) constraint is violated', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       await migrator.test({
         migration: '00006_targeted_messaging',
         after: async (sql: Sql) => {
@@ -214,8 +204,6 @@ describe('Migration 00006_targeted_messaging', () => {
 
   describe('Submissions', () => {
     it('should upsert the updated_at timestamp when updating a submission', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       const result: {
         before: unknown;
         after: Submission[];
@@ -260,8 +248,6 @@ describe('Migration 00006_targeted_messaging', () => {
     });
 
     it('should trigger a cascade delete when the referenced target_safe is deleted', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       const result: {
         before: unknown;
         after: Submission[];
@@ -291,8 +277,6 @@ describe('Migration 00006_targeted_messaging', () => {
     });
 
     it('should throw an error if the unique(targeted_safe_id, signer_address) constraint is violated', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       await migrator.test({
         migration: '00006_targeted_messaging',
         after: async (sql: Sql) => {

--- a/migrations/deprecated/__tests__/00007_targeted_messaging_update.spec.ts
+++ b/migrations/deprecated/__tests__/00007_targeted_messaging_update.spec.ts
@@ -21,8 +21,6 @@ describe('Migration 00007_targeted_messaging_update', () => {
   });
 
   it('runs successfully', async () => {
-    await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
     const result = await migrator.test({
       migration: '00007_targeted_messaging_update',
       after: async (sql: Sql) => {
@@ -57,8 +55,6 @@ describe('Migration 00007_targeted_messaging_update', () => {
 
   describe('Outreaches update', () => {
     it('should throw an error if the unique(source_id) constraint is violated', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       await migrator.test({
         migration: '00007_targeted_messaging_update',
         after: async (sql: Sql) => {
@@ -89,8 +85,6 @@ describe('Migration 00007_targeted_messaging_update', () => {
     });
 
     it('should default to null for source_file, source_file_processed_date, and source_file_checksum', async () => {
-      await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
       await migrator.test({
         migration: '00007_targeted_messaging_update',
         after: async (sql: Sql) => {

--- a/migrations/deprecated/__tests__/00008_targeted_messaging_add_outreach_1.spec.ts
+++ b/migrations/deprecated/__tests__/00008_targeted_messaging_add_outreach_1.spec.ts
@@ -19,8 +19,6 @@ describe('Migration 00008_targeted_messaging_add_outreach_1', () => {
   });
 
   it('runs successfully', async () => {
-    await sql`DROP TABLE IF EXISTS outreaches, targeted_safes, submissions CASCADE;`;
-
     const result = await migrator.test({
       migration: '00008_targeted_messaging_add_outreach_1',
       after: async (sql: Sql) => {

--- a/migrations/deprecated/__tests__/00009_account-names.spec.ts
+++ b/migrations/deprecated/__tests__/00009_account-names.spec.ts
@@ -13,10 +13,6 @@ describe('Migration 00006_accounts-names', () => {
     migrator = new PostgresDatabaseMigrator(sql);
   });
 
-  beforeEach(async () => {
-    await sql`DROP TABLE IF EXISTS groups, accounts, outreaches, targeted_safes, submissions CASCADE;`;
-  });
-
   afterAll(async () => {
     await testDbFactory.destroyTestDatabase(sql);
   });


### PR DESCRIPTION
## Changes
- Removes unnecessary `DROP TABLE` sentences from migration tests.
- Adds these statements to the migrations themselves, in line with the rest of the migration files.
