### PR TITLE
Don't create `DataSourceError` from `ZodError`s

### DIFF
--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -38,7 +38,7 @@ import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { rawify, type Raw } from '@/validation/entities/raw.entity';
 import { Inject, Injectable } from '@nestjs/common';
 import { getAddress } from 'viem';
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 
 export const IZerionBalancesApi = Symbol('IZerionBalancesApi');
 
@@ -147,7 +147,7 @@ export class ZerionBalancesApi implements IBalancesApi {
       );
       return this._mapBalances(chainName, zerionBalances.data);
     } catch (error) {
-      if (error instanceof LimitReachedError) {
+      if (error instanceof LimitReachedError || error instanceof ZodError) {
         throw error;
       }
       throw this.httpErrorFactory.from(error);
@@ -210,6 +210,9 @@ export class ZerionBalancesApi implements IBalancesApi {
           zerionCollectibles.data,
         );
       } catch (error) {
+        if (error instanceof ZodError) {
+          throw error;
+        }
         throw this.httpErrorFactory.from(error);
       }
     }


### PR DESCRIPTION
## Summary

We now use validation schemas to ensure the incoming `Raw<T>` responses are as expected as it is "safer" than casting. If validation errors are thrown, however, they are therefore caught and thrown as `DataSourceError`s.

This throws any `ZodError`s directly, to be caught by the `ZodErrorFilter`.

## Changes

- Throw `ZodError`s directly within methods that parse against schemas.