### PR TITLE
Remove TODO from `AssetPriceSchema`

### DIFF
--- a/src/datasources/balances-api/entities/asset-price.entity.ts
+++ b/src/datasources/balances-api/entities/asset-price.entity.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 export type AssetPrice = z.infer<typeof AssetPriceSchema>;
 
-// TODO: Enforce Ethereum address keys (and maybe checksum them)
 export const AssetPriceSchema = z.record(z.record(z.number().nullable()));
 
 export const AssetPricesSchema = z.array(AssetPriceSchema);


### PR DESCRIPTION
## Summary

There is a TODO to add address valdidation to the keys of `AssetPriceSchema`.

The response from the prices provider, however, does not have address keys, [rather IDs](https://docs.coingecko.com/reference/simple-price). This therefore removes the TODO as it has an incorrect assumption.

## Changes

- Remove TODO from `AssetPriceSchema`