### PR TITLE
Add portfolio API key placeholder

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,13 +45,6 @@
 # PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL=
 # PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY=
 
-# Portfolio Provider - Octav
-# The portfolio provider to be used.
-# (default=https://octav-api.hasura.app)
-# PORTFOLIO_API_BASE_URI=
-# The API key to be used.
-# PORTFOLIO_API_KEY=
-
 # Relay Provider
 # The relay provider to be used.
 # (default='https://api.gelato.digital')

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -30,7 +30,7 @@ describe('Configuration validator', () => {
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: faker.internet.email(),
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY:
       faker.string.alphanumeric(),
-    PORTFOLIO_API_KEY: faker.string.uuid(),
+    // PORTFOLIO_API_KEY: faker.string.uuid(),
     RELAY_PROVIDER_API_KEY_OPTIMISM: faker.string.uuid(),
     RELAY_PROVIDER_API_KEY_BSC: faker.string.uuid(),
     RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),
@@ -77,7 +77,7 @@ describe('Configuration validator', () => {
     { key: 'PUSH_NOTIFICATIONS_API_PROJECT' },
     { key: 'PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL' },
     { key: 'PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY' },
-    { key: 'PORTFOLIO_API_KEY' },
+    // { key: 'PORTFOLIO_API_KEY' },
     { key: 'RELAY_PROVIDER_API_KEY_OPTIMISM' },
     { key: 'RELAY_PROVIDER_API_KEY_BSC' },
     { key: 'RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN' },
@@ -129,7 +129,7 @@ describe('Configuration validator', () => {
         faker.internet.email(),
       PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY:
         faker.string.alphanumeric(),
-      PORTFOLIO_API_KEY: faker.string.uuid(),
+      // PORTFOLIO_API_KEY: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_OPTIMISM: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_BSC: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),
@@ -180,7 +180,7 @@ describe('Configuration validator', () => {
         faker.internet.email(),
       PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY:
         faker.string.alphanumeric(),
-      PORTFOLIO_API_KEY: faker.string.uuid(),
+      // PORTFOLIO_API_KEY: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_OPTIMISM: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_BSC: faker.string.uuid(),
       RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: faker.string.uuid(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -299,7 +299,7 @@ export default () => ({
   portfolio: {
     baseUri:
       process.env.PORTFOLIO_API_BASE_URI || 'https://octav-api.hasura.app',
-    apiKey: process.env.PORTFOLIO_API_KEY,
+    apiKey: process.env.PORTFOLIO_API_KEY || 'TODO',
   },
   pushNotifications: {
     baseUri:

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -23,7 +23,7 @@ export const RootConfigurationSchema = z
     INFURA_API_KEY: z.string(),
     JWT_ISSUER: z.string(),
     JWT_SECRET: z.string(),
-    PORTFOLIO_API_KEY: z.string(),
+    // PORTFOLIO_API_KEY: z.string(),
     PUSH_NOTIFICATIONS_API_PROJECT: z.string(),
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: z.string().email(),
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY: z.string(),


### PR DESCRIPTION
## Summary

Until the forthcoming portfolio feature is ready, we should not be validating the presence of the API key.

This adds a temporary fallback value, with the intention of reverting this.

## Changes

- Add fallback value for portfolio API key
- Comment out value validation and test coverage