### PR TITLE
Create new outreach campaign

### DIFF
--- a/migrations/deprecated/00013_targeted_messaging_add_outreach_2/index.sql
+++ b/migrations/deprecated/00013_targeted_messaging_add_outreach_2/index.sql
@@ -1,0 +1,17 @@
+INSERT INTO outreaches (
+    source_id,
+    name,
+    start_date,
+    end_date,
+    type,
+    team_name,
+	target_all
+) VALUES (
+    2,
+    'micro-campaign',
+    '2025-01-01 00:00:00.000',
+    '2025-03-01 00:00:00.000',
+    '',
+    '',
+	true
+);

--- a/migrations/deprecated/00013_targeted_messaging_add_outreach_2/index.sql
+++ b/migrations/deprecated/00013_targeted_messaging_add_outreach_2/index.sql
@@ -5,7 +5,7 @@ INSERT INTO outreaches (
     end_date,
     type,
     team_name,
-	target_all
+    target_all
 ) VALUES (
     2,
     'micro-campaign',
@@ -13,5 +13,5 @@ INSERT INTO outreaches (
     '2025-03-01 00:00:00.000',
     '',
     '',
-	true
+    true
 );

--- a/migrations/deprecated/__tests__/00013_targeted_messaging_add_outreach_2.spec.ts
+++ b/migrations/deprecated/__tests__/00013_targeted_messaging_add_outreach_2.spec.ts
@@ -1,0 +1,58 @@
+import { TestDbFactory } from '@/__tests__/db.factory';
+import { PostgresDatabaseMigrator } from '@/datasources/db/v1/postgres-database.migrator';
+import { faker } from '@faker-js/faker';
+import type postgres from 'postgres';
+import type { Sql } from 'postgres';
+
+describe('Migration 00013_targeted_messaging_add_outreach_2', () => {
+  let sql: postgres.Sql;
+  let migrator: PostgresDatabaseMigrator;
+  const testDbFactory = new TestDbFactory();
+
+  beforeAll(async () => {
+    sql = await testDbFactory.createTestDatabase(faker.string.uuid());
+    migrator = new PostgresDatabaseMigrator(sql);
+  });
+
+  afterAll(async () => {
+    await testDbFactory.destroyTestDatabase(sql);
+  });
+
+  it('runs successfully', async () => {
+    const result = await migrator.test({
+      migration: '00013_targeted_messaging_add_outreach_2',
+      before: async (sql: Sql) => {
+        await sql`DELETE FROM outreaches`;
+      },
+      after: async (sql: Sql) => {
+        return {
+          outreaches: {
+            rows: await sql`SELECT * FROM outreaches`,
+          },
+        };
+      },
+    });
+
+    expect(result.after).toStrictEqual({
+      outreaches: {
+        rows: [
+          {
+            id: expect.any(Number),
+            source_id: 2,
+            name: 'micro-campaign',
+            start_date: new Date('2025-01-01'),
+            end_date: new Date('2025-03-01'),
+            type: '',
+            team_name: '',
+            source_file: null,
+            source_file_checksum: null,
+            source_file_processed_date: null,
+            target_all: true,
+            created_at: expect.any(Date),
+            updated_at: expect.any(Date),
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Creates a second outreach campaign for collecting user feedback.

## Changes
Creates a migration to insert a new entry into `outreaches`. 
This outreach will be shown to all safes (target_all=true)
