### PR TITLE
Log init/destroy success after call

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -237,6 +237,7 @@ export default () => ({
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
     accounts: process.env.FF_ACCOUNTS?.toLowerCase() === 'true',
+    // TODO: When enabled, we must add `db` as a requirement alongside `redis`
     pushNotifications:
       process.env.FF_PUSH_NOTIFICATIONS?.toLowerCase() === 'true',
     hookHttpPostEvent:

--- a/src/datasources/db/v2/postgres-database.service.ts
+++ b/src/datasources/db/v2/postgres-database.service.ts
@@ -44,8 +44,8 @@ export class PostgresDatabaseService {
    */
   public async initializeDatabaseConnection(): Promise<DataSource> {
     if (!this.isInitialized()) {
-      this.loggingService.info('PostgresDatabaseService initialized...');
       await this.dataSource.initialize();
+      this.loggingService.info('PostgresDatabaseService initialized...');
     }
 
     return this.dataSource;
@@ -58,8 +58,8 @@ export class PostgresDatabaseService {
    */
   public async destroyDatabaseConnection(): Promise<DataSource> {
     if (this.isInitialized()) {
-      this.loggingService.info('PostgresDatabaseService destroyed...');
       await this.dataSource.destroy();
+      this.loggingService.info('PostgresDatabaseService destroyed...');
     }
 
     return this.dataSource;


### PR DESCRIPTION
## Summary

If push notifications are enabled, we initialise/destroy the v2 DB implementation. There are associated logs with init/destroy, but these happen before their relevant calls. The logs therefore happen regardless of whether the calls succeed/throw.

This moves the logs after the relevant calls, as well as adds a TODO regarding the feature flag.

## Changes

- Move logs after respective calls
- Add TODO regarding README