### PR TITLE
fix: balances getSupportedFiatCode wrong swagger return example

### DIFF
--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -44,6 +44,7 @@ export class BalancesController {
   }
 
   @Get('balances/supported-fiat-codes')
+  @ApiOkResponse({ type: [String] })
   async getSupportedFiatCodes(): Promise<Array<string>> {
     return this.balancesService.getSupportedFiatCodes();
   }


### PR DESCRIPTION
The endpoint returns an array of strings e.g. [“USD”, “EUR”], but the swagger api was claiming otherwise.