### PR TITLE
Return notification subscriptions using TypeOrm transaction runner

### DIFF
--- a/migrations/1733761866546-cleanNotificationData.ts
+++ b/migrations/1733761866546-cleanNotificationData.ts
@@ -1,0 +1,13 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CleanNotificationData1733761866546 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM notification_subscription_notification_types;`,
+    );
+    await queryRunner.query(`DELETE FROM notification_subscriptions;`);
+    await queryRunner.query(`DELETE FROM push_notification_devices;`);
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -212,20 +212,19 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
       (subscriptionIdentifier) => subscriptionIdentifier.id,
     );
 
-    const subscriptions = await this.getSubscriptionsById(subscriptionIds);
+    const subscriptions = await this.getSubscriptionsById(
+      entityManager,
+      subscriptionIds,
+    );
 
     return subscriptions;
   }
 
-  public async getSubscriptionsById(
+  private async getSubscriptionsById(
+    entityManager: EntityManager,
     subscriptionIds: Array<number>,
   ): Promise<Array<NotificationSubscription>> {
-    const notificationSubscriptionRepository =
-      await this.postgresDatabaseService.getRepository(
-        NotificationSubscription,
-      );
-
-    return await notificationSubscriptionRepository.find({
+    return await entityManager.find(NotificationSubscription, {
       where: { id: In(subscriptionIds) },
     });
   }


### PR DESCRIPTION
## Summary
This pull request fixes a bug where the subscription ID for a notification subscription type was not being inserted into the database. The issue occurred because the data was being fetched from the database within a transaction but without using the transaction runner.

## Changes
- Fetches notification subscriptions using the database transaction runner
- Adds a new migration script to clean up redundant or outdated notification data in the database.