### PR TITLE
fix: Allow medium confidence checks for vpn eligibility

### DIFF
--- a/src/datasources/locking-api/fingerprint-api.service.spec.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.spec.ts
@@ -234,7 +234,7 @@ describe('FingerprintApiService', () => {
       });
     });
 
-    it('should return isVpn:false for a medium confidence score', async () => {
+    it('should return isVpn:true for a medium confidence score', async () => {
       const eligibilityRequest = eligibilityRequestBuilder().build();
       const unsealedData = fingerprintUnsealedDataBuilder()
         .with('products', {
@@ -252,7 +252,7 @@ describe('FingerprintApiService', () => {
       expect(result).toEqual({
         requestId: eligibilityRequest.requestId,
         isAllowed: expect.anything(),
-        isVpn: false,
+        isVpn: true,
       });
     });
 

--- a/src/datasources/locking-api/fingerprint-api.service.ts
+++ b/src/datasources/locking-api/fingerprint-api.service.ts
@@ -77,7 +77,8 @@ export class FingerprintApiService implements IIdentityApi {
   private isVpn(unsealedData: FingerprintUnsealedData): boolean {
     return (
       unsealedData.products.vpn?.data?.result === true &&
-      unsealedData.products.vpn?.data?.confidence === 'high'
+      (unsealedData.products.vpn?.data?.confidence === 'medium' ||
+        unsealedData.products.vpn?.data?.confidence === 'high')
     );
   }
 }


### PR DESCRIPTION
## Summary

Follow up on #2150

## Changes

- Also considers `medium` confidence results for `isVpn` to reduce number of false negatives.
