### PR TITLE
Enhance Service Liveliness Check with Redis and AMQP Monitoring

### DIFF
--- a/src/datasources/queues/__tests__/test.queues-api.module.ts
+++ b/src/datasources/queues/__tests__/test.queues-api.module.ts
@@ -19,7 +19,7 @@ import { Module } from '@nestjs/common';
       provide: QueueReadiness,
       useFactory: (): jest.MockedObjectDeep<IQueueReadiness> => {
         return jest.mocked({
-          isReady: jest.fn(),
+          isReady: jest.fn().mockReturnValue(true),
         });
       },
     },

--- a/src/domain/health/entities/healthError.entity.ts
+++ b/src/domain/health/entities/healthError.entity.ts
@@ -1,0 +1,5 @@
+export class HealthCheckError extends Error {
+  public constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/domain/health/health.repository.interface.ts
+++ b/src/domain/health/health.repository.interface.ts
@@ -16,6 +16,7 @@ export interface IHealthRepository {
    * returns {@link HealthEntity.NOT_READY}
    */
   isReady(): Promise<HealthEntity>;
+  isAlive(): Promise<HealthEntity>;
 }
 
 @Module({

--- a/src/routes/health/health.controller.spec.ts
+++ b/src/routes/health/health.controller.spec.ts
@@ -93,7 +93,30 @@ describe('Health Controller tests', () => {
   });
 
   describe('liveness tests', () => {
-    it('service is alive if it accepts requests', async () => {
+    it('cache service is not ready', async () => {
+      cacheService.setReadyState(false);
+      queuesApi.isReady.mockReturnValue(true);
+
+      await request(app.getHttpServer())
+        .get(`/health/live`)
+        .expect(503)
+        .expect({ status: 'KO' });
+    });
+
+    it('queues are not ready', async () => {
+      cacheService.setReadyState(true);
+      queuesApi.isReady.mockReturnValue(false);
+
+      await request(app.getHttpServer())
+        .get(`/health/live`)
+        .expect(503)
+        .expect({ status: 'KO' });
+    });
+
+    it('service is alive if it accepts requests, cache service and queues are ready', async () => {
+      cacheService.setReadyState(true);
+      queuesApi.isReady.mockReturnValue(true);
+
       await request(app.getHttpServer())
         .get(`/health/live`)
         .expect(200)

--- a/src/routes/health/health.controller.ts
+++ b/src/routes/health/health.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiExcludeController, ApiOkResponse } from '@nestjs/swagger';
-import { Health, HealthStatus } from '@/routes/health/entities/health.entity';
+import { Health } from '@/routes/health/entities/health.entity';
 import { HealthService } from '@/routes/health/health.service';
 
 @Controller({ path: 'health' })
@@ -10,8 +10,8 @@ export class HealthController {
 
   @ApiOkResponse({ type: Health })
   @Get('live')
-  liveness(): Health {
-    return new Health(HealthStatus.OK);
+  liveness(): Promise<Health> {
+    return this.service.isAlive();
   }
 
   @ApiOkResponse({ type: Health })

--- a/src/routes/health/health.service.ts
+++ b/src/routes/health/health.service.ts
@@ -18,14 +18,23 @@ export class HealthService {
   ) {}
 
   async isReady(): Promise<Health> {
-    const readiness = await this.healthRepository.isReady();
-    switch (readiness) {
+    return this.handleHealthCheckError(await this.healthRepository.isReady());
+  }
+
+  async isAlive(): Promise<Health> {
+    return this.handleHealthCheckError(await this.healthRepository.isAlive());
+  }
+
+  handleHealthCheckError(healthMetric: HealthEntity): Health {
+    switch (healthMetric) {
       case HealthEntity.READY:
         return new Health(HealthStatus.OK);
       case HealthEntity.NOT_READY:
         throw new ServiceUnavailableException(new Health(HealthStatus.KO));
       default:
-        this.loggingService.error(`Readiness status ${readiness} not handled`);
+        this.loggingService.error(
+          `Readiness status ${healthMetric} not handled`,
+        );
         return new Health(HealthStatus.KO);
     }
   }


### PR DESCRIPTION
## Summary
This PR improves the service liveliness check by incorporating Redis and AMQP (e.g., RabbitMQ) health monitoring. These enhancements help detect connectivity issues early, ensuring better system reliability.

## Changes
- Implemented a `Redis` liveliness check.
- Implemented a `Amqp` liveliness check.
- Refactored Existing Health Check Logic
- Updated Unit Tests
- Ensured that failures in either Redis or AMQP are correctly reflected in the liveliness probe.