### PR TITLE
Create dependabot group for `@aws-sdk/*` packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
           - '@nestjs/core'
           - '@nestjs/platform-express'
           - '@nestjs/testing'
+      aws-sdk:
+        patterns:
+          - '@aws-sdk/*'
 
   - package-ecosystem: 'docker'
     directory: '/'


### PR DESCRIPTION
## Summary

Updating one of several `@aws-sdk/*` packages [can cause type issues within mocks](https://github.com/m-radzikowski/aws-sdk-client-mock/issues/197). (We saw this in a [recent dependabot PR](https://github.com/safe-global/safe-client-gateway/pull/2155/commits/6504a598bd83a923cbed48a1890055dd863a4d87).)

The main way to fix the above is to update all `@aws-sdk/*` packages together. As such, this creates a respective dependabot group to prevent individual update PRs.

## Changes

- Create new dependabot group for `@aws-sdk/*` packages