### PR TITLE
fix: gitignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lerna-debug.log*
 .env
 .env.test
 .env.dev
+.envrc
 
 # Database mounted volume
 data


### PR DESCRIPTION
## Summary

The `.envrc` was added as part of #2214 but never actually did anything. It is needed in case direnv is used locally so we can gitignore it. More info [here](https://direnv.net/#the-stdlib).

## Changes

- Adds `.envrc` to the gitignore and removes the empty file