### PR TITLE
Remove timestamp-reference transaction from start of page

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -53,14 +53,25 @@ export class TransactionsHistoryMapper {
     if (transactionsDomain.length == 0) {
       return [];
     }
-    // Must be retrieved before mapping others as we remove it from transactionsDomain
-    const previousTransaction = await this.getPreviousTransaction({
-      offset,
-      transactionsDomain,
-      chainId,
-      safe,
-      onlyTrusted,
-    });
+
+    let previousTransaction: TransactionItem | undefined;
+
+    /**
+     * We insert a {@link DateLabel} between transactions on different days.
+     * On subsequent pages (offset > 0), we fetch the last transaction of previous page
+     * to determine if the first transaction of the current page is on the same day.
+     */
+    if (offset > 0 && transactionsDomain.length > 1) {
+      previousTransaction = await this.getPreviousTransaction({
+        transactionsDomain,
+        chainId,
+        safe,
+        onlyTrusted,
+      });
+
+      // Remove first transaction that was requested to get previous day timestamp
+      transactionsDomain = transactionsDomain.slice(1);
+    }
 
     const mappedTransactions = await this.getMappedTransactions({
       transactionsDomain,
@@ -97,16 +108,11 @@ export class TransactionsHistoryMapper {
   }
 
   private async getPreviousTransaction(args: {
-    offset: number;
     transactionsDomain: TransactionDomain[];
     chainId: string;
     safe: Safe;
     onlyTrusted: boolean;
   }): Promise<TransactionItem | undefined> {
-    // More than 1 element is required to get the previous transaction
-    if (args.offset <= 0 || args.transactionsDomain.length <= 1) {
-      return;
-    }
     const prevDomainTransaction = args.transactionsDomain[0];
     // We map in order to filter last list item against it
     const mappedPreviousTransaction = await this.mapTransaction(
@@ -115,8 +121,6 @@ export class TransactionsHistoryMapper {
       args.safe,
       args.onlyTrusted,
     );
-    // Remove first transaction that was requested to get previous day timestamp
-    args.transactionsDomain = args.transactionsDomain.slice(1);
 
     return Array.isArray(mappedPreviousTransaction)
       ? // All transfers should have same execution date but the last is "true" previous


### PR DESCRIPTION
## Summary

We group transactions by day, in between which we add date labels.

When fetching the first page of transactions (`offeset=0`), we group/label the result as is. For subsequent pages (`offset>0`), we modify the pagination to request the last transaction of the previous page in order to determine whether we return an initial date label or not, before removing it and mapping the remanining transactions.

Currently, the removal of this "extra" transaction is not assigning correctly due to abstraction into a separate function. This adjusts the logic flow to ensure the "extra" transaction is removed where it is passed to the mapper.

## Changes

- Move `slice` into main mapping function.