### PR TITLE
Automatically type all network requests as `Raw`

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -157,7 +157,7 @@ describe('Balances API Manager Tests', () => {
         throw new Error(`Unexpected key: ${key}`);
       });
       configApiMock.getChain.mockResolvedValue(rawify(chain));
-      dataSourceMock.get.mockResolvedValue([]);
+      dataSourceMock.get.mockResolvedValue(rawify([]));
       coingeckoApiMock.getTokenPrices.mockResolvedValue(rawify([]));
       const balancesApiManager = new BalancesApiManager(
         configurationService,

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -13,6 +13,7 @@ import { sortBy } from 'lodash';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { pricesProviderBuilder } from '@/domain/chains/entities/__tests__/prices-provider.builder';
+import { rawify } from '@/validation/entities/raw.entity';
 
 const mockCacheFirstDataSource = jest.mocked({
   get: jest.fn(),
@@ -109,7 +110,9 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should return fiat codes (using an API key)', async () => {
-    mockCacheFirstDataSource.get.mockResolvedValue(['usd', 'eur', 'eth']);
+    mockCacheFirstDataSource.get.mockResolvedValue(
+      rawify(['usd', 'eur', 'eth']),
+    );
 
     const fiatCodes = await service.getFiatCodes();
 
@@ -128,7 +131,9 @@ describe('CoingeckoAPI', () => {
   });
 
   it('should return fiat codes (with no API key)', async () => {
-    mockCacheFirstDataSource.get.mockResolvedValue(['usd', 'eur', 'eth']);
+    mockCacheFirstDataSource.get.mockResolvedValue(
+      rawify(['usd', 'eur', 'eth']),
+    );
     fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
     const service = new CoingeckoApi(
       fakeConfigurationService,
@@ -187,7 +192,7 @@ describe('CoingeckoAPI', () => {
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
-      data: coingeckoPrice,
+      data: rawify(coingeckoPrice),
       status: 200,
     });
 
@@ -238,7 +243,7 @@ describe('CoingeckoAPI', () => {
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
-      data: coingeckoPrice,
+      data: rawify(coingeckoPrice),
       status: 200,
     });
     const service = new CoingeckoApi(
@@ -298,7 +303,7 @@ describe('CoingeckoAPI', () => {
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
-      data: coingeckoPrice,
+      data: rawify(coingeckoPrice),
       status: 200,
     });
 
@@ -399,7 +404,7 @@ describe('CoingeckoAPI', () => {
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
-      data: coingeckoPrice,
+      data: rawify(coingeckoPrice),
       status: 200,
     });
     fakeConfigurationService.set(
@@ -503,7 +508,7 @@ describe('CoingeckoAPI', () => {
     );
     mockCacheService.hGet.mockResolvedValueOnce(undefined);
     mockNetworkService.get.mockResolvedValue({
-      data: coingeckoPrice,
+      data: rawify(coingeckoPrice),
       status: 200,
     });
 
@@ -607,7 +612,7 @@ describe('CoingeckoAPI', () => {
     );
     mockCacheService.hGet.mockResolvedValueOnce(undefined);
     mockNetworkService.get.mockResolvedValue({
-      data: coingeckoPrice,
+      data: rawify(coingeckoPrice),
       status: 200,
     });
 
@@ -685,7 +690,7 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const expectedAssetPrice: AssetPrice = { gnosis: { eur: 98.86 } };
-    mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
+    mockCacheFirstDataSource.get.mockResolvedValue(rawify(expectedAssetPrice));
 
     await service.getNativeCoinPrice({ chain, fiatCode });
 
@@ -714,7 +719,7 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const expectedAssetPrice: AssetPrice = { gnosis: { eur: 98.86 } };
-    mockCacheFirstDataSource.get.mockResolvedValue(expectedAssetPrice);
+    mockCacheFirstDataSource.get.mockResolvedValue(rawify(expectedAssetPrice));
     fakeConfigurationService.set('balances.providers.safe.prices.apiKey', null);
     const service = new CoingeckoApi(
       fakeConfigurationService,

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -24,10 +24,6 @@ import { Chain } from '@/domain/chains/entities/chain.entity';
 import { z } from 'zod';
 import { rawify, type Raw } from '@/validation/entities/raw.entity';
 
-/**
- * TODO: Move all usage of Raw to NetworkService/CacheFirstDataSource after fully migrated
- * to "Raw" type implementation.
- */
 @Injectable()
 export class CoingeckoApi implements IPricesApi {
   /**
@@ -134,7 +130,7 @@ export class CoingeckoApi implements IPricesApi {
       });
       const url = `${this.baseUrl}/simple/price`;
       const result = await this.dataSource
-        .get<Raw<AssetPrice>>({
+        .get<AssetPrice>({
           cacheDir,
           url,
           networkRequest: {
@@ -221,7 +217,7 @@ export class CoingeckoApi implements IPricesApi {
       const cacheDir = CacheRouter.getPriceFiatCodesCacheDir();
       const url = `${this.baseUrl}/simple/supported_vs_currencies`;
       const result = await this.dataSource
-        .get<Raw<string[]>>({
+        .get<string[]>({
           cacheDir,
           url,
           networkRequest: {
@@ -337,7 +333,7 @@ export class CoingeckoApi implements IPricesApi {
   }): Promise<Raw<AssetPrice>> {
     try {
       const url = `${this.baseUrl}/simple/token_price/${args.chainName}`;
-      const { data } = await this.networkService.get<Raw<AssetPrice>>({
+      const { data } = await this.networkService.get<AssetPrice>({
         url,
         networkRequest: {
           params: {

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -17,10 +17,6 @@ import { Chain } from '@/domain/chains/entities/chain.entity';
 import { rawify, type Raw } from '@/validation/entities/raw.entity';
 import { AssetPricesSchema } from '@/datasources/balances-api/entities/asset-price.entity';
 
-/**
- * TODO: Move all usage of Raw to NetworkService/CacheFirstDataSource after fully migrated
- * to "Raw" type implementation.
- */
 @Injectable()
 export class SafeBalancesApi implements IBalancesApi {
   private readonly defaultExpirationTimeInSeconds: number;
@@ -71,7 +67,7 @@ export class SafeBalancesApi implements IBalancesApi {
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/balances/`;
       const data = await this.dataSource
-        .get<Raw<Balance[]>>({
+        .get<Balance[]>({
           cacheDir,
           url,
           notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -116,7 +112,7 @@ export class SafeBalancesApi implements IBalancesApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v2/safes/${args.safeAddress}/collectibles/`;
-      return await this.dataSource.get<Raw<Page<Collectible>>>({
+      return await this.dataSource.get<Page<Collectible>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,

--- a/src/datasources/balances-api/zerion-balances-api.service.spec.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.spec.ts
@@ -6,6 +6,7 @@ import type { INetworkService } from '@/datasources/network/network.service.inte
 import { balancesProviderBuilder } from '@/domain/chains/entities/__tests__/balances-provider.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import type { ILoggingService } from '@/logging/logging.interface';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 
@@ -115,7 +116,7 @@ describe('ZerionBalancesApiService', () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const fiatCode = faker.helpers.arrayElement(supportedFiatCodes);
       mockNetworkService.get.mockResolvedValue({
-        data: { data: [] },
+        data: rawify({ data: [] }),
         status: 200,
       });
 
@@ -149,7 +150,7 @@ describe('ZerionBalancesApiService', () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const fiatCode = faker.helpers.arrayElement(supportedFiatCodes);
       mockNetworkService.get.mockResolvedValue({
-        data: { data: [] },
+        data: rawify({ data: [] }),
         status: 200,
       });
 

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -194,7 +194,7 @@ export class ZerionBalancesApi implements IBalancesApi {
             ...(pageAfter && { 'page[after]': pageAfter }),
           },
         };
-        const data = await this.networkService
+        const zerionCollectibles = await this.networkService
           .get<ZerionCollectibles>({
             url,
             networkRequest,
@@ -202,10 +202,13 @@ export class ZerionBalancesApi implements IBalancesApi {
           .then(({ data }) => ZerionCollectiblesSchema.parse(data));
         await this.cacheService.hSet(
           cacheDir,
-          JSON.stringify(data),
+          JSON.stringify(zerionCollectibles),
           this.defaultExpirationTimeInSeconds,
         );
-        return this._buildCollectiblesPage(data.links.next, data.data);
+        return this._buildCollectiblesPage(
+          zerionCollectibles.links.next,
+          zerionCollectibles.data,
+        );
       } catch (error) {
         throw this.httpErrorFactory.from(error);
       }

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -22,6 +22,7 @@ import {
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { isArray } from 'lodash';
 import { Safe } from '@/domain/safe/entities/safe.entity';
+import { Raw } from '@/validation/entities/raw.entity';
 
 /**
  * A data source which tries to retrieve values from cache using
@@ -70,7 +71,7 @@ export class CacheFirstDataSource {
     notFoundExpireTimeSeconds: number;
     networkRequest?: NetworkRequest;
     expireTimeSeconds?: number;
-  }): Promise<T> {
+  }): Promise<Raw<T>> {
     const cached = await this.cacheService.hGet(args.cacheDir);
     if (cached != null) return this._getFromCachedData(args.cacheDir, cached);
 
@@ -117,7 +118,7 @@ export class CacheFirstDataSource {
     url: string;
     networkRequest?: NetworkRequest;
     expireTimeSeconds?: number;
-  }): Promise<T> {
+  }): Promise<Raw<T>> {
     const { key, field } = args.cacheDir;
     this.loggingService.debug({ type: 'cache_miss', key, field });
     const startTimeMs = Date.now();
@@ -143,7 +144,7 @@ export class CacheFirstDataSource {
         this.logTransactionsCacheWrite(
           startTimeMs,
           args.cacheDir,
-          data as Page<Transaction>,
+          data as unknown as Page<Transaction>,
         );
       }
 
@@ -151,7 +152,7 @@ export class CacheFirstDataSource {
         this.logSafeMetadataCacheWrite(
           startTimeMs,
           args.cacheDir,
-          data as Safe,
+          data as unknown as Safe,
         );
       }
 

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -8,6 +8,7 @@ import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { safeAppBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app.builder';
 import type { ILoggingService } from '@/logging/logging.interface';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 
 const dataSource = {
@@ -79,7 +80,7 @@ describe('ConfigApi', () => {
 
   it('should return the chains retrieved', async () => {
     const data = [chainBuilder().build(), chainBuilder().build()];
-    mockDataSource.get.mockResolvedValue(data);
+    mockDataSource.get.mockResolvedValue(rawify(data));
 
     const actual = await service.getChains({});
 
@@ -97,7 +98,7 @@ describe('ConfigApi', () => {
 
   it('should return the chain retrieved', async () => {
     const data = chainBuilder().build();
-    mockDataSource.get.mockResolvedValue(data);
+    mockDataSource.get.mockResolvedValue(rawify(data));
 
     const actual = await service.getChain(data.chainId);
 
@@ -115,7 +116,7 @@ describe('ConfigApi', () => {
   it('should return the safe apps retrieved by chainId', async () => {
     const chainId = faker.string.numeric();
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
-    mockDataSource.get.mockResolvedValue(data);
+    mockDataSource.get.mockResolvedValue(rawify(data));
 
     const actual = await service.getSafeApps({ chainId });
 
@@ -140,7 +141,7 @@ describe('ConfigApi', () => {
     const chainId = faker.string.numeric();
     const url = faker.internet.url({ appendSlash: false });
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
-    mockDataSource.get.mockResolvedValue(data);
+    mockDataSource.get.mockResolvedValue(rawify(data));
 
     const actual = await service.getSafeApps({ chainId, url });
 
@@ -163,7 +164,7 @@ describe('ConfigApi', () => {
     const chainId = faker.string.numeric();
     const clientUrl = faker.internet.url({ appendSlash: false });
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
-    mockDataSource.get.mockResolvedValue(data);
+    mockDataSource.get.mockResolvedValue(rawify(data));
 
     const actual = await service.getSafeApps({ chainId, clientUrl });
 
@@ -187,7 +188,7 @@ describe('ConfigApi', () => {
     const clientUrl = faker.internet.url({ appendSlash: false });
     const onlyListed = faker.datatype.boolean();
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
-    mockDataSource.get.mockResolvedValue(data);
+    mockDataSource.get.mockResolvedValue(rawify(data));
 
     const actual = await service.getSafeApps({
       chainId,

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -14,10 +14,6 @@ import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { Raw } from '@/validation/entities/raw.entity';
 import { Inject, Injectable } from '@nestjs/common';
 
-/**
- * TODO: Move all usage of Raw to CacheFirstDataSource after fully migrated
- * to "Raw" type implementation.
- */
 @Injectable()
 export class ConfigApi implements IConfigApi {
   private readonly baseUri: string;
@@ -57,7 +53,7 @@ export class ConfigApi implements IConfigApi {
       const url = `${this.baseUri}/api/v1/chains`;
       const params = { limit: args.limit, offset: args.offset };
       const cacheDir = CacheRouter.getChainsCacheDir(args);
-      return await this.dataSource.get<Raw<Chain>>({
+      return await this.dataSource.get<Chain>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -73,7 +69,7 @@ export class ConfigApi implements IConfigApi {
     try {
       const url = `${this.baseUri}/api/v1/chains/${chainId}`;
       const cacheDir = CacheRouter.getChainCacheDir(chainId);
-      return await this.dataSource.get<Raw<Chain>>({
+      return await this.dataSource.get<Chain>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,

--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -17,6 +17,7 @@ import { campaignBuilder } from '@/domain/community/entities/__tests__/campaign.
 import { campaignRankBuilder } from '@/domain/community/entities/__tests__/campaign-rank.builder';
 import type { CampaignRank } from '@/domain/community/entities/campaign-rank.entity';
 import { campaignActivityBuilder } from '@/domain/community/entities/__tests__/campaign-activity.builder';
+import { rawify } from '@/validation/entities/raw.entity';
 
 const networkService = {
   get: jest.fn(),
@@ -52,7 +53,7 @@ describe('LockingApi', () => {
       const campaign = campaignBuilder().build();
 
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaign,
+        data: rawify(campaign),
         status: 200,
       });
 
@@ -93,7 +94,7 @@ describe('LockingApi', () => {
         .build();
 
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignsPage,
+        data: rawify(campaignsPage),
         status: 200,
       });
 
@@ -119,7 +120,7 @@ describe('LockingApi', () => {
         .build();
 
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignsPage,
+        data: rawify(campaignsPage),
         status: 200,
       });
 
@@ -169,7 +170,7 @@ describe('LockingApi', () => {
         .build();
 
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignActivityPage,
+        data: rawify(campaignActivityPage),
         status: 200,
       });
 
@@ -202,7 +203,7 @@ describe('LockingApi', () => {
         .build();
 
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignActivityPage,
+        data: rawify(campaignActivityPage),
         status: 200,
       });
 
@@ -237,7 +238,7 @@ describe('LockingApi', () => {
         .build();
 
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignActivityPage,
+        data: rawify(campaignActivityPage),
         status: 200,
       });
 
@@ -294,7 +295,7 @@ describe('LockingApi', () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const campaignRank = campaignRankBuilder().build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignRank,
+        data: rawify(campaignRank),
         status: 200,
       });
 
@@ -336,7 +337,7 @@ describe('LockingApi', () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const lockingRank = lockingRankBuilder().build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: lockingRank,
+        data: rawify(lockingRank),
         status: 200,
       });
 
@@ -376,7 +377,7 @@ describe('LockingApi', () => {
         .with('results', [lockingRankBuilder().build()])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: leaderboardPage,
+        data: rawify(leaderboardPage),
         status: 200,
       });
 
@@ -401,7 +402,7 @@ describe('LockingApi', () => {
         .with('results', [lockingRankBuilder().build()])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: leaderboardPage,
+        data: rawify(leaderboardPage),
         status: 200,
       });
 
@@ -449,7 +450,7 @@ describe('LockingApi', () => {
         ])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignRankPage,
+        data: rawify(campaignRankPage),
         status: 200,
       });
 
@@ -478,7 +479,7 @@ describe('LockingApi', () => {
         ])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: campaignRankPage,
+        data: rawify(campaignRankPage),
         status: 200,
       });
 
@@ -528,7 +529,7 @@ describe('LockingApi', () => {
         ])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: lockingHistoryPage,
+        data: rawify(lockingHistoryPage),
         status: 200,
       });
 
@@ -557,7 +558,7 @@ describe('LockingApi', () => {
         ])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: lockingHistoryPage,
+        data: rawify(lockingHistoryPage),
         status: 200,
       });
 

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -14,10 +14,6 @@ import { LockingRank } from '@/domain/community/entities/locking-rank.entity';
 import { Inject } from '@nestjs/common';
 import type { Raw } from '@/validation/entities/raw.entity';
 
-/**
- * TODO: Move all usage of Raw to NetworkService after fully migrated
- * to "Raw" type implementation.
- */
 export class LockingApi implements ILockingApi {
   private readonly baseUri: string;
 
@@ -35,7 +31,7 @@ export class LockingApi implements ILockingApi {
   async getCampaignById(resourceId: string): Promise<Raw<Campaign>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${resourceId}`;
-      const { data } = await this.networkService.get<Raw<Campaign>>({ url });
+      const { data } = await this.networkService.get<Campaign>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -48,7 +44,7 @@ export class LockingApi implements ILockingApi {
   }): Promise<Raw<Page<Campaign>>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns`;
-      const { data } = await this.networkService.get<Raw<Page<Campaign>>>({
+      const { data } = await this.networkService.get<Page<Campaign>>({
         url,
         networkRequest: {
           params: {
@@ -95,7 +91,7 @@ export class LockingApi implements ILockingApi {
   }): Promise<Raw<CampaignRank>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard/${args.safeAddress}`;
-      const { data } = await this.networkService.get<Raw<CampaignRank>>({
+      const { data } = await this.networkService.get<CampaignRank>({
         url,
       });
       return data;
@@ -107,7 +103,7 @@ export class LockingApi implements ILockingApi {
   async getLockingRank(safeAddress: `0x${string}`): Promise<Raw<LockingRank>> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard/${safeAddress}`;
-      const { data } = await this.networkService.get<Raw<LockingRank>>({ url });
+      const { data } = await this.networkService.get<LockingRank>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -120,7 +116,7 @@ export class LockingApi implements ILockingApi {
   }): Promise<Raw<Page<LockingRank>>> {
     try {
       const url = `${this.baseUri}/api/v1/leaderboard`;
-      const { data } = await this.networkService.get<Raw<Page<LockingRank>>>({
+      const { data } = await this.networkService.get<Page<LockingRank>>({
         url,
         networkRequest: {
           params: {
@@ -142,7 +138,7 @@ export class LockingApi implements ILockingApi {
   }): Promise<Raw<Page<CampaignRank>>> {
     try {
       const url = `${this.baseUri}/api/v1/campaigns/${args.resourceId}/leaderboard`;
-      const { data } = await this.networkService.get<Raw<Page<CampaignRank>>>({
+      const { data } = await this.networkService.get<Page<CampaignRank>>({
         url,
         networkRequest: {
           params: {
@@ -164,7 +160,7 @@ export class LockingApi implements ILockingApi {
   }): Promise<Raw<Page<LockingEvent>>> {
     try {
       const url = `${this.baseUri}/api/v1/all-events/${args.safeAddress}`;
-      const { data } = await this.networkService.get<Raw<Page<LockingEvent>>>({
+      const { data } = await this.networkService.get<Page<LockingEvent>>({
         url,
         networkRequest: {
           params: {

--- a/src/datasources/network/entities/network.response.entity.ts
+++ b/src/datasources/network/entities/network.response.entity.ts
@@ -1,4 +1,6 @@
+import type { Raw } from '@/validation/entities/raw.entity';
+
 export interface NetworkResponse<T> {
-  data: T;
+  data: Raw<T>;
   status: number;
 }

--- a/src/datasources/network/network.module.ts
+++ b/src/datasources/network/network.module.ts
@@ -7,6 +7,7 @@ import {
   NetworkRequestError,
   NetworkResponseError,
 } from '@/datasources/network/entities/network.error.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
 
 export type FetchClient = <T>(
   url: string,
@@ -43,7 +44,7 @@ function fetchClientFactory(
     }
 
     // We validate data so don't need worry about casting `null` response
-    const data = (await response.json().catch(() => null)) as T;
+    const data = (await response.json().catch(() => null)) as Raw<T>;
 
     if (!response.ok) {
       throw new NetworkResponseError(urlObject, response, data);

--- a/src/datasources/push-notifications-api/entities/firebase-oauth2-token.entity.ts
+++ b/src/datasources/push-notifications-api/entities/firebase-oauth2-token.entity.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const FirebaseOauth2TokenSchema = z.object({
+  access_token: z.string(),
+  expires_in: z.number(),
+  token_type: z.string(),
+});
+
+export type FirebaseOauth2Token = z.infer<typeof FirebaseOauth2TokenSchema>;

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -6,6 +6,7 @@ import type { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { firebaseNotificationBuilder } from '@/datasources/push-notifications-api/__tests__/firebase-notification.builder';
 import { FirebaseCloudMessagingApiService } from '@/datasources/push-notifications-api/firebase-cloud-messaging-api.service';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 
 const mockNetworkService = jest.mocked({
@@ -75,10 +76,11 @@ describe('FirebaseCloudMessagingApiService', () => {
     mockJwtService.sign.mockReturnValue(oauth2AssertionJwt);
     mockNetworkService.post.mockResolvedValueOnce({
       status: 200,
-      data: {
+      data: rawify({
         access_token: oauth2Token,
         expires_in: oauth2TokenExpiresIn,
-      },
+        token_type: 'Bearer',
+      }),
     });
 
     await expect(

--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -9,6 +9,7 @@ import { NetworkResponseError } from '@/datasources/network/entities/network.err
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { rawify } from '@/validation/entities/raw.entity';
 
 const mockNetworkService = jest.mocked({
   post: jest.fn(),
@@ -67,9 +68,9 @@ describe('GelatoApi', () => {
       fakeConfigurationService.set(`relay.apiKey.${chainId}`, apiKey);
       mockNetworkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {
+        data: rawify({
           taskId,
-        },
+        }),
       });
 
       await target.relay({
@@ -100,9 +101,9 @@ describe('GelatoApi', () => {
       fakeConfigurationService.set(`relay.apiKey.${chainId}`, apiKey);
       mockNetworkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {
+        data: rawify({
           taskId,
-        },
+        }),
       });
 
       await target.relay({

--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -14,10 +14,6 @@ import {
 import type { Relay } from '@/domain/relay/entities/relay.entity';
 import type { Raw } from '@/validation/entities/raw.entity';
 
-/**
- * TODO: Move all usage of Raw to NetworkService after fully migrated
- * to "Raw" type implementation.
- */
 @Injectable()
 export class GelatoApi implements IRelayApi {
   /**
@@ -56,7 +52,7 @@ export class GelatoApi implements IRelayApi {
 
     try {
       const url = `${this.baseUri}/relays/v2/sponsored-call`;
-      const { data } = await this.networkService.post<Raw<Relay>>({
+      const { data } = await this.networkService.post<Relay>({
         url,
         data: {
           sponsorApiKey,

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -15,6 +15,7 @@ import { transactionStatusBuilder } from '@/datasources/staking-api/entities/__t
 import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
 
@@ -85,11 +86,13 @@ describe('KilnApi', () => {
         () => deploymentBuilder().build(),
         { count: { min: 1, max: 5 } },
       );
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: deployments,
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: deployments,
+        }),
+      );
 
       const actual = await target.getDeployments();
 
@@ -145,11 +148,13 @@ describe('KilnApi', () => {
   describe('getNetworkStats', () => {
     it('should return network stats', async () => {
       const networkStats = networkStatsBuilder().build();
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: networkStats,
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: networkStats,
+        }),
+      );
 
       const actual = await target.getNetworkStats();
 
@@ -205,11 +210,13 @@ describe('KilnApi', () => {
   describe('getDedicatedStakingStats', () => {
     it('should return the dedicated staking stats', async () => {
       const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: dedicatedStakingStats,
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: dedicatedStakingStats,
+        }),
+      );
 
       const actual = await target.getDedicatedStakingStats();
 
@@ -265,11 +272,13 @@ describe('KilnApi', () => {
   describe('getPooledStakingStats', () => {
     it('should return the pooled staking integration', async () => {
       const pooledStakingStats = pooledStakingStatsBuilder().build();
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: pooledStakingStats,
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: pooledStakingStats,
+        }),
+      );
 
       const actual = await target.getPooledStakingStats(
         pooledStakingStats.address,
@@ -357,11 +366,13 @@ describe('KilnApi', () => {
         .with('chain', chain)
         .with('chain_id', chain_id)
         .build();
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: [defiVaultStats],
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: [defiVaultStats],
+        }),
+      );
 
       const actual = await target.getDefiVaultStats(defiVaultStats.vault);
 
@@ -475,11 +486,13 @@ describe('KilnApi', () => {
         count: validatorsPublicKeys.length,
       });
       const getStakesUrl = `${baseUrl}/v1/eth/stakes`;
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: stakes,
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: stakes,
+        }),
+      );
 
       const actual = await target.getStakes({
         safeAddress,
@@ -584,11 +597,13 @@ describe('KilnApi', () => {
       const txHash = faker.string.hexadecimal({ length: 64 }) as `0x${string}`;
       const transactionStatus = transactionStatusBuilder().build();
       const getTransactionStatusUrl = `${baseUrl}/v1/eth/transaction/status`;
-      dataSource.get.mockResolvedValue({
-        status: 200,
-        // Note: Kiln always return { data: T }
-        data: transactionStatus,
-      });
+      dataSource.get.mockResolvedValue(
+        rawify({
+          status: 200,
+          // Note: Kiln always return { data: T }
+          data: transactionStatus,
+        }),
+      );
 
       const actual = await target.getTransactionStatus(txHash);
 

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -15,11 +15,8 @@ import type { Stake } from '@/datasources/staking-api/entities/stake.entity';
 import type { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
 import type { IStakingApi } from '@/domain/interfaces/staking-api.interface';
 import type { Raw } from '@/validation/entities/raw.entity';
+import { z } from 'zod';
 
-/**
- * TODO: Move all usage of Raw to NetworkService after fully migrated
- * to "Raw" type implementation.
- */
 export class KilnApi implements IStakingApi {
   public static DefiVaultStatsChains: {
     [key in (typeof DefiVaultStatsChains)[number]]: string;
@@ -59,9 +56,8 @@ export class KilnApi implements IStakingApi {
     try {
       const url = `${this.baseUrl}/v1/deployments`;
       const cacheDir = CacheRouter.getStakingDeploymentsCacheDir();
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{
-        data: Raw<Array<Deployment>>;
+      const { data } = await this.get<{
+        data: Array<Deployment>;
       }>({
         cacheDir,
         url,
@@ -85,8 +81,7 @@ export class KilnApi implements IStakingApi {
     try {
       const url = `${this.baseUrl}/v1/eth/network-stats`;
       const cacheDir = CacheRouter.getStakingNetworkStatsCacheDir();
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{ data: Raw<NetworkStats> }>({
+      const { data } = await this.get<{ data: NetworkStats }>({
         cacheDir,
         url,
         networkRequest: {
@@ -109,9 +104,8 @@ export class KilnApi implements IStakingApi {
     try {
       const url = `${this.baseUrl}/v1/eth/kiln-stats`;
       const cacheDir = CacheRouter.getStakingDedicatedStakingStatsCacheDir();
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{
-        data: Raw<DedicatedStakingStats>;
+      const { data } = await this.get<{
+        data: DedicatedStakingStats;
       }>({
         cacheDir,
         url,
@@ -122,7 +116,7 @@ export class KilnApi implements IStakingApi {
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         expireTimeSeconds: this.stakingExpirationTimeInSeconds,
-      });
+      }).then((res) => z.object({ data: z.any() }).parse(res));
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -137,9 +131,8 @@ export class KilnApi implements IStakingApi {
     try {
       const url = `${this.baseUrl}/v1/eth/onchain/v2/network-stats`;
       const cacheDir = CacheRouter.getStakingPooledStakingStatsCacheDir(pool);
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{
-        data: Raw<PooledStakingStats>;
+      const { data } = await this.get<{
+        data: PooledStakingStats;
       }>({
         cacheDir,
         url,
@@ -153,7 +146,7 @@ export class KilnApi implements IStakingApi {
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         expireTimeSeconds: this.stakingExpirationTimeInSeconds,
-      });
+      }).then((res) => z.object({ data: z.any() }).parse(res));
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -171,9 +164,8 @@ export class KilnApi implements IStakingApi {
         chainId: this.chainId,
         vault,
       });
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{
-        data: Raw<Array<DefiVaultStats>>;
+      const { data } = await this.get<{
+        data: Array<DefiVaultStats>;
       }>({
         cacheDir,
         url,
@@ -187,7 +179,7 @@ export class KilnApi implements IStakingApi {
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         expireTimeSeconds: this.stakingExpirationTimeInSeconds,
-      });
+      }).then((res) => z.object({ data: z.any() }).parse(res));
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -216,9 +208,8 @@ export class KilnApi implements IStakingApi {
         safeAddress: args.safeAddress,
         validatorsPublicKeys: args.validatorsPublicKeys,
       });
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{
-        data: Raw<Array<Stake>>;
+      const { data } = await this.get<{
+        data: Array<Stake>;
       }>({
         cacheDir,
         url,
@@ -234,7 +225,7 @@ export class KilnApi implements IStakingApi {
         },
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         expireTimeSeconds: this.stakingExpirationTimeInSeconds,
-      });
+      }).then((res) => z.object({ data: z.any() }).parse(res));
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -263,10 +254,7 @@ export class KilnApi implements IStakingApi {
         chainId: this.chainId,
         txHash,
       });
-      // Note: Kiln always return { data: T }
-      const { data } = await this.dataSource.get<{
-        data: Raw<TransactionStatus>;
-      }>({
+      const { data } = await this.get<TransactionStatus>({
         cacheDir,
         url,
         networkRequest: {
@@ -284,6 +272,23 @@ export class KilnApi implements IStakingApi {
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
+  }
+
+  /**
+   * Parses response from Raw<T> to { data: Raw<T> } as Kiln API returns { data: T }
+   * @param args - arguments for {@link CacheFirstDataSource.get}
+   * @returns rawified response
+   */
+  private async get<T>(
+    args: Parameters<typeof this.dataSource.get>[0],
+  ): Promise<{ data: Raw<T> }> {
+    return this.dataSource
+      .get<{
+        data: TransactionStatus;
+      }>(args)
+      .then((res) => {
+        return z.object({ data: z.unknown() }).parse(res) as { data: Raw<T> };
+      });
   }
 
   /**

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -287,6 +287,7 @@ export class KilnApi implements IStakingApi {
         data: TransactionStatus;
       }>(args)
       .then((res) => {
+        // Ensuring response is { data: T }, the data is parsed in the domain
         return z.object({ data: z.unknown() }).parse(res) as { data: Raw<T> };
       });
   }

--- a/src/datasources/swaps-api/cowswap-api.service.ts
+++ b/src/datasources/swaps-api/cowswap-api.service.ts
@@ -5,10 +5,6 @@ import type { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import type { FullAppData } from '@/domain/swaps/entities/full-app-data.entity';
 import type { Raw } from '@/validation/entities/raw.entity';
 
-/**
- * TODO: Move all usage of Raw to NetworkService after fully migrated
- * to "Raw" type implementation.
- */
 export class CowSwapApi implements ISwapsApi {
   constructor(
     private readonly baseUrl: string,
@@ -19,7 +15,7 @@ export class CowSwapApi implements ISwapsApi {
   async getOrder(uid: string): Promise<Raw<Order>> {
     try {
       const url = `${this.baseUrl}/api/v1/orders/${uid}`;
-      const { data } = await this.networkService.get<Raw<Order>>({ url });
+      const { data } = await this.networkService.get<Order>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -29,7 +25,7 @@ export class CowSwapApi implements ISwapsApi {
   async getOrders(txHash: string): Promise<Raw<Array<Order>>> {
     try {
       const url = `${this.baseUrl}/api/v1/transactions/${txHash}/orders`;
-      const { data } = await this.networkService.get<Raw<Array<Order>>>({
+      const { data } = await this.networkService.get<Array<Order>>({
         url,
       });
       return data;
@@ -41,7 +37,7 @@ export class CowSwapApi implements ISwapsApi {
   async getFullAppData(appDataHash: `0x${string}`): Promise<Raw<FullAppData>> {
     try {
       const url = `${this.baseUrl}/api/v1/app_data/${appDataHash}`;
-      const { data } = await this.networkService.get<Raw<FullAppData>>({ url });
+      const { data } = await this.networkService.get<FullAppData>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -27,6 +27,7 @@ import { getAddress } from 'viem';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { indexingStatusBuilder } from '@/domain/chains/entities/__tests__/indexing-status.builder';
 import { fakeJson } from '@/__tests__/faker';
+import { rawify } from '@/validation/entities/raw.entity';
 
 const dataSource = {
   get: jest.fn(),
@@ -116,7 +117,7 @@ describe('TransactionApi', () => {
       const decodedData = dataDecodedBuilder().build();
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: decodedData,
+        data: rawify(decodedData),
       });
 
       const actual = await service.getDataDecoded({ data, to });
@@ -174,7 +175,7 @@ describe('TransactionApi', () => {
       const data = backboneBuilder().build();
       const getBackboneUrl = `${baseUrl}/api/v1/about`;
       const cacheDir = new CacheDir(`${chainId}_backbone`, '');
-      mockDataSource.get.mockResolvedValueOnce(data);
+      mockDataSource.get.mockResolvedValueOnce(rawify(data));
 
       const actual = await service.getBackbone();
 
@@ -226,7 +227,7 @@ describe('TransactionApi', () => {
       const singletons = [singletonBuilder().build()];
       const getSingletonsUrl = `${baseUrl}/api/v1/about/singletons/`;
       const cacheDir = new CacheDir(`${chainId}_singletons`, '');
-      mockDataSource.get.mockResolvedValueOnce(singletons);
+      mockDataSource.get.mockResolvedValueOnce(rawify(singletons));
 
       const actual = await service.getSingletons();
 
@@ -278,7 +279,7 @@ describe('TransactionApi', () => {
       const indexingStatus = indexingStatusBuilder().build();
       const getIndexingStatusUrl = `${baseUrl}/api/v1/about/indexing/`;
       const cacheDir = new CacheDir(`${chainId}_indexing`, '');
-      mockDataSource.get.mockResolvedValueOnce(indexingStatus);
+      mockDataSource.get.mockResolvedValueOnce(rawify(indexingStatus));
 
       const actual = await service.getIndexingStatus();
 
@@ -329,7 +330,7 @@ describe('TransactionApi', () => {
       const safe = safeBuilder().build();
       const getSafeUrl = `${baseUrl}/api/v1/safes/${safe.address}`;
       const cacheDir = new CacheDir(`${chainId}_safe_${safe.address}`, '');
-      mockDataSource.get.mockResolvedValueOnce(safe);
+      mockDataSource.get.mockResolvedValueOnce(rawify(safe));
 
       const actual = await service.getSafe(safe.address);
 
@@ -398,7 +399,10 @@ describe('TransactionApi', () => {
         '',
       );
       cacheService.hGet.mockResolvedValueOnce(undefined);
-      networkService.get.mockResolvedValueOnce({ status: 200, data: safe });
+      networkService.get.mockResolvedValueOnce({
+        status: 200,
+        data: rawify(safe),
+      });
 
       const actual = await service.isSafe(safe.address);
 
@@ -425,7 +429,10 @@ describe('TransactionApi', () => {
       );
       const isSafe = faker.datatype.boolean();
       cacheService.hGet.mockResolvedValueOnce(JSON.stringify(isSafe));
-      networkService.get.mockResolvedValueOnce({ status: 200, data: safe });
+      networkService.get.mockResolvedValueOnce({
+        status: 200,
+        data: rawify(safe),
+      });
 
       const actual = await service.isSafe(safe.address);
 
@@ -443,7 +450,10 @@ describe('TransactionApi', () => {
         '',
       );
       cacheService.hGet.mockResolvedValueOnce(undefined);
-      networkService.get.mockResolvedValueOnce({ status: 404, data: null });
+      networkService.get.mockResolvedValueOnce({
+        status: 404,
+        data: rawify(null),
+      });
 
       const actual = await service.isSafe(safe.address);
 
@@ -521,7 +531,7 @@ describe('TransactionApi', () => {
         `${chainId}_contract_${contract.address}`,
         '',
       );
-      mockDataSource.get.mockResolvedValueOnce(contract);
+      mockDataSource.get.mockResolvedValueOnce(rawify(contract));
 
       const actual = await service.getContract(contract.address);
 
@@ -580,7 +590,7 @@ describe('TransactionApi', () => {
         `${chainId}_delegates_${delegate.safe}`,
         `${delegate.delegate}_${delegate.delegator}_${delegate.label}_${limit}_${offset}`,
       );
-      mockDataSource.get.mockResolvedValueOnce(delegatesPage);
+      mockDataSource.get.mockResolvedValueOnce(rawify(delegatesPage));
 
       const actual = await service.getDelegates({
         ...delegate,
@@ -664,7 +674,7 @@ describe('TransactionApi', () => {
       const postDelegateUrl = `${baseUrl}/api/v1/delegates/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.postDelegate({
@@ -731,7 +741,7 @@ describe('TransactionApi', () => {
       const deleteDelegateUrl = `${baseUrl}/api/v1/delegates/${delegate.delegate}`;
       networkService.delete.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.deleteDelegate({
@@ -800,7 +810,7 @@ describe('TransactionApi', () => {
       const deleteSafeDelegateUrl = `${baseUrl}/api/v1/safes/${delegate.safe}/delegates/${delegate.delegate}`;
       networkService.delete.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.deleteSafeDelegate({
@@ -872,7 +882,7 @@ describe('TransactionApi', () => {
       );
       networkService.get.mockResolvedValueOnce({
         status: 200,
-        data: transfer,
+        data: rawify(transfer),
       });
 
       const actual = await service.getTransfer(transfer.transferId);
@@ -937,7 +947,7 @@ describe('TransactionApi', () => {
       );
       networkService.get.mockResolvedValueOnce({
         status: 200,
-        data: transfersPage,
+        data: rawify(transfersPage),
       });
 
       const actual = await service.getTransfers({
@@ -1060,7 +1070,7 @@ describe('TransactionApi', () => {
       );
       networkService.get.mockResolvedValueOnce({
         status: 200,
-        data: incomingTransfersPage,
+        data: rawify(incomingTransfersPage),
       });
 
       const actual = await service.getIncomingTransfers({
@@ -1186,7 +1196,7 @@ describe('TransactionApi', () => {
       const postConfirmationUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.postConfirmation({
@@ -1253,7 +1263,7 @@ describe('TransactionApi', () => {
       };
       const getSafesByModuleUrl = `${baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
       mockNetworkService.get.mockResolvedValueOnce({
-        data: safesByModule,
+        data: rawify(safesByModule),
         status: 200,
       });
 
@@ -1307,7 +1317,7 @@ describe('TransactionApi', () => {
         `${chainId}_module_transaction_${moduleTransactionId}`,
         '',
       );
-      mockDataSource.get.mockResolvedValueOnce(moduleTransaction);
+      mockDataSource.get.mockResolvedValueOnce(rawify(moduleTransaction));
 
       const actual = await service.getModuleTransaction(moduleTransactionId);
 
@@ -1373,7 +1383,7 @@ describe('TransactionApi', () => {
         `${chainId}_module_transactions_${moduleTransaction.safe}`,
         `${moduleTransaction.to}_${moduleTransaction.module}_${moduleTransaction.transactionHash}_${limit}_${offset}`,
       );
-      mockDataSource.get.mockResolvedValueOnce(moduleTransactionsPage);
+      mockDataSource.get.mockResolvedValueOnce(rawify(moduleTransactionsPage));
 
       const actual = await service.getModuleTransactions({
         safeAddress: moduleTransaction.safe,
@@ -1489,7 +1499,9 @@ describe('TransactionApi', () => {
         `${chainId}_multisig_transactions_${multisigTransaction.safe}`,
         `${ordering}_${multisigTransaction.isExecuted}_${multisigTransaction.trusted}_${executedDateGte}_${executedDateLte}_${multisigTransaction.to}_${multisigTransaction.value}_${multisigTransaction.nonce}_${multisigTransaction.nonce}_${limit}_${offset}`,
       );
-      mockDataSource.get.mockResolvedValueOnce(multisigTransactionsPage);
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify(multisigTransactionsPage),
+      );
 
       const actual = await service.getMultisigTransactions({
         safeAddress: multisigTransaction.safe,
@@ -1626,7 +1638,7 @@ describe('TransactionApi', () => {
         `${chainId}_multisig_transaction_${multisigTransaction.safeTxHash}`,
         '',
       );
-      mockDataSource.get.mockResolvedValueOnce(multisigTransaction);
+      mockDataSource.get.mockResolvedValueOnce(rawify(multisigTransaction));
 
       const actual = await service.getMultisigTransaction(
         multisigTransaction.safeTxHash,
@@ -1688,7 +1700,7 @@ describe('TransactionApi', () => {
       const deleteTransactionUrl = `${baseUrl}/api/v1/multisig-transactions/${safeTxHash}`;
       networkService.delete.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.deleteTransaction({
@@ -1766,7 +1778,7 @@ describe('TransactionApi', () => {
         `${chainId}_creation_transaction_${safeAddress}`,
         '',
       );
-      mockDataSource.get.mockResolvedValueOnce(creationTransaction);
+      mockDataSource.get.mockResolvedValueOnce(rawify(creationTransaction));
 
       const actual = await service.getCreationTransaction(safeAddress);
 
@@ -1837,7 +1849,7 @@ describe('TransactionApi', () => {
         `${chainId}_all_transactions_${safeAddress}`,
         `${ordering}_${executed}_${queued}_${limit}_${offset}`,
       );
-      mockDataSource.get.mockResolvedValueOnce(allTransactionsPage);
+      mockDataSource.get.mockResolvedValueOnce(rawify(allTransactionsPage));
 
       const actual = await service.getAllTransactions({
         safeAddress,
@@ -1947,7 +1959,7 @@ describe('TransactionApi', () => {
       const token = tokenBuilder().build();
       const getTokenUrl = `${baseUrl}/api/v1/tokens/${token.address}`;
       const cacheDir = new CacheDir(`${chainId}_token_${token.address}`, '');
-      mockDataSource.get.mockResolvedValueOnce(token);
+      mockDataSource.get.mockResolvedValueOnce(rawify(token));
 
       const actual = await service.getToken(token.address);
 
@@ -2003,7 +2015,7 @@ describe('TransactionApi', () => {
       const offset = faker.number.int();
       const getTokensUrl = `${baseUrl}/api/v1/tokens/`;
       const cacheDir = new CacheDir(`${chainId}_tokens`, `${limit}_${offset}`);
-      mockDataSource.get.mockResolvedValueOnce(tokensPage);
+      mockDataSource.get.mockResolvedValueOnce(rawify(tokensPage));
 
       const actual = await service.getTokens({
         limit,
@@ -2083,7 +2095,7 @@ describe('TransactionApi', () => {
       };
       const getSafesByOwnerUrl = `${baseUrl}/api/v1/owners/${owner}/safes/`;
       const cacheDir = new CacheDir(`${chainId}_owner_safes_${owner}`, '');
-      mockDataSource.get.mockResolvedValueOnce(safeList);
+      mockDataSource.get.mockResolvedValueOnce(rawify(safeList));
 
       const actual = await service.getSafesByOwner(owner);
 
@@ -2153,7 +2165,7 @@ describe('TransactionApi', () => {
       const postDeviceRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.postDeviceRegistration({
@@ -2218,7 +2230,7 @@ describe('TransactionApi', () => {
       const deleteDeviceRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/${uuid}`;
       networkService.delete.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.deleteDeviceRegistration(uuid);
@@ -2268,7 +2280,7 @@ describe('TransactionApi', () => {
       const deleteSafeRegistrationUrl = `${baseUrl}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
       networkService.delete.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.deleteSafeRegistration({ uuid, safeAddress });
@@ -2324,7 +2336,7 @@ describe('TransactionApi', () => {
       };
       const getEstimationUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/estimations/`;
       networkService.post.mockResolvedValueOnce({
-        data: estimation,
+        data: rawify(estimation),
         status: 200,
       });
 
@@ -2397,7 +2409,7 @@ describe('TransactionApi', () => {
       const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}`;
       const message = messageBuilder().build();
       const cacheDir = new CacheDir(`${chainId}_message_${messageHash}`, '');
-      mockDataSource.get.mockResolvedValueOnce(message);
+      mockDataSource.get.mockResolvedValueOnce(rawify(message));
 
       const actual = await service.getMessageByHash(messageHash);
 
@@ -2458,7 +2470,7 @@ describe('TransactionApi', () => {
         `${chainId}_messages_${safeAddress}`,
         `${limit}_${offset}`,
       );
-      mockDataSource.get.mockResolvedValueOnce(message);
+      mockDataSource.get.mockResolvedValueOnce(rawify(message));
 
       const actual = await service.getMessagesBySafe({
         safeAddress,
@@ -2540,7 +2552,7 @@ describe('TransactionApi', () => {
       const postMultisigTransactionUrl = `${baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.postMultisigTransaction({
@@ -2610,7 +2622,7 @@ describe('TransactionApi', () => {
       const postMessageUrl = `${baseUrl}/api/v1/safes/${safeAddress}/messages/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.postMessage({
@@ -2688,7 +2700,7 @@ describe('TransactionApi', () => {
       const postMessageSignatureUrl = `${baseUrl}/api/v1/messages/${messageHash}/signatures/`;
       networkService.post.mockResolvedValueOnce({
         status: 200,
-        data: {},
+        data: rawify({}),
       });
 
       await service.postMessageSignature({
@@ -2820,7 +2832,7 @@ describe('TransactionApi', () => {
         `${holeskyChainId}_tokens`,
         `${limit}_${offset}`,
       );
-      mockDataSource.get.mockResolvedValueOnce(tokensPage);
+      mockDataSource.get.mockResolvedValueOnce(rawify(tokensPage));
 
       const actual = await service.getTokens({
         limit,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -32,10 +32,6 @@ import type { ILoggingService } from '@/logging/logging.interface';
 import type { Raw } from '@/validation/entities/raw.entity';
 import { get } from 'lodash';
 
-/**
- * TODO: Move all usage of Raw to NetworkService after fully migrated
- * to "Raw" type implementation.
- */
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
   private static readonly HOLESKY_CHAIN_ID = '17000';
@@ -122,7 +118,7 @@ export class TransactionApi implements ITransactionApi {
     try {
       const cacheDir = CacheRouter.getBackboneCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about`;
-      return await this.dataSource.get<Raw<Backbone>>({
+      return await this.dataSource.get<Backbone>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -139,7 +135,7 @@ export class TransactionApi implements ITransactionApi {
     try {
       const cacheDir = CacheRouter.getSingletonsCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about/singletons/`;
-      return await this.dataSource.get<Raw<Singleton[]>>({
+      return await this.dataSource.get<Singleton[]>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -154,7 +150,7 @@ export class TransactionApi implements ITransactionApi {
     try {
       const cacheDir = CacheRouter.getIndexingCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about/indexing/`;
-      return await this.dataSource.get<Raw<IndexingStatus>>({
+      return await this.dataSource.get<IndexingStatus>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -172,7 +168,7 @@ export class TransactionApi implements ITransactionApi {
         safeAddress,
       });
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
-      return await this.dataSource.get<Raw<Safe>>({
+      return await this.dataSource.get<Safe>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -263,7 +259,7 @@ export class TransactionApi implements ITransactionApi {
         contractAddress,
       });
       const url = `${this.baseUrl}/api/v1/contracts/${contractAddress}`;
-      return await this.dataSource.get<Raw<Contract>>({
+      return await this.dataSource.get<Contract>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.contractNotFoundExpirationTimeSeconds,
@@ -288,7 +284,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/delegates/`;
-      return await this.dataSource.get<Raw<Page<Delegate>>>({
+      return await this.dataSource.get<Page<Delegate>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -322,7 +318,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v2/delegates/`;
-      return await this.dataSource.get<Raw<Page<Delegate>>>({
+      return await this.dataSource.get<Page<Delegate>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -468,7 +464,7 @@ export class TransactionApi implements ITransactionApi {
         transferId,
       });
       const url = `${this.baseUrl}/api/v1/transfer/${transferId}`;
-      return await this.dataSource.get<Raw<Transfer>>({
+      return await this.dataSource.get<Transfer>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -492,7 +488,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/transfers/`;
-      return await this.dataSource.get<Raw<Page<Transfer>>>({
+      return await this.dataSource.get<Page<Transfer>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -536,7 +532,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/incoming-transfers/`;
-      return await this.dataSource.get<Raw<Page<Transfer>>>({
+      return await this.dataSource.get<Page<Transfer>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -587,7 +583,7 @@ export class TransactionApi implements ITransactionApi {
   async getSafesByModule(moduleAddress: `0x${string}`): Promise<Raw<SafeList>> {
     try {
       const url = `${this.baseUrl}/api/v1/modules/${moduleAddress}/safes/`;
-      const { data } = await this.networkService.get<Raw<SafeList>>({ url });
+      const { data } = await this.networkService.get<SafeList>({ url });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(this.mapError(error));
@@ -605,7 +601,7 @@ export class TransactionApi implements ITransactionApi {
         moduleTransactionId,
       });
       const url = `${this.baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
-      return await this.dataSource.get<Raw<ModuleTransaction>>({
+      return await this.dataSource.get<ModuleTransaction>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -630,7 +626,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/module-transactions/`;
-      return await this.dataSource.get<Raw<Page<ModuleTransaction>>>({
+      return await this.dataSource.get<Page<ModuleTransaction>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -678,7 +674,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/multisig-transactions/`;
-      return await this.dataSource.get<Raw<Page<MultisigTransaction>>>({
+      return await this.dataSource.get<Page<MultisigTransaction>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -722,7 +718,7 @@ export class TransactionApi implements ITransactionApi {
         safeTransactionHash,
       });
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
-      return await this.dataSource.get<Raw<MultisigTransaction>>({
+      return await this.dataSource.get<MultisigTransaction>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -762,7 +758,7 @@ export class TransactionApi implements ITransactionApi {
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
   async getCreationTransaction(
     safeAddress: `0x${string}`,
-  ): Promise<CreationTransaction> {
+  ): Promise<Raw<CreationTransaction>> {
     try {
       const cacheDir = CacheRouter.getCreationTransactionCacheDir({
         chainId: this.chainId,
@@ -794,7 +790,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/all-transactions/`;
-      return await this.dataSource.get<Raw<Page<Transaction>>>({
+      return await this.dataSource.get<Page<Transaction>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -832,7 +828,7 @@ export class TransactionApi implements ITransactionApi {
         address,
       });
       const url = `${this.baseUrl}/api/v1/tokens/${address}`;
-      return await this.dataSource.get<Raw<Token>>({
+      return await this.dataSource.get<Token>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.tokenNotFoundExpirationTimeSeconds,
@@ -855,7 +851,7 @@ export class TransactionApi implements ITransactionApi {
         ...args,
       });
       const url = `${this.baseUrl}/api/v1/tokens/`;
-      return await this.dataSource.get<Raw<Page<Token>>>({
+      return await this.dataSource.get<Page<Token>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -881,7 +877,7 @@ export class TransactionApi implements ITransactionApi {
         ownerAddress,
       });
       const url = `${this.baseUrl}/api/v1/owners/${ownerAddress}/safes/`;
-      return await this.dataSource.get<Raw<SafeList>>({
+      return await this.dataSource.get<SafeList>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -969,7 +965,7 @@ export class TransactionApi implements ITransactionApi {
         chainId: this.chainId,
         messageHash,
       });
-      return await this.dataSource.get<Raw<Message>>({
+      return await this.dataSource.get<Message>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -991,7 +987,7 @@ export class TransactionApi implements ITransactionApi {
         chainId: this.chainId,
         ...args,
       });
-      return await this.dataSource.get<Raw<Page<Message>>>({
+      return await this.dataSource.get<Page<Message>>({
         cacheDir,
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
@@ -1047,7 +1043,7 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<Raw<Message>> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/messages/`;
-      const { data } = await this.networkService.post<Raw<Message>>({
+      const { data } = await this.networkService.post<Message>({
         url,
         data: {
           message: args.message,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -176,7 +176,7 @@ export interface ITransactionApi {
 
   getCreationTransaction(
     safeAddress: `0x${string}`,
-  ): Promise<CreationTransaction>;
+  ): Promise<Raw<CreationTransaction>>;
 
   getAllTransactions(args: {
     safeAddress: `0x${string}`;

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -39,6 +39,7 @@ import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.post
 import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Balances Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -192,10 +193,10 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`:
               return Promise.resolve({
-                data: zerionApiBalancesResponse,
+                data: rawify(zerionApiBalancesResponse),
                 status: 200,
               });
             default:
@@ -343,10 +344,10 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`:
               return Promise.resolve({
-                data: zerionApiBalancesResponse,
+                data: rawify(zerionApiBalancesResponse),
                 status: 200,
               });
             default:
@@ -426,7 +427,7 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             default:
               return Promise.reject(new Error(`Could not match ${url}`));
           }
@@ -463,7 +464,7 @@ describe('Balances Controller (Unit)', () => {
               return Promise.reject(error);
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`:
               return Promise.resolve({
-                data: zerionBalancesBuilder().with('data', []).build(),
+                data: rawify(zerionBalancesBuilder().with('data', []).build()),
                 status: 200,
               });
             default:
@@ -491,7 +492,7 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`:
               return Promise.reject(new Error('test error'));
             default:
@@ -559,10 +560,10 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`:
               return Promise.resolve({
-                data: zerionApiBalancesResponse,
+                data: rawify(zerionApiBalancesResponse),
                 status: 200,
               });
             default:
@@ -631,10 +632,10 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/positions`:
               return Promise.resolve({
-                data: zerionApiBalancesResponse,
+                data: rawify(zerionApiBalancesResponse),
                 status: 200,
               });
             default:

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -25,6 +25,7 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NULL_ADDRESS } from '@/routes/common/constants';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
@@ -126,25 +127,25 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           case `${pricesProviderUrl}/simple/price`:
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           default:
@@ -268,20 +269,20 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           default:
@@ -323,20 +324,20 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           case `${pricesProviderUrl}/simple/price`:
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           default:
@@ -391,15 +392,15 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           default:
@@ -459,15 +460,15 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           default:
@@ -537,20 +538,20 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           default:
@@ -645,15 +646,15 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
               return Promise.resolve({
-                data: safeBuilder().build(),
+                data: rawify(safeBuilder().build()),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
               return Promise.resolve({
-                data: transactionApiBalancesResponse,
+                data: rawify(transactionApiBalancesResponse),
                 status: 200,
               });
             case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
@@ -709,20 +710,20 @@ describe('Balances Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
               return Promise.resolve({
-                data: safeBuilder().build(),
+                data: rawify(safeBuilder().build()),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}/balances/`:
               return Promise.resolve({
-                data: transactionApiBalancesResponse,
+                data: rawify(transactionApiBalancesResponse),
                 status: 200,
               });
             case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`:
               return Promise.resolve({
-                data: tokenPriceProviderResponse,
+                data: rawify(tokenPriceProviderResponse),
                 status: 200,
               });
             default:
@@ -770,13 +771,16 @@ describe('Balances Controller (Unit)', () => {
         const transactionServiceUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/`;
         networkService.get.mockImplementation(({ url }) => {
           if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
-            return Promise.resolve({ data: chainResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
           } else if (
             url ==
             `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`
           ) {
             return Promise.resolve({
-              data: safeBuilder().build(),
+              data: rawify(safeBuilder().build()),
               status: 200,
             });
           } else if (url == transactionServiceUrl) {
@@ -810,13 +814,13 @@ describe('Balances Controller (Unit)', () => {
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url == `${safeConfigUrl}/api/v1/chains/${chainId}`) {
-          return Promise.resolve({ data: chainResponse, status: 200 });
+          return Promise.resolve({ data: rawify(chainResponse), status: 200 });
         } else if (
           url ==
           `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/`
         ) {
           return Promise.resolve({
-            data: [{ invalid: 'data' }],
+            data: rawify([{ invalid: 'data' }]),
             status: 200,
           });
         } else if (
@@ -824,7 +828,7 @@ describe('Balances Controller (Unit)', () => {
           `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`
         ) {
           return Promise.resolve({
-            data: safeBuilder().build(),
+            data: rawify(safeBuilder().build()),
             status: 200,
           });
         } else {
@@ -852,10 +856,10 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/1`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
             return Promise.resolve({
-              data: pricesProviderFiatCodes,
+              data: rawify(pricesProviderFiatCodes),
               status: 200,
             });
           default:
@@ -876,10 +880,10 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/1`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
             return Promise.resolve({
-              data: pricesProviderFiatCodes,
+              data: rawify(pricesProviderFiatCodes),
               status: 200,
             });
           default:
@@ -898,7 +902,7 @@ describe('Balances Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/1`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${pricesProviderUrl}/simple/supported_vs_currencies`:
             return Promise.reject(new Error());
           default:

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -38,6 +38,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Chains Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -98,7 +99,7 @@ describe('Chains Controller (Unit)', () => {
   describe('GET /chains', () => {
     it('Success', async () => {
       networkService.get.mockResolvedValueOnce({
-        data: chainsResponse,
+        data: rawify(chainsResponse),
         status: 200,
       });
 
@@ -208,12 +209,12 @@ describe('Chains Controller (Unit)', () => {
     it('should exclude items not passing validation', async () => {
       const invalidChains = [{ invalid: 'item' }];
       networkService.get.mockResolvedValueOnce({
-        data: {
+        data: rawify({
           ...chainsResponse,
           // Ensure count does not include invalid chains
           count: chainsResponse.results.length + invalidChains.length,
           results: [...chainsResponse.results, ...invalidChains],
-        },
+        }),
         status: 200,
       });
 
@@ -296,10 +297,10 @@ describe('Chains Controller (Unit)', () => {
 
     it('Failure: received data is not valid', async () => {
       networkService.get.mockResolvedValueOnce({
-        data: {
+        data: rawify({
           ...chainsResponse,
           count: chainsResponse.count?.toString(),
-        },
+        }),
         status: 200,
       });
 
@@ -352,7 +353,7 @@ describe('Chains Controller (Unit)', () => {
         contractAddresses: chainDomain.contractAddresses,
       };
       networkService.get.mockResolvedValueOnce({
-        data: chainDomain,
+        data: rawify(chainDomain),
         status: 200,
       });
 
@@ -405,11 +406,11 @@ describe('Chains Controller (Unit)', () => {
   describe('GET /:chainId/about/backbone', () => {
     it('Success', async () => {
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       networkService.get.mockResolvedValueOnce({
-        data: backboneResponse,
+        data: rawify(backboneResponse),
         status: 200,
       });
 
@@ -433,11 +434,11 @@ describe('Chains Controller (Unit)', () => {
     it('Validate the response', async () => {
       const invalidResponse = { invalid: 'value' };
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       networkService.get.mockResolvedValueOnce({
-        data: invalidResponse,
+        data: rawify(invalidResponse),
         status: 200,
       });
 
@@ -492,7 +493,7 @@ describe('Chains Controller (Unit)', () => {
         } as Response,
       );
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       networkService.get.mockRejectedValueOnce(error);
@@ -521,7 +522,7 @@ describe('Chains Controller (Unit)', () => {
   describe('GET /:chainId/about/master-copies', () => {
     it('Success', async () => {
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       const domainSingletonsResponse: Singleton[] = [
@@ -529,7 +530,7 @@ describe('Chains Controller (Unit)', () => {
         singletonBuilder().build(),
       ];
       networkService.get.mockResolvedValueOnce({
-        data: domainSingletonsResponse,
+        data: rawify(domainSingletonsResponse),
         status: 200,
       });
       const masterCopiesResponse: Array<MasterCopy> = [
@@ -591,7 +592,7 @@ describe('Chains Controller (Unit)', () => {
         } as Response,
       );
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       networkService.get.mockRejectedValueOnce(error);
@@ -618,7 +619,7 @@ describe('Chains Controller (Unit)', () => {
 
     it('Should return validation error', async () => {
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       const domainSingletonsResponse = [
@@ -626,7 +627,7 @@ describe('Chains Controller (Unit)', () => {
         singletonBuilder().build(),
       ];
       networkService.get.mockResolvedValueOnce({
-        data: domainSingletonsResponse,
+        data: rawify(domainSingletonsResponse),
         status: 200,
       });
 
@@ -646,7 +647,7 @@ describe('Chains Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`) {
           return Promise.resolve({
-            data: chainResponse,
+            data: rawify(chainResponse),
             status: 200,
           });
         }
@@ -654,7 +655,7 @@ describe('Chains Controller (Unit)', () => {
           url === `${chainResponse.transactionService}/api/v1/about/indexing/`
         ) {
           return Promise.resolve({
-            data: indexingStatus,
+            data: rawify(indexingStatus),
             status: 200,
           });
         }
@@ -718,7 +719,7 @@ describe('Chains Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`) {
           return Promise.resolve({
-            data: chainResponse,
+            data: rawify(chainResponse),
             status: 200,
           });
         }
@@ -752,14 +753,14 @@ describe('Chains Controller (Unit)', () => {
 
     it('Should return validation error', async () => {
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       const indexingStatus = {
         invalid: 'indexingStatus',
       };
       networkService.get.mockResolvedValueOnce({
-        data: indexingStatus,
+        data: rawify(indexingStatus),
         status: 200,
       });
 
@@ -783,7 +784,7 @@ describe('Chains Controller (Unit)', () => {
         buildNumber,
       };
       networkService.get.mockResolvedValueOnce({
-        data: chainDomain,
+        data: rawify(chainDomain),
         status: 200,
       });
 

--- a/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
+++ b/src/routes/collectibles/__tests__/controllers/zerion-collectibles.controller.spec.ts
@@ -33,6 +33,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Zerion Collectibles Controller', () => {
   let app: INestApplication<Server>;
@@ -149,10 +150,10 @@ describe('Zerion Collectibles Controller', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
-                data: zerionApiCollectiblesResponse,
+                data: rawify(zerionApiCollectiblesResponse),
                 status: 200,
               });
             default:
@@ -299,10 +300,10 @@ describe('Zerion Collectibles Controller', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
-                data: zerionApiCollectiblesResponse,
+                data: rawify(zerionApiCollectiblesResponse),
                 status: 200,
               });
             default:
@@ -371,10 +372,10 @@ describe('Zerion Collectibles Controller', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
-                data: zerionApiCollectiblesResponse,
+                data: rawify(zerionApiCollectiblesResponse),
                 status: 200,
               });
             default:
@@ -442,10 +443,10 @@ describe('Zerion Collectibles Controller', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${zerionBaseUri}/v1/wallets/${safeAddress}/nft-positions`:
               return Promise.resolve({
-                data: zerionApiCollectiblesResponse,
+                data: rawify(zerionApiCollectiblesResponse),
                 status: 200,
               });
             default:

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -38,6 +38,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -109,11 +110,17 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
           case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
-            return Promise.resolve({ data: safeResponse, status: 200 });
+            return Promise.resolve({ data: rawify(safeResponse), status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
-            return Promise.resolve({ data: collectiblesResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(collectiblesResponse),
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -154,11 +161,17 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
           case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
-            return Promise.resolve({ data: safeResponse, status: 200 });
+            return Promise.resolve({ data: rawify(safeResponse), status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
-            return Promise.resolve({ data: collectiblesResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(collectiblesResponse),
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -200,11 +213,17 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
           case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
-            return Promise.resolve({ data: safeResponse, status: 200 });
+            return Promise.resolve({ data: rawify(safeResponse), status: 200 });
           case `${chainResponse.transactionService}/api/v2/safes/${safeAddress}/collectibles/`:
-            return Promise.resolve({ data: collectiblesResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(collectiblesResponse),
+              status: 200,
+            });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -242,9 +261,12 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
           case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
-            return Promise.resolve({ data: safeResponse, status: 200 });
+            return Promise.resolve({ data: rawify(safeResponse), status: 200 });
           case transactionServiceUrl:
             return Promise.reject(transactionServiceError);
           default:
@@ -274,9 +296,12 @@ describe('Collectibles Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-            return Promise.resolve({ data: chainResponse, status: 200 });
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
           case `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`:
-            return Promise.resolve({ data: safeResponse, status: 200 });
+            return Promise.resolve({ data: rawify(safeResponse), status: 200 });
           case transactionServiceUrl:
             return Promise.reject(transactionServiceError);
           default:

--- a/src/routes/community/community.controller.spec.ts
+++ b/src/routes/community/community.controller.spec.ts
@@ -52,6 +52,7 @@ import { IIdentityApi } from '@/domain/interfaces/identity-api.interface';
 import { eligibilityBuilder } from '@/domain/community/entities/__tests__/eligibility.builder';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Community (Unit)', () => {
   let app: INestApplication<Server>;
@@ -109,7 +110,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.resolve({ data: campaignsPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignsPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -137,7 +141,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.resolve({ data: campaignsPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignsPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -164,7 +171,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns`:
-            return Promise.resolve({ data: campaignsPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignsPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -231,7 +241,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}`:
-            return Promise.resolve({ data: campaign, status: 200 });
+            return Promise.resolve({ data: rawify(campaign), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -251,7 +261,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${invalidCampaign.resourceId}`:
-            return Promise.resolve({ data: invalidCampaign, status: 200 });
+            return Promise.resolve({
+              data: rawify(invalidCampaign),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -312,7 +325,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/activities`:
-            return Promise.resolve({ data: campaignActivityPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignActivityPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -344,7 +360,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/activities`:
-            return Promise.resolve({ data: campaignActivityPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignActivityPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -391,7 +410,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/activities`:
-            return Promise.resolve({ data: campaignActivityPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignActivityPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -451,7 +473,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/activities`:
-            return Promise.resolve({ data: campaignActivityPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignActivityPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -521,7 +546,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
-            return Promise.resolve({ data: campaignRankPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignRankPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -550,7 +578,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
-            return Promise.resolve({ data: campaignRankPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignRankPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -581,7 +612,10 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${campaign.resourceId}/leaderboard`:
-            return Promise.resolve({ data: campaignRankPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(campaignRankPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -651,7 +685,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`:
-            return Promise.resolve({ data: campaignRank, status: 200 });
+            return Promise.resolve({ data: rawify(campaignRank), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -685,7 +719,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/campaigns/${resourceId}/leaderboard/${safeAddress}`:
-            return Promise.resolve({ data: campaignRank, status: 200 });
+            return Promise.resolve({ data: rawify(campaignRank), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -786,7 +820,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.resolve({ data: leaderboard, status: 200 });
+            return Promise.resolve({ data: rawify(leaderboard), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -824,7 +858,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.resolve({ data: leaderboard, status: 200 });
+            return Promise.resolve({ data: rawify(leaderboard), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -862,7 +896,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard`:
-            return Promise.resolve({ data: leaderboard, status: 200 });
+            return Promise.resolve({ data: rawify(leaderboard), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -915,7 +949,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard/${lockingRank.holder}`:
-            return Promise.resolve({ data: lockingRank, status: 200 });
+            return Promise.resolve({ data: rawify(lockingRank), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -947,7 +981,7 @@ describe('Community (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${lockingBaseUri}/api/v1/leaderboard/${safeAddress}`:
-            return Promise.resolve({ data: lockingRank, status: 200 });
+            return Promise.resolve({ data: rawify(lockingRank), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -1013,7 +1047,10 @@ describe('Community (Unit)', () => {
         switch (url) {
           // Service will have checksummed address
           case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(lockingHistoryPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -1059,7 +1096,10 @@ describe('Community (Unit)', () => {
         switch (url) {
           // Service will have checksummed address
           case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(lockingHistoryPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -1115,7 +1155,10 @@ describe('Community (Unit)', () => {
         switch (url) {
           // Service will have checksummed address
           case `${lockingBaseUri}/api/v1/all-events/${getAddress(safeAddress)}`:
-            return Promise.resolve({ data: lockingHistoryPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(lockingHistoryPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -26,6 +26,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Contracts controller', () => {
   let app: INestApplication<Server>;
@@ -75,9 +76,9 @@ describe('Contracts controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
-            return Promise.resolve({ data: contract, status: 200 });
+            return Promise.resolve({ data: rawify(contract), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -113,7 +114,7 @@ describe('Contracts controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case transactionServiceUrl:
             return Promise.reject(
               new NetworkResponseError(new URL(transactionServiceUrl), {
@@ -136,10 +137,10 @@ describe('Contracts controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
             return Promise.resolve({
-              data: { ...contract, name: false },
+              data: rawify({ ...contract, name: false }),
               status: 200,
             });
           default:

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -33,6 +33,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Delegates controller', () => {
   let app: INestApplication<Server>;
@@ -86,10 +87,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${chain.transactionService}/api/v1/delegates/`) {
-          return Promise.resolve({ data: delegatesPage, status: 200 });
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -114,10 +115,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${chain.transactionService}/api/v1/delegates/`) {
-          return Promise.resolve({ data: delegatesPage, status: 200 });
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -142,10 +143,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${chain.transactionService}/api/v1/delegates/`) {
-          return Promise.resolve({ data: delegatesPage, status: 200 });
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -177,12 +178,12 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation(({ url }) =>
         url === `${chain.transactionService}/api/v1/delegates/`
-          ? Promise.resolve({ status: 201, data: {} })
+          ? Promise.resolve({ status: 201, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -215,12 +216,12 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation(({ url }) =>
         url === `${chain.transactionService}/api/v1/delegates/`
-          ? Promise.resolve({ status: 201, data: {} })
+          ? Promise.resolve({ status: 201, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -235,7 +236,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/delegates/`;
@@ -267,7 +268,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/delegates/`;
@@ -297,13 +298,13 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`
-          ? Promise.resolve({ data: {}, status: 204 })
+          ? Promise.resolve({ data: rawify({}), status: 204 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -320,7 +321,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`;
@@ -354,7 +355,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`;
@@ -427,13 +428,13 @@ describe('Delegates controller', () => {
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${deleteSafeDelegateDto.safe}/delegates/${deleteSafeDelegateDto.delegate}`
-          ? Promise.resolve({ data: {}, status: 204 })
+          ? Promise.resolve({ data: rawify({}), status: 204 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -450,7 +451,7 @@ describe('Delegates controller', () => {
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/safes/${deleteSafeDelegateDto.safe}/delegates/${deleteSafeDelegateDto.delegate}`;

--- a/src/routes/delegates/v2/delegates.v2.controller.spec.ts
+++ b/src/routes/delegates/v2/delegates.v2.controller.spec.ts
@@ -24,6 +24,7 @@ import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { createDelegateDtoBuilder } from '@/routes/delegates/entities/__tests__/create-delegate.dto.builder';
 import { deleteDelegateV2DtoBuilder } from '@/routes/delegates/v2/entities/__tests__/delete-delegate.v2.dto.builder';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
@@ -94,10 +95,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${chain.transactionService}/api/v2/delegates/`) {
-          return Promise.resolve({ data: delegatesPage, status: 200 });
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -122,10 +123,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${chain.transactionService}/api/v2/delegates/`) {
-          return Promise.resolve({ data: delegatesPage, status: 200 });
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -150,10 +151,10 @@ describe('Delegates controller', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${chain.transactionService}/api/v2/delegates/`) {
-          return Promise.resolve({ data: delegatesPage, status: 200 });
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -185,12 +186,12 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation(({ url }) =>
         url === `${chain.transactionService}/api/v2/delegates/`
-          ? Promise.resolve({ status: 201, data: {} })
+          ? Promise.resolve({ status: 201, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -223,12 +224,12 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation(({ url }) =>
         url === `${chain.transactionService}/api/v2/delegates/`
-          ? Promise.resolve({ status: 201, data: {} })
+          ? Promise.resolve({ status: 201, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -243,7 +244,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/`;
@@ -275,7 +276,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/`;
@@ -306,13 +307,13 @@ describe('Delegates controller', () => {
       const delegateAddress = getAddress(faker.finance.ethereumAddress());
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
-          ? Promise.resolve({ data: {}, status: 204 })
+          ? Promise.resolve({ data: rawify({}), status: 204 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -339,13 +340,13 @@ describe('Delegates controller', () => {
       const delegateAddress = getAddress(faker.finance.ethereumAddress());
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
-          ? Promise.resolve({ data: {}, status: 204 })
+          ? Promise.resolve({ data: rawify({}), status: 204 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -386,9 +387,12 @@ describe('Delegates controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v2/delegates/`:
-            return Promise.resolve({ data: delegatesPage, status: 200 });
+            return Promise.resolve({
+              data: rawify(delegatesPage),
+              status: 200,
+            });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -396,7 +400,7 @@ describe('Delegates controller', () => {
       networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
-          ? Promise.resolve({ data: {}, status: 204 })
+          ? Promise.resolve({ data: rawify({}), status: 204 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -422,7 +426,7 @@ describe('Delegates controller', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/${delegateAddress}`;
@@ -455,7 +459,7 @@ describe('Delegates controller', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/${delegateAddress}`;

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -34,6 +34,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Estimations Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -87,17 +88,19 @@ describe('Estimations Controller (Unit)', () => {
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
         const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
         if (url === chainsUrl) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === getSafeUrl) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (url === multisigTransactionsUrl) {
           return Promise.resolve({
-            data: pageBuilder()
-              .with('count', 1)
-              .with('results', [multisigTransactionToJson(lastTransaction)])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('count', 1)
+                .with('results', [multisigTransactionToJson(lastTransaction)])
+                .build(),
+            ),
             status: 200,
           });
         }
@@ -106,7 +109,7 @@ describe('Estimations Controller (Unit)', () => {
       networkService.post.mockImplementation(({ url }) => {
         const estimationsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/estimations/`;
         return url === estimationsUrl
-          ? Promise.resolve({ data: estimation, status: 200 })
+          ? Promise.resolve({ data: rawify(estimation), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`);
       });
 
@@ -139,17 +142,19 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('count', 1)
-            .with('results', [multisigTransactionToJson(lastTransaction)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('count', 1)
+              .with('results', [multisigTransactionToJson(lastTransaction)])
+              .build(),
+          ),
           status: 200,
         });
       }
@@ -158,7 +163,7 @@ describe('Estimations Controller (Unit)', () => {
     networkService.post.mockImplementation(({ url }) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation, status: 200 })
+        ? Promise.resolve({ data: rawify(estimation), status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 
@@ -219,17 +224,19 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('count', 1)
-            .with('results', [multisigTransactionToJson(lastTransaction)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('count', 1)
+              .with('results', [multisigTransactionToJson(lastTransaction)])
+              .build(),
+          ),
           status: 200,
         });
       }
@@ -239,7 +246,7 @@ describe('Estimations Controller (Unit)', () => {
       // Param ValidationPipe checksums address
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation, status: 200 })
+        ? Promise.resolve({ data: rawify(estimation), status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 
@@ -272,14 +279,16 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
-          data: pageBuilder().with('count', 0).with('results', []).build(),
+          data: rawify(
+            pageBuilder().with('count', 0).with('results', []).build(),
+          ),
           status: 200,
         });
       }
@@ -289,7 +298,7 @@ describe('Estimations Controller (Unit)', () => {
       // Param ValidationPipe checksums address
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation, status: 200 })
+        ? Promise.resolve({ data: rawify(estimation), status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 
@@ -325,17 +334,19 @@ describe('Estimations Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/`;
       if (url === chainsUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url === multisigTransactionsUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('count', 1)
-            .with('results', [multisigTransactionToJson(lastTransaction)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('count', 1)
+              .with('results', [multisigTransactionToJson(lastTransaction)])
+              .build(),
+          ),
           status: 200,
         });
       }
@@ -345,7 +356,7 @@ describe('Estimations Controller (Unit)', () => {
       // Param ValidationPipe checksums address
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${getAddress(address)}/multisig-transactions/estimations/`;
       return url === estimationsUrl
-        ? Promise.resolve({ data: estimation, status: 200 })
+        ? Promise.resolve({ data: rawify(estimation), status: 200 })
         : Promise.reject(`No matching rule for url: ${url}`);
     });
 

--- a/src/routes/hooks/hooks-cache.controller.spec.ts
+++ b/src/routes/hooks/hooks-cache.controller.spec.ts
@@ -36,6 +36,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 // TODO: Migrate to E2E tests as TransactionEventType events are already being received via queue.
 // Add *_DELEGATE event tests here if we unskip this
@@ -186,7 +187,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -210,7 +211,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/1`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', '1').build(),
+            data: rawify(chainBuilder().with('chainId', '1').build()),
             status: 200,
           });
         default:
@@ -297,11 +298,11 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -356,7 +357,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -413,7 +414,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -462,7 +463,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -517,7 +518,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -577,11 +578,11 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -633,7 +634,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -682,7 +683,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -726,7 +727,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -795,7 +796,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -842,7 +843,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -878,7 +879,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -913,7 +914,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chain.chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chain.chainId).build()),
             status: 200,
           });
         default:
@@ -944,7 +945,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -977,7 +978,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -1010,7 +1011,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -1044,7 +1045,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', chainId).build(),
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
             status: 200,
           });
         default:
@@ -1083,7 +1084,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         default:
@@ -1114,7 +1115,7 @@ describe.skip('Post Hook Events for Cache (Unit)', () => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${data.chainId}`:
           return Promise.resolve({
-            data: chainBuilder().with('chainId', data.chainId).build(),
+            data: rawify(chainBuilder().with('chainId', data.chainId).build()),
             status: 200,
           });
         default:

--- a/src/routes/hooks/hooks-notifications.spec.ts
+++ b/src/routes/hooks/hooks-notifications.spec.ts
@@ -56,6 +56,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 // TODO: Migrate to E2E tests as TransactionEventType events are already being received via queue.
 describe.skip('Post Hook Events for Notifications (Unit)', () => {
@@ -164,7 +165,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
         return Promise.resolve({
-          data: chain,
+          data: rawify(chain),
           status: 200,
         });
       } else {
@@ -218,7 +219,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -241,9 +242,11 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
           ];
           return Promise.resolve({
             status: 200,
-            data: pageBuilder()
-              .with('results', [faker.helpers.arrayElement(transfers)])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [faker.helpers.arrayElement(transfers)])
+                .build(),
+            ),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -298,7 +301,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -324,9 +327,11 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
           ];
           return Promise.resolve({
             status: 200,
-            data: pageBuilder()
-              .with('results', [faker.helpers.arrayElement(transfers)])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [faker.helpers.arrayElement(transfers)])
+                .build(),
+            ),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -375,7 +380,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -383,7 +388,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (
           url ===
@@ -391,7 +396,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -447,7 +452,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -455,7 +460,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -509,7 +514,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -517,7 +522,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (
           url ===
@@ -525,7 +530,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -577,7 +582,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -585,7 +590,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (
           url ===
@@ -593,7 +598,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -661,7 +666,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -669,7 +674,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (
           url ===
@@ -677,7 +682,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -733,7 +738,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -741,7 +746,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -796,7 +801,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -804,7 +809,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (
           url ===
@@ -812,7 +817,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -864,7 +869,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -872,7 +877,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (
           url ===
@@ -880,7 +885,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -954,7 +959,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -962,12 +967,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else if (
           url ===
@@ -975,7 +980,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1033,7 +1038,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1041,12 +1046,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1102,7 +1107,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1110,12 +1115,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else if (
           url ===
@@ -1123,7 +1128,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1181,7 +1186,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1189,12 +1194,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else if (
           url ===
@@ -1202,7 +1207,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1272,7 +1277,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1280,12 +1285,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else if (
           url ===
@@ -1293,7 +1298,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1351,7 +1356,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1359,12 +1364,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1421,7 +1426,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1429,12 +1434,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else if (
           url ===
@@ -1442,7 +1447,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1500,7 +1505,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1508,12 +1513,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', delegates).build(),
+            data: rawify(pageBuilder().with('results', delegates).build()),
           });
         } else if (
           url ===
@@ -1521,7 +1526,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1590,7 +1595,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1598,12 +1603,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', []).build(),
+            data: rawify(pageBuilder().with('results', []).build()),
           });
         } else if (
           url ===
@@ -1611,7 +1616,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: multisigTransaction,
+            data: rawify(multisigTransaction),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1657,7 +1662,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
           return Promise.resolve({
-            data: chain,
+            data: rawify(chain),
             status: 200,
           });
         } else if (
@@ -1665,12 +1670,12 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: safe,
+            data: rawify(safe),
           });
         } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
           return Promise.resolve({
             status: 200,
-            data: pageBuilder().with('results', []).build(),
+            data: rawify(pageBuilder().with('results', []).build()),
           });
         } else if (
           url ===
@@ -1678,7 +1683,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: message,
+            data: rawify(message),
           });
         } else {
           return Promise.reject(`No matching rule for url: ${url}`);
@@ -1759,7 +1764,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
         return Promise.resolve({
-          data: chain,
+          data: rawify(chain),
           status: 200,
         });
       } else if (
@@ -1767,22 +1772,24 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: safe,
+          data: rawify(safe),
         });
       } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
         return Promise.resolve({
           status: 200,
-          data: pageBuilder()
-            .with(
-              'results',
-              delegateSubscriptions.map((subscription) => {
-                return delegateBuilder()
-                  .with('delegate', subscription.subscriber)
-                  .with('safe', safe.address)
-                  .build();
-              }),
-            )
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with(
+                'results',
+                delegateSubscriptions.map((subscription) => {
+                  return delegateBuilder()
+                    .with('delegate', subscription.subscriber)
+                    .with('safe', safe.address)
+                    .build();
+                }),
+              )
+              .build(),
+          ),
         });
       } else if (
         url ===
@@ -1790,7 +1797,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: multisigTransaction,
+          data: rawify(multisigTransaction),
         });
       } else {
         return Promise.reject(`No matching rule for url: ${url}`);
@@ -1900,7 +1907,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
         return Promise.resolve({
-          data: chain,
+          data: rawify(chain),
           status: 200,
         });
       } else if (
@@ -1908,22 +1915,24 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: safe,
+          data: rawify(safe),
         });
       } else if (url === `${chain.transactionService}/api/v2/delegates/`) {
         return Promise.resolve({
           status: 200,
-          data: pageBuilder()
-            .with(
-              'results',
-              delegateSubscriptions.map((subscription) => {
-                return delegateBuilder()
-                  .with('delegate', subscription.subscriber)
-                  .with('safe', safe.address)
-                  .build();
-              }),
-            )
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with(
+                'results',
+                delegateSubscriptions.map((subscription) => {
+                  return delegateBuilder()
+                    .with('delegate', subscription.subscriber)
+                    .with('safe', safe.address)
+                    .build();
+                }),
+              )
+              .build(),
+          ),
         });
       } else if (
         url ===
@@ -1931,7 +1940,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: message,
+          data: rawify(message),
         });
       } else {
         return Promise.reject(`No matching rule for url: ${url}`);
@@ -1999,7 +2008,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${event.chainId}`) {
         return Promise.resolve({
-          data: chain,
+          data: rawify(chain),
           status: 200,
         });
       } else {
@@ -2091,7 +2100,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
         return Promise.resolve({
-          data: chain,
+          data: rawify(chain),
           status: 200,
         });
       } else if (
@@ -2099,7 +2108,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: safe,
+          data: rawify(safe),
         });
       } else if (
         url ===
@@ -2107,7 +2116,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: multisigTransaction,
+          data: rawify(multisigTransaction),
         });
       } else if (
         url ===
@@ -2115,7 +2124,7 @@ describe.skip('Post Hook Events for Notifications (Unit)', () => {
       ) {
         return Promise.resolve({
           status: 200,
-          data: message,
+          data: rawify(message),
         });
       } else {
         return Promise.reject(`No matching rule for url: ${url}`);

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -38,6 +38,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Messages controller', () => {
   let app: INestApplication<Server>;
@@ -96,16 +97,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
             return Promise.resolve({
-              data: messageToJson(message),
+              data: rawify(messageToJson(message)),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps, status: 200 });
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -164,16 +165,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
             return Promise.resolve({
-              data: messageToJson(message),
+              data: rawify(messageToJson(message)),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps, status: 200 });
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -229,16 +230,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
             return Promise.resolve({
-              data: messageToJson(message),
+              data: rawify(messageToJson(message)),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps, status: 200 });
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -297,16 +298,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
             return Promise.resolve({
-              data: messageToJson(message),
+              data: rawify(messageToJson(message)),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: safeApps, status: 200 });
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -362,16 +363,16 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
             return Promise.resolve({
-              data: messageToJson(message),
+              data: rawify(messageToJson(message)),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${safeConfigUrl}/api/v1/safe-apps/`:
-            return Promise.resolve({ data: [], status: 200 });
+            return Promise.resolve({ data: rawify([]), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -427,14 +428,14 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
             return Promise.resolve({
-              data: messageToJson(message),
+              data: rawify(messageToJson(message)),
               status: 200,
             });
           case `${chain.transactionService}/api/v1/safes/${message.safe}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -480,12 +481,12 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
             return Promise.resolve({
-              data: { ...page, previous: faker.number.int() },
+              data: rawify({ ...page, previous: faker.number.int() }),
               status: 200,
             });
           default:
@@ -525,11 +526,11 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
-            return Promise.resolve({ data: page, status: 200 });
+            return Promise.resolve({ data: rawify(page), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -612,11 +613,11 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
-            return Promise.resolve({ data: page, status: 200 });
+            return Promise.resolve({ data: rawify(page), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -711,11 +712,11 @@ describe('Messages controller', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`:
-            return Promise.resolve({ data: page, status: 200 });
+            return Promise.resolve({ data: rawify(page), status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
         }
@@ -773,13 +774,16 @@ describe('Messages controller', () => {
       const message = messageBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`
-          ? Promise.resolve({ data: messageToJson(message), status: 200 })
+          ? Promise.resolve({
+              data: rawify(messageToJson(message)),
+              status: 200,
+            })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -796,7 +800,7 @@ describe('Messages controller', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`;
@@ -849,18 +853,20 @@ describe('Messages controller', () => {
         .with('created', faker.date.recent())
         .build();
       const expectedResponse = {
-        data: { signature: faker.string.hexadecimal() },
-        status: 200,
+        signature: faker.string.hexadecimal(),
       };
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       networkService.post.mockImplementation(({ url }) =>
         url ===
         `${chain.transactionService}/api/v1/messages/${message.messageHash}/signatures/`
-          ? Promise.resolve(expectedResponse)
+          ? Promise.resolve({
+              data: rawify(expectedResponse),
+              status: 200,
+            })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -870,7 +876,7 @@ describe('Messages controller', () => {
         )
         .send(updateMessageSignatureDtoBuilder().build())
         .expect(200)
-        .expect(expectedResponse.data);
+        .expect(expectedResponse);
     });
 
     it('should return an error from the provider', async () => {
@@ -882,7 +888,7 @@ describe('Messages controller', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
       const transactionServiceUrl = `${chain.transactionService}/api/v1/messages/${message.messageHash}/signatures/`;

--- a/src/routes/notifications/v1/notifications.controller.spec.ts
+++ b/src/routes/notifications/v1/notifications.controller.spec.ts
@@ -30,6 +30,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Notifications Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -91,12 +92,15 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation(({ url }) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
+          ? Promise.resolve({
+              data: rawify(chainBuilder().build()),
+              status: 200,
+            })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -111,7 +115,10 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation(({ url }) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
+          ? Promise.resolve({
+              data: rawify(chainBuilder().build()),
+              status: 200,
+            })
           : rejectForUrl(url);
       });
       networkService.post.mockImplementationOnce(({ url }) =>
@@ -128,7 +135,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -149,7 +156,10 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation(({ url }) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
+          ? Promise.resolve({
+              data: rawify(chainBuilder().build()),
+              status: 200,
+            })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementationOnce(({ url }) =>
@@ -166,7 +176,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -185,7 +195,10 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation(({ url }) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
+          ? Promise.resolve({
+              data: rawify(chainBuilder().build()),
+              status: 200,
+            })
           : rejectForUrl(url);
       });
       networkService.post.mockImplementationOnce(({ url }) =>
@@ -214,7 +227,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -236,12 +249,15 @@ describe('Notifications Controller (Unit)', () => {
       const registerDeviceDto = buildInputDto();
       networkService.get.mockImplementation(({ url }) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
-          ? Promise.resolve({ data: chainBuilder().build(), status: 200 })
+          ? Promise.resolve({
+              data: rawify(chainBuilder().build()),
+              status: 200,
+            })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementationOnce(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
       networkService.post.mockImplementationOnce(({ url }) =>
@@ -251,7 +267,7 @@ describe('Notifications Controller (Unit)', () => {
       );
       networkService.post.mockImplementation(({ url }) =>
         url.includes('/api/v1/notifications/devices/')
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -274,12 +290,12 @@ describe('Notifications Controller (Unit)', () => {
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}`;
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation(({ url }) =>
         url === expectedProviderURL
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -313,7 +329,7 @@ describe('Notifications Controller (Unit)', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation(({ url }) =>
@@ -339,12 +355,12 @@ describe('Notifications Controller (Unit)', () => {
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}/safes/${getAddress(safeAddress)}`;
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation(({ url }) =>
         url === expectedProviderURL
-          ? Promise.resolve({ data: {}, status: 200 })
+          ? Promise.resolve({ data: rawify({}), status: 200 })
           : rejectForUrl(url),
       );
 
@@ -384,7 +400,7 @@ describe('Notifications Controller (Unit)', () => {
       const chain = chainBuilder().build();
       networkService.get.mockImplementation(({ url }) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
-          ? Promise.resolve({ data: chain, status: 200 })
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
           : rejectForUrl(url),
       );
       networkService.delete.mockImplementation(({ url }) =>

--- a/src/routes/notifications/v2/notifications.controller.spec.ts
+++ b/src/routes/notifications/v2/notifications.controller.spec.ts
@@ -47,6 +47,7 @@ import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-me
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
 import { TestAddressBooksDataSourceModule } from '@/datasources/accounts/address-books/__tests__/test.address-books.datasource.module';
 import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-books/address-books.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Notifications Controller V2 (Unit)', () => {
   let app: INestApplication<Server>;
@@ -138,22 +139,24 @@ describe('Notifications Controller V2 (Unit)', () => {
           const chain = chains[safe.chainId];
 
           if (url === `${safeConfigUrl}/api/v1/chains/${safe.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (
             url === `${chain.transactionService}/api/v1/safes/${safe.address}`
           ) {
             return Promise.resolve({
-              data: safeBuilder()
-                .with('address', safe.address)
-                .with('owners', [signerAddress])
-                .build(),
+              data: rawify(
+                safeBuilder()
+                  .with('address', safe.address)
+                  .with('owners', [signerAddress])
+                  .build(),
+              ),
               status: 200,
             });
           }
           if (url === `${chain.transactionService}/api/v2/delegates/`) {
             return Promise.resolve({
-              data: pageBuilder().with('results', []).build(),
+              data: rawify(pageBuilder().with('results', []).build()),
               status: 200,
             });
           }
@@ -204,26 +207,28 @@ describe('Notifications Controller V2 (Unit)', () => {
           const chain = chains[safe.chainId];
 
           if (url === `${safeConfigUrl}/api/v1/chains/${safe.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (
             url === `${chain.transactionService}/api/v1/safes/${safe.address}`
           ) {
             return Promise.resolve({
-              data: safeBuilder().with('address', safe.address).build(),
+              data: rawify(safeBuilder().with('address', safe.address).build()),
               status: 200,
             });
           }
           if (url === `${chain.transactionService}/api/v2/delegates/`) {
             return Promise.resolve({
-              data: pageBuilder()
-                .with('results', [
-                  delegateBuilder()
-                    .with('delegate', signerAddress)
-                    .with('safe', safe.address)
-                    .build(),
-                ])
-                .build(),
+              data: rawify(
+                pageBuilder()
+                  .with('results', [
+                    delegateBuilder()
+                      .with('delegate', signerAddress)
+                      .with('safe', safe.address)
+                      .build(),
+                  ])
+                  .build(),
+              ),
               status: 200,
             });
           }
@@ -276,22 +281,24 @@ describe('Notifications Controller V2 (Unit)', () => {
           const chain = chains[safe.chainId];
 
           if (url === `${safeConfigUrl}/api/v1/chains/${safe.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (
             url === `${chain.transactionService}/api/v1/safes/${safe.address}`
           ) {
             return Promise.resolve({
-              data: safeBuilder()
-                .with('address', safe.address)
-                .with('owners', [signerAddress])
-                .build(),
+              data: rawify(
+                safeBuilder()
+                  .with('address', safe.address)
+                  .with('owners', [signerAddress])
+                  .build(),
+              ),
               status: 200,
             });
           }
           if (url === `${chain.transactionService}/api/v2/delegates/`) {
             return Promise.resolve({
-              data: pageBuilder().with('results', []).build(),
+              data: rawify(pageBuilder().with('results', []).build()),
               status: 200,
             });
           }
@@ -346,22 +353,24 @@ describe('Notifications Controller V2 (Unit)', () => {
           const chain = chains[safe.chainId];
 
           if (url === `${safeConfigUrl}/api/v1/chains/${safe.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (
             url === `${chain.transactionService}/api/v1/safes/${safe.address}`
           ) {
             return Promise.resolve({
-              data: safeBuilder()
-                .with('address', safe.address)
-                .with('owners', [signerAddress])
-                .build(),
+              data: rawify(
+                safeBuilder()
+                  .with('address', safe.address)
+                  .with('owners', [signerAddress])
+                  .build(),
+              ),
               status: 200,
             });
           }
           if (url === `${chain.transactionService}/api/v2/delegates/`) {
             return Promise.resolve({
-              data: pageBuilder().with('results', []).build(),
+              data: rawify(pageBuilder().with('results', []).build()),
               status: 200,
             });
           }
@@ -431,22 +440,24 @@ describe('Notifications Controller V2 (Unit)', () => {
           const chain = chains[safe.chainId];
 
           if (url === `${safeConfigUrl}/api/v1/chains/${safe.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (
             url === `${chain.transactionService}/api/v1/safes/${safe.address}`
           ) {
             return Promise.resolve({
-              data: safeBuilder()
-                .with('address', safe.address)
-                .with('owners', [signerAddress])
-                .build(),
+              data: rawify(
+                safeBuilder()
+                  .with('address', safe.address)
+                  .with('owners', [signerAddress])
+                  .build(),
+              ),
               status: 200,
             });
           }
           if (url === `${chain.transactionService}/api/v2/delegates/`) {
             return Promise.resolve({
-              data: pageBuilder().with('results', []).build(),
+              data: rawify(pageBuilder().with('results', []).build()),
               status: 200,
             });
           }

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -32,6 +32,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -87,11 +88,11 @@ describe('Owners Controller (Unit)', () => {
         ],
       };
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       networkService.get.mockResolvedValueOnce({
-        data: transactionApiSafeListResponse,
+        data: rawify(transactionApiSafeListResponse),
         status: 200,
       });
 
@@ -138,7 +139,7 @@ describe('Owners Controller (Unit)', () => {
       const ownerAddress = faker.finance.ethereumAddress();
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       const error = new NetworkResponseError(
@@ -182,11 +183,11 @@ describe('Owners Controller (Unit)', () => {
         ],
       };
       networkService.get.mockResolvedValueOnce({
-        data: chainResponse,
+        data: rawify(chainResponse),
         status: 200,
       });
       networkService.get.mockResolvedValueOnce({
-        data: transactionApiSafeListResponse,
+        data: rawify(transactionApiSafeListResponse),
         status: 200,
       });
 
@@ -225,24 +226,26 @@ describe('Owners Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains`: {
             return Promise.resolve({
-              data: pageBuilder()
-                .with('results', [chain1, chain2])
-                .with('next', null)
-                .build(),
+              data: rawify(
+                pageBuilder()
+                  .with('results', [chain1, chain2])
+                  .with('next', null)
+                  .build(),
+              ),
               status: 200,
             });
           }
 
           case `${safeConfigUrl}/api/v1/chains/${chainId1}`: {
             return Promise.resolve({
-              data: chain1,
+              data: rawify(chain1),
               status: 200,
             });
           }
 
           case `${safeConfigUrl}/api/v1/chains/${chainId2}`: {
             return Promise.resolve({
-              data: chain2,
+              data: rawify(chain2),
               status: 200,
             });
           }
@@ -250,14 +253,14 @@ describe('Owners Controller (Unit)', () => {
           // ValidationPipe checksums ownerAddress param
           case `${chain1.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`: {
             return Promise.resolve({
-              data: { safes: safesOnChain1 },
+              data: rawify({ safes: safesOnChain1 }),
               status: 200,
             });
           }
 
           case `${chain2.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`: {
             return Promise.resolve({
-              data: { safes: safesOnChain2 },
+              data: rawify({ safes: safesOnChain2 }),
               status: 200,
             });
           }
@@ -312,26 +315,26 @@ describe('Owners Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url, networkRequest }) => {
         if (url === chainsUrl && !networkRequest!.params!.offset) {
           return Promise.resolve({
-            data: chainsPage1,
+            data: rawify(chainsPage1),
             status: 200,
           });
         }
         if (url === chainsUrl && networkRequest!.params!.offset === offset) {
           return Promise.resolve({
-            data: chainsPage2,
+            data: rawify(chainsPage2),
             status: 200,
           });
         }
         if (url === `${safeConfigUrl}/api/v1/chains/${chainId1}`) {
           return Promise.resolve({
-            data: chain1,
+            data: rawify(chain1),
             status: 200,
           });
         }
 
         if (url === `${safeConfigUrl}/api/v1/chains/${chainId2}`) {
           return Promise.resolve({
-            data: chain2,
+            data: rawify(chain2),
             status: 200,
           });
         }
@@ -342,7 +345,7 @@ describe('Owners Controller (Unit)', () => {
           `${chain1.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`
         ) {
           return Promise.resolve({
-            data: { safes: safesOnChain1 },
+            data: rawify({ safes: safesOnChain1 }),
             status: 200,
           });
         }
@@ -352,7 +355,7 @@ describe('Owners Controller (Unit)', () => {
           `${chain2.transactionService}/api/v1/owners/${getAddress(ownerAddress)}/safes/`
         ) {
           return Promise.resolve({
-            data: { safes: safesOnChain2 },
+            data: rawify({ safes: safesOnChain2 }),
             status: 200,
           });
         }
@@ -420,23 +423,23 @@ describe('Owners Controller (Unit)', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains`: {
             return Promise.resolve({
-              data: {
+              data: rawify({
                 results: [chain],
-              },
+              }),
               status: 200,
             });
           }
 
           case `${safeConfigUrl}/api/v1/chains/${chainId}`: {
             return Promise.resolve({
-              data: chain,
+              data: rawify(chain),
               status: 200,
             });
           }
 
           case `${chain.transactionService}/api/v1/owners/${ownerAddress}/safes/`: {
             return Promise.resolve({
-              data: { safes: safesOnChain },
+              data: rawify({ safes: safesOnChain }),
               status: 200,
             });
           }

--- a/src/routes/recovery/recovery.controller.spec.ts
+++ b/src/routes/recovery/recovery.controller.spec.ts
@@ -45,6 +45,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Recovery (Unit)', () => {
   let app: INestApplication<Server>;
@@ -137,12 +138,12 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         if (
           url ===
@@ -150,7 +151,7 @@ describe('Recovery (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: { safes: [safe.address] },
+            data: rawify({ safes: [safe.address] }),
           });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
@@ -158,7 +159,7 @@ describe('Recovery (Unit)', () => {
       networkService.post.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
-          ? Promise.resolve({ status: 200, data: {} })
+          ? Promise.resolve({ status: 200, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -181,12 +182,12 @@ describe('Recovery (Unit)', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -211,12 +212,12 @@ describe('Recovery (Unit)', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -244,12 +245,12 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         if (
           url ===
@@ -257,7 +258,7 @@ describe('Recovery (Unit)', () => {
         ) {
           return Promise.resolve({
             status: 200,
-            data: { safes: [] },
+            data: rawify({ safes: [] }),
           });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
@@ -265,7 +266,7 @@ describe('Recovery (Unit)', () => {
       networkService.post.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/address`
-          ? Promise.resolve({ status: 200, data: {} })
+          ? Promise.resolve({ status: 200, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -333,12 +334,12 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -379,12 +380,12 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -417,19 +418,19 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
       networkService.delete.mockImplementation(({ url }) =>
         url ===
         `${alertsUrl}/api/v1/account/${alertsAccount}/project/${alertsProject}/contract/${chain.chainId}/${moduleAddress}`
-          ? Promise.resolve({ status: 204, data: {} })
+          ? Promise.resolve({ status: 204, data: rawify({}) })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
 
@@ -453,12 +454,12 @@ describe('Recovery (Unit)', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -484,12 +485,12 @@ describe('Recovery (Unit)', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -530,12 +531,12 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
@@ -582,12 +583,12 @@ describe('Recovery (Unit)', () => {
 
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ status: 200, data: chain });
+          return Promise.resolve({ status: 200, data: rawify(chain) });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ status: 200, data: safe });
+          return Promise.resolve({ status: 200, data: rawify(safe) });
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -61,6 +61,7 @@ import {
 } from '@/domain/alerts/contracts/__tests__/encoders/delay-modifier-encoder.builder';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 const supportedChainIds = faker.helpers.arrayElements(
   Object.keys(configuration().relay.apiKey),
@@ -174,9 +175,15 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                    return Promise.resolve({ data: { safes }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ safes }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -184,7 +191,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -255,9 +265,15 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                    return Promise.resolve({ data: { safes }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ safes }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -265,7 +281,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -301,10 +320,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -312,7 +337,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -341,10 +369,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -352,7 +386,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -426,10 +463,16 @@ describe('Relay controller', () => {
                   networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                        return Promise.resolve({ data: chain, status: 200 });
+                        return Promise.resolve({
+                          data: rawify(chain),
+                          status: 200,
+                        });
                       case `${chain.transactionService}/api/v1/safes/${safe.address}`:
                         // Official mastercopy
-                        return Promise.resolve({ data: safe, status: 200 });
+                        return Promise.resolve({
+                          data: rawify(safe),
+                          status: 200,
+                        });
                       default:
                         return Promise.reject(
                           `No matching rule for url: ${url}`,
@@ -440,7 +483,7 @@ describe('Relay controller', () => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
-                          data: { taskId },
+                          data: rawify({ taskId }),
                           status: 200,
                         });
                       default:
@@ -476,10 +519,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -487,7 +536,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -546,10 +598,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -557,7 +615,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -616,10 +677,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -627,7 +694,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -683,7 +753,10 @@ describe('Relay controller', () => {
                   networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                        return Promise.resolve({ data: chain, status: 200 });
+                        return Promise.resolve({
+                          data: rawify(chain),
+                          status: 200,
+                        });
                       default:
                         return Promise.reject(
                           `No matching rule for url: ${url}`,
@@ -694,7 +767,7 @@ describe('Relay controller', () => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
-                          data: { taskId },
+                          data: rawify({ taskId }),
                           status: 200,
                         });
                       default:
@@ -742,7 +815,10 @@ describe('Relay controller', () => {
                   networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                        return Promise.resolve({ data: chain, status: 200 });
+                        return Promise.resolve({
+                          data: rawify(chain),
+                          status: 200,
+                        });
                       default:
                         return Promise.reject(
                           `No matching rule for url: ${url}`,
@@ -753,7 +829,7 @@ describe('Relay controller', () => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
-                          data: { taskId },
+                          data: rawify({ taskId }),
                           status: 200,
                         });
                       default:
@@ -808,7 +884,10 @@ describe('Relay controller', () => {
                   networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                        return Promise.resolve({ data: chain, status: 200 });
+                        return Promise.resolve({
+                          data: rawify(chain),
+                          status: 200,
+                        });
                       default:
                         return Promise.reject(
                           `No matching rule for url: ${url}`,
@@ -819,7 +898,7 @@ describe('Relay controller', () => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
-                          data: { taskId },
+                          data: rawify({ taskId }),
                           status: 200,
                         });
                       default:
@@ -867,7 +946,10 @@ describe('Relay controller', () => {
                   networkService.get.mockImplementation(({ url }) => {
                     switch (url) {
                       case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                        return Promise.resolve({ data: chain, status: 200 });
+                        return Promise.resolve({
+                          data: rawify(chain),
+                          status: 200,
+                        });
                       default:
                         return Promise.reject(
                           `No matching rule for url: ${url}`,
@@ -878,7 +960,7 @@ describe('Relay controller', () => {
                     switch (url) {
                       case `${relayUrl}/relays/v2/sponsored-call`:
                         return Promise.resolve({
-                          data: { taskId },
+                          data: rawify({ taskId }),
                           status: 200,
                         });
                       default:
@@ -946,9 +1028,15 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                      return Promise.resolve({ data: { safes }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ safes }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -956,7 +1044,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1006,9 +1097,15 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                      return Promise.resolve({ data: { safes }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ safes }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1016,7 +1113,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1097,9 +1197,15 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                      return Promise.resolve({ data: { safes }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ safes }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1107,7 +1213,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1185,9 +1294,15 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                      return Promise.resolve({ data: { safes }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ safes }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1195,7 +1310,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1273,9 +1391,15 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                      return Promise.resolve({ data: { safes }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ safes }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1283,7 +1407,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1353,9 +1480,15 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                      return Promise.resolve({ data: { safes }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ safes }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1363,7 +1496,10 @@ describe('Relay controller', () => {
                 networkService.post.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
-                      return Promise.resolve({ data: { taskId }, status: 200 });
+                      return Promise.resolve({
+                        data: rawify({ taskId }),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1403,10 +1539,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1441,10 +1583,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1481,10 +1629,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1522,10 +1676,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1558,10 +1718,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1592,7 +1758,10 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Unofficial mastercopy
                       return Promise.reject(new Error('Not found'));
@@ -1651,10 +1820,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safe.address}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1663,7 +1838,7 @@ describe('Relay controller', () => {
                   switch (url) {
                     case `${relayUrl}/relays/v2/sponsored-call`:
                       return Promise.resolve({
-                        data: { taskId },
+                        data: rawify({ taskId }),
                         status: 200,
                       });
                     default:
@@ -1718,7 +1893,10 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Unofficial mastercopy
                       return Promise.reject(new Error('Not found'));
@@ -1771,7 +1949,10 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Unofficial mastercopy
                       return Promise.reject(new Error('Not found'));
@@ -1823,10 +2004,16 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                       // Official mastercopy
-                      return Promise.resolve({ data: safe, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(safe),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1871,7 +2058,10 @@ describe('Relay controller', () => {
                 networkService.get.mockImplementation(({ url }) => {
                   switch (url) {
                     case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                      return Promise.resolve({ data: chain, status: 200 });
+                      return Promise.resolve({
+                        data: rawify(chain),
+                        status: 200,
+                      });
                     default:
                       return Promise.reject(`No matching rule for url: ${url}`);
                   }
@@ -1933,10 +2123,10 @@ describe('Relay controller', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                 // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
+                return Promise.resolve({ data: rawify(safe), status: 200 });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -1991,9 +2181,15 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                    return Promise.resolve({ data: { safes }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ safes }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2001,7 +2197,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2080,9 +2279,15 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   case `${chain.transactionService}/api/v1/modules/${moduleAddress}/safes/`:
-                    return Promise.resolve({ data: { safes }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ safes }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2090,7 +2295,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2133,10 +2341,13 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                     // Official mastercopy
-                    return Promise.resolve({ data: safe, status: 200 });
+                    return Promise.resolve({ data: rawify(safe), status: 200 });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2144,7 +2355,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2205,10 +2419,13 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                     // Official mastercopy
-                    return Promise.resolve({ data: safe, status: 200 });
+                    return Promise.resolve({ data: rawify(safe), status: 200 });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2216,7 +2433,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2274,7 +2494,10 @@ describe('Relay controller', () => {
               networkService.get.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                    return Promise.resolve({ data: chain, status: 200 });
+                    return Promise.resolve({
+                      data: rawify(chain),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2282,7 +2505,10 @@ describe('Relay controller', () => {
               networkService.post.mockImplementation(({ url }) => {
                 switch (url) {
                   case `${relayUrl}/relays/v2/sponsored-call`:
-                    return Promise.resolve({ data: { taskId }, status: 200 });
+                    return Promise.resolve({
+                      data: rawify({ taskId }),
+                      status: 200,
+                    });
                   default:
                     return Promise.reject(`No matching rule for url: ${url}`);
                 }
@@ -2323,11 +2549,11 @@ describe('Relay controller', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${chain.transactionService}/api/v1/safes/${nonChecksummedAddress}`:
               case `${chain.transactionService}/api/v1/safes/${checksummedSafeAddress}`:
                 // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
+                return Promise.resolve({ data: rawify(safe), status: 200 });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -2335,7 +2561,10 @@ describe('Relay controller', () => {
           networkService.post.mockImplementation(({ url }) => {
             switch (url) {
               case `${relayUrl}/relays/v2/sponsored-call`:
-                return Promise.resolve({ data: { taskId }, status: 200 });
+                return Promise.resolve({
+                  data: rawify({ taskId }),
+                  status: 200,
+                });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -2382,10 +2611,10 @@ describe('Relay controller', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                 // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
+                return Promise.resolve({ data: rawify(safe), status: 200 });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -2393,7 +2622,10 @@ describe('Relay controller', () => {
           networkService.post.mockImplementation(({ url }) => {
             switch (url) {
               case `${relayUrl}/relays/v2/sponsored-call`:
-                return Promise.resolve({ data: { taskId }, status: 200 });
+                return Promise.resolve({
+                  data: rawify({ taskId }),
+                  status: 200,
+                });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -2428,10 +2660,10 @@ describe('Relay controller', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
                 // Official mastercopy
-                return Promise.resolve({ data: safe, status: 200 });
+                return Promise.resolve({ data: rawify(safe), status: 200 });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -2439,7 +2671,10 @@ describe('Relay controller', () => {
           networkService.post.mockImplementation(({ url }) => {
             switch (url) {
               case `${relayUrl}/relays/v2/sponsored-call`:
-                return Promise.resolve({ data: { taskId }, status: 200 });
+                return Promise.resolve({
+                  data: rawify({ taskId }),
+                  status: 200,
+                });
               default:
                 return Promise.reject(`No matching rule for url: ${url}`);
             }
@@ -2480,10 +2715,10 @@ describe('Relay controller', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               // Official mastercopy
-              return Promise.resolve({ data: safe, status: 200 });
+              return Promise.resolve({ data: rawify(safe), status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -2530,10 +2765,10 @@ describe('Relay controller', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${chain.transactionService}/api/v1/safes/${safeAddress}`:
               // Official mastercopy
-              return Promise.resolve({ data: safe, status: 200 });
+              return Promise.resolve({ data: rawify(safe), status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }
@@ -2541,7 +2776,7 @@ describe('Relay controller', () => {
         networkService.post.mockImplementation(({ url }) => {
           switch (url) {
             case `${relayUrl}/relays/v2/sponsored-call`:
-              return Promise.resolve({ data: { taskId }, status: 200 });
+              return Promise.resolve({ data: rawify({ taskId }), status: 200 });
             default:
               return Promise.reject(`No matching rule for url: ${url}`);
           }

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -28,6 +28,7 @@ import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Safe Apps Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -94,7 +95,10 @@ describe('Safe Apps Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
-          return Promise.resolve({ data: safeAppsResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(safeAppsResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -154,7 +158,7 @@ describe('Safe Apps Controller (Unit)', () => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({
-            data: [
+            data: rawify([
               {
                 ...safeAppsResponse[0],
                 accessControl: {
@@ -162,7 +166,7 @@ describe('Safe Apps Controller (Unit)', () => {
                   value: null,
                 },
               },
-            ],
+            ]),
             status: 200,
           });
         }
@@ -215,7 +219,10 @@ describe('Safe Apps Controller (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
-          return Promise.resolve({ data: safeAppsResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(safeAppsResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });

--- a/src/routes/safes/safes.controller.nonces.spec.ts
+++ b/src/routes/safes/safes.controller.nonces.spec.ts
@@ -30,6 +30,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Safes Controller Nonces (Unit)', () => {
   let app: INestApplication<Server>;
@@ -83,12 +84,12 @@ describe('Safes Controller Nonces (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: multisigTransactionsPage,
+            data: rawify(multisigTransactionsPage),
             status: 200,
           });
       }
@@ -120,12 +121,12 @@ describe('Safes Controller Nonces (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: multisigTransactionsPage,
+            data: rawify(multisigTransactionsPage),
             status: 200,
           });
       }
@@ -149,12 +150,12 @@ describe('Safes Controller Nonces (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: multisigTransactionsPage,
+            data: rawify(multisigTransactionsPage),
             status: 200,
           });
       }

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -36,6 +36,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Safes Controller Overview (Unit)', () => {
   let app: INestApplication<Server>;
@@ -154,32 +155,32 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            return Promise.resolve({ data: safeInfo, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions,
+              data: rawify(queuedTransactions),
               status: 200,
             });
           }
@@ -326,32 +327,32 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            return Promise.resolve({ data: safeInfo, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions,
+              data: rawify(queuedTransactions),
               status: 200,
             });
           }
@@ -518,72 +519,72 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
-            return Promise.resolve({ data: chain1, status: 200 });
+            return Promise.resolve({ data: rawify(chain1), status: 200 });
           }
           case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
-            return Promise.resolve({ data: chain2, status: 200 });
+            return Promise.resolve({ data: rawify(chain2), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
-            return Promise.resolve({ data: safeInfo1, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo1), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
-            return Promise.resolve({ data: safeInfo2, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo2), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
-            return Promise.resolve({ data: safeInfo3, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo3), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse1,
+              data: rawify(transactionApiBalancesResponse1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse2,
+              data: rawify(transactionApiBalancesResponse2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse3,
+              data: rawify(transactionApiBalancesResponse3),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
 
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions1,
+              data: rawify(queuedTransactions1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions2,
+              data: rawify(queuedTransactions2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions3,
+              data: rawify(queuedTransactions3),
               status: 200,
             });
           }
@@ -742,71 +743,71 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
-            return Promise.resolve({ data: chain1, status: 200 });
+            return Promise.resolve({ data: rawify(chain1), status: 200 });
           }
           case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
-            return Promise.resolve({ data: chain2, status: 200 });
+            return Promise.resolve({ data: rawify(chain2), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
-            return Promise.resolve({ data: safeInfo1, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo1), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
-            return Promise.resolve({ data: safeInfo2, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo2), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
-            return Promise.resolve({ data: safeInfo3, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo3), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse1,
+              data: rawify(transactionApiBalancesResponse1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse2,
+              data: rawify(transactionApiBalancesResponse2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse3,
+              data: rawify(transactionApiBalancesResponse3),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions1,
+              data: rawify(queuedTransactions1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions2,
+              data: rawify(queuedTransactions2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions3,
+              data: rawify(queuedTransactions3),
               status: 200,
             });
           }
@@ -922,32 +923,32 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            return Promise.resolve({ data: safeInfo, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions,
+              data: rawify(queuedTransactions),
               status: 200,
             });
           }
@@ -1073,32 +1074,32 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            return Promise.resolve({ data: safeInfo, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions,
+              data: rawify(queuedTransactions),
               status: 200,
             });
           }
@@ -1275,68 +1276,68 @@ describe('Safes Controller Overview (Unit)', () => {
             return Promise.reject(error);
           }
           case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
-            return Promise.resolve({ data: chain2, status: 200 });
+            return Promise.resolve({ data: rawify(chain2), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
-            return Promise.resolve({ data: safeInfo1, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo1), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
-            return Promise.resolve({ data: safeInfo2, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo2), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
-            return Promise.resolve({ data: safeInfo3, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo3), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse1,
+              data: rawify(transactionApiBalancesResponse1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse2,
+              data: rawify(transactionApiBalancesResponse2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse3,
+              data: rawify(transactionApiBalancesResponse3),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions1,
+              data: rawify(queuedTransactions1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions2,
+              data: rawify(queuedTransactions2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions3,
+              data: rawify(queuedTransactions3),
               status: 200,
             });
           }
@@ -1459,10 +1460,10 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
-            return Promise.resolve({ data: chain1, status: 200 });
+            return Promise.resolve({ data: rawify(chain1), status: 200 });
           }
           case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
-            return Promise.resolve({ data: chain2, status: 200 });
+            return Promise.resolve({ data: rawify(chain2), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
             const error = new NetworkResponseError(
@@ -1476,50 +1477,50 @@ describe('Safes Controller Overview (Unit)', () => {
             return Promise.reject(error);
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
-            return Promise.resolve({ data: safeInfo2, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo2), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
-            return Promise.resolve({ data: safeInfo3, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo3), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse2,
+              data: rawify(transactionApiBalancesResponse2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse3,
+              data: rawify(transactionApiBalancesResponse3),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions2,
+              data: rawify(queuedTransactions2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions3,
+              data: rawify(queuedTransactions3),
               status: 200,
             });
           }
@@ -1660,71 +1661,71 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain1.chainId}`: {
-            return Promise.resolve({ data: chain1, status: 200 });
+            return Promise.resolve({ data: rawify(chain1), status: 200 });
           }
           case `${safeConfigUrl}/api/v1/chains/${chain2.chainId}`: {
-            return Promise.resolve({ data: chain2, status: 200 });
+            return Promise.resolve({ data: rawify(chain2), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}`: {
-            return Promise.resolve({ data: 'invalid', status: 200 });
+            return Promise.resolve({ data: rawify('invalid'), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}`: {
-            return Promise.resolve({ data: safeInfo2, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo2), status: 200 });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}`: {
-            return Promise.resolve({ data: safeInfo3, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo3), status: 200 });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse1,
+              data: rawify(transactionApiBalancesResponse1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse2,
+              data: rawify(transactionApiBalancesResponse2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse3,
+              data: rawify(transactionApiBalancesResponse3),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain1.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/token_price/${chain2.pricesProvider.chainName}`: {
             return Promise.resolve({
-              data: tokenPriceProviderResponse,
+              data: rawify(tokenPriceProviderResponse),
               status: 200,
             });
           }
           case `${chain1.transactionService}/api/v1/safes/${safeInfo1.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions1,
+              data: rawify(queuedTransactions1),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo2.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions2,
+              data: rawify(queuedTransactions2),
               status: 200,
             });
           }
           case `${chain2.transactionService}/api/v1/safes/${safeInfo3.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions3,
+              data: rawify(queuedTransactions3),
               status: 200,
             });
           }
@@ -1810,20 +1811,20 @@ describe('Safes Controller Overview (Unit)', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`: {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`: {
-            return Promise.resolve({ data: safeInfo, status: 200 });
+            return Promise.resolve({ data: rawify(safeInfo), status: 200 });
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`: {
             return Promise.resolve({
-              data: transactionApiBalancesResponse,
+              data: rawify(transactionApiBalancesResponse),
               status: 200,
             });
           }
           case `${pricesProviderUrl}/simple/price`: {
             return Promise.resolve({
-              data: nativeCoinPriceProviderResponse,
+              data: rawify(nativeCoinPriceProviderResponse),
               status: 200,
             });
           }
@@ -1832,7 +1833,7 @@ describe('Safes Controller Overview (Unit)', () => {
           }
           case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`: {
             return Promise.resolve({
-              data: queuedTransactions,
+              data: rawify(queuedTransactions),
               status: 200,
             });
           }

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -47,6 +47,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Safes Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -134,47 +135,60 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                erc721TransferToJson(
-                  erc721TransferBuilder()
-                    .with('executionDate', new Date('2016-09-19T02:55:04+0000'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  erc721TransferToJson(
+                    erc721TransferBuilder()
+                      .with(
+                        'executionDate',
+                        new Date('2016-09-19T02:55:04+0000'),
+                      )
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2049-01-30T14:23:07Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2049-01-30T14:23:07Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -245,25 +259,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -300,25 +326,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -356,25 +394,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -415,25 +465,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -473,25 +535,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -526,46 +600,57 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-18T03:52:02Z'))
-                    .build(),
-                ),
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-16T03:52:02Z'))
-                    .build(),
-                ),
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-14T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-18T03:52:02Z'))
+                      .build(),
+                  ),
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-16T03:52:02Z'))
+                      .build(),
+                  ),
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-14T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -601,25 +686,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -654,25 +751,34 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -726,25 +832,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -780,25 +898,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -833,25 +963,34 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -886,46 +1025,57 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-18T03:52:02Z'))
-                    .build(),
-                ),
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-16T03:52:02Z'))
-                    .build(),
-                ),
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-14T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-18T03:52:02Z'))
+                      .build(),
+                  ),
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-16T03:52:02Z'))
+                      .build(),
+                  ),
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-14T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -960,49 +1110,60 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', null)
-                    .with('submissionDate', new Date('2020-09-17T03:52:02Z'))
-                    .build(),
-                ),
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-16T03:52:02Z'))
-                    .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
-                    .build(),
-                ),
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-14T03:52:02Z'))
-                    .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', null)
+                      .with('submissionDate', new Date('2020-09-17T03:52:02Z'))
+                      .build(),
+                  ),
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-16T03:52:02Z'))
+                      .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+                      .build(),
+                  ),
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-14T03:52:02Z'))
+                      .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1036,48 +1197,58 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                erc721TransferToJson(
-                  erc721TransferBuilder()
-                    .with('executionDate', new Date('2020-09-17T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  erc721TransferToJson(
+                    erc721TransferBuilder()
+                      .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-16T03:52:02Z'))
-                    .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-16T03:52:02Z'))
+                      .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1110,51 +1281,58 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
-            data: pageBuilder().build(),
+            data: rawify(pageBuilder().build()),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                multisigTransactionToJson(
-                  multisigTransactionBuilder()
-                    .with('modified', new Date('2020-09-16T03:52:02Z'))
-                    .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  multisigTransactionToJson(
+                    multisigTransactionBuilder()
+                      .with('modified', new Date('2020-09-16T03:52:02Z'))
+                      .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                moduleTransactionToJson(
-                  moduleTransactionBuilder()
-                    .with('executionDate', new Date('2020-09-17T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  moduleTransactionToJson(
+                    moduleTransactionBuilder()
+                      .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1190,25 +1368,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: multisigTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1241,39 +1431,44 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                erc721TransferToJson(
-                  erc721TransferBuilder()
-                    .with('executionDate', new Date('2020-09-17T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  erc721TransferToJson(
+                    erc721TransferBuilder()
+                      .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.resolve({
-            data: pageBuilder().build(),
+            data: rawify(pageBuilder().build()),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1306,36 +1501,41 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.resolve({
-            data: pageBuilder()
-              .with('results', [
-                moduleTransactionToJson(
-                  moduleTransactionBuilder()
-                    .with('executionDate', new Date('2020-09-17T03:52:02Z'))
-                    .build(),
-                ),
-              ])
-              .build(),
+            data: rawify(
+              pageBuilder()
+                .with('results', [
+                  moduleTransactionToJson(
+                    moduleTransactionBuilder()
+                      .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+                      .build(),
+                  ),
+                ])
+                .build(),
+            ),
             status: 200,
           });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1368,17 +1568,20 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
@@ -1386,7 +1589,7 @@ describe('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
           return Promise.reject({ status: 500 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1441,25 +1644,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1496,25 +1711,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1555,31 +1782,43 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${module1}`:
-          return Promise.resolve({ data: moduleInfo1, status: 200 });
+          return Promise.resolve({ data: rawify(moduleInfo1), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${module2}`:
-          return Promise.resolve({ data: moduleInfo2, status: 200 });
+          return Promise.resolve({ data: rawify(moduleInfo2), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${module3}`:
-          return Promise.resolve({ data: moduleInfo3, status: 200 });
+          return Promise.resolve({ data: rawify(moduleInfo3), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1632,25 +1871,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1684,25 +1935,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${safeInfo.fallbackHandler}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1731,26 +1994,35 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${safeInfo.fallbackHandler}`:
           // Return 404 for Fallback Handler Info
           return Promise.reject({ status: 404 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1786,25 +2058,37 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
-          return Promise.resolve({ data: fallbackHandlerInfo, status: 200 });
+          return Promise.resolve({
+            data: rawify(fallbackHandlerInfo),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
-          return Promise.resolve({ data: guardInfo, status: 200 });
+          return Promise.resolve({ data: rawify(guardInfo), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -1834,26 +2118,35 @@ describe('Safes Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
-          return Promise.resolve({ data: safeInfo, status: 200 });
+          return Promise.resolve({ data: rawify(safeInfo), status: 200 });
         case `${chain.transactionService}/api/v1/about/singletons/`:
-          return Promise.resolve({ data: singletons, status: 200 });
+          return Promise.resolve({ data: rawify(singletons), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${singletonInfo.address}`:
-          return Promise.resolve({ data: singletonInfo, status: 200 });
+          return Promise.resolve({ data: rawify(singletonInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${safeInfo.fallbackHandler}`:
-          return Promise.resolve({ data: fallbackInfo, status: 200 });
+          return Promise.resolve({ data: rawify(fallbackInfo), status: 200 });
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
           // Return 404 for Guard Info
           return Promise.reject({ status: 404 });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers, status: 200 });
+          return Promise.resolve({
+            data: rawify(collectibleTransfers),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(queuedTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
-          return Promise.resolve({ data: moduleTransactions, status: 200 });
+          return Promise.resolve({
+            data: rawify(moduleTransactions),
+            status: 200,
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
-          return Promise.resolve({ data: messages, status: 200 });
+          return Promise.resolve({ data: rawify(messages), status: 200 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });

--- a/src/routes/targeted-messaging/targeted-messaging.controller.spec.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.controller.spec.ts
@@ -26,6 +26,7 @@ import { SubmissionNotFoundError } from '@/domain/targeted-messaging/errors/subm
 import { TargetedSafeNotFoundError } from '@/domain/targeted-messaging/errors/targeted-safe-not-found.error';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker/.';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
@@ -100,10 +101,10 @@ describe('TargetedMessagingController', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({
-              data: safe,
+              data: rawify(safe),
               status: 200,
             });
           default:
@@ -148,10 +149,10 @@ describe('TargetedMessagingController', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({
-              data: safe,
+              data: rawify(safe),
               status: 200,
             });
           default:
@@ -214,10 +215,10 @@ describe('TargetedMessagingController', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({
-              data: safe,
+              data: rawify(safe),
               status: 200,
             });
           default:
@@ -290,10 +291,10 @@ describe('TargetedMessagingController', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({
-              data: safe,
+              data: rawify(safe),
               status: 200,
             });
           default:
@@ -360,10 +361,10 @@ describe('TargetedMessagingController', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({
-              data: safe,
+              data: rawify(safe),
               status: 200,
             });
           default:
@@ -412,10 +413,10 @@ describe('TargetedMessagingController', () => {
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({
-              data: safe,
+              data: rawify(safe),
               status: 200,
             });
           default:

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -27,6 +27,7 @@ import { NetworkService } from '@/datasources/network/network.service.interface'
 import { addConfirmationDtoBuilder } from '@/routes/transactions/__tests__/entities/add-confirmation.dto.builder';
 import { getAddress } from 'viem';
 import type { Server } from 'net';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Add transaction confirmations - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -98,21 +99,24 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: transaction, status: 200 });
+          return Promise.resolve({ data: rawify(transaction), status: 200 });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
+          return Promise.resolve({
+            data: rawify(rejectionTxsPage),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeApps, status: 200 });
+          return Promise.resolve({ data: rawify(safeApps), status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken, status: 200 });
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getToTokenUrl:
-          return Promise.resolve({ data: token, status: 200 });
+          return Promise.resolve({ data: rawify(token), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -121,7 +125,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       switch (url) {
         case postConfirmationUrl:
-          return Promise.resolve({ data: {}, status: 200 });
+          return Promise.resolve({ data: rawify({}), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/delete-transaction.transactions.controller.spec.ts
@@ -34,6 +34,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Delete Transaction - Transactions Controller (Unit', () => {
   let app: INestApplication<Server>;
@@ -108,13 +109,16 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
 
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (
         url ===
         `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}/`
       ) {
-        return Promise.resolve({ data: multisigToJson(tx), status: 200 });
+        return Promise.resolve({
+          data: rawify(multisigToJson(tx)),
+          status: 200,
+        });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -123,7 +127,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
         url ===
         `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}`
       ) {
-        return Promise.resolve({ data: {}, status: 204 });
+        return Promise.resolve({ data: rawify({}), status: 204 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -143,13 +147,16 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
 
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (
         url ===
         `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}/`
       ) {
-        return Promise.resolve({ data: multisigToJson(tx), status: 200 });
+        return Promise.resolve({
+          data: rawify(multisigToJson(tx)),
+          status: 200,
+        });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -158,7 +165,7 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
         url ===
         `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}`
       ) {
-        return Promise.resolve({ data: {}, status: 204 });
+        return Promise.resolve({ data: rawify({}), status: 204 });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -192,13 +199,16 @@ describe('Delete Transaction - Transactions Controller (Unit', () => {
     const tx = multisigTransactionBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (
         url ===
         `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}/`
       ) {
-        return Promise.resolve({ data: multisigToJson(tx), status: 200 });
+        return Promise.resolve({
+          data: rawify(multisigToJson(tx)),
+          status: 200,
+        });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });

--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -25,6 +25,7 @@ import {
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { rawify } from '@/validation/entities/raw.entity';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
@@ -80,10 +81,10 @@ describe('Get creation transaction', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getCreationTransactionUrl:
           return Promise.resolve({
-            data: creationTransactionToJson(creationTransaction),
+            data: rawify(creationTransactionToJson(creationTransaction)),
             status: 200,
           });
         default:
@@ -112,7 +113,7 @@ describe('Get creation transaction', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getCreationTransactionUrl:
           return Promise.reject(
             new NetworkResponseError(new URL(getCreationTransactionUrl), {
@@ -139,7 +140,7 @@ describe('Get creation transaction', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getCreationTransactionUrl:
           return Promise.reject(new Error());
         default:
@@ -166,7 +167,7 @@ describe('Get creation transaction', () => {
           return Promise.reject(new Error());
         case getCreationTransactionUrl:
           return Promise.resolve({
-            data: creationTransactionToJson(creationTransaction),
+            data: rawify(creationTransactionToJson(creationTransaction)),
             status: 200,
           });
         default:

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -46,6 +46,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Get by id - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -122,7 +123,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getModuleTransactionUrl: {
           const error = new NetworkResponseError(
             new URL(getModuleTransactionUrl),
@@ -165,9 +166,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getModuleTransactionUrl: {
           const error = new NetworkResponseError(
             new URL(getModuleTransactionUrl),
@@ -216,18 +217,18 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getModuleTransactionUrl:
           return Promise.resolve({
-            data: moduleTransactionToJson(moduleTransaction),
+            data: rawify(moduleTransactionToJson(moduleTransaction)),
             status: 200,
           });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getModuleContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -285,9 +286,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getTransferUrl: {
           const error = new NetworkResponseError(new URL(getTransferUrl), {
             status: 404,
@@ -328,18 +329,18 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getTransferUrl:
           return Promise.resolve({
-            data: nativeTokenTransferToJson(transfer),
+            data: rawify(nativeTokenTransferToJson(transfer)),
             status: 200,
           });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getFromContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -385,9 +386,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getMultisigTransactionUrl: {
           const error = new NetworkResponseError(
             new URL(getMultisigTransactionUrl),
@@ -469,21 +470,30 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(tx), status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigToJson(tx)),
+            status: 200,
+          });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
+          return Promise.resolve({
+            data: rawify(rejectionTxsPage),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken, status: 200 });
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getToTokenUrl:
-          return Promise.resolve({ data: token, status: 200 });
+          return Promise.resolve({ data: rawify(token), status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(safeAppsResponse),
+            status: 200,
+          });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -636,21 +646,30 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(tx), status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigToJson(tx)),
+            status: 200,
+          });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
+          return Promise.resolve({
+            data: rawify(rejectionTxsPage),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken, status: 200 });
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getToTokenUrl:
-          return Promise.resolve({ data: token, status: 200 });
+          return Promise.resolve({ data: rawify(token), status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(safeAppsResponse),
+            status: 200,
+          });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -804,19 +823,28 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getMultisigTransactionUrl:
-          return Promise.resolve({ data: multisigToJson(tx), status: 200 });
+          return Promise.resolve({
+            data: rawify(multisigToJson(tx)),
+            status: 200,
+          });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rejectionTxsPage, status: 200 });
+          return Promise.resolve({
+            data: rawify(rejectionTxsPage),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken, status: 200 });
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeAppsResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(safeAppsResponse),
+            status: 200,
+          });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -43,6 +43,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('List incoming transfers by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -117,7 +118,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const limit = faker.number.int({ min: 0, max: 100 });
     const offset = faker.number.int({ min: 0, max: 100 });
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     const error = new NetworkResponseError(
@@ -157,11 +158,11 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     networkService.get.mockResolvedValueOnce({
-      data: { results: ['invalidData'] },
+      data: rawify({ results: ['invalidData'] }),
       status: 200,
     });
 
@@ -175,9 +176,12 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
     const page = pageBuilder().build();
-    networkService.get.mockResolvedValueOnce({ data: chain, status: 200 });
     networkService.get.mockResolvedValueOnce({
-      data: { ...page, next: faker.datatype.boolean() },
+      data: rawify(chain),
+      status: 200,
+    });
+    networkService.get.mockResolvedValueOnce({
+      data: rawify({ ...page, next: faker.datatype.boolean() }),
       status: 200,
     });
 
@@ -210,24 +214,26 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${erc20Transfer.tokenAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [erc20TransferToJson(erc20Transfer)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [erc20TransferToJson(erc20Transfer)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found' });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token, status: 200 });
+        return Promise.resolve({ data: rawify(token), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -295,24 +301,26 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${erc20Transfer.tokenAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [erc20TransferToJson(erc20Transfer)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [erc20TransferToJson(erc20Transfer)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found' });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token, status: 200 });
+        return Promise.resolve({ data: rawify(token), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -379,24 +387,26 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${erc20Transfer.tokenAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [erc20TransferToJson(erc20Transfer)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [erc20TransferToJson(erc20Transfer)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found' });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token, status: 200 });
+        return Promise.resolve({ data: rawify(token), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -432,24 +442,26 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${erc721Transfer.tokenAddress}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [erc721TransferToJson(erc721Transfer)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [erc721TransferToJson(erc721Transfer)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found' });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token, status: 200 });
+        return Promise.resolve({ data: rawify(token), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -506,18 +518,20 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getIncomingTransfersUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [nativeTokenTransferToJson(nativeTokenTransfer)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [nativeTokenTransferToJson(nativeTokenTransfer)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found', status: 404 });

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -32,6 +32,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('List module transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -102,7 +103,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     const error = new NetworkResponseError(
@@ -132,9 +133,12 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const safeAddress = faker.finance.ethereumAddress();
     const page = pageBuilder().build();
     const chain = chainBuilder().with('chainId', chainId).build();
-    networkService.get.mockResolvedValueOnce({ data: chain, status: 200 });
     networkService.get.mockResolvedValueOnce({
-      data: { ...page, count: faker.word.words() },
+      data: rawify(chain),
+      status: 200,
+    });
+    networkService.get.mockResolvedValueOnce({
+      data: rawify({ ...page, count: faker.word.words() }),
       status: 200,
     });
 
@@ -152,7 +156,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     const error = new NetworkResponseError(
@@ -195,14 +199,17 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
 
     const safe = safeBuilder().build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     networkService.get.mockResolvedValueOnce({
-      data: moduleTransaction,
+      data: rawify(moduleTransaction),
       status: 200,
     });
-    networkService.get.mockResolvedValueOnce({ data: safe, status: 200 });
+    networkService.get.mockResolvedValueOnce({
+      data: rawify(safe),
+      status: 200,
+    });
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -42,6 +42,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('List multisig transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -114,7 +115,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     const error = new NetworkResponseError(
@@ -156,11 +157,11 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     networkService.get.mockResolvedValueOnce({
-      data: { results: ['invalidData'] },
+      data: rawify({ results: ['invalidData'] }),
       status: 200,
     });
 
@@ -176,11 +177,11 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     const page = pageBuilder().build();
     networkService.get.mockResolvedValueOnce({
-      data: chainResponse,
+      data: rawify(chainResponse),
       status: 200,
     });
     networkService.get.mockResolvedValueOnce({
-      data: { ...page, count: 'invalid' },
+      data: rawify({ ...page, count: 'invalid' }),
       status: 200,
     });
 
@@ -237,24 +238,26 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [multisigTransactionToJson(multisigTransaction)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [multisigTransactionToJson(multisigTransaction)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found', status: 404 });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token, status: 200 });
+        return Promise.resolve({ data: rawify(token), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -361,24 +364,26 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/0x7Af3460d552f832fD7E2DE973c628ACeA59B0712`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [multisigTransactionToJson(multisigTransaction)])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [multisigTransactionToJson(multisigTransaction)])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found', status: 404 });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: token, status: 200 });
+        return Promise.resolve({ data: rawify(token), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -462,22 +467,25 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${domainTransaction.safe}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeAppsResponse), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
-          data: multisigTransactionsPage,
+          data: rawify(multisigTransactionsPage),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeBuilder().build(), status: 200 });
+        return Promise.resolve({
+          data: rawify(safeBuilder().build()),
+          status: 200,
+        });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse, status: 200 });
+        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -30,6 +30,7 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import type { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
@@ -91,16 +92,16 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
-          data: { ...page, count: faker.word.words() },
+          data: rawify({ ...page, count: faker.word.words() }),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -191,27 +192,27 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
-          data: {
+          data: rawify({
             count: 6,
             next: null,
             previous: null,
             results: transactions,
-          },
+          }),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeAppsResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse, status: 200 });
+        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -385,11 +386,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         return Promise.resolve({
-          data: {
+          data: rawify({
             count: 20,
             next: `${faker.internet.url({
               appendSlash: false,
@@ -398,18 +399,18 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
               appendSlash: false,
             })}/?limit=10&offset=30`,
             results: transactions,
-          },
+          }),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeAppsResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse, status: 200 });
+        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -526,7 +527,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getMultisigTransactionsUrl) {
         if (!networkRequest?.params) {
@@ -535,23 +536,23 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         expect(networkRequest.params.trusted).toBe(false);
 
         return Promise.resolve({
-          data: {
+          data: rawify({
             count: 2,
             next: null,
             previous: null,
             results: transactions,
-          },
+          }),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: safeAppsResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeAppsResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse, status: 200 });
+        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
@@ -38,6 +38,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -120,38 +121,41 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -249,44 +253,47 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${swapTransaction.to}`
         ) {
-          return Promise.resolve({ data: tokenResponse, status: 200 });
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -372,38 +379,41 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -443,7 +453,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
           return Promise.reject({ status: 500 });
@@ -451,20 +461,23 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -500,10 +513,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
@@ -513,25 +526,28 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -567,15 +583,15 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
@@ -585,20 +601,23 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -636,38 +655,41 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
         ) {
-          return Promise.resolve({ data: contractResponse, status: 200 });
+          return Promise.resolve({
+            data: rawify(contractResponse),
+            status: 200,
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -732,40 +754,40 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${buyToken.address}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${sellToken.address}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/app_data/${appDataHash}`) {
-          return Promise.resolve({ data: fullAppData, status: 200 });
+          return Promise.resolve({ data: rawify(fullAppData), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contract.address}`
         ) {
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -862,46 +884,46 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${buyToken.address}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${sellToken.address}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/app_data/${appDataHash}`) {
-          return Promise.resolve({ data: fullAppData, status: 200 });
+          return Promise.resolve({ data: rawify(fullAppData), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contract.address}`
         ) {
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${twapTransaction.to}`
         ) {
-          return Promise.resolve({ data: tokenResponse, status: 200 });
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -983,7 +1005,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (
           url ===
@@ -995,28 +1017,28 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
           url ===
           `${chain.transactionService}/api/v1/tokens/${sellToken.address}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/app_data/${appDataHash}`) {
-          return Promise.resolve({ data: fullAppData, status: 200 });
+          return Promise.resolve({ data: rawify(fullAppData), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contract.address}`
         ) {
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -1045,13 +1067,13 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${buyToken.address}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url ===
@@ -1060,25 +1082,25 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
           return Promise.reject({ status: 500 });
         }
         if (url === `${swapsApiUrl}/api/v1/app_data/${appDataHash}`) {
-          return Promise.resolve({ data: fullAppData, status: 200 });
+          return Promise.resolve({ data: rawify(fullAppData), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contract.address}`
         ) {
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -1114,40 +1136,40 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       };
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${buyToken.address}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${sellToken.address}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/app_data/${appDataHash}`) {
-          return Promise.resolve({ data: fullAppData, status: 200 });
+          return Promise.resolve({ data: rawify(fullAppData), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/safes/${safe.address}`
         ) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/contracts/${contract.address}`
         ) {
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -50,6 +50,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -123,35 +124,35 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/kiln-stats`:
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             default:
@@ -160,7 +161,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -269,45 +270,45 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/kiln-stats`:
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${depositContractResponse.address}`:
               return Promise.resolve({
-                data: depositContractResponse,
+                data: rawify(depositContractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${depositTokenResponse.address}`:
               return Promise.resolve({
-                data: depositTokenResponse,
+                data: rawify(depositTokenResponse),
                 status: 200,
               });
             default:
@@ -316,7 +317,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -404,24 +405,24 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.reject({
                 status: 500,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -430,7 +431,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -470,25 +471,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -497,7 +498,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -538,25 +539,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -565,7 +566,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -604,25 +605,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -631,7 +632,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -671,25 +672,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -698,7 +699,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -739,10 +740,10 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/kiln-stats`:
@@ -751,22 +752,22 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -775,7 +776,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -816,15 +817,15 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/kiln-stats`:
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
@@ -833,17 +834,17 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -852,7 +853,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -906,30 +907,30 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             default:
@@ -938,7 +939,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1042,45 +1043,45 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${requestValidatorsExiContractResponse.address}`:
               return Promise.resolve({
-                data: requestValidatorsExiContractResponse,
+                data: rawify(requestValidatorsExiContractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${requestValidatorsExitTokenResponse.address}`:
               return Promise.resolve({
-                data: requestValidatorsExitTokenResponse,
+                data: rawify(requestValidatorsExitTokenResponse),
                 status: 200,
               });
             default:
@@ -1089,7 +1090,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1167,24 +1168,24 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.reject({
                 status: 500,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1193,7 +1194,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1242,25 +1243,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1269,7 +1270,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1320,25 +1321,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1347,7 +1348,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1396,25 +1397,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1423,7 +1424,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1477,10 +1478,10 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
@@ -1489,22 +1490,22 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1513,7 +1514,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1564,15 +1565,15 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
@@ -1581,17 +1582,17 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1600,7 +1601,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1661,25 +1662,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             default:
@@ -1688,7 +1689,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1796,40 +1797,40 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${batchWithdrawCLFeeContractResponse.address}`:
               return Promise.resolve({
-                data: batchWithdrawCLFeeContractResponse,
+                data: rawify(batchWithdrawCLFeeContractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${batchWithdrawCLFeeTokenResponse.address}`:
               return Promise.resolve({
-                data: batchWithdrawCLFeeTokenResponse,
+                data: rawify(batchWithdrawCLFeeTokenResponse),
                 status: 200,
               });
             default:
@@ -1838,7 +1839,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1917,24 +1918,24 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.reject({
                 status: 500,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -1943,7 +1944,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -1997,25 +1998,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -2024,7 +2025,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -2079,25 +2080,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -2106,7 +2107,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -2159,25 +2160,25 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
               return Promise.resolve({
-                data: tokenResponse,
+                data: rawify(tokenResponse),
                 status: 200,
               });
             default:
@@ -2186,7 +2187,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });
@@ -2237,10 +2238,10 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
@@ -2249,12 +2250,12 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
-                data: safe,
+                data: rawify(safe),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: contractResponse,
+                data: rawify(contractResponse),
                 status: 200,
               });
             default:
@@ -2263,7 +2264,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         });
         networkService.post.mockImplementation(({ url }) => {
           if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-            return Promise.resolve({ data: dataDecoded, status: 200 });
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           }
           return Promise.reject(new Error(`Could not match ${url}`));
         });

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -34,6 +34,7 @@ import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Preview transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -109,20 +110,23 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse, status: 200 });
+        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
     networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
-        return Promise.resolve({ data: dataDecodedResponse, status: 200 });
+        return Promise.resolve({
+          data: rawify(dataDecodedResponse),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -175,10 +179,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ status: 404 });
@@ -188,7 +192,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
-        return Promise.resolve({ data: dataDecodedResponse, status: 200 });
+        return Promise.resolve({
+          data: rawify(dataDecodedResponse),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -240,10 +247,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ status: 404 });
@@ -320,20 +327,23 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safeResponse, status: 200 });
+        return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: contractResponse, status: 200 });
+        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
     networkService.post.mockImplementation(({ url }) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
-        return Promise.resolve({ data: dataDecodedResponse, status: 200 });
+        return Promise.resolve({
+          data: rawify(dataDecodedResponse),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -36,6 +36,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Propose transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -121,24 +122,24 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getMultisigTransactionUrl:
           return Promise.resolve({
-            data: multisigToJson(transaction),
+            data: rawify(multisigToJson(transaction)),
             status: 200,
           });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: transactions, status: 200 });
+          return Promise.resolve({ data: rawify(transactions), status: 200 });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case getSafeAppsUrl:
-          return Promise.resolve({ data: safeApps, status: 200 });
+          return Promise.resolve({ data: rawify(safeApps), status: 200 });
         case getContractUrl:
-          return Promise.resolve({ data: contract, status: 200 });
+          return Promise.resolve({ data: rawify(contract), status: 200 });
         case getTokenUrl:
-          return Promise.resolve({ data: token, status: 200 });
+          return Promise.resolve({ data: rawify(token), status: 200 });
         case getGasTokenContractUrl:
-          return Promise.resolve({ data: gasToken, status: 200 });
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -147,7 +148,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       switch (url) {
         case proposeTransactionUrl:
-          return Promise.resolve({ data: {}, status: 200 });
+          return Promise.resolve({ data: rawify({}), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -66,6 +66,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -149,7 +150,7 @@ describe('Transactions History Controller (Unit)', () => {
       // Param ValidationPipe checksums address
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         const error = new NetworkResponseError(new URL(getAllTransactions), {
@@ -180,11 +181,11 @@ describe('Transactions History Controller (Unit)', () => {
       // Param ValidationPipe checksums address
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: page,
+          data: rawify(page),
           status: 200,
         });
       }
@@ -219,20 +220,20 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/creation/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: transactionHistoryBuilder,
+          data: rawify(transactionHistoryBuilder),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url === getSafeCreationUrl) {
         return Promise.resolve({
-          data: creationTransactionToJson(creationTransaction),
+          data: rawify(creationTransactionToJson(creationTransaction)),
           status: 200,
         });
       }
@@ -288,16 +289,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: transactionHistoryBuilder,
+          data: rawify(transactionHistoryBuilder),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -347,16 +348,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: transactionHistoryBuilder,
+          data: rawify(transactionHistoryBuilder),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -403,16 +404,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: transactionHistoryBuilder,
+          data: rawify(transactionHistoryBuilder),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -473,16 +474,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: transactionHistoryBuilder,
+          data: rawify(transactionHistoryBuilder),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -570,25 +571,27 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: pageBuilder()
-            .with('results', [
-              moduleTransactionToJson(moduleTransaction),
-              multisigTransactionToJson(multisigTransaction),
-              ethereumTransactionToJson(incomingTransaction),
-            ])
-            .build(),
+          data: rawify(
+            pageBuilder()
+              .with('results', [
+                moduleTransactionToJson(moduleTransaction),
+                multisigTransactionToJson(multisigTransaction),
+                ethereumTransactionToJson(incomingTransaction),
+              ])
+              .build(),
+          ),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url === getTokenUrlPattern) {
-        return Promise.resolve({ data: tokenResponse, status: 200 });
+        return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -726,23 +729,23 @@ describe('Transactions History Controller (Unit)', () => {
       const getContractUrl = `${chainResponse.transactionService}/api/v1/contracts/`;
       const getSafeCreationUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/creation/`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: allTransactionsResponse,
+          data: rawify(allTransactionsResponse),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
         return Promise.resolve({
-          data: safe,
+          data: rawify(safe),
           status: 200,
         });
       }
       if (url === getSafeCreationUrl) {
         return Promise.resolve({
-          data: creationTransactionToJson(creationTransaction),
+          data: rawify(creationTransactionToJson(creationTransaction)),
           status: 200,
         });
       }
@@ -806,16 +809,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${getAddress(safeAddress)}`;
       if (url === getChainUrl) {
-        return Promise.resolve({ data: chainResponse, status: 200 });
+        return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
       if (url === getAllTransactions) {
         return Promise.resolve({
-          data: transactionHistoryBuilder,
+          data: rawify(transactionHistoryBuilder),
           status: 200,
         });
       }
       if (url === getSafeUrl) {
-        return Promise.resolve({ data: safe, status: 200 });
+        return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -881,11 +884,14 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -946,15 +952,18 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(trustedToken), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(untrustedToken), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1038,13 +1047,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(untrustedToken), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1139,15 +1151,18 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(trustedToken), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(untrustedToken), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1227,15 +1242,18 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(trustedToken), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${untrustedToken.address}`:
-          return Promise.resolve({ data: untrustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(untrustedToken), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1308,13 +1326,16 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedToken.address}`:
-          return Promise.resolve({ data: trustedToken, status: 200 });
+          return Promise.resolve({ data: rawify(trustedToken), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -1384,15 +1405,21 @@ describe('Transactions History Controller (Unit)', () => {
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       switch (url) {
         case getChainUrl:
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         case getAllTransactions:
-          return Promise.resolve({ data: transactionHistoryData, status: 200 });
+          return Promise.resolve({
+            data: rawify(transactionHistoryData),
+            status: 200,
+          });
         case getSafeUrl:
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${trustedErc721.address}`:
-          return Promise.resolve({ data: trustedErc721, status: 200 });
+          return Promise.resolve({ data: rawify(trustedErc721), status: 200 });
         case `${chain.transactionService}/api/v1/tokens/${notTrustedErc721.address}`:
-          return Promise.resolve({ data: notTrustedErc721, status: 200 });
+          return Promise.resolve({
+            data: rawify(notTrustedErc721),
+            status: 200,
+          });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -54,6 +54,7 @@ import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.mo
 import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+import { rawify } from '@/validation/entities/raw.entity';
 
 describe('Transactions History Controller (Unit) - Imitation Transactions', () => {
   let app: INestApplication<Server>;
@@ -333,32 +334,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -604,32 +605,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
 
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -876,32 +877,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
 
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -1067,32 +1068,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
 
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -1365,32 +1366,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -1645,32 +1646,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -1926,32 +1927,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -2206,32 +2207,32 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
           if (url === getImitationTokenAddressUrl) {
             return Promise.resolve({
-              data: imitationToken,
+              data: rawify(imitationToken),
               status: 200,
             });
           }
@@ -2532,20 +2533,20 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
       ];
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === getAllTransactionsUrl) {
           return Promise.resolve({
-            data: pageBuilder().with('results', results).build(),
+            data: rawify(pageBuilder().with('results', results).build()),
             status: 200,
           });
         }
         if (url === getSafeUrl) {
-          return Promise.resolve({ data: safe, status: 200 });
+          return Promise.resolve({ data: rawify(safe), status: 200 });
         }
         if (url === getTokenAddressUrl) {
           return Promise.resolve({
-            data: multisigToken,
+            data: rawify(multisigToken),
             status: 200,
           });
         }
@@ -2554,7 +2555,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
           `${chain.transactionService}/api/v1/tokens/${imitationWithDifferentDecimalsToken.address}`
         ) {
           return Promise.resolve({
-            data: imitationWithDifferentDecimalsToken,
+            data: rawify(imitationWithDifferentDecimalsToken),
             status: 200,
           });
         }
@@ -2830,20 +2831,20 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         const results = [imitationIncomingTransaction, multisigTransaction];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
@@ -2960,26 +2961,26 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
 
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
@@ -3224,20 +3225,20 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         const results = [imitationIncomingTransaction, multisigTransaction];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
@@ -3314,26 +3315,26 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
 
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }
@@ -3620,20 +3621,20 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         const results = [aboveLimitIncomingTransaction, multisigTransaction];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
@@ -3758,26 +3759,26 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         ];
         networkService.get.mockImplementation(({ url }) => {
           if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-            return Promise.resolve({ data: chain, status: 200 });
+            return Promise.resolve({ data: rawify(chain), status: 200 });
           }
           if (url === getAllTransactionsUrl) {
             return Promise.resolve({
-              data: pageBuilder().with('results', results).build(),
+              data: rawify(pageBuilder().with('results', results).build()),
               status: 200,
             });
           }
           if (url === getSafeUrl) {
-            return Promise.resolve({ data: safe, status: 200 });
+            return Promise.resolve({ data: rawify(safe), status: 200 });
           }
           if (url === getTokenAddressUrl) {
             return Promise.resolve({
-              data: multisigToken,
+              data: rawify(multisigToken),
               status: 200,
             });
           }
           if (url === getNotImitatedTokenAddressUrl) {
             return Promise.resolve({
-              data: notImitatedMultisigToken,
+              data: rawify(notImitatedMultisigToken),
               status: 200,
             });
           }

--- a/src/routes/transactions/transactions-view.controller.spec.ts
+++ b/src/routes/transactions/transactions-view.controller.spec.ts
@@ -37,6 +37,7 @@ import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { NULL_ADDRESS } from '@/routes/common/constants';
+import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import { NotFoundException, ServiceUnavailableException } from '@nestjs/common';
@@ -109,13 +110,13 @@ describe('TransactionsViewController tests', () => {
     const dataDecoded = dataDecodedBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: chain, status: 200 });
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
     networkService.post.mockImplementation(({ url }) => {
       if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-        return Promise.resolve({ data: dataDecoded, status: 200 });
+        return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -150,27 +151,27 @@ describe('TransactionsViewController tests', () => {
       const sellToken = tokenBuilder().with('address', order.sellToken).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -255,29 +256,29 @@ describe('TransactionsViewController tests', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${buyToken.address}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url ===
           `${chain.transactionService}/api/v1/tokens/${sellToken.address}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/app_data/${appDataHash}`) {
-          return Promise.resolve({ data: fullAppData, status: 200 });
+          return Promise.resolve({ data: rawify(fullAppData), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -314,7 +315,7 @@ describe('TransactionsViewController tests', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
           return Promise.reject({ status: 500 });
@@ -324,7 +325,7 @@ describe('TransactionsViewController tests', () => {
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -359,10 +360,10 @@ describe('TransactionsViewController tests', () => {
       const sellToken = tokenBuilder().with('address', order.sellToken).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
@@ -372,14 +373,14 @@ describe('TransactionsViewController tests', () => {
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -414,15 +415,15 @@ describe('TransactionsViewController tests', () => {
       const buyToken = tokenBuilder().with('address', order.sellToken).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
@@ -434,7 +435,7 @@ describe('TransactionsViewController tests', () => {
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -471,27 +472,27 @@ describe('TransactionsViewController tests', () => {
       const sellToken = tokenBuilder().with('address', order.sellToken).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -528,27 +529,27 @@ describe('TransactionsViewController tests', () => {
       const sellToken = tokenBuilder().with('address', order.sellToken).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-          return Promise.resolve({ data: chain, status: 200 });
+          return Promise.resolve({ data: rawify(chain), status: 200 });
         }
         if (url === `${swapsApiUrl}/api/v1/orders/${order.uid}`) {
-          return Promise.resolve({ data: order, status: 200 });
+          return Promise.resolve({ data: rawify(order), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.buyToken}`
         ) {
-          return Promise.resolve({ data: buyToken, status: 200 });
+          return Promise.resolve({ data: rawify(buyToken), status: 200 });
         }
         if (
           url === `${chain.transactionService}/api/v1/tokens/${order.sellToken}`
         ) {
-          return Promise.resolve({ data: sellToken, status: 200 });
+          return Promise.resolve({ data: rawify(sellToken), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
       networkService.post.mockImplementation(({ url }) => {
         if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
           return Promise.resolve({
-            data: dataDecoded,
+            data: rawify(dataDecoded),
             status: 200,
           });
         }
@@ -595,25 +596,25 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/kiln-stats`:
                 return Promise.resolve({
-                  data: { data: dedicatedStakingStats },
+                  data: rawify({ data: dedicatedStakingStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/network-stats`:
                 return Promise.resolve({
-                  data: { data: networkStats },
+                  data: rawify({ data: networkStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -622,7 +623,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -699,25 +703,25 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/kiln-stats`:
                 return Promise.resolve({
-                  data: { data: dedicatedStakingStats },
+                  data: rawify({ data: dedicatedStakingStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/network-stats`:
                 return Promise.resolve({
-                  data: { data: networkStats },
+                  data: rawify({ data: networkStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -726,7 +730,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -802,25 +809,25 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/kiln-stats`:
                 return Promise.resolve({
-                  data: { data: dedicatedStakingStats },
+                  data: rawify({ data: dedicatedStakingStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/network-stats`:
                 return Promise.resolve({
-                  data: { data: networkStats },
+                  data: rawify({ data: networkStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -918,29 +925,29 @@ describe('TransactionsViewController tests', () => {
             .encode();
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/network-stats`) {
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/stakes`) {
               return Promise.resolve({
-                data: { data: stakes },
+                data: rawify({ data: stakes }),
                 status: 200,
               });
             }
@@ -948,7 +955,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1012,7 +1022,7 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.reject(new NotFoundException());
@@ -1021,7 +1031,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1056,11 +1069,11 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
@@ -1068,7 +1081,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1104,11 +1120,11 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
@@ -1116,7 +1132,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1152,11 +1171,11 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
@@ -1164,7 +1183,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1199,11 +1221,11 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
@@ -1211,7 +1233,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1247,11 +1272,11 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
@@ -1260,7 +1285,7 @@ describe('TransactionsViewController tests', () => {
             }
             if (url === `${stakingApiUrl}/v1/eth/network-stats`) {
               return Promise.resolve({
-                data: { data: networkStats },
+                data: rawify({ data: networkStats }),
                 status: 200,
               });
             }
@@ -1268,7 +1293,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1304,17 +1332,17 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
@@ -1325,7 +1353,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1391,20 +1422,20 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/network-stats`:
                 return Promise.resolve({
-                  data: { data: networkStats },
+                  data: rawify({ data: networkStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -1413,7 +1444,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1488,20 +1522,20 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/network-stats`:
                 return Promise.resolve({
-                  data: { data: networkStats },
+                  data: rawify({ data: networkStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -1577,14 +1611,14 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.reject(new NotFoundException());
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
@@ -1592,7 +1626,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1630,17 +1667,17 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
@@ -1648,7 +1685,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1687,17 +1727,17 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
@@ -1705,7 +1745,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1744,17 +1787,17 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
@@ -1762,7 +1805,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1801,17 +1847,17 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.get.mockImplementation(({ url }) => {
             if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-              return Promise.resolve({ data: chain, status: 200 });
+              return Promise.resolve({ data: rawify(chain), status: 200 });
             }
             if (url === `${stakingApiUrl}/v1/deployments`) {
               return Promise.resolve({
-                data: { data: [deployment] },
+                data: rawify({ data: [deployment] }),
                 status: 200,
               });
             }
             if (url === `${stakingApiUrl}/v1/eth/kiln-stats`) {
               return Promise.resolve({
-                data: { data: dedicatedStakingStats },
+                data: rawify({ data: dedicatedStakingStats }),
                 status: 200,
               });
             }
@@ -1822,7 +1868,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1882,15 +1931,15 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/network-stats`:
                 return Promise.resolve({
-                  data: { data: networkStats },
+                  data: rawify({ data: networkStats }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
@@ -1901,7 +1950,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -1985,15 +2037,15 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -2002,7 +2054,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -2071,15 +2126,15 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
                 return Promise.resolve({
-                  data: { data: stakes },
+                  data: rawify({ data: stakes }),
                   status: 200,
                 });
               default:
@@ -2147,7 +2202,7 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.reject(new NotFoundException());
               default:
@@ -2156,7 +2211,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -2196,10 +2254,10 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               default:
@@ -2208,7 +2266,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -2249,10 +2310,10 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               default:
@@ -2261,7 +2322,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -2301,10 +2365,10 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               default:
@@ -2313,7 +2377,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });
@@ -2377,10 +2444,10 @@ describe('TransactionsViewController tests', () => {
           networkService.get.mockImplementation(({ url }) => {
             switch (url) {
               case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
-                return Promise.resolve({ data: chain, status: 200 });
+                return Promise.resolve({ data: rawify(chain), status: 200 });
               case `${stakingApiUrl}/v1/deployments`:
                 return Promise.resolve({
-                  data: { data: [deployment] },
+                  data: rawify({ data: [deployment] }),
                   status: 200,
                 });
               case `${stakingApiUrl}/v1/eth/stakes`:
@@ -2391,7 +2458,10 @@ describe('TransactionsViewController tests', () => {
           });
           networkService.post.mockImplementation(({ url }) => {
             if (url === `${chain.transactionService}/api/v1/data-decoder/`) {
-              return Promise.resolve({ data: dataDecoded, status: 200 });
+              return Promise.resolve({
+                data: rawify(dataDecoded),
+                status: 200,
+              });
             }
             return Promise.reject(new Error(`Could not match ${url}`));
           });


### PR DESCRIPTION
## Summary

We transitioned all datasources to manually type responses as `Raw`. This moves the manual typing into the `NetworkService` - all requests wrap the given type as `Raw`.

Note: all changes inside tests are type related, wrapping request objects in the `rawify` helper.

## Changes

- Wrap `NetworkResponse['data']` in `Raw` utility
- Remove all manual `Raw` implementations
- Propagate type requirements
- Update tests accordingly