### PR TITLE
Add `to` to pending/executed multisig events

### DIFF
--- a/src/domain/hooks/helpers/event-notifications.helper.ts
+++ b/src/domain/hooks/helpers/event-notifications.helper.ts
@@ -347,6 +347,7 @@ export class EventNotificationsHelper {
 
     return {
       type: NotificationType.CONFIRMATION_REQUEST,
+      to: event.to,
       chainId: event.chainId,
       address: event.address,
       safeTxHash: event.safeTxHash,

--- a/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -122,10 +122,12 @@ describe('Events queue processing e2e tests', () => {
   it.each([
     {
       type: 'PENDING_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -168,10 +170,12 @@ describe('Events queue processing e2e tests', () => {
   it.each([
     {
       type: 'PENDING_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -214,6 +218,7 @@ describe('Events queue processing e2e tests', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -252,6 +257,7 @@ describe('Events queue processing e2e tests', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -295,6 +301,7 @@ describe('Events queue processing e2e tests', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },

--- a/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/routes/hooks/__tests__/event-hooks-queue.e2e-spec.ts
@@ -421,6 +421,7 @@ describe('Events queue processing e2e tests', () => {
     },
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },

--- a/src/routes/hooks/entities/__tests__/executed-transaction.builder.ts
+++ b/src/routes/hooks/entities/__tests__/executed-transaction.builder.ts
@@ -8,6 +8,7 @@ import { getAddress } from 'viem';
 export function executedTransactionEventBuilder(): IBuilder<ExecutedTransaction> {
   return new Builder<ExecutedTransaction>()
     .with('type', TransactionEventType.EXECUTED_MULTISIG_TRANSACTION)
+    .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('chainId', faker.string.numeric())
     .with('safeTxHash', faker.string.hexadecimal())

--- a/src/routes/hooks/entities/__tests__/pending-transaction.builder.ts
+++ b/src/routes/hooks/entities/__tests__/pending-transaction.builder.ts
@@ -8,6 +8,7 @@ import { getAddress } from 'viem';
 export function pendingTransactionEventBuilder(): IBuilder<PendingTransaction> {
   return new Builder<PendingTransaction>()
     .with('type', TransactionEventType.PENDING_MULTISIG_TRANSACTION)
+    .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('chainId', faker.string.numeric())
     .with('safeTxHash', faker.string.hexadecimal());

--- a/src/routes/hooks/entities/schemas/__tests__/executed-transaction.schema.spec.ts
+++ b/src/routes/hooks/entities/schemas/__tests__/executed-transaction.schema.spec.ts
@@ -42,44 +42,51 @@ describe('ExecutedTransactionEventSchema', () => {
     );
   });
 
-  it('should not allow a non-address address', () => {
-    const executedTransactionEvent = executedTransactionEventBuilder()
-      .with('address', faker.string.sample() as `0x${string}`)
-      .build();
+  it.each(['to' as const, 'address' as const])(
+    'should not allow a non-address %s',
+    (field) => {
+      const executedTransactionEvent = executedTransactionEventBuilder()
+        .with(field, faker.string.sample() as `0x${string}`)
+        .build();
 
-    const result = ExecutedTransactionEventSchema.safeParse(
-      executedTransactionEvent,
-    );
+      const result = ExecutedTransactionEventSchema.safeParse(
+        executedTransactionEvent,
+      );
 
-    expect(!result.success && result.error).toStrictEqual(
-      new ZodError([
-        {
-          code: 'custom',
-          message: 'Invalid address',
-          path: ['address'],
-        },
-      ]),
-    );
-  });
+      expect(!result.success && result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'custom',
+            message: 'Invalid address',
+            path: [field],
+          },
+        ]),
+      );
+    },
+  );
 
-  it('should checksum the address', () => {
-    const nonChecksummedAddress = faker.finance
-      .ethereumAddress()
-      .toLowerCase() as `0x${string}`;
-    const executedTransactionEvent = executedTransactionEventBuilder()
-      .with('address', nonChecksummedAddress)
-      .build();
+  it.each(['to' as const, 'address' as const])(
+    'should checksum the %s',
+    (field) => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase() as `0x${string}`;
+      const executedTransactionEvent = executedTransactionEventBuilder()
+        .with(field, nonChecksummedAddress)
+        .build();
 
-    const result = ExecutedTransactionEventSchema.safeParse(
-      executedTransactionEvent,
-    );
-    expect(result.success && result.data.address).toBe(
-      getAddress(nonChecksummedAddress),
-    );
-  });
+      const result = ExecutedTransactionEventSchema.safeParse(
+        executedTransactionEvent,
+      );
+      expect(result.success && result.data[field]).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    },
+  );
 
   it.each([
     'type' as const,
+    'to' as const,
     'address' as const,
     'chainId' as const,
     'safeTxHash' as const,

--- a/src/routes/hooks/entities/schemas/__tests__/pending-transaction.schema.spec.ts
+++ b/src/routes/hooks/entities/schemas/__tests__/pending-transaction.schema.spec.ts
@@ -42,44 +42,51 @@ describe('PendingTransactionEventSchema', () => {
     );
   });
 
-  it('should not allow a non-address address', () => {
-    const pendingTransactionEvent = pendingTransactionEventBuilder()
-      .with('address', faker.string.sample() as `0x${string}`)
-      .build();
+  it.each(['to' as const, 'address' as const])(
+    'should not allow a non-address %s',
+    (field) => {
+      const pendingTransactionEvent = pendingTransactionEventBuilder()
+        .with(field, faker.string.sample() as `0x${string}`)
+        .build();
 
-    const result = PendingTransactionEventSchema.safeParse(
-      pendingTransactionEvent,
-    );
+      const result = PendingTransactionEventSchema.safeParse(
+        pendingTransactionEvent,
+      );
 
-    expect(!result.success && result.error).toStrictEqual(
-      new ZodError([
-        {
-          code: 'custom',
-          message: 'Invalid address',
-          path: ['address'],
-        },
-      ]),
-    );
-  });
+      expect(!result.success && result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'custom',
+            message: 'Invalid address',
+            path: [field],
+          },
+        ]),
+      );
+    },
+  );
 
-  it('should checksum the address', () => {
-    const nonChecksummedAddress = faker.finance
-      .ethereumAddress()
-      .toLowerCase() as `0x${string}`;
-    const pendingTransactionEvent = pendingTransactionEventBuilder()
-      .with('address', nonChecksummedAddress)
-      .build();
+  it.each(['to' as const, 'address' as const])(
+    'should checksum the %s',
+    (field) => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase() as `0x${string}`;
+      const pendingTransactionEvent = pendingTransactionEventBuilder()
+        .with(field, nonChecksummedAddress)
+        .build();
 
-    const result = PendingTransactionEventSchema.safeParse(
-      pendingTransactionEvent,
-    );
-    expect(result.success && result.data.address).toBe(
-      getAddress(nonChecksummedAddress),
-    );
-  });
+      const result = PendingTransactionEventSchema.safeParse(
+        pendingTransactionEvent,
+      );
+      expect(result.success && result.data[field]).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    },
+  );
 
   it.each([
     'type' as const,
+    'to' as const,
     'address' as const,
     'chainId' as const,
     'safeTxHash' as const,

--- a/src/routes/hooks/entities/schemas/executed-transaction.schema.ts
+++ b/src/routes/hooks/entities/schemas/executed-transaction.schema.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 export const ExecutedTransactionEventSchema = z.object({
   type: z.literal(TransactionEventType.EXECUTED_MULTISIG_TRANSACTION),
+  to: AddressSchema,
   address: AddressSchema,
   chainId: z.string(),
   safeTxHash: z.string(),

--- a/src/routes/hooks/entities/schemas/pending-transaction.schema.ts
+++ b/src/routes/hooks/entities/schemas/pending-transaction.schema.ts
@@ -4,6 +4,7 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 export const PendingTransactionEventSchema = z.object({
   type: z.literal(TransactionEventType.PENDING_MULTISIG_TRANSACTION),
+  to: AddressSchema,
   address: AddressSchema,
   chainId: z.string(),
   safeTxHash: z.string(),

--- a/src/routes/hooks/hooks-cache.spec.ts
+++ b/src/routes/hooks/hooks-cache.spec.ts
@@ -177,10 +177,12 @@ describe('Hook Events for Cache (Unit)', () => {
   it.each([
     {
       type: 'PENDING_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -231,10 +233,12 @@ describe('Hook Events for Cache (Unit)', () => {
   it.each([
     {
       type: 'PENDING_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
     },
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -285,6 +289,7 @@ describe('Hook Events for Cache (Unit)', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -331,6 +336,7 @@ describe('Hook Events for Cache (Unit)', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -383,6 +389,7 @@ describe('Hook Events for Cache (Unit)', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -442,6 +449,7 @@ describe('Hook Events for Cache (Unit)', () => {
   it.each([
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },
@@ -585,6 +593,7 @@ describe('Hook Events for Cache (Unit)', () => {
     },
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
+      to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
     },


### PR DESCRIPTION
## Summary

A new `to` field is to-be-added to the pending/executed multisig events [on the Transaction Service](https://github.com/safe-global/safe-events-service/pull/331). This adds them to the codebase, validating them and propagating them across tests.

## Changes

- Add `to` to `TransactionEventType.PENDING_MULTISIG_TRANSACTION` and `TransactionEventType.EXECUTED_MULTISIG_TRANSACTION` `type` events
- Update tests accordingly