### PR TITLE
Allow `deposit_paused` as a staking deployment status

### DIFF
--- a/src/datasources/staking-api/entities/deployment.entity.ts
+++ b/src/datasources/staking-api/entities/deployment.entity.ts
@@ -6,7 +6,12 @@ export const DeploymentProductTypes = ['defi', 'pooling', 'dedicated'] as const;
 
 export const DeploymentChains = ['eth', 'arb', 'bsc', 'matic', 'op'] as const;
 
-export const DeploymentStatuses = ['active', 'pending', 'disabled'] as const;
+export const DeploymentStatuses = [
+  'active',
+  'deposit_paused',
+  'pending',
+  'disabled',
+] as const;
 
 export const DeploymentSchema = z.object({
   id: z.string().uuid(),


### PR DESCRIPTION
## Summary

We decode staking transactions based on the official Kiln deployments. Currently, we expect the statuses of a deployment to be `active` or `pending`, otherwise they are `unknown`. However, is possible for contracts to have a `deposit_paused` status.

This adds `deposit_paused` as a supported status.

## Changes

- Add `deposit_paused` as a deployment status