### PR TITLE
Add correct SSL CA path for database test

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -120,7 +120,8 @@ export default (): ReturnType<typeof configuration> => ({
           enabled: true,
           requestCert: true,
           rejectUnauthorized: true,
-          caPath: process.env.POSTGRES_SSL_CA_PATH,
+          caPath:
+            process.env.POSTGRES_SSL_CA_PATH || 'db_config/test/server.crt',
         },
       },
     },


### PR DESCRIPTION
## Summary

Database-related tests previously only ran in the E2E env. where a default [CA path is set](https://github.com/safe-global/safe-client-gateway/blob/postgres-ssl-ca-path/test/e2e-setup.ts#L20). As we now "generally" run these, the same value needs be set for tests to pass.

This adds a default value to test configuration for the Postgres SSL CA path.

## Changes

- Default `db.connection.postgres.ssl.caPath` to `'db_config/test/server.crt'`