### PR TITLE
Directly import required lodash methods

### DIFF
--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -2,7 +2,7 @@ import { fakeJson } from '@/__tests__/faker';
 import configurationValidator from '@/config/configuration.validator';
 import { RootConfigurationSchema } from '@/config/entities/schemas/configuration.schema';
 import { faker } from '@faker-js/faker';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 
 describe('Configuration validator', () => {
   const validConfiguration: Record<string, unknown> = {

--- a/src/datasources/accounts/accounts.datasource.ts
+++ b/src/datasources/accounts/accounts.datasource.ts
@@ -26,7 +26,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import crypto from 'crypto';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import postgres from 'postgres';
 
 @Injectable()

--- a/src/datasources/accounts/address-books/address-books.datasource.ts
+++ b/src/datasources/accounts/address-books/address-books.datasource.ts
@@ -12,6 +12,7 @@ import { Account } from '@/domain/accounts/entities/account.entity';
 import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
 import { IEncryptionApiManager } from '@/domain/interfaces/encryption-api.manager.interface';
 import { Inject, Injectable } from '@nestjs/common';
+import max from 'lodash/max';
 import postgres from 'postgres';
 
 @Injectable()
@@ -33,7 +34,7 @@ export class AddressBooksDatasource implements IAddressBooksDatasource {
       args.chainId,
     );
     const addressBookItem = {
-      id: Math.max(...addressBook.data.map((i) => i.id).concat(0)) + 1,
+      id: max(addressBook.data.map((i) => i.id)) ?? 0,
       address: args.createAddressBookItemDto.address,
       name: args.createAddressBookItemDto.name,
     };

--- a/src/datasources/accounts/address-books/address-books.datasource.ts
+++ b/src/datasources/accounts/address-books/address-books.datasource.ts
@@ -34,7 +34,7 @@ export class AddressBooksDatasource implements IAddressBooksDatasource {
       args.chainId,
     );
     const addressBookItem = {
-      id: max(addressBook.data.map((i) => i.id)) ?? 0,
+      id: (max(addressBook.data.map((i) => i.id)) ?? 0) + 1,
       address: args.createAddressBookItemDto.address,
       name: args.createAddressBookItemDto.name,
     };

--- a/src/datasources/accounts/address-books/address-books.datasource.ts
+++ b/src/datasources/accounts/address-books/address-books.datasource.ts
@@ -33,7 +33,7 @@ export class AddressBooksDatasource implements IAddressBooksDatasource {
       args.chainId,
     );
     const addressBookItem = {
-      id: (Math.max(...addressBook.data.map((i) => i.id)) ?? 0) + 1,
+      id: Math.max(...addressBook.data.map((i) => i.id).concat(0)) + 1,
       address: args.createAddressBookItemDto.address,
       name: args.createAddressBookItemDto.name,
     };

--- a/src/datasources/accounts/address-books/address-books.datasource.ts
+++ b/src/datasources/accounts/address-books/address-books.datasource.ts
@@ -12,7 +12,6 @@ import { Account } from '@/domain/accounts/entities/account.entity';
 import { IAddressBooksDatasource } from '@/domain/interfaces/address-books.datasource.interface';
 import { IEncryptionApiManager } from '@/domain/interfaces/encryption-api.manager.interface';
 import { Inject, Injectable } from '@nestjs/common';
-import { max } from 'lodash';
 import postgres from 'postgres';
 
 @Injectable()
@@ -34,7 +33,7 @@ export class AddressBooksDatasource implements IAddressBooksDatasource {
       args.chainId,
     );
     const addressBookItem = {
-      id: (max(addressBook.data.map((i) => i.id)) ?? 0) + 1,
+      id: (Math.max(...addressBook.data.map((i) => i.id)) ?? 0) + 1,
       address: args.createAddressBookItemDto.address,
       name: args.createAddressBookItemDto.name,
     };

--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -9,7 +9,7 @@ import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import type { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
-import { sample } from 'lodash';
+import sample from 'lodash/sample';
 import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import type { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
 import { rawify } from '@/validation/entities/raw.entity';

--- a/src/datasources/balances-api/balances-api.manager.ts
+++ b/src/datasources/balances-api/balances-api.manager.ts
@@ -12,7 +12,7 @@ import { IBalancesApiManager } from '@/domain/interfaces/balances-api.manager.in
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { IPricesApi } from '@/datasources/balances-api/prices-api.interface';
 import { Inject, Injectable } from '@nestjs/common';
-import { intersection } from 'lodash';
+import intersection from 'lodash/intersection';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
 import { z } from 'zod';

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@/datasources/balances-api/entities/asset-price.entity';
 import type { ICacheService } from '@/datasources/cache/cache.service.interface';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { pricesProviderBuilder } from '@/domain/chains/entities/__tests__/prices-provider.builder';

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -16,7 +16,9 @@ import {
   NetworkService,
   INetworkService,
 } from '@/datasources/network/network.service.interface';
-import { difference, get, random } from 'lodash';
+import difference from 'lodash/difference';
+import get from 'lodash/get';
+import random from 'lodash/random';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { asError } from '@/logging/utils';

--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -20,7 +20,6 @@ import {
   Transaction,
 } from '@/domain/safe/entities/transaction.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { isArray } from 'lodash';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import { Raw } from '@/validation/entities/raw.entity';
 
@@ -232,7 +231,7 @@ export class CacheFirstDataSource {
       cacheWriteTime: new Date(),
       requestStartTime: new Date(requestStartTime),
       txHashes:
-        isArray(data?.results) && // no validation executed yet at this point
+        Array.isArray(data?.results) && // no validation executed yet at this point
         data.results.map((transaction) => {
           if (isMultisigTransaction(transaction)) {
             return {

--- a/src/datasources/errors/http-error-factory.ts
+++ b/src/datasources/errors/http-error-factory.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 /**
  * Maps a {@link NetworkError} or {@link Error} into a {@link DataSourceError}

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -30,7 +30,7 @@ import type { AddConfirmationDto } from '@/domain/transactions/entities/add-conf
 import type { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
 import type { ILoggingService } from '@/logging/logging.interface';
 import type { Raw } from '@/validation/entities/raw.entity';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';

--- a/src/domain/chains/chains.repository.spec.ts
+++ b/src/domain/chains/chains.repository.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker/.';
-import { chunk } from 'lodash';
+import chunk from 'lodash/chunk';
 import { getAddress } from 'viem';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import {

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -15,7 +15,7 @@ import {
   IndexingStatusSchema,
 } from '@/domain/indexing/entities/indexing-status.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { differenceBy } from 'lodash';
+import differenceBy from 'lodash/differenceBy';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { LenientBasePageSchema } from '@/domain/entities/schemas/page.schema.factory';

--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -22,7 +22,8 @@ import {
 import { Event } from '@/routes/hooks/entities/event.entity';
 import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { memoize, MemoizedFunction } from 'lodash';
+import memoize from 'lodash/memoize';
+import type { MemoizedFunction } from 'lodash';
 
 @Injectable()
 export class EventCacheHelper {

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -11,7 +11,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { NotificationSubscription } from '@/datasources/notifications/entities/notification-subscription.entity.db';
 import { NotificationDevice } from '@/datasources/notifications/entities/notification-devices.entity.db';

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { Page } from '@/domain/entities/page.entity';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { CreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';

--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -1,5 +1,5 @@
 import type { Request } from 'express';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 const HEADER_IP_ADDRESS = 'X-Real-IP';
 const HEADER_SAFE_APP_USER_AGENT = 'Safe-App-User-Agent';

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -31,7 +31,7 @@ import { getAddress } from 'viem';
 import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import type { Server } from 'net';
-import { sample } from 'lodash';
+import sample from 'lodash/sample';
 import { balancesProviderBuilder } from '@/domain/chains/entities/__tests__/balances-provider.builder';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -7,7 +7,7 @@ import { Balance } from '@/routes/balances/entities/balance.entity';
 import { Balances } from '@/routes/balances/entities/balances.entity';
 import { TokenType } from '@/routes/balances/entities/token-type.entity';
 import { NULL_ADDRESS } from '@/routes/common/constants';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { getNumberString } from '@/domain/common/utils/utils';
 
 @Injectable()

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';

--- a/src/routes/delegates/v2/delegates.v2.controller.spec.ts
+++ b/src/routes/delegates/v2/delegates.v2.controller.spec.ts
@@ -29,7 +29,7 @@ import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import type { Server } from 'net';
 import request from 'supertest';
 import { getAddress } from 'viem';

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import request from 'supertest';
 import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { groupBy } from 'lodash';
+import groupBy from 'lodash/groupBy';
 import { Message as DomainMessage } from '@/domain/messages/entities/message.entity';
 import { MessagesRepository } from '@/domain/messages/messages.repository';
 import { IMessagesRepository } from '@/domain/messages/messages.repository.interface';

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { max } from 'lodash';
+import max from 'lodash/max';
 import semver from 'semver';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
 import { Singleton } from '@/domain/chains/entities/singleton.entity';

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Operation } from '@/domain/safe/entities/operation.entity';

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import {

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { groupBy } from 'lodash';
+import groupBy from 'lodash/groupBy';
 import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper';

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { groupBy } from 'lodash';
+import groupBy from 'lodash/groupBy';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import {
   isCreationTransaction,


### PR DESCRIPTION
## Summary

We use several methods from `lodash` throughout the project. As they are not imported directly, they import the entire library.

This adjusts all imports to import directly, as well as replacing a few unnecessary methods with their native counterpart.

## Changes

- Change imports to be direct
- Favour `Array.isArray` over `isArray`
- Favour `Math.max` over `max` (for numbers)