### PR TITLE
AddressBook creation and retrieval API endpoints

### DIFF
--- a/src/datasources/accounts/address-books/__tests__/test.address-books.datasource.module.ts
+++ b/src/datasources/accounts/address-books/__tests__/test.address-books.datasource.module.ts
@@ -1,0 +1,23 @@
+import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
+import { Module } from '@nestjs/common';
+
+const addressBooksDatasource = {
+  createAddressBookItem: jest.fn(),
+  getAddressBook: jest.fn(),
+  updateAddressBookItem: jest.fn(),
+  deleteAddressBook: jest.fn(),
+  deleteAddressBookItem: jest.fn(),
+} as jest.MockedObjectDeep<IAddressBooksDatasource>;
+
+@Module({
+  providers: [
+    {
+      provide: IAddressBooksDatasource,
+      useFactory: (): jest.MockedObjectDeep<IAddressBooksDatasource> => {
+        return jest.mocked(addressBooksDatasource);
+      },
+    },
+  ],
+  exports: [IAddressBooksDatasource],
+})
+export class TestAddressBooksDataSourceModule {}

--- a/src/datasources/accounts/address-books/address-books.datasource.module.ts
+++ b/src/datasources/accounts/address-books/address-books.datasource.module.ts
@@ -1,18 +1,18 @@
 import { AddressBooksDatasource } from '@/datasources/accounts/address-books/address-books.datasource';
 import { AddressBookDbMapper } from '@/datasources/accounts/address-books/entities/address-book.db.mapper';
+import { EncryptionApiManager } from '@/datasources/accounts/encryption/encryption-api.manager';
 import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
-import { IAddressBooksDataSource } from '@/domain/interfaces/address-books.datasource.interface';
+import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
+import { IEncryptionApiManager } from '@/domain/interfaces/encryption-api.manager.interface';
 import { Module } from '@nestjs/common';
 
 @Module({
   imports: [PostgresDatabaseModule],
   providers: [
     AddressBookDbMapper,
-    {
-      provide: IAddressBooksDataSource,
-      useClass: AddressBooksDatasource,
-    },
+    { provide: IAddressBooksDatasource, useClass: AddressBooksDatasource },
+    { provide: IEncryptionApiManager, useClass: EncryptionApiManager },
   ],
-  exports: [IAddressBooksDataSource],
+  exports: [IAddressBooksDatasource, IEncryptionApiManager],
 })
 export class AddressBooksDatasourceModule {}

--- a/src/datasources/accounts/address-books/address-books.datasource.ts
+++ b/src/datasources/accounts/address-books/address-books.datasource.ts
@@ -9,14 +9,14 @@ import { UpdateAddressBookItemDto } from '@/domain/accounts/address-books/entiti
 import { AddressBookItemNotFoundError } from '@/domain/accounts/address-books/errors/address-book-item-not-found.error';
 import { AddressBookNotFoundError } from '@/domain/accounts/address-books/errors/address-book-not-found.error';
 import { Account } from '@/domain/accounts/entities/account.entity';
-import { IAddressBooksDataSource } from '@/domain/interfaces/address-books.datasource.interface';
+import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
 import { IEncryptionApiManager } from '@/domain/interfaces/encryption-api.manager.interface';
 import { Inject, Injectable } from '@nestjs/common';
 import { max } from 'lodash';
 import postgres from 'postgres';
 
 @Injectable()
-export class AddressBooksDatasource implements IAddressBooksDataSource {
+export class AddressBooksDatasource implements IAddressBooksDatasource {
   constructor(
     @Inject('DB_INSTANCE') private readonly sql: postgres.Sql,
     @Inject(IEncryptionApiManager)

--- a/src/domain/accounts/address-books/address-books.repository.interface.ts
+++ b/src/domain/accounts/address-books/address-books.repository.interface.ts
@@ -1,0 +1,39 @@
+import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-books/address-books.datasource.module';
+import { AccountsRepositoryModule } from '@/domain/accounts/accounts.repository.interface';
+import { AddressBooksRepository } from '@/domain/accounts/address-books/address-books.repository';
+import type {
+  AddressBook,
+  AddressBookItem,
+} from '@/domain/accounts/address-books/entities/address-book.entity';
+import { CreateAddressBookItemDto } from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
+import { Module } from '@nestjs/common';
+
+export const IAddressBooksRepository = Symbol.for('IAddressBooksRepository');
+
+export interface IAddressBooksRepository {
+  getAddressBook(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+    chainId: string;
+  }): Promise<AddressBook>;
+
+  createAddressBookItem(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+    chainId: string;
+    createAddressBookItemDto: CreateAddressBookItemDto;
+  }): Promise<AddressBookItem>;
+}
+
+@Module({
+  imports: [AccountsRepositoryModule, AddressBooksDatasourceModule],
+  providers: [
+    {
+      provide: IAddressBooksRepository,
+      useClass: AddressBooksRepository,
+    },
+  ],
+  exports: [IAddressBooksRepository],
+})
+export class AddressBooksRepositoryModule {}

--- a/src/domain/accounts/address-books/address-books.repository.ts
+++ b/src/domain/accounts/address-books/address-books.repository.ts
@@ -1,0 +1,125 @@
+import { IAccountsRepository } from '@/domain/accounts/accounts.repository.interface';
+import type { IAddressBooksRepository } from '@/domain/accounts/address-books/address-books.repository.interface';
+import type {
+  AddressBook,
+  AddressBookItem,
+} from '@/domain/accounts/address-books/entities/address-book.entity';
+import { CreateAddressBookItemDto } from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
+import {
+  AccountDataType,
+  AccountDataTypeNames,
+} from '@/domain/accounts/entities/account-data-type.entity';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
+import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import {
+  GoneException,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+@Injectable()
+export class AddressBooksRepository implements IAddressBooksRepository {
+  constructor(
+    @Inject(IAddressBooksDatasource)
+    private readonly datasource: IAddressBooksDatasource,
+    @Inject(IAccountsRepository)
+    private readonly accountsRepository: IAccountsRepository,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  /**
+   * Gets an AddressBook.
+   * Checks that the account has the AddressBooks Data Setting enabled.
+   */
+  async getAddressBook(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+    chainId: string;
+  }): Promise<AddressBook> {
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+    await this.checkAddressBooksIsEnabled({
+      authPayload: args.authPayload,
+      address: args.address,
+    });
+    const account = await this.accountsRepository.getAccount({
+      authPayload: args.authPayload,
+      address: args.address,
+    });
+    return await this.datasource.getAddressBook({
+      account,
+      chainId: args.chainId,
+    });
+  }
+
+  /**
+   * Creates an AddressBookItem.
+   * Checks that the account has the AddressBooks Data Setting enabled.
+   *
+   * If an AddressBook for the Account and chainId does not exist, it's created.
+   */
+  async createAddressBookItem(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+    chainId: string;
+    createAddressBookItemDto: CreateAddressBookItemDto;
+  }): Promise<AddressBookItem> {
+    if (!args.authPayload.isForSigner(args.address)) {
+      throw new UnauthorizedException();
+    }
+    await this.checkAddressBooksIsEnabled({
+      authPayload: args.authPayload,
+      address: args.address,
+    });
+    const account = await this.accountsRepository.getAccount({
+      authPayload: args.authPayload,
+      address: args.address,
+    });
+    // TODO: implement a configurable MAX_ADDRESS_BOOK_ITEMS limitation.
+    return this.datasource.createAddressBookItem({
+      account,
+      chainId: args.chainId,
+      createAddressBookItemDto: args.createAddressBookItemDto,
+    });
+  }
+
+  // TODO: Extract this functionality in AccountsRepository['checkIsEnabled(DataType, Account)']
+  private async checkAddressBooksIsEnabled(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+  }): Promise<void> {
+    const addressBookDataType = await this.checkAddressBookDataTypeIsActive();
+    const accountDataSettings =
+      await this.accountsRepository.getAccountDataSettings({
+        authPayload: args.authPayload,
+        address: args.address,
+      });
+    const addressBookSetting = accountDataSettings.find(
+      (setting) => setting.account_data_type_id === addressBookDataType.id,
+    );
+    if (!addressBookSetting?.enabled) {
+      this.loggingService.warn({
+        message: `Account ${args.address} does not have AddressBooks enabled`,
+      });
+      throw new GoneException();
+    }
+  }
+
+  // TODO: Extract this functionality in AccountsRepository['checkIsActive(DataType)']
+  private async checkAddressBookDataTypeIsActive(): Promise<AccountDataType> {
+    const dataTypes = await this.accountsRepository.getDataTypes();
+    const addressBookDataType = dataTypes.find(
+      (dataType) => dataType.name === AccountDataTypeNames.AddressBook,
+    );
+    if (!addressBookDataType?.is_active) {
+      this.loggingService.warn({
+        message: `${AccountDataTypeNames.AddressBook} data type is not active`,
+      });
+      throw new GoneException();
+    }
+    return addressBookDataType;
+  }
+}

--- a/src/domain/accounts/address-books/entities/__tests__/address-book-item-name.builder.ts
+++ b/src/domain/accounts/address-books/entities/__tests__/address-book-item-name.builder.ts
@@ -1,0 +1,9 @@
+import { faker } from '@faker-js/faker/.';
+
+// Note: regular expression is simplified because faker has limited support for regex.
+// https://fakerjs.dev/api/helpers#fromregexp
+export const addressBookItemNameSimpleRegex = /[a-zA-Z0-9]{18,40}/i;
+
+export function addressBookItemNameBuilder(): string {
+  return faker.helpers.fromRegExp(addressBookItemNameSimpleRegex);
+}

--- a/src/domain/accounts/address-books/entities/__tests__/address-book.builder.ts
+++ b/src/domain/accounts/address-books/entities/__tests__/address-book.builder.ts
@@ -1,0 +1,31 @@
+import { type IBuilder, Builder } from '@/__tests__/builder';
+import { addressBookItemNameBuilder } from '@/domain/accounts/address-books/entities/__tests__/address-book-item-name.builder';
+import type {
+  AddressBook,
+  AddressBookItem,
+} from '@/domain/accounts/address-books/entities/address-book.entity';
+import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+export function addressBookItemBuilder(): IBuilder<AddressBookItem> {
+  return new Builder<AddressBookItem>()
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('id', faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }))
+    .with('name', addressBookItemNameBuilder());
+}
+
+export function addressBookBuilder(): IBuilder<AddressBook> {
+  return new Builder<AddressBook>()
+    .with('id', faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }))
+    .with('accountId', faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }))
+    .with('chainId', faker.string.numeric({ length: 6 }))
+    .with(
+      'data',
+      faker.helpers.multiple(() => addressBookItemBuilder().build(), {
+        count: { min: 1, max: 5 },
+      }),
+    )
+    .with('created_at', faker.date.recent())
+    .with('updated_at', faker.date.recent());
+}

--- a/src/domain/accounts/address-books/entities/address-book.entity.spec.ts
+++ b/src/domain/accounts/address-books/entities/address-book.entity.spec.ts
@@ -1,0 +1,191 @@
+import { addressBookBuilder } from '@/domain/accounts/address-books/entities/__tests__/address-book.builder';
+import { AddressBookSchema } from '@/domain/accounts/address-books/entities/address-book.entity';
+import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+describe('AddressBookSchema', () => {
+  it('should verify an AddressBook', () => {
+    const addressBook = addressBookBuilder().build();
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not verify an AddressBook with a float accountId', () => {
+    const addressBook = addressBookBuilder()
+      .with('accountId', faker.number.float())
+      .build();
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'integer',
+        message: 'Expected integer, received float',
+        path: ['accountId'],
+        received: 'float',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBook with a number chainId', () => {
+    const addressBook = addressBookBuilder()
+      // @ts-expect-error - should be strings
+      .with('chainId', faker.number.int())
+      .build();
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Expected string, received number',
+        path: ['chainId'],
+        received: 'number',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBook with a string data', () => {
+    const addressBook = addressBookBuilder()
+      // @ts-expect-error - should be array
+      .with('data', faker.string.alphanumeric())
+      .build();
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'array',
+        message: 'Expected array, received string',
+        path: ['data'],
+        received: 'string',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBookItem with a float id', () => {
+    const addressBook = addressBookBuilder().build();
+    addressBook.data[0].id = faker.number.float({
+      min: 1.01,
+      max: DB_MAX_SAFE_INTEGER,
+    });
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'integer',
+        message: 'Expected integer, received float',
+        path: ['data', 0, 'id'],
+        received: 'float',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBookItem with a string id', () => {
+    const addressBook = addressBookBuilder().build();
+    // @ts-expect-error - should be numbers
+    addressBook.data[0].id = faker.string.alphanumeric();
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Expected number, received string',
+        path: ['data', 0, 'id'],
+        received: 'string',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBookItem with a shorter name', () => {
+    const addressBook = addressBookBuilder().build();
+    addressBook.data[0].name = 'e'; // min length is 3
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'too_small',
+        exact: false,
+        inclusive: true,
+        message: 'Address Books items names must be at least 3 characters long',
+        minimum: 3,
+        path: ['data', 0, 'name'],
+        type: 'string',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBookItem with a longer name', () => {
+    const addressBook = addressBookBuilder().build();
+    addressBook.data[0].name = 'e'.repeat(51); // max length is 50
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'too_big',
+        exact: false,
+        inclusive: true,
+        message: 'Address Books items names must be at most 50 characters long',
+        maximum: 50,
+        path: ['data', 0, 'name'],
+        type: 'string',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBookItem with a malformed name', () => {
+    const addressBook = addressBookBuilder().build();
+    addressBook.data[0].name = '////'; // must start with a letter or number
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_string',
+        message:
+          'Address Books items names must start with a letter or number and can contain alphanumeric characters, periods, underscores, or hyphens',
+        path: ['data', 0, 'name'],
+        validation: 'regex',
+      },
+    ]);
+  });
+
+  it('should not verify an AddressBookItem with a malformed address', () => {
+    const addressBook = addressBookBuilder().build();
+    addressBook.data[0].address = '0x123';
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid address',
+        path: ['data', 0, 'address'],
+      },
+    ]);
+  });
+
+  it('should checksum the address of an AddressBookItem', () => {
+    const addressBook = addressBookBuilder().build();
+    // @ts-expect-error - address should be `0x${string}`
+    addressBook.data[0].address = addressBook.data[0].address.toLowerCase();
+
+    const result = AddressBookSchema.safeParse(addressBook);
+
+    expect(result.success && result.data.data[0].address).toBe(
+      getAddress(addressBook.data[0].address),
+    );
+  });
+});

--- a/src/domain/accounts/address-books/entities/address-book.entity.ts
+++ b/src/domain/accounts/address-books/entities/address-book.entity.ts
@@ -1,11 +1,14 @@
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
+import { AddressBookItemNameSchema } from '@/domain/accounts/address-books/entities/schemas/address-book-item-name.schema';
 import { AccountSchema } from '@/domain/accounts/entities/account.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
 
 export const AddressBookItemSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  address: z.string(),
+  // TODO: add limitation to the id according to MAX_ADDRESS_BOOK_ITEMS
+  id: z.number().int().gte(1),
+  name: AddressBookItemNameSchema,
+  address: AddressSchema,
 });
 
 export const AddressBookSchema = RowSchema.extend({

--- a/src/domain/accounts/address-books/entities/create-address-book-item.dto.entity.ts
+++ b/src/domain/accounts/address-books/entities/create-address-book-item.dto.entity.ts
@@ -1,9 +1,9 @@
-import { AccountNameSchema } from '@/domain/accounts/entities/schemas/account-name.schema';
+import { AddressBookItemNameSchema } from '@/domain/accounts/address-books/entities/schemas/address-book-item-name.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
 
 export const CreateAddressBookItemDtoSchema = z.object({
-  name: AccountNameSchema,
+  name: AddressBookItemNameSchema,
   address: AddressSchema,
 });
 

--- a/src/domain/accounts/address-books/entities/schemas/address-book-item-name.schema.spec.ts
+++ b/src/domain/accounts/address-books/entities/schemas/address-book-item-name.schema.spec.ts
@@ -1,0 +1,108 @@
+import { AddressBookItemNameSchema } from '@/domain/accounts/address-books/entities/schemas/address-book-item-name.schema';
+import { faker } from '@faker-js/faker/.';
+import { ZodError } from 'zod';
+
+describe('AddressBookItemNameSchema', () => {
+  it('should validate a valid address book item name', () => {
+    const addressBookItemName = 'a-valid_AddressBookItem.name';
+
+    const result = AddressBookItemNameSchema.safeParse(addressBookItemName);
+
+    expect(result.success && result.data).toBe(addressBookItemName);
+  });
+
+  it('should not validate an non-string name', () => {
+    const name = 123;
+
+    const result = AddressBookItemNameSchema.safeParse(name);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'number',
+          path: [],
+          message: 'Expected string, received number',
+        },
+      ]),
+    );
+  });
+
+  it('should not validate null name', () => {
+    const result = AddressBookItemNameSchema.safeParse(null);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'null',
+          path: [],
+          message: 'Expected string, received null',
+        },
+      ]),
+    );
+  });
+
+  it('should not validate an account name shorter than 3 characters', () => {
+    const accountName = faker.string.alphanumeric(2);
+
+    const result = AddressBookItemNameSchema.safeParse(accountName);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'too_small',
+          minimum: 3,
+          type: 'string',
+          inclusive: true,
+          exact: false,
+          message:
+            'Address Books items names must be at least 3 characters long',
+          path: [],
+        },
+      ]),
+    );
+  });
+
+  it('should not validate an account name larger than 50 characters', () => {
+    const accountName = faker.string.alphanumeric(51);
+
+    const result = AddressBookItemNameSchema.safeParse(accountName);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'too_big',
+          maximum: 50,
+          type: 'string',
+          inclusive: true,
+          exact: false,
+          message:
+            'Address Books items names must be at most 50 characters long',
+          path: [],
+        },
+      ]),
+    );
+  });
+
+  it('should not validate an account name containing not allowed characters', () => {
+    const forbiddenCharsString = '!@#$%^&*()';
+    const accountName = `${faker.string.alphanumeric(2)}${faker.string.fromCharacters(forbiddenCharsString)}${faker.string.alphanumeric(2)}`;
+
+    const result = AddressBookItemNameSchema.safeParse(accountName);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          validation: 'regex',
+          code: 'invalid_string',
+          message:
+            'Address Books items names must start with a letter or number and can contain alphanumeric characters, periods, underscores, or hyphens',
+          path: [],
+        },
+      ]),
+    );
+  });
+});

--- a/src/domain/accounts/address-books/entities/schemas/address-book-item-name.schema.ts
+++ b/src/domain/accounts/address-books/entities/schemas/address-book-item-name.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const AddressBookItemNameSchema = z
+  .string()
+  .min(3, {
+    message: 'Address Books items names must be at least 3 characters long',
+  })
+  .max(50, {
+    message: 'Address Books items names must be at most 50 characters long',
+  })
+  .regex(/^[a-zA-Z0-9]+(?:[._-][a-zA-Z0-9]+)*$/, {
+    message:
+      'Address Books items names must start with a letter or number and can contain alphanumeric characters, periods, underscores, or hyphens',
+  });

--- a/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.ts
+++ b/src/domain/accounts/counterfactual-safes/counterfactual-safes.repository.ts
@@ -142,6 +142,7 @@ export class CounterfactualSafesRepository
     return this.datasource.deleteCounterfactualSafesForAccount(account);
   }
 
+  // TODO: Extract this functionality in AccountsRepository['checkIsEnabled(DataType, Account)']
   private async checkCounterfactualSafesIsEnabled(args: {
     authPayload: AuthPayload;
     address: `0x${string}`;
@@ -165,6 +166,7 @@ export class CounterfactualSafesRepository
     }
   }
 
+  // TODO: Extract this functionality in AccountsRepository['checkIsActive(DataType)']
   private async checkCounterfactualSafeDataTypeIsActive(): Promise<AccountDataType> {
     const dataTypes = await this.accountsRepository.getDataTypes();
     const counterfactualSafeDataType = dataTypes.find(

--- a/src/domain/interfaces/address-books.datasource.interface.ts
+++ b/src/domain/interfaces/address-books.datasource.interface.ts
@@ -6,9 +6,9 @@ import type { CreateAddressBookItemDto } from '@/domain/accounts/address-books/e
 import type { UpdateAddressBookItemDto } from '@/domain/accounts/address-books/entities/update-address-book.item.dto.entity';
 import type { Account } from '@/domain/accounts/entities/account.entity';
 
-export const IAddressBooksDataSource = Symbol('IAddressBooksDataSource');
+export const IAddressBooksDatasource = Symbol('IAddressBooksDatasource');
 
-export interface IAddressBooksDataSource {
+export interface IAddressBooksDatasource {
   createAddressBookItem(args: {
     account: Account;
     chainId: string;

--- a/src/routes/accounts/accounts.controller.spec.ts
+++ b/src/routes/accounts/accounts.controller.spec.ts
@@ -4,6 +4,8 @@ import { AppModule } from '@/app.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { TestAccountsDataSourceModule } from '@/datasources/accounts/__tests__/test.accounts.datasource.module';
 import { AccountsDatasourceModule } from '@/datasources/accounts/accounts.datasource.module';
+import { TestAddressBooksDataSourceModule } from '@/datasources/accounts/address-books/__tests__/test.address-books.datasource.module';
+import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-books/address-books.datasource.module';
 import { TestCounterfactualSafesDataSourceModule } from '@/datasources/accounts/counterfactual-safes/__tests__/test.counterfactual-safes.datasource.module';
 import { CounterfactualSafesDatasourceModule } from '@/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.module';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
@@ -70,6 +72,8 @@ describe('AccountsController', () => {
       .useModule(TestPostgresDatabaseModule)
       .overrideModule(AccountsDatasourceModule)
       .useModule(TestAccountsDataSourceModule)
+      .overrideModule(AddressBooksDatasourceModule)
+      .useModule(TestAddressBooksDataSourceModule)
       .overrideModule(CounterfactualSafesDatasourceModule)
       .useModule(TestCounterfactualSafesDataSourceModule)
       .overrideModule(TargetedMessagingDatasourceModule)

--- a/src/routes/accounts/accounts.module.ts
+++ b/src/routes/accounts/accounts.module.ts
@@ -1,8 +1,11 @@
 import { AccountsRepositoryModule } from '@/domain/accounts/accounts.repository.interface';
+import { AddressBooksRepositoryModule } from '@/domain/accounts/address-books/address-books.repository.interface';
 import { CounterfactualSafesRepositoryModule } from '@/domain/accounts/counterfactual-safes/counterfactual-safes.repository.interface';
 import { AuthRepositoryModule } from '@/domain/auth/auth.repository.interface';
 import { AccountsController } from '@/routes/accounts/accounts.controller';
 import { AccountsService } from '@/routes/accounts/accounts.service';
+import { AddressBooksController } from '@/routes/accounts/address-books/address-books.controller';
+import { AddressBooksService } from '@/routes/accounts/address-books/address-books.service';
 import { CounterfactualSafesController } from '@/routes/accounts/counterfactual-safes/counterfactual-safes.controller';
 import { CounterfactualSafesService } from '@/routes/accounts/counterfactual-safes/counterfactual-safes.service';
 import { Module } from '@nestjs/common';
@@ -10,10 +13,15 @@ import { Module } from '@nestjs/common';
 @Module({
   imports: [
     AccountsRepositoryModule,
+    AddressBooksRepositoryModule,
     AuthRepositoryModule,
     CounterfactualSafesRepositoryModule,
   ],
-  controllers: [AccountsController, CounterfactualSafesController],
-  providers: [AccountsService, CounterfactualSafesService],
+  controllers: [
+    AccountsController,
+    AddressBooksController,
+    CounterfactualSafesController,
+  ],
+  providers: [AccountsService, AddressBooksService, CounterfactualSafesService],
 })
 export class AccountsModule {}

--- a/src/routes/accounts/address-books/address-books.controller.spec.ts
+++ b/src/routes/accounts/address-books/address-books.controller.spec.ts
@@ -1,0 +1,348 @@
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { checkGuardIsApplied } from '@/__tests__/util/check-guard';
+import { AppModule } from '@/app.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { TestAccountsDataSourceModule } from '@/datasources/accounts/__tests__/test.accounts.datasource.module';
+import { AccountsDatasourceModule } from '@/datasources/accounts/accounts.datasource.module';
+import { TestAddressBooksDataSourceModule } from '@/datasources/accounts/address-books/__tests__/test.address-books.datasource.module';
+import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-books/address-books.datasource.module';
+import { TestCounterfactualSafesDataSourceModule } from '@/datasources/accounts/counterfactual-safes/__tests__/test.counterfactual-safes.datasource.module';
+import { CounterfactualSafesDatasourceModule } from '@/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.module';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
+import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import type { IAccountsRepository } from '@/domain/accounts/accounts.repository.interface';
+import {
+  addressBookBuilder,
+  addressBookItemBuilder,
+} from '@/domain/accounts/address-books/entities/__tests__/address-book.builder';
+import { IAccountsDatasource } from '@/domain/interfaces/accounts.datasource.interface';
+import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { AddressBooksController } from '@/routes/accounts/address-books/address-books.controller';
+import { AuthGuard } from '@/routes/auth/guards/auth.guard';
+import { faker } from '@faker-js/faker/.';
+import type { INestApplication } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Server } from 'http';
+import { getAddress } from 'viem';
+import request from 'supertest';
+import { authPayloadDtoBuilder } from '@/domain/auth/entities/__tests__/auth-payload-dto.entity.builder';
+import { accountBuilder } from '@/domain/accounts/entities/__tests__/account.builder';
+import { accountDataTypeBuilder } from '@/domain/accounts/entities/__tests__/account-data-type.builder';
+import { AccountDataTypeNames } from '@/domain/accounts/entities/account-data-type.entity';
+import { accountDataSettingBuilder } from '@/domain/accounts/entities/__tests__/account-data-setting.builder';
+import { createAddressBookItemDtoBuilder } from '@/domain/accounts/address-books/entities/__tests__/create-address-book-item.dto.builder';
+
+describe('AddressBooksController', () => {
+  let app: INestApplication<Server>;
+  let jwtService: IJwtService;
+  let accountsRepository: jest.MockedObjectDeep<IAccountsRepository>;
+  let addressBooksDatasource: jest.MockedObjectDeep<IAddressBooksDatasource>;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        auth: true,
+        accounts: true,
+      },
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(testConfiguration)],
+    })
+      .overrideModule(AccountsDatasourceModule)
+      .useModule(TestAccountsDataSourceModule)
+      .overrideModule(AddressBooksDatasourceModule)
+      .useModule(TestAddressBooksDataSourceModule)
+      .overrideModule(CounterfactualSafesDatasourceModule)
+      .useModule(TestCounterfactualSafesDataSourceModule)
+      .overrideModule(TargetedMessagingDatasourceModule)
+      .useModule(TestTargetedMessagingDatasourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
+      .overrideModule(PostgresDatabaseModuleV2)
+      .useModule(TestPostgresDatabaseModuleV2)
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
+      .compile();
+    jwtService = moduleFixture.get<IJwtService>(IJwtService);
+    accountsRepository = moduleFixture.get(IAccountsDatasource);
+    addressBooksDatasource = moduleFixture.get(IAddressBooksDatasource);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('AuthGuard', () => {
+    it('checks that the AuthGuard is applied to the proper controller endpoints', () => {
+      const protectedEndpoints = [
+        AddressBooksController.prototype.getAddressBook,
+        AddressBooksController.prototype.createAddressBookItem,
+      ];
+      protectedEndpoints.forEach((fn) => checkGuardIsApplied(AuthGuard, fn));
+    });
+  });
+
+  describe('GET /accounts/:address/address-books/:chainId', () => {
+    it('should return an AddressBook', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const account = accountBuilder().build();
+      const accountDataTypes = [
+        accountDataTypeBuilder()
+          .with('name', AccountDataTypeNames.AddressBook)
+          .with('is_active', true)
+          .build(),
+      ];
+      accountsRepository.getAccount.mockResolvedValue(account);
+      accountsRepository.getDataTypes.mockResolvedValue(accountDataTypes);
+      accountsRepository.getAccountDataSettings.mockResolvedValue([
+        accountDataSettingBuilder()
+          .with('account_id', account.id)
+          .with('account_data_type_id', accountDataTypes[0].id)
+          .with('enabled', true)
+          .build(),
+      ]);
+      const addressBook = addressBookBuilder().build();
+      addressBooksDatasource.getAddressBook.mockResolvedValue(addressBook);
+
+      await request(app.getHttpServer())
+        .get(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200)
+        .expect({
+          id: addressBook.id.toString(),
+          accountId: addressBook.accountId.toString(),
+          chainId: addressBook.chainId,
+          data: addressBook.data.map((item) => ({
+            id: item.id.toString(),
+            name: item.name,
+            address: item.address,
+          })),
+        });
+    });
+
+    it('should fail if the authPayload does not match the URL address', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', getAddress(faker.finance.ethereumAddress())) // Different address
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+
+      await request(app.getHttpServer())
+        .get(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(401);
+    });
+
+    it('should fail if the account does not have the AddressBooks data setting enabled', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const account = accountBuilder().build();
+      const accountDataTypes = [
+        accountDataTypeBuilder()
+          .with('name', AccountDataTypeNames.AddressBook)
+          .with('is_active', true)
+          .build(),
+      ];
+      accountsRepository.getAccount.mockResolvedValue(account);
+      accountsRepository.getDataTypes.mockResolvedValue(accountDataTypes);
+      accountsRepository.getAccountDataSettings.mockResolvedValue([
+        accountDataSettingBuilder()
+          .with('account_id', account.id)
+          .with('account_data_type_id', accountDataTypes[0].id)
+          .with('enabled', false) // AddressBooks setting is not enabled
+          .build(),
+      ]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(410);
+    });
+
+    it('should not propagate a database error', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      accountsRepository.getAccount.mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await request(app.getHttpServer())
+        .get(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(500)
+        .expect({
+          code: 500,
+          message: 'Internal server error',
+        });
+    });
+  });
+
+  describe('POST /accounts/:address/address-books/:chainId', () => {
+    it('should create an AddressBookItem', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const account = accountBuilder().build();
+      const accountDataTypes = [
+        accountDataTypeBuilder()
+          .with('name', AccountDataTypeNames.AddressBook)
+          .with('is_active', true)
+          .build(),
+      ];
+      accountsRepository.getAccount.mockResolvedValue(account);
+      accountsRepository.getDataTypes.mockResolvedValue(accountDataTypes);
+      accountsRepository.getAccountDataSettings.mockResolvedValue([
+        accountDataSettingBuilder()
+          .with('account_id', account.id)
+          .with('account_data_type_id', accountDataTypes[0].id)
+          .with('enabled', true)
+          .build(),
+      ]);
+      const addressBook = addressBookBuilder().build();
+      addressBooksDatasource.getAddressBook.mockResolvedValue(addressBook);
+      const addressBookItem = addressBookItemBuilder().build();
+      addressBooksDatasource.createAddressBookItem.mockResolvedValue(
+        addressBookItem,
+      );
+      const createAddressBookItemDto =
+        createAddressBookItemDtoBuilder().build();
+
+      await request(app.getHttpServer())
+        .post(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send(createAddressBookItemDto)
+        .expect(201)
+        .expect({
+          id: addressBookItem.id.toString(),
+          name: addressBookItem.name,
+          address: addressBookItem.address,
+        });
+    });
+
+    it('should fail if the authPayload does not match the URL address', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', getAddress(faker.finance.ethereumAddress())) // Different address
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const createAddressBookItemDto =
+        createAddressBookItemDtoBuilder().build();
+
+      await request(app.getHttpServer())
+        .post(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send(createAddressBookItemDto)
+        .expect(401);
+    });
+
+    it('should fail if the account does not have the AddressBooks data setting enabled', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const account = accountBuilder().build();
+      const accountDataTypes = [
+        accountDataTypeBuilder()
+          .with('name', AccountDataTypeNames.AddressBook)
+          .with('is_active', true)
+          .build(),
+      ];
+      const createAddressBookItemDto =
+        createAddressBookItemDtoBuilder().build();
+      accountsRepository.getAccount.mockResolvedValue(account);
+      accountsRepository.getDataTypes.mockResolvedValue(accountDataTypes);
+      accountsRepository.getAccountDataSettings.mockResolvedValue([
+        accountDataSettingBuilder()
+          .with('account_id', account.id)
+          .with('account_data_type_id', accountDataTypes[0].id)
+          .with('enabled', false) // AddressBooks setting is not enabled
+          .build(),
+      ]);
+
+      await request(app.getHttpServer())
+        .post(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send(createAddressBookItemDto)
+        .expect(410);
+    });
+
+    it('should not propagate a database error', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const chainId = faker.string.numeric();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('chain_id', chainId)
+        .with('signer_address', address)
+        .build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const createAddressBookItemDto =
+        createAddressBookItemDtoBuilder().build();
+      accountsRepository.getAccount.mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await request(app.getHttpServer())
+        .post(`/v1/accounts/${address}/address-books/${chainId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send(createAddressBookItemDto)
+        .expect(500)
+        .expect({
+          code: 500,
+          message: 'Internal server error',
+        });
+    });
+  });
+});

--- a/src/routes/accounts/address-books/address-books.controller.ts
+++ b/src/routes/accounts/address-books/address-books.controller.ts
@@ -1,13 +1,11 @@
-import {
-  CreateAddressBookItemDto,
-  CreateAddressBookItemDtoSchema,
-} from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
+import { CreateAddressBookItemDtoSchema } from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
 import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { AddressBooksService } from '@/routes/accounts/address-books/address-books.service';
 import {
   AddressBook,
   AddressBookItem,
 } from '@/routes/accounts/address-books/entities/address-book.entity';
+import { CreateAddressBookItemDto } from '@/routes/accounts/address-books/entities/create-address-book-item.dto.entity';
 import { Auth } from '@/routes/auth/decorators/auth.decorator';
 import { AuthGuard } from '@/routes/auth/guards/auth.guard';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';

--- a/src/routes/accounts/address-books/address-books.controller.ts
+++ b/src/routes/accounts/address-books/address-books.controller.ts
@@ -1,0 +1,56 @@
+import {
+  CreateAddressBookItemDto,
+  CreateAddressBookItemDtoSchema,
+} from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
+import { AddressBooksService } from '@/routes/accounts/address-books/address-books.service';
+import {
+  AddressBook,
+  AddressBookItem,
+} from '@/routes/accounts/address-books/entities/address-book.entity';
+import { Auth } from '@/routes/auth/decorators/auth.decorator';
+import { AuthGuard } from '@/routes/auth/guards/auth.guard';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('accounts')
+@Controller({ path: 'accounts', version: '1' })
+export class AddressBooksController {
+  constructor(private readonly service: AddressBooksService) {}
+
+  @ApiOkResponse({ type: AddressBook })
+  @Get(':address/address-books/:chainId')
+  @UseGuards(AuthGuard)
+  async getAddressBook(
+    @Auth() authPayload: AuthPayload,
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+  ): Promise<AddressBook> {
+    return this.service.getAddressBook({
+      authPayload,
+      address,
+      chainId,
+    });
+  }
+
+  @ApiOkResponse({ type: AddressBookItem })
+  @Post(':address/address-books/:chainId')
+  @UseGuards(AuthGuard)
+  async createAddressBookItem(
+    @Auth() authPayload: AuthPayload,
+    @Param('address', new ValidationPipe(AddressSchema)) address: `0x${string}`,
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Body(new ValidationPipe(CreateAddressBookItemDtoSchema))
+    createAddressBookItemDto: CreateAddressBookItemDto,
+  ): Promise<AddressBookItem> {
+    return this.service.createAddressBookItem({
+      authPayload,
+      address,
+      chainId,
+      createAddressBookItemDto,
+    });
+  }
+}

--- a/src/routes/accounts/address-books/address-books.service.ts
+++ b/src/routes/accounts/address-books/address-books.service.ts
@@ -1,0 +1,61 @@
+import {
+  AddressBook,
+  AddressBookItem,
+} from '@/routes/accounts/address-books/entities/address-book.entity';
+import { AddressBook as DomainAddressBook } from '@/domain/accounts/address-books/entities/address-book.entity';
+import { AddressBookItem as DomainAddressBookItem } from '@/domain/accounts/address-books/entities/address-book.entity';
+import { Inject, Injectable } from '@nestjs/common';
+import { IAddressBooksRepository } from '@/domain/accounts/address-books/address-books.repository.interface';
+import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
+import { CreateAddressBookItemDto } from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
+
+@Injectable()
+export class AddressBooksService {
+  constructor(
+    @Inject(IAddressBooksRepository)
+    private readonly repository: IAddressBooksRepository,
+  ) {}
+
+  async getAddressBook(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+    chainId: string;
+  }): Promise<AddressBook> {
+    const domainAddressBook = await this.repository.getAddressBook(args);
+    return this.mapAddressBook(domainAddressBook);
+  }
+
+  async createAddressBookItem(args: {
+    authPayload: AuthPayload;
+    address: `0x${string}`;
+    chainId: string;
+    createAddressBookItemDto: CreateAddressBookItemDto;
+  }): Promise<AddressBookItem> {
+    const domainAddressBookItem =
+      await this.repository.createAddressBookItem(args);
+    return this.mapAddressBookItem(domainAddressBookItem);
+  }
+
+  private mapAddressBook(domainAddressBook: DomainAddressBook): AddressBook {
+    return {
+      id: domainAddressBook.id.toString(),
+      accountId: domainAddressBook.accountId.toString(),
+      chainId: domainAddressBook.chainId,
+      data: domainAddressBook.data.map((item) => ({
+        id: item.id.toString(),
+        name: item.name,
+        address: item.address,
+      })),
+    };
+  }
+
+  private mapAddressBookItem(
+    domainAddressBookItem: DomainAddressBookItem,
+  ): AddressBookItem {
+    return {
+      id: domainAddressBookItem.id.toString(),
+      name: domainAddressBookItem.name,
+      address: domainAddressBookItem.address,
+    };
+  }
+}

--- a/src/routes/accounts/address-books/entities/address-book.entity.ts
+++ b/src/routes/accounts/address-books/entities/address-book.entity.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddressBookItem {
+  @ApiProperty()
+  id: string;
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  address: `0x${string}`;
+
+  constructor(id: string, name: string, address: `0x${string}`) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+  }
+}
+
+export class AddressBook {
+  @ApiProperty()
+  id: string;
+  @ApiProperty()
+  accountId: string;
+  @ApiProperty()
+  chainId: string;
+  @ApiProperty()
+  data: AddressBookItem[];
+
+  constructor(
+    id: string,
+    accountId: string,
+    chainId: string,
+    data: AddressBookItem[],
+  ) {
+    this.id = id;
+    this.accountId = accountId;
+    this.chainId = chainId;
+    this.data = data;
+  }
+}

--- a/src/routes/accounts/address-books/entities/address-book.entity.ts
+++ b/src/routes/accounts/address-books/entities/address-book.entity.ts
@@ -22,7 +22,7 @@ export class AddressBook {
   accountId: string;
   @ApiProperty()
   chainId: string;
-  @ApiProperty()
+  @ApiProperty({ type: AddressBookItem, isArray: true })
   data: AddressBookItem[];
 
   constructor(

--- a/src/routes/accounts/address-books/entities/create-address-book-item.dto.entity.ts
+++ b/src/routes/accounts/address-books/entities/create-address-book-item.dto.entity.ts
@@ -1,0 +1,11 @@
+import { CreateAddressBookItemDto as DomainCreateAddressBookItemDto } from '@/domain/accounts/address-books/entities/create-address-book-item.dto.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateAddressBookItemDto
+  implements DomainCreateAddressBookItemDto
+{
+  @ApiProperty()
+  name!: string;
+  @ApiProperty()
+  address!: `0x${string}`;
+}

--- a/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.spec.ts
+++ b/src/routes/accounts/counterfactual-safes/counterfactual-safes.controller.spec.ts
@@ -4,6 +4,8 @@ import { AppModule } from '@/app.module';
 import configuration from '@/config/entities/__tests__/configuration';
 import { TestAccountsDataSourceModule } from '@/datasources/accounts/__tests__/test.accounts.datasource.module';
 import { AccountsDatasourceModule } from '@/datasources/accounts/accounts.datasource.module';
+import { TestAddressBooksDataSourceModule } from '@/datasources/accounts/address-books/__tests__/test.address-books.datasource.module';
+import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-books/address-books.datasource.module';
 import { TestCounterfactualSafesDataSourceModule } from '@/datasources/accounts/counterfactual-safes/__tests__/test.counterfactual-safes.datasource.module';
 import { CounterfactualSafesDatasourceModule } from '@/datasources/accounts/counterfactual-safes/counterfactual-safes.datasource.module';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
@@ -66,6 +68,8 @@ describe('CounterfactualSafesController', () => {
     })
       .overrideModule(AccountsDatasourceModule)
       .useModule(TestAccountsDataSourceModule)
+      .overrideModule(AddressBooksDatasourceModule)
+      .useModule(TestAddressBooksDataSourceModule)
       .overrideModule(CounterfactualSafesDatasourceModule)
       .useModule(TestCounterfactualSafesDataSourceModule)
       .overrideModule(TargetedMessagingDatasourceModule)

--- a/src/routes/notifications/v2/notifications.controller.spec.ts
+++ b/src/routes/notifications/v2/notifications.controller.spec.ts
@@ -45,6 +45,8 @@ import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { TestAddressBooksDataSourceModule } from '@/datasources/accounts/address-books/__tests__/test.address-books.datasource.module';
+import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-books/address-books.datasource.module';
 
 describe('Notifications Controller V2 (Unit)', () => {
   let app: INestApplication<Server>;
@@ -74,6 +76,8 @@ describe('Notifications Controller V2 (Unit)', () => {
       .useModule(TestPostgresDatabaseModule)
       .overrideModule(AccountsDatasourceModule)
       .useModule(TestAccountsDataSourceModule)
+      .overrideModule(AddressBooksDatasourceModule)
+      .useModule(TestAddressBooksDataSourceModule)
       .overrideModule(CounterfactualSafesDatasourceModule)
       .useModule(TestCounterfactualSafesDataSourceModule)
       .overrideModule(TargetedMessagingDatasourceModule)


### PR DESCRIPTION
## Summary
This PR adds the ability to create `AddressBookItems` and retrieve an `AddressBook` by adding the following endpoints to the service:

```
GET /accounts/:address/address-books/:chainId
```
```
POST /accounts/:address/address-books/:chainId
```

Both endpoints are behind the `Accounts` scope and require authentication.

## Changes
- Adds controller, repository, and service for `AddressBook` instances.
- Adds controller tests and entities/schema tests.
- Chains the functionality under `AccountsModule`.