### PR TITLE
Add demonstrative `DeduplicationInterceptor` to reduce duplicate requests

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { CollectiblesModule } from '@/routes/collectibles/collectibles.module';
 import { CommunityModule } from '@/routes/community/community.module';
 import { ContractsModule } from '@/routes/contracts/contracts.module';
 import { DataDecodedModule } from '@/routes/data-decode/data-decoded.module';
+import { DeduplicationInterceptor } from '@/routes/common/interceptors/deduplication.interceptor';
 import { DelegatesModule } from '@/routes/delegates/delegates.module';
 import {
   HooksModule,
@@ -159,6 +160,10 @@ export class AppModule implements NestModule {
         {
           provide: APP_INTERCEPTOR,
           useClass: CacheControlInterceptor,
+        },
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: DeduplicationInterceptor,
         },
         {
           provide: APP_FILTER,

--- a/src/routes/common/interceptors/deduplication.interceptor.spec.ts
+++ b/src/routes/common/interceptors/deduplication.interceptor.spec.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import { Test } from '@nestjs/testing';
+import { Controller, UseInterceptors, Get, Injectable } from '@nestjs/common';
+import type { INestApplication } from '@nestjs/common';
+import type { Server } from 'node:http';
+
+import { DeduplicationInterceptor } from '@/routes/common/interceptors/deduplication.interceptor';
+
+@Injectable()
+class TestService {
+  async fetchData(): Promise<{ message: string }> {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve({ message: 'Hello, world!' }), 100);
+    });
+  }
+}
+
+@Controller()
+@UseInterceptors(DeduplicationInterceptor)
+class TestController {
+  constructor(private readonly testService: TestService) {}
+
+  @Get('/get')
+  async get(): Promise<{ message: string }> {
+    return this.testService.fetchData();
+  }
+}
+
+describe('DeduplicationInterceptor', () => {
+  let app: INestApplication<Server>;
+  let testService: TestService;
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      controllers: [TestController],
+      providers: [TestService],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    testService = moduleFixture.get<TestService>(TestService);
+
+    jest.spyOn(testService, 'fetchData');
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should deduplicate requests', async () => {
+    const [response1, response2] = await Promise.all([
+      request(app.getHttpServer()).get('/get'),
+      request(app.getHttpServer()).get('/get'),
+    ]);
+
+    expect(response1.body).toEqual({ message: 'Hello, world!' });
+    expect(response2.body).toEqual({ message: 'Hello, world!' });
+
+    expect(testService.fetchData).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle different requests separately', async () => {
+    (testService.fetchData as jest.Mock).mockClear();
+
+    const response1 = await request(app.getHttpServer()).get('/get');
+    const response2 = await request(app.getHttpServer())
+      .get('/get')
+      .query({ param: 'value' });
+
+    expect(response1.body).toEqual({ message: 'Hello, world!' });
+    expect(response2.body).toEqual({ message: 'Hello, world!' });
+
+    expect(testService.fetchData).toHaveBeenCalledTimes(2);
+  });
+
+  it.todo('test all variations of registry key');
+});

--- a/src/routes/common/interceptors/deduplication.interceptor.ts
+++ b/src/routes/common/interceptors/deduplication.interceptor.ts
@@ -1,0 +1,81 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+import { createHash } from 'crypto';
+
+/**
+ * This interceptor can be used to deduplicate requests based on their
+ * method, protocol, hostname, URL, query, headers, and body.
+ */
+@Injectable()
+export class DeduplicationInterceptor implements NestInterceptor {
+  private registry = new Map<string, Promise<unknown>>();
+
+  /**
+   * Intercepts the request and checks if a request with the same properties
+   * is pending. If it is, it waits for the pending request to finish and
+   * returns its result. If it is not, it registers the request and waits
+   * for the result.
+   *
+   * @param context - {@link ExecutionContext} instance
+   * @param next - {@link CallHandler} instance
+   * @returns an {@link Observable} that emits the result of the request.
+   */
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request: Request = context.switchToHttp().getRequest();
+    const key = this.getRegistryKey(request);
+
+    return new Observable((observer) => {
+      this.getOrRegister(key, () => next.handle().toPromise())
+        .then((result) => {
+          observer.next(result);
+          observer.complete();
+        })
+        .catch((err) => {
+          observer.error(err);
+        });
+    });
+  }
+
+  /**
+   * Returns a promise that resolves to the result of the provided function.
+   * If a promise with the same key is already pending, it returns that
+   * promise, otherwise it registers the promise and returns it.
+   */
+  async getOrRegister<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    if (this.registry.has(key)) {
+      return this.registry.get(key) as Promise<T>;
+    }
+
+    const promise = fn().finally(() => {
+      this.registry.delete(key);
+    });
+
+    this.registry.set(key, promise);
+
+    return promise;
+  }
+
+  /**
+   * Generates a unique key for the request based on its method, protocol,
+   * hostname, URL, query, headers, and body.
+   *
+   * @param request - {@link Request} instance
+   * @returns a unique key for the request.
+   */
+  private getRegistryKey(request: Request): string {
+    const { method, protocol, hostname, url, query, headers, body } = request;
+
+    const stringifiedQuery = JSON.stringify(query);
+    const stringifiedHeaders = JSON.stringify(headers);
+    const stringifiedBody = JSON.stringify(body);
+
+    const key = `${method}_${protocol}_${hostname}_${url}_${stringifiedQuery}_${stringifiedHeaders}_${stringifiedBody}`;
+    return createHash('sha256').update(key).digest('hex');
+  }
+}


### PR DESCRIPTION
⚠️ This is demonstrative and to-be-discussed within the team.

## Summary

Ideates on #2181 and our previous (reverted) [promise registry](https://github.com/safe-global/safe-client-gateway/pull/586) implementation.

Due to the async nature of the project, services can send several requests of the same requests in parallel. Only after one of these succeeds is the result cached.

This implements an interceptor which registers each `Request` promise in a registry. Should a subsequent `Request` happen and the aforementioned registration exist, it is returned instead of making a parallel one.

## Changes

- Create and register `DeduplicationInterceptor` in the app
- Add appropriate test coverage