### PR TITLE
Ensure chainId is returned correctly during notification errors

### DIFF
--- a/src/routes/notifications/v1/notifications.service.ts
+++ b/src/routes/notifications/v1/notifications.service.ts
@@ -124,16 +124,14 @@ export class NotificationsService {
     registrationResults: PromiseSettledResult<DomainSafeRegistration>[],
     safeRegistrations: SafeRegistration[],
   ): string {
-    const successChainIds = (
-      registrationResults.filter(
-        ({ status }) => status === 'fulfilled',
-      ) as PromiseFulfilledResult<DomainSafeRegistration>[]
-    ).map((registrationResult) => registrationResult.value.chainId);
+    const failedRegistrationChainIds = registrationResults
+      .map((result, index) => ({
+        result,
+        safeRegistration: safeRegistrations[index],
+      }))
+      .filter(({ result }) => result.status === 'rejected')
+      .map(({ safeRegistration }) => safeRegistration.chainId);
 
-    const erroredChainIds = safeRegistrations
-      .map((safeRegistration) => safeRegistration.chainId)
-      .filter((chainId) => !successChainIds.includes(chainId));
-
-    return `Push notification registration failed for chain IDs: ${erroredChainIds}`;
+    return `Push notification registration failed for chain IDs: ${failedRegistrationChainIds}`;
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where the chainId was incorrectly returned as null when the notification service threw an error. Previously, even when a valid chainId was available, it was not being included in the response due to improper handling.

The fix ensures that the correct chainId is always returned, improving error visibility and debugging when safe registration or notification processes fail.

## Changes
- Addressed a bug where chainId was null during notification service failures.
