### PR TITLE
Enhance Logs with Color-Coding and Improved Readability

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -136,7 +136,10 @@
 # JWT_SECRET=
 
 # Log level for the service.
-# LOG_LEVEL=
+# LOG_LEVEL=q
+
+# Make logs prrety and colorize
+# LOG_PRETTY_COLORIZE=
 
 # Targeted Messaging
 # TARGETED_MESSAGING_FILE_STORAGE_TYPE=

--- a/.env.sample
+++ b/.env.sample
@@ -136,7 +136,7 @@
 # JWT_SECRET=
 
 # Log level for the service.
-# LOG_LEVEL=q
+# LOG_LEVEL=
 
 # Make logs prrety and colorize
 # LOG_PRETTY_COLORIZE=

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -176,6 +176,7 @@ export default (): ReturnType<typeof configuration> => ({
   log: {
     level: 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
+    prettyColorize: process.env.LOG_PRETTY_COLORIZE?.toLowerCase() === 'true',
   },
   mappings: {
     imitation: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -270,6 +270,7 @@ export default () => ({
   log: {
     level: process.env.LOG_LEVEL || 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
+    prettyColorize: process.env.LOG_PRETTY_COLORIZE?.toLowerCase() === 'true',
   },
   owners: {
     // There is no hook to invalidate the owners, so defaulting 0 disables the cache

--- a/src/logging/logging.module.ts
+++ b/src/logging/logging.module.ts
@@ -30,9 +30,13 @@ const LoggerTransports = Symbol('LoggerTransports');
 function winstonTransportsFactory(
   configurationService: IConfigurationService,
 ): Array<Transport> | Transport {
+  const prettyColorize =
+    configurationService.getOrThrow<boolean>('log.prettyColorize');
   return new winston.transports.Console({
     level: configurationService.getOrThrow<string>('log.level'),
-    format: winston.format.json(),
+    format: prettyColorize
+      ? winston.format.prettyPrint({ colorize: true })
+      : winston.format.json(),
   });
 }
 


### PR DESCRIPTION
## Summary
This PR introduces color-coding and formatting to logs to improve their readability and make debugging more efficient.

## Changes
- Add prretyPrint and color to log messages
- Introduced the `LOG_PRETTY_COLORIZE` environment variable to toggle pretty logs on or off, allowing flexibility in different environments.