### PR TITLE
Add API for swaps on Base

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -250,6 +250,7 @@ export default (): ReturnType<typeof configuration> => ({
     api: {
       1: faker.internet.url({ appendSlash: false }),
       100: faker.internet.url({ appendSlash: false }),
+      8453: faker.internet.url({ appendSlash: false }),
       42161: faker.internet.url({ appendSlash: false }),
       11155111: faker.internet.url({ appendSlash: false }),
     },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -371,6 +371,7 @@ export default () => ({
     api: {
       1: 'https://api.cow.fi/mainnet',
       100: 'https://api.cow.fi/xdai',
+      8453: 'https://api.cow.fi/base',
       42161: 'https://api.cow.fi/arbitrum_one',
       11155111: 'https://api.cow.fi/sepolia',
     },


### PR DESCRIPTION
## Summary

We have API URIs for swap decoding in our configuration. This adds that for Base.

## Changes

- Add `swaps.api[8453` configuration value