### PR TITLE
fix: swagger return type for getSafeOverview missing

### DIFF
--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -51,6 +51,7 @@ export class SafesController {
   @ApiQuery({ name: 'trusted', required: false, type: Boolean })
   @ApiQuery({ name: 'exclude_spam', required: false, type: Boolean })
   @Get('safes')
+  @ApiOkResponse({ type: SafeOverview, isArray: true })
   async getSafeOverview(
     @Query('currency') currency: string,
     @Query('safes', new ValidationPipe(Caip10AddressesSchema))


### PR DESCRIPTION
## Summary
without this change swagger was not showing the return type for getSafeOverview
![grafik](https://github.com/user-attachments/assets/4bba9fbf-d3c3-4d21-8467-1fbe444c9b78)

with the change:
![grafik](https://github.com/user-attachments/assets/f9479095-17b7-47ed-8ce4-cd578079d686)

## Changes
