### PR TITLE
Don't create `DataSourceError`s from `ZodError`s in `SafeBalancesApi`

### DIFF
--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -16,6 +16,7 @@ import { Injectable } from '@nestjs/common';
 import { Chain } from '@/domain/chains/entities/chain.entity';
 import { rawify, type Raw } from '@/validation/entities/raw.entity';
 import { AssetPricesSchema } from '@/datasources/balances-api/entities/asset-price.entity';
+import { ZodError } from 'zod';
 
 @Injectable()
 export class SafeBalancesApi implements IBalancesApi {
@@ -87,6 +88,9 @@ export class SafeBalancesApi implements IBalancesApi {
         chain: args.chain,
       });
     } catch (error) {
+      if (error instanceof ZodError) {
+        throw error;
+      }
       throw this.httpErrorFactory.from(error);
     }
   }


### PR DESCRIPTION
## Summary

Similarly to https://github.com/safe-global/safe-client-gateway/pull/2166, we are traversing between `Raw<T>` and `T` within the `IBalancesApi` by validating instead of casting.

The `ZerionBalancesApi` was adjusted to not convert `ZodError`s to `DataSourceError`s. This makes the same adjustment for the `SafeBalancesApi`.

## Changes

- Don't wrap `ZodError`s as `DataSourceError`s