### PR TITLE
Remove validation of `fullFeeAmount`

### DIFF
--- a/src/domain/swaps/entities/__tests__/order.builder.ts
+++ b/src/domain/swaps/entities/__tests__/order.builder.ts
@@ -87,7 +87,6 @@ export function orderBuilder(): IBuilder<Order> {
     .with('executedFeeAmount', faker.number.bigInt({ min: 1 }))
     .with('invalidated', faker.datatype.boolean())
     .with('status', faker.helpers.arrayElement(Object.values(OrderStatus)))
-    .with('fullFeeAmount', faker.number.bigInt({ min: 1 }))
     .with('isLiquidityOrder', faker.datatype.boolean())
     .with(
       'ethflowData',

--- a/src/domain/swaps/entities/order.entity.ts
+++ b/src/domain/swaps/entities/order.entity.ts
@@ -74,7 +74,6 @@ export const OrderSchema = z.object({
   executedFeeAmount: z.coerce.bigint(),
   invalidated: z.boolean(),
   status: z.nativeEnum(OrderStatus).catch(OrderStatus.Unknown),
-  fullFeeAmount: z.coerce.bigint(),
   isLiquidityOrder: z.boolean(),
   ethflowData: z
     .object({

--- a/src/domain/swaps/swaps.repository.e2e-spec.ts
+++ b/src/domain/swaps/swaps.repository.e2e-spec.ts
@@ -33,7 +33,6 @@ const orderIds = {
         from: null,
         fullAppData:
           '{"version":"0.4.0","appCode":"DefiLlama","environment":"production","metadata":{"referrer":{"version":"0.1.0","address":"0x08a3c2A819E3de7ACa384c798269B3Ce1CD0e437"}}}',
-        fullFeeAmount: BigInt('0'),
         invalidated: false,
         isLiquidityOrder: false,
         kind: 'sell',
@@ -78,7 +77,6 @@ const orderIds = {
         from: null,
         fullAppData:
           '{"appCode":"CoW Swap","environment":"production","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":"200"}},"version":"0.11.0"}',
-        fullFeeAmount: BigInt('0'),
         invalidated: false,
         isLiquidityOrder: false,
         kind: 'sell',

--- a/src/routes/transactions/helpers/swap-order.helper.spec.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.spec.ts
@@ -105,7 +105,6 @@ describe('Swap Order Helper tests', () => {
         feeAmount: order.feeAmount,
         from: order.from,
         fullAppData: order.fullAppData,
-        fullFeeAmount: order.fullFeeAmount,
         invalidated: order.invalidated,
         isLiquidityOrder: order.isLiquidityOrder,
         kind: order.kind,

--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -217,7 +217,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      solverFee: '0',
       isLiquidityOrder: false,
       fullAppData:
         '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -256,8 +255,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-
-      solverFee: '0',
       isLiquidityOrder: false,
       fullAppData:
         '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -395,7 +392,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      solverFee: '0',
       isLiquidityOrder: false,
       fullAppData:
         '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -627,7 +623,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      solverFee: '0',
       isLiquidityOrder: false,
       fullAppData: JSON.parse(
         '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -726,7 +721,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      solverFee: '0',
       isLiquidityOrder: false,
       fullAppData: JSON.parse(
         '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -931,7 +925,6 @@ describe('TwapOrderMapper', () => {
           status: 'open',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1049,7 +1042,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1167,7 +1159,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1206,7 +1197,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1327,7 +1317,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1366,7 +1355,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1406,7 +1394,6 @@ describe('TwapOrderMapper', () => {
           status: 'open',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1524,7 +1511,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1563,7 +1549,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',
@@ -1602,7 +1587,6 @@ describe('TwapOrderMapper', () => {
           status: 'expired',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
             '{"appCode":"Safe Wallet Swaps","metadata":{"orderClass":{"orderClass":"twap"},"partnerFee":{"bps":35,"recipient":"0x63695Eee2c3141BDE314C5a6f89B98E62808d716"},"quote":{"slippageBips":1000},"widget":{"appCode":"CoW Swap-SafeApp","environment":"production"}},"version":"1.1.0"}',

--- a/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/twap-order.mapper.spec.ts
@@ -217,7 +217,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      fullFeeAmount: '0',
       solverFee: '0',
       isLiquidityOrder: false,
       fullAppData:
@@ -257,7 +256,7 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      fullFeeAmount: '0',
+
       solverFee: '0',
       isLiquidityOrder: false,
       fullAppData:
@@ -396,7 +395,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      fullFeeAmount: '0',
       solverFee: '0',
       isLiquidityOrder: false,
       fullAppData:
@@ -629,7 +627,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      fullFeeAmount: '0',
       solverFee: '0',
       isLiquidityOrder: false,
       fullAppData: JSON.parse(
@@ -729,7 +726,6 @@ describe('TwapOrderMapper', () => {
       status: 'fulfilled',
       class: 'limit',
       settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-      fullFeeAmount: '0',
       solverFee: '0',
       isLiquidityOrder: false,
       fullAppData: JSON.parse(
@@ -935,7 +931,6 @@ describe('TwapOrderMapper', () => {
           status: 'open',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1054,7 +1049,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1173,7 +1167,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1213,7 +1206,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1335,7 +1327,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1375,7 +1366,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1416,7 +1406,6 @@ describe('TwapOrderMapper', () => {
           status: 'open',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1535,7 +1524,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1575,7 +1563,6 @@ describe('TwapOrderMapper', () => {
           status: 'fulfilled',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:
@@ -1615,7 +1602,6 @@ describe('TwapOrderMapper', () => {
           status: 'expired',
           class: 'limit',
           settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-          fullFeeAmount: '0',
           solverFee: '0',
           isLiquidityOrder: false,
           fullAppData:

--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
@@ -262,7 +262,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        fullFeeAmount: '0',
         solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
@@ -299,7 +298,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        fullFeeAmount: '0',
         solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
@@ -422,7 +420,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        fullFeeAmount: '0',
         solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
@@ -459,7 +456,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        fullFeeAmount: '0',
         solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:

--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
@@ -262,7 +262,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
           '{"appCode":"CoW Swap","environment":"production","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50},"utm":{"utmContent":"header-cta-button","utmMedium":"web","utmSource":"cow.fi"}},"version":"1.1.0"}',
@@ -298,7 +297,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
           '{"appCode":"CoW Swap","environment":"production","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50},"utm":{"utmContent":"header-cta-button","utmMedium":"web","utmSource":"cow.fi"}},"version":"1.1.0"}',
@@ -420,7 +418,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
           '{"appCode":"CoW Swap","environment":"production","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50},"utm":{"utmContent":"header-cta-button","utmMedium":"web","utmSource":"cow.fi"}},"version":"1.1.0"}',
@@ -456,7 +453,6 @@ describe('SwapTransferInfoMapper', () => {
         status: 'fulfilled',
         class: 'limit',
         settlementContract: '0x9008d19f58aabd9ed0d60971565aa8510560ab41',
-        solverFee: '0',
         isLiquidityOrder: false,
         fullAppData:
           '{"appCode":"CoW Swap","environment":"production","metadata":{"orderClass":{"orderClass":"market"},"quote":{"slippageBips":50},"utm":{"utmContent":"header-cta-button","utmMedium":"web","utmSource":"cow.fi"}},"version":"1.1.0"}',


### PR DESCRIPTION
## Summary

We currently validate the presence of `fullFeeAmount` in `Order`s. This field is [no longer returned by CoW](https://github.com/cowprotocol/services/pull/3223) and, as such, breaks Swap decoding.

As we are not reliant on the field, it can be safely removed. As such, validation is no longer included and all presence of the field removed accross the codebase.

Note: `solverFee` has also been removed from mock data as that is also not used (though not validated)

## Changes

- Remove validation of `fullFeeAmount`
- Remove mock `solveFee` values
- Propagate across codebase