### PR TITLE
Tighten eligibility vpn check

### DIFF
--- a/src/datasources/locking-api/entities/__tests__/fingerprint-unsealed-data.entity.builder.ts
+++ b/src/datasources/locking-api/entities/__tests__/fingerprint-unsealed-data.entity.builder.ts
@@ -18,6 +18,7 @@ export function fingerprintLocationSpoofingBuilder(): IBuilder<FingerprintLocati
 export function fingerprintVpnBuilder(): IBuilder<FingerprintVpn> {
   return new Builder<FingerprintVpn>().with('data', {
     result: faker.datatype.boolean(),
+    confidence: 'high',
   });
 }
 

--- a/src/datasources/locking-api/entities/fingerprint-unsealed-data.entity.ts
+++ b/src/datasources/locking-api/entities/fingerprint-unsealed-data.entity.ts
@@ -29,7 +29,13 @@ export const FingerprintIpInfoSchema = z.object({
 export type FingerprintIpInfo = z.infer<typeof FingerprintIpInfoSchema>;
 
 export const FingerprintVpnSchema = z.object({
-  data: z.object({ result: z.boolean() }).nullish().default(null),
+  data: z
+    .object({
+      result: z.boolean(),
+      confidence: z.enum(['low', 'medium', 'high']),
+    })
+    .nullish()
+    .default(null),
 });
 
 export type FingerprintVpn = z.infer<typeof FingerprintVpnSchema>;

--- a/src/datasources/locking-api/entities/fingerprint-unsealed-data.entity.ts
+++ b/src/datasources/locking-api/entities/fingerprint-unsealed-data.entity.ts
@@ -28,11 +28,15 @@ export const FingerprintIpInfoSchema = z.object({
 
 export type FingerprintIpInfo = z.infer<typeof FingerprintIpInfoSchema>;
 
+export const FingerprintConfidenceLevels = ['low', 'medium', 'high'] as const;
+
 export const FingerprintVpnSchema = z.object({
   data: z
     .object({
       result: z.boolean(),
-      confidence: z.enum(['low', 'medium', 'high']),
+      confidence: z
+        .enum([...FingerprintConfidenceLevels, 'unknown'])
+        .catch('unknown'),
     })
     .nullish()
     .default(null),

--- a/src/datasources/locking-api/fingerprint-api.service.spec.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.spec.ts
@@ -277,5 +277,27 @@ describe('FingerprintApiService', () => {
         isVpn: true,
       });
     });
+
+    it('should return isVpn:false for an unknown confidence score', async () => {
+      const eligibilityRequest = eligibilityRequestBuilder().build();
+      const unsealedData = fingerprintUnsealedDataBuilder()
+        .with('products', {
+          ipInfo: null,
+          locationSpoofing: fingerprintLocationSpoofingBuilder().build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: true, confidence: 'unknown' })
+            .build(),
+        })
+        .build();
+      (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
+
+      const result = await service.checkEligibility(eligibilityRequest);
+
+      expect(result).toEqual({
+        requestId: eligibilityRequest.requestId,
+        isAllowed: expect.anything(),
+        isVpn: false,
+      });
+    });
   });
 });

--- a/src/datasources/locking-api/fingerprint-api.service.spec.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.spec.ts
@@ -64,7 +64,9 @@ describe('FingerprintApiService', () => {
           locationSpoofing: fingerprintLocationSpoofingBuilder()
             .with('data', { result: false })
             .build(),
-          vpn: fingerprintVpnBuilder().with('data', { result: false }).build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: false, confidence: 'high' })
+            .build(),
         })
         .build();
       (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
@@ -93,7 +95,9 @@ describe('FingerprintApiService', () => {
           locationSpoofing: fingerprintLocationSpoofingBuilder()
             .with('data', { result: false })
             .build(),
-          vpn: fingerprintVpnBuilder().with('data', { result: false }).build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: false, confidence: 'high' })
+            .build(),
         })
         .build();
       (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
@@ -122,7 +126,9 @@ describe('FingerprintApiService', () => {
           locationSpoofing: fingerprintLocationSpoofingBuilder()
             .with('data', { result: false })
             .build(),
-          vpn: fingerprintVpnBuilder().with('data', { result: true }).build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: true, confidence: 'high' })
+            .build(),
         })
         .build();
       (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
@@ -144,7 +150,9 @@ describe('FingerprintApiService', () => {
           locationSpoofing: fingerprintLocationSpoofingBuilder()
             .with('data', { result: false })
             .build(),
-          vpn: fingerprintVpnBuilder().with('data', { result: true }).build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: true, confidence: 'high' })
+            .build(),
         })
         .build();
       (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);

--- a/src/datasources/locking-api/fingerprint-api.service.spec.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.spec.ts
@@ -211,5 +211,71 @@ describe('FingerprintApiService', () => {
         isVpn: vpn.data?.result,
       });
     });
+
+    it('should return isVpn:false for a low confidence score', async () => {
+      const eligibilityRequest = eligibilityRequestBuilder().build();
+      const unsealedData = fingerprintUnsealedDataBuilder()
+        .with('products', {
+          ipInfo: null,
+          locationSpoofing: fingerprintLocationSpoofingBuilder().build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: true, confidence: 'low' })
+            .build(),
+        })
+        .build();
+      (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
+
+      const result = await service.checkEligibility(eligibilityRequest);
+
+      expect(result).toEqual({
+        requestId: eligibilityRequest.requestId,
+        isAllowed: expect.anything(),
+        isVpn: false,
+      });
+    });
+
+    it('should return isVpn:false for a medium confidence score', async () => {
+      const eligibilityRequest = eligibilityRequestBuilder().build();
+      const unsealedData = fingerprintUnsealedDataBuilder()
+        .with('products', {
+          ipInfo: null,
+          locationSpoofing: fingerprintLocationSpoofingBuilder().build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: true, confidence: 'medium' })
+            .build(),
+        })
+        .build();
+      (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
+
+      const result = await service.checkEligibility(eligibilityRequest);
+
+      expect(result).toEqual({
+        requestId: eligibilityRequest.requestId,
+        isAllowed: expect.anything(),
+        isVpn: false,
+      });
+    });
+
+    it('should return isVpn:true for a high confidence score', async () => {
+      const eligibilityRequest = eligibilityRequestBuilder().build();
+      const unsealedData = fingerprintUnsealedDataBuilder()
+        .with('products', {
+          ipInfo: null,
+          locationSpoofing: fingerprintLocationSpoofingBuilder().build(),
+          vpn: fingerprintVpnBuilder()
+            .with('data', { result: true, confidence: 'high' })
+            .build(),
+        })
+        .build();
+      (unsealEventsResponse as jest.Mock).mockResolvedValue(unsealedData);
+
+      const result = await service.checkEligibility(eligibilityRequest);
+
+      expect(result).toEqual({
+        requestId: eligibilityRequest.requestId,
+        isAllowed: expect.anything(),
+        isVpn: true,
+      });
+    });
   });
 });

--- a/src/datasources/locking-api/fingerprint-api.service.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.ts
@@ -39,7 +39,9 @@ export class FingerprintApiService implements IIdentityApi {
     return {
       requestId,
       isAllowed: this.isAllowed(unsealedData),
-      isVpn: unsealedData.products.vpn?.data?.result === true,
+      isVpn:
+        unsealedData.products.vpn?.data?.result === true &&
+        unsealedData.products.vpn?.data?.confidence === 'high',
     };
   }
 

--- a/src/datasources/locking-api/fingerprint-api.service.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.ts
@@ -39,9 +39,7 @@ export class FingerprintApiService implements IIdentityApi {
     return {
       requestId,
       isAllowed: this.isAllowed(unsealedData),
-      isVpn:
-        unsealedData.products.vpn?.data?.result === true &&
-        unsealedData.products.vpn?.data?.confidence === 'high',
+      isVpn: this.isVpn(unsealedData),
     };
   }
 
@@ -73,6 +71,13 @@ export class FingerprintApiService implements IIdentityApi {
     // Both IP geolocation results must be either null or not in the non-eligible countries list.
     return ipCountryCodes.every(
       (code) => code === null || !this.nonEligibleCountryCodes.includes(code),
+    );
+  }
+
+  private isVpn(unsealedData: FingerprintUnsealedData): boolean {
+    return (
+      unsealedData.products.vpn?.data?.result === true &&
+      unsealedData.products.vpn?.data?.confidence === 'high'
     );
   }
 }


### PR DESCRIPTION
## Summary

Follow up on https://github.com/safe-global/safe-client-gateway/pull/2103

Through testing we noticed that Fingerprint sometimes mistakenly marks a request as using a VPN but with a low confidence. This change tightens the condition that decides whether vpn is true or false by also checking the confidence score.

## Changes

- Only marks vpn: true if it also has a confidence score of high
