### PR TITLE
Fix: use origin.note for tx notes

### DIFF
--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper.spec.ts
@@ -8,10 +8,7 @@ describe('Multisig Transaction note mapper (Unit)', () => {
   it('should parse transaction `origin` and return a note', () => {
     const noteText = faker.lorem.sentence();
     const transaction = multisigTransactionBuilder()
-      .with(
-        'origin',
-        JSON.stringify({ name: JSON.stringify({ note: noteText }) }),
-      )
+      .with('origin', JSON.stringify({ note: noteText }))
       .build();
 
     const note = mapper.mapTxNote(transaction);

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper.ts
@@ -7,9 +7,8 @@ export class MultisigTransactionNoteMapper {
     if (transaction.origin) {
       try {
         const origin = JSON.parse(transaction.origin);
-        const parsedName = origin.name && JSON.parse(String(origin.name));
-        if (typeof parsedName.note === 'string') {
-          return parsedName.note;
+        if (typeof origin.note === 'string') {
+          return origin.note;
         }
       } catch {
         // Ignore, no note


### PR DESCRIPTION
## Summary

A follow-up on #2223 thanks to @iamacook's diligence:
* We'll now use a separate sub-field of the `origin` field that doesn't interfere with any previous logic in tx-service
* `origin.note` is taken as is and passed to the `TransactionDetails.note` field for multisig txs