### PR TITLE
Enable hooks to be triggered via HTTP when the feature flag is activated

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -155,6 +155,7 @@ export default (): ReturnType<typeof configuration> => ({
     counterfactualBalances: false,
     accounts: false,
     pushNotifications: false,
+    hookHttpPostEvent: false,
     improvedAddressPoisoning: false,
   },
   httpClient: { requestTimeout: faker.number.int() },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -239,6 +239,8 @@ export default () => ({
     accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
     pushNotifications:
       process.env.FF_PUSH_NOTIFICATIONS?.toLowerCase() === 'true',
+    hookHttpPostEvent:
+      process.env.FF_HOOK_HTTP_POST_EVENT?.toLowerCase() === 'true',
     improvedAddressPoisoning:
       process.env.FF_IMPROVED_ADDRESS_POISONING?.toLowerCase() === 'true',
   },

--- a/src/routes/hooks/hooks.http.controller.spec.ts
+++ b/src/routes/hooks/hooks.http.controller.spec.ts
@@ -1,0 +1,102 @@
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
+import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { AppModule } from '@/app.module';
+import { CacheModule } from '@/datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '@/logging/logging.module';
+import { NetworkModule } from '@/datasources/network/network.module';
+import { TestQueuesApiModule } from '@/datasources/queues/__tests__/test.queues-api.module';
+import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
+import type { Server } from 'net';
+import { TestPostgresDatabaseModule } from '@/datasources/db/__tests__/test.postgres-database.module';
+import { PostgresDatabaseModule } from '@/datasources/db/v1/postgres-database.module';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-database.module';
+import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
+import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
+
+describe('Post Hook Events Http (Unit)', () => {
+  let app: INestApplication<Server>;
+  let authToken: string;
+  let configurationService: IConfigurationService;
+
+  async function initApp(): Promise<void> {
+    const defaultConfiguration = configuration();
+
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        hookHttpPostEvent: true,
+      },
+    });
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule.register(testConfiguration)],
+    })
+      .overrideModule(PostgresDatabaseModule)
+      .useModule(TestPostgresDatabaseModule)
+      .overrideModule(TargetedMessagingDatasourceModule)
+      .useModule(TestTargetedMessagingDatasourceModule)
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .overrideModule(QueuesApiModule)
+      .useModule(TestQueuesApiModule)
+      .overrideModule(PostgresDatabaseModuleV2)
+      .useModule(TestPostgresDatabaseModuleV2)
+      .compile();
+    app = moduleFixture.createNestApplication();
+
+    configurationService = moduleFixture.get(IConfigurationService);
+    authToken = configurationService.getOrThrow('auth.token');
+
+    await app.init();
+  }
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    await initApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should not return 410 if the feature flag is enabled', async () => {
+    const payload = {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.string.hexadecimal({ length: 32 }),
+    };
+    const safeAddress = faker.finance.ethereumAddress();
+    const chainId = faker.string.numeric();
+    const data = {
+      address: safeAddress,
+      chainId: chainId,
+      ...payload,
+    };
+
+    await request(app.getHttpServer())
+      .post(`/hooks/events`)
+      .set('Authorization', `Basic ${authToken}`)
+      .send(data)
+      .expect(202);
+  });
+
+  it('should throw an error if authorization is not sent in the request headers', async () => {
+    await request(app.getHttpServer())
+      .post(`/hooks/events`)
+      .send({})
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary
This PR introduces functionality to trigger hooks via HTTP when a specified feature flag is activated. The implementation ensures that hooks are invoked dynamically based on feature flag status. The intention of this PR is to help make testing new networks that don’t have a staging environment easier on the staging app.

## Changes
- Introduced a new feature flag to enable HTTP-based hook calls.
- Added support for non-configured hooks to be triggered via HTTP.
- Included unit tests to verify hook execution flow.

## Testing Notes
- Tested feature flag activation triggering multiple hook endpoints.
- Verified HTTP responses and error handling for unreachable or misconfigured endpoints.