### PR TITLE
Add `IPortfolioRepository` domain and implementation

### DIFF
--- a/src/datasources/portfolio-api/entities/octav-get-portfolio.entity.spec.ts
+++ b/src/datasources/portfolio-api/entities/octav-get-portfolio.entity.spec.ts
@@ -1,11 +1,13 @@
 import { ZodError } from 'zod';
 import { OctavGetPortfolioSchema } from '@/datasources/portfolio-api/entities/octav-get-portfolio.entity';
 import type { OctavGetPortfolio } from '@/datasources/portfolio-api/entities/octav-get-portfolio.entity';
+import { portfolioBuilder } from '@/domain/portfolio/entities/__tests__/portfolio.builder';
 
 describe('OctavGetPortfolioSchema', () => {
   it('should validate a getPortfolio response', () => {
-    const portfolio = { example: 'payload' };
-    const getPortfolio: OctavGetPortfolio = { getPortfolio: [portfolio] };
+    const getPortfolio: OctavGetPortfolio = {
+      getPortfolio: [portfolioBuilder().build()],
+    };
 
     const result = OctavGetPortfolioSchema.safeParse(getPortfolio);
 

--- a/src/datasources/portfolio-api/octav-api.service.spec.ts
+++ b/src/datasources/portfolio-api/octav-api.service.spec.ts
@@ -8,6 +8,7 @@ import { OctavApi } from '@/datasources/portfolio-api/octav-api.service';
 import { rawify } from '@/validation/entities/raw.entity';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import type { OctavGetPortfolio } from '@/datasources/portfolio-api/entities/octav-get-portfolio.entity';
+import { portfolioBuilder } from '@/domain/portfolio/entities/__tests__/portfolio.builder';
 
 const mockNetworkService = jest.mocked({
   get: jest.fn(),
@@ -70,8 +71,9 @@ describe('OctavApiService', () => {
   describe('getPortfolio', () => {
     it('should get portfolio', async () => {
       const safeAddress = getAddress(faker.finance.ethereumAddress());
-      const portfolio = { example: 'payload' };
-      const getPortfolio: OctavGetPortfolio = { getPortfolio: [portfolio] };
+      const getPortfolio: OctavGetPortfolio = {
+        getPortfolio: [portfolioBuilder().build()],
+      };
       mockNetworkService.get.mockResolvedValueOnce({
         status: 200,
         data: rawify(getPortfolio),

--- a/src/domain/portfolio/entities/__tests__/portfolio.builder.ts
+++ b/src/domain/portfolio/entities/__tests__/portfolio.builder.ts
@@ -1,0 +1,135 @@
+import { faker } from '@faker-js/faker';
+import { Builder } from '@/__tests__/builder';
+import type { IBuilder } from '@/__tests__/builder';
+import {
+  ProtocolChainKeys,
+  ProtocolPositionType,
+  type AssetByProtocol,
+  type ComplexPosition,
+  type Portfolio,
+  type PortfolioAsset,
+  type ProtocolPositions,
+  type RegularPosition,
+} from '@/domain/portfolio/entities/portfolio.entity';
+import { getAddress } from 'viem';
+
+export function portfolioBuilder(): IBuilder<Portfolio> {
+  return new Builder<Portfolio>().with(
+    'assetByProtocols',
+    assetByProtocolsBuilder().build(),
+  );
+}
+
+function assetByProtocolsBuilder(): IBuilder<Portfolio['assetByProtocols']> {
+  const builder = new Builder<Portfolio['assetByProtocols']>();
+  const protocols = faker.helpers.multiple(() => faker.string.sample(), {
+    count: {
+      min: 1,
+      max: 5,
+    },
+  });
+  for (const protocol of protocols) {
+    builder.with(protocol, assetByProtocolBuilder().build());
+  }
+  return builder;
+}
+
+export function assetByProtocolBuilder(): IBuilder<AssetByProtocol> {
+  return new Builder<AssetByProtocol>()
+    .with('chains', assetByProtocolChainBuilder().build())
+    .with('name', faker.string.sample())
+    .with('imgLarge', faker.internet.url())
+    .with('value', faker.string.numeric());
+}
+
+export function assetByProtocolChainBuilder(): IBuilder<
+  AssetByProtocol['chains']
+> {
+  const builder = new Builder<AssetByProtocol['chains']>();
+  const keys = faker.helpers.arrayElements(ProtocolChainKeys, {
+    min: 1,
+    max: 5,
+  });
+  for (const key of keys) {
+    builder.with(key, {
+      protocolPositions: protocolPositionsBuilder().build(),
+    });
+  }
+  return builder;
+}
+
+export function protocolPositionsBuilder(): IBuilder<ProtocolPositions> {
+  const builder = new Builder<ProtocolPositions>();
+  const types = faker.helpers.arrayElements(ProtocolPositionType, {
+    min: 1,
+    max: 5,
+  });
+  for (const type of types) {
+    builder.with(
+      type,
+      faker.datatype.boolean()
+        ? regularPositionBuilder().build()
+        : complexPositionBuilder().build(),
+    );
+  }
+  return builder;
+}
+
+function getPortfolioAssets(): Array<PortfolioAsset> {
+  return faker.helpers.multiple(() => portfolioAssetBuilder().build(), {
+    count: {
+      min: 1,
+      max: 5,
+    },
+  });
+}
+
+export function regularPositionBuilder(): IBuilder<RegularPosition> {
+  return new Builder<RegularPosition>()
+    .with('name', faker.string.sample())
+    .with('assets', getPortfolioAssets())
+    .with('totalValue', faker.string.numeric());
+}
+
+export function complexPositionBuilder(): IBuilder<ComplexPosition> {
+  return new Builder<ComplexPosition>()
+    .with('name', faker.string.sample())
+    .with(
+      'protocolPositions',
+      faker.helpers.multiple(() => complexPositionPositionBuilder().build(), {
+        count: {
+          min: 1,
+          max: 5,
+        },
+      }),
+    );
+}
+
+function getOptionalPortfolioAssets(): Array<PortfolioAsset> | undefined {
+  return faker.datatype.boolean() ? getPortfolioAssets() : undefined;
+}
+
+export function complexPositionPositionBuilder(): IBuilder<
+  ComplexPosition['protocolPositions'][number]
+> {
+  return new Builder<ComplexPosition['protocolPositions'][number]>()
+    .with('name', faker.string.sample())
+    .with('value', faker.string.numeric())
+    .with('assets', getPortfolioAssets())
+    .with('borrowAssets', getOptionalPortfolioAssets())
+    .with('dexAssets', getOptionalPortfolioAssets())
+    .with('rewardAssets', getOptionalPortfolioAssets())
+    .with('supplyAssets', getOptionalPortfolioAssets());
+}
+
+export function portfolioAssetBuilder(): IBuilder<PortfolioAsset> {
+  return new Builder<PortfolioAsset>()
+    .with('balance', faker.string.numeric())
+    .with('decimal', faker.number.int({ min: 1, max: 18 }))
+    .with('name', faker.string.sample())
+    .with('price', faker.string.numeric())
+    .with('symbol', faker.string.sample())
+    .with('value', faker.string.numeric())
+    .with('contract', getAddress(faker.finance.ethereumAddress()))
+    .with('imgSmall', faker.internet.url());
+}

--- a/src/domain/portfolio/entities/portfolio.entity.spec.ts
+++ b/src/domain/portfolio/entities/portfolio.entity.spec.ts
@@ -1,1 +1,670 @@
-it.todo('PortfolioSchema');
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import {
+  assetByProtocolBuilder,
+  assetByProtocolChainBuilder,
+  complexPositionBuilder,
+  complexPositionPositionBuilder,
+  portfolioAssetBuilder,
+  portfolioBuilder,
+  protocolPositionsBuilder,
+  regularPositionBuilder,
+} from '@/domain/portfolio/entities/__tests__/portfolio.builder';
+import {
+  AssetByProtocolChainSchema,
+  AssetByProtocolSchema,
+  ComplexPositionPositionSchema,
+  ComplexPositionSchema,
+  PortfolioAssetSchema,
+  PortfolioSchema,
+  ProtocolPositionsSchema,
+  RegularPositionSchema,
+} from '@/domain/portfolio/entities/portfolio.entity';
+import type {
+  ComplexPositionPosition,
+  PortfolioAsset,
+  ProtocolChainKeys,
+  ProtocolPositionType,
+} from '@/domain/portfolio/entities/portfolio.entity';
+
+describe('Portfolio', () => {
+  describe('PortfolioAssetSchema', () => {
+    it('should validate a PortfolioAsset', () => {
+      const portfolioAssets = portfolioAssetBuilder().build();
+
+      const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+      expect(result.success).toBe(true);
+    });
+
+    it.each<keyof PortfolioAsset>(['balance', 'price', 'value'])(
+      `should not allow a non-numerical %s`,
+      (key) => {
+        const portfolioAssets = portfolioAssetBuilder()
+          .with(key, faker.string.alpha())
+          .build();
+
+        const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+        expect(!result.success && result.error.issues).toStrictEqual([
+          {
+            code: 'custom',
+            message: 'Invalid base-10 numeric string',
+            path: [key],
+          },
+        ]);
+      },
+    );
+
+    it('should coerce the decimal to a number', () => {
+      const portfolioAssets = portfolioAssetBuilder()
+        .with('decimal', faker.string.numeric() as unknown as number)
+        .build();
+
+      const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+      expect(result.success && result.data.decimal).toBe(
+        Number(portfolioAssets.decimal),
+      );
+    });
+
+    it('should not allow a non-address contract', () => {
+      const portfolioAssets = portfolioAssetBuilder()
+        .with('contract', faker.string.alpha() as `0x${string}`)
+        .build();
+
+      const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'custom',
+          message: 'Invalid address',
+          path: ['contract'],
+        },
+      ]);
+    });
+
+    it('should checksum the contract address', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase() as `0x${string}`;
+      const portfolioAssets = portfolioAssetBuilder()
+        .with('contract', nonChecksummedAddress)
+        .build();
+
+      const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+      expect(result.success && result.data.contract).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    });
+
+    it('should not allow a non-url imgSmall', () => {
+      const portfolioAssets = portfolioAssetBuilder()
+        .with('imgSmall', faker.string.sample())
+        .build();
+
+      const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_string',
+          message: 'Invalid url',
+          path: ['imgSmall'],
+          validation: 'url',
+        },
+      ]);
+    });
+
+    it('should not validate an invalid PortfolioAsset', () => {
+      const portfolioAssets = { invalid: 'portfolioAsset' };
+
+      const result = PortfolioAssetSchema.safeParse(portfolioAssets);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['balance'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'number',
+          message: 'Expected number, received nan',
+          path: ['decimal'],
+          received: 'nan',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['name'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['price'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['symbol'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['value'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['contract'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['imgSmall'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('RegularPositionSchema', () => {
+    it('should validate a RegularPosition', () => {
+      const regularPosition = regularPositionBuilder().build();
+
+      const result = RegularPositionSchema.safeParse(regularPosition);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not allow a non-numerical totalValue', () => {
+      const regularPosition = regularPositionBuilder()
+        .with('totalValue', faker.string.alpha())
+        .build();
+
+      const result = RegularPositionSchema.safeParse(regularPosition);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'custom',
+          message: 'Invalid base-10 numeric string',
+          path: ['totalValue'],
+        },
+      ]);
+    });
+
+    it('should not validate an invalid RegularPosition', () => {
+      const regularPosition = { invalid: 'regularPosition' };
+
+      const result = RegularPositionSchema.safeParse(regularPosition);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['name'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['assets'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['totalValue'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('ComplexPositionPositionSchema', () => {
+    it('should validate a ComplexPositionPosition', () => {
+      const complexPositionPosition = complexPositionPositionBuilder().build();
+
+      const result = ComplexPositionPositionSchema.safeParse(
+        complexPositionPosition,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it.each<keyof ComplexPositionPosition>(['value', 'healthRate'])(
+      'should not allow a non-numerical %s',
+      (key) => {
+        const complexPositionPosition = complexPositionPositionBuilder()
+          .with(key, faker.string.alpha())
+          .build();
+
+        const result = ComplexPositionPositionSchema.safeParse(
+          complexPositionPosition,
+        );
+
+        expect(!result.success && result.error.issues).toStrictEqual([
+          {
+            code: 'custom',
+            message: 'Invalid base-10 numeric string',
+            path: [key],
+          },
+        ]);
+      },
+    );
+
+    it('should not validate an invalid ComplexPositionPosition', () => {
+      const complexPositionPosition = { invalid: 'complexPositionPosition' };
+
+      const result = ComplexPositionPositionSchema.safeParse(
+        complexPositionPosition,
+      );
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['name'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['value'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['assets'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('ComplexPositionSchema', () => {
+    it('should validate a ComplexPosition', () => {
+      const complexPosition = complexPositionBuilder().build();
+
+      const result = ComplexPositionSchema.safeParse(complexPosition);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not validate an invalid ComplexPosition', () => {
+      const complexPosition = { invalid: 'complexPosition' };
+
+      const result = ComplexPositionSchema.safeParse(complexPosition);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['name'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['protocolPositions'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('ProtocolPositionsSchema', () => {
+    it('should validate a ProtocolPosition', () => {
+      const protocolPositions = protocolPositionsBuilder().build();
+
+      const result = ProtocolPositionsSchema.safeParse(protocolPositions);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not allow an unknown position type', () => {
+      const type = faker.word.verb() as (typeof ProtocolPositionType)[number];
+      const protocolPositions = protocolPositionsBuilder()
+        .with(
+          type,
+          faker.datatype.boolean()
+            ? regularPositionBuilder().build()
+            : complexPositionBuilder().build(),
+        )
+        .build();
+
+      const result = ProtocolPositionsSchema.safeParse(protocolPositions);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_enum_value',
+          message: `Invalid enum value. Expected 'DEPOSIT' | 'FARMING' | 'GOVERNANCE' | 'INSURANCEBUYER' | 'INSURANCESELLER' | 'INVESTMENT' | 'LENDING' | 'LEVERAGE' | 'LEVERAGED FARMING' | 'LIQUIDITYPOOL' | 'LOCKED' | 'MARGIN' | 'MARGINPS' | 'NFTBORROWER' | 'NFTFRACTION' | 'NFTLENDER' | 'NFTLENDING' | 'NFTLIQUIDITYPOOL' | 'NFTSTAKED' | 'OPTIONSBUYER' | 'OPTIONSSELLER' | 'PERPETUALS' | 'REWARDS' | 'SPOT' | 'STAKED' | 'VAULT' | 'VAULTPS' | 'VESTING' | 'WALLET' | 'YIELD', received '${type}'`,
+          options: [
+            'DEPOSIT',
+            'FARMING',
+            'GOVERNANCE',
+            'INSURANCEBUYER',
+            'INSURANCESELLER',
+            'INVESTMENT',
+            'LENDING',
+            'LEVERAGE',
+            'LEVERAGED FARMING',
+            'LIQUIDITYPOOL',
+            'LOCKED',
+            'MARGIN',
+            'MARGINPS',
+            'NFTBORROWER',
+            'NFTFRACTION',
+            'NFTLENDER',
+            'NFTLENDING',
+            'NFTLIQUIDITYPOOL',
+            'NFTSTAKED',
+            'OPTIONSBUYER',
+            'OPTIONSSELLER',
+            'PERPETUALS',
+            'REWARDS',
+            'SPOT',
+            'STAKED',
+            'VAULT',
+            'VAULTPS',
+            'VESTING',
+            'WALLET',
+            'YIELD',
+          ],
+          path: [type],
+          received: type,
+        },
+      ]);
+    });
+
+    it('should not validate an invalid ProtocolPosition', () => {
+      const protocolPositions = { invalid: 'protocolPositions' };
+
+      const result = ComplexPositionPositionSchema.safeParse(protocolPositions);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['name'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['value'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Required',
+          path: ['assets'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('AssetByProtocolChainSchema', () => {
+    it('should validate an AssetByProtocolChain', () => {
+      const assetByProtocolChain = assetByProtocolChainBuilder().build();
+
+      const result = AssetByProtocolChainSchema.safeParse(assetByProtocolChain);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not allow an unknown position chain key', () => {
+      const key = faker.word.noun() as (typeof ProtocolChainKeys)[number];
+      const assetByProtocolChain = assetByProtocolChainBuilder()
+        .with(key, {
+          protocolPositions: protocolPositionsBuilder().build(),
+        })
+        .build();
+
+      const result = AssetByProtocolChainSchema.safeParse(assetByProtocolChain);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_enum_value',
+          message: `Invalid enum value. Expected 'ancient8' | 'arbitrum' | 'arbitrum_nova' | 'aurora' | 'avalanche' | 'base' | 'binance' | 'blast' | 'bob' | 'boba' | 'celo' | 'core' | 'cronos' | 'era' | 'ethereum' | 'fantom' | 'fraxtal' | 'gnosis' | 'hyperliquid' | 'kava' | 'kroma' | 'linea' | 'manta' | 'mantle' | 'metis' | 'mint' | 'mode' | 'optimism' | 'polygon' | 'polygon_zkevm' | 'rari' | 'scroll' | 'solana' | 'taiko' | 'wc' | 'xlayer' | 'zora', received '${key}'`,
+          options: [
+            'ancient8',
+            'arbitrum',
+            'arbitrum_nova',
+            'aurora',
+            'avalanche',
+            'base',
+            'binance',
+            'blast',
+            'bob',
+            'boba',
+            'celo',
+            'core',
+            'cronos',
+            'era',
+            'ethereum',
+            'fantom',
+            'fraxtal',
+            'gnosis',
+            'hyperliquid',
+            'kava',
+            'kroma',
+            'linea',
+            'manta',
+            'mantle',
+            'metis',
+            'mint',
+            'mode',
+            'optimism',
+            'polygon',
+            'polygon_zkevm',
+            'rari',
+            'scroll',
+            'solana',
+            'taiko',
+            'wc',
+            'xlayer',
+            'zora',
+          ],
+          path: [key],
+          received: key,
+        },
+      ]);
+    });
+
+    it('should not validate an invalid AssetByProtocolChain', () => {
+      const assetByProtocolChain = { invalid: 'assetByProtocolChain' };
+
+      const result = AssetByProtocolChainSchema.safeParse(assetByProtocolChain);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_enum_value',
+          message:
+            "Invalid enum value. Expected 'ancient8' | 'arbitrum' | 'arbitrum_nova' | 'aurora' | 'avalanche' | 'base' | 'binance' | 'blast' | 'bob' | 'boba' | 'celo' | 'core' | 'cronos' | 'era' | 'ethereum' | 'fantom' | 'fraxtal' | 'gnosis' | 'hyperliquid' | 'kava' | 'kroma' | 'linea' | 'manta' | 'mantle' | 'metis' | 'mint' | 'mode' | 'optimism' | 'polygon' | 'polygon_zkevm' | 'rari' | 'scroll' | 'solana' | 'taiko' | 'wc' | 'xlayer' | 'zora', received 'invalid'",
+          options: [
+            'ancient8',
+            'arbitrum',
+            'arbitrum_nova',
+            'aurora',
+            'avalanche',
+            'base',
+            'binance',
+            'blast',
+            'bob',
+            'boba',
+            'celo',
+            'core',
+            'cronos',
+            'era',
+            'ethereum',
+            'fantom',
+            'fraxtal',
+            'gnosis',
+            'hyperliquid',
+            'kava',
+            'kroma',
+            'linea',
+            'manta',
+            'mantle',
+            'metis',
+            'mint',
+            'mode',
+            'optimism',
+            'polygon',
+            'polygon_zkevm',
+            'rari',
+            'scroll',
+            'solana',
+            'taiko',
+            'wc',
+            'xlayer',
+            'zora',
+          ],
+          path: ['invalid'],
+          received: 'invalid',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'object',
+          message: 'Expected object, received string',
+          path: ['invalid'],
+          received: 'string',
+        },
+      ]);
+    });
+  });
+
+  describe('AssetByProtocolSchema', () => {
+    it('should validate an AssetByProtocol', () => {
+      const assetByProtocol = assetByProtocolBuilder().build();
+
+      const result = AssetByProtocolSchema.safeParse(assetByProtocol);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not allow a non-url imgLarge', () => {
+      const assetByProtocol = assetByProtocolBuilder()
+        .with('imgLarge', faker.string.sample())
+        .build();
+
+      const result = AssetByProtocolSchema.safeParse(assetByProtocol);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_string',
+          message: 'Invalid url',
+          path: ['imgLarge'],
+          validation: 'url',
+        },
+      ]);
+    });
+
+    it('should not allow a non-numerical value', () => {
+      const assetByProtocol = assetByProtocolBuilder()
+        .with('value', faker.string.alpha())
+        .build();
+
+      const result = AssetByProtocolSchema.safeParse(assetByProtocol);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'custom',
+          message: 'Invalid base-10 numeric string',
+          path: ['value'],
+        },
+      ]);
+    });
+
+    it('should not validate an invalid AssetByProtocol', () => {
+      const assetByProtocol = { invalid: 'assetByProtocol' };
+
+      const result = AssetByProtocolSchema.safeParse(assetByProtocol);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'object',
+          message: 'Required',
+          path: ['chains'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['name'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['imgLarge'],
+          received: 'undefined',
+        },
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          message: 'Required',
+          path: ['value'],
+          received: 'undefined',
+        },
+      ]);
+    });
+  });
+
+  describe('PortfolioSchema', () => {
+    it('should validate a Portfolio', () => {
+      const portfolio = portfolioBuilder().build();
+
+      const result = PortfolioSchema.safeParse(portfolio);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not validate an invalid Portfolio', () => {
+      const portfolio = { invalid: 'portfolio' };
+
+      const result = PortfolioSchema.safeParse(portfolio);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'object',
+          received: 'undefined',
+          path: ['assetByProtocols'],
+          message: 'Required',
+        },
+      ]);
+    });
+  });
+});

--- a/src/domain/portfolio/entities/portfolio.entity.ts
+++ b/src/domain/portfolio/entities/portfolio.entity.ts
@@ -1,5 +1,160 @@
 import { z } from 'zod';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
-export const PortfolioSchema = z.unknown();
+// Assets
+
+export const PortfolioAssetSchema = z.object({
+  balance: NumericStringSchema,
+  decimal: z.coerce.number(),
+  name: z.string(),
+  price: NumericStringSchema,
+  symbol: z.string(),
+  value: NumericStringSchema,
+  contract: AddressSchema,
+  imgSmall: z.string().url(),
+});
+
+export type PortfolioAsset = z.infer<typeof PortfolioAssetSchema>;
+
+// Positions
+
+// Regular positions only have top-level assets, no nested protocolPositions assets
+export const RegularPositionSchema = z.object({
+  name: z.string(),
+  assets: z.array(PortfolioAssetSchema),
+  totalValue: NumericStringSchema,
+});
+
+export type RegularPosition = z.infer<typeof RegularPositionSchema>;
+
+// Complex positions no top-level assets, but nested protocolPositions assets
+
+export const ComplexPositionPositionSchema = z.object({
+  name: z.string(),
+  value: NumericStringSchema,
+  healthRate: NumericStringSchema.optional(),
+  assets: z.array(PortfolioAssetSchema),
+  borrowAssets: z.array(PortfolioAssetSchema).optional(),
+  dexAssets: z.array(PortfolioAssetSchema).optional(),
+  rewardAssets: z.array(PortfolioAssetSchema).optional(),
+  supplyAssets: z.array(PortfolioAssetSchema).optional(),
+});
+
+export type ComplexPositionPosition = z.infer<
+  typeof ComplexPositionPositionSchema
+>;
+
+export const ComplexPositionSchema = z.object({
+  name: z.string(),
+  protocolPositions: z.array(ComplexPositionPositionSchema),
+});
+
+export type ComplexPosition = z.infer<typeof ComplexPositionSchema>;
+
+export const ProtocolPositionType = [
+  'DEPOSIT',
+  'FARMING',
+  'GOVERNANCE',
+  'INSURANCEBUYER',
+  'INSURANCESELLER',
+  'INVESTMENT',
+  'LENDING',
+  'LEVERAGE',
+  'LEVERAGED FARMING',
+  'LIQUIDITYPOOL',
+  'LOCKED',
+  'MARGIN',
+  'MARGINPS',
+  'NFTBORROWER',
+  'NFTFRACTION',
+  'NFTLENDER',
+  'NFTLENDING',
+  'NFTLIQUIDITYPOOL',
+  'NFTSTAKED',
+  'OPTIONSBUYER',
+  'OPTIONSSELLER',
+  'PERPETUALS',
+  'REWARDS',
+  'SPOT',
+  'STAKED',
+  'VAULT',
+  'VAULTPS',
+  'VESTING',
+  'WALLET',
+  'YIELD',
+] as const;
+
+export const ProtocolPositionsSchema = z.record(
+  z.enum(ProtocolPositionType),
+  RegularPositionSchema.or(ComplexPositionSchema),
+);
+
+export type ProtocolPositions = z.infer<typeof ProtocolPositionsSchema>;
+
+export const ProtocolChainKeys = [
+  'ancient8',
+  'arbitrum',
+  'arbitrum_nova',
+  'aurora',
+  'avalanche',
+  'base',
+  'binance',
+  'blast',
+  'bob',
+  'boba',
+  'celo',
+  'core',
+  'cronos',
+  'era', // zkSync Era
+  'ethereum',
+  'fantom',
+  'fraxtal',
+  'gnosis',
+  'hyperliquid',
+  'kava',
+  'kroma',
+  'linea',
+  'manta',
+  'mantle',
+  'metis',
+  'mint',
+  'mode',
+  'optimism',
+  'polygon',
+  'polygon_zkevm',
+  'rari',
+  'scroll',
+  'solana',
+  'taiko',
+  'wc', // World Chain
+  'xlayer',
+  'zora',
+] as const;
+
+export const AssetByProtocolChainSchema = z.record(
+  z.enum(ProtocolChainKeys),
+  z.object({
+    protocolPositions: ProtocolPositionsSchema,
+  }),
+);
+
+export const AssetByProtocolSchema = z.object({
+  chains: AssetByProtocolChainSchema,
+  name: z.string(),
+  imgLarge: z.string().url(),
+  value: NumericStringSchema,
+});
+
+export type AssetByProtocol = z.infer<typeof AssetByProtocolSchema>;
+
+// Protocols
+
+// aave2, compound, convex, etc.
+const ProtocolNameSchema = z.string();
+
+export const PortfolioSchema = z.object({
+  assetByProtocols: z.record(ProtocolNameSchema, AssetByProtocolSchema),
+});
 
 export type Portfolio = z.infer<typeof PortfolioSchema>;

--- a/src/domain/portfolio/entities/portfolio.entity.ts
+++ b/src/domain/portfolio/entities/portfolio.entity.ts
@@ -19,18 +19,7 @@ export type PortfolioAsset = z.infer<typeof PortfolioAssetSchema>;
 
 // Positions
 
-// Regular positions only have top-level assets, no nested protocolPositions assets
-export const RegularPositionSchema = z.object({
-  name: z.string(),
-  assets: z.array(PortfolioAssetSchema),
-  totalValue: NumericStringSchema,
-});
-
-export type RegularPosition = z.infer<typeof RegularPositionSchema>;
-
-// Complex positions no top-level assets, but nested protocolPositions assets
-
-export const ComplexPositionPositionSchema = z.object({
+export const NestedProtocolPositionSchema = z.object({
   name: z.string(),
   value: NumericStringSchema,
   healthRate: NumericStringSchema.optional(),
@@ -41,16 +30,25 @@ export const ComplexPositionPositionSchema = z.object({
   supplyAssets: z.array(PortfolioAssetSchema).optional(),
 });
 
-export type ComplexPositionPosition = z.infer<
-  typeof ComplexPositionPositionSchema
+export type NestedProtocolPosition = z.infer<
+  typeof NestedProtocolPositionSchema
 >;
 
-export const ComplexPositionSchema = z.object({
+/**
+ * "regular" positions have assets, and no protocolPositions
+ * "complex" positions have no assets, and protocolPositions
+ *
+ * Splitting this into "regular" and "complex" schemas proved difficult
+ * as WALLET position type can have no assets or protocolPositions
+ */
+export const ProtocolPositionSchema = z.object({
   name: z.string(),
-  protocolPositions: z.array(ComplexPositionPositionSchema),
+  assets: z.array(PortfolioAssetSchema),
+  protocolPositions: z.array(NestedProtocolPositionSchema),
+  totalValue: NumericStringSchema,
 });
 
-export type ComplexPosition = z.infer<typeof ComplexPositionSchema>;
+export type ProtocolPosition = z.infer<typeof ProtocolPositionSchema>;
 
 export const ProtocolPositionType = [
   'DEPOSIT',
@@ -87,7 +85,7 @@ export const ProtocolPositionType = [
 
 export const ProtocolPositionsSchema = z.record(
   z.enum(ProtocolPositionType),
-  RegularPositionSchema.or(ComplexPositionSchema),
+  ProtocolPositionSchema,
 );
 
 export type ProtocolPositions = z.infer<typeof ProtocolPositionsSchema>;

--- a/src/domain/portfolio/portfolio.repository.interface.ts
+++ b/src/domain/portfolio/portfolio.repository.interface.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { PortfolioApiModule } from '@/datasources/portfolio-api/portfolio-api.module';
+import { Portfolio } from '@/domain/portfolio/entities/portfolio.entity';
+import { PortfolioRepository } from '@/domain/portfolio/portfolio.repository';
+
+export const IPortfolioRepository = Symbol('IPortfolioRepository');
+
+export interface IPortfolioRepository {
+  getPortfolio(safeAddress: `0x${string}`): Promise<Portfolio>;
+}
+
+@Module({
+  imports: [PortfolioApiModule],
+  providers: [
+    {
+      provide: IPortfolioRepository,
+      useClass: PortfolioRepository,
+    },
+  ],
+  exports: [IPortfolioRepository],
+})
+export class PortfolioRepositoryModule {}

--- a/src/domain/portfolio/portfolio.repository.ts
+++ b/src/domain/portfolio/portfolio.repository.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IPortfolioApi } from '@/domain/interfaces/portfolio-api.interface';
+import {
+  Portfolio,
+  PortfolioSchema,
+} from '@/domain/portfolio/entities/portfolio.entity';
+import type { IPortfolioRepository } from '@/domain/portfolio/portfolio.repository.interface';
+
+@Injectable()
+export class PortfolioRepository implements IPortfolioRepository {
+  constructor(
+    @Inject(IPortfolioApi) private readonly portfolioApi: IPortfolioApi,
+  ) {}
+
+  public async getPortfolio(safeAddress: `0x${string}`): Promise<Portfolio> {
+    const portfolio = await this.portfolioApi.getPortfolio(safeAddress);
+    return PortfolioSchema.parse(portfolio);
+  }
+}


### PR DESCRIPTION
## Summary

This adds the domain layer for the forthcoming portfolio feature.

A new `IPortfolioRepositry`, including a method to get the portfolio for a specified address. The implementation of which fetches a portfolio and validates it according to the Octav-based `PortfolioSchema`.

## Changes

- Add `IPortfolioRepositry` with implementation
- Implement and test `PortfolioSchema`
- Add builders for `Portfolio` and constituent entities