### PR TITLE
Add tests for v1 notification compatibility with v2

### DIFF
--- a/src/routes/notifications/v1/notifications.controller.ts
+++ b/src/routes/notifications/v1/notifications.controller.ts
@@ -29,7 +29,7 @@ import {
 @ApiTags('notifications')
 @Controller({ path: '', version: '1' })
 export class NotificationsController {
-  private isPushNotificationV2Enabled = false;
+  private isPushNotificationV2Enabled: boolean;
   constructor(
     // Adding NotificationServiceV2 to ensure compatibility with V1.
     // @TODO Remove NotificationModuleV2 after all clients have migrated and compatibility is no longer needed.


### PR DESCRIPTION
## Summary
This PR introduces tests to ensure backward compatibility between v1 and v2 notifications. The goal is to verify that v2 changes do not break existing v1 functionality or introduce regressions.

## Changes
- Added new test cases to validate v1 notifications’ behavior with v2 changes.
- Updated test suite to include compatibility scenarios.