### PR TITLE
Serialize `Error` messages for logs

### DIFF
--- a/src/logging/__tests__/logger-factory.spec.ts
+++ b/src/logging/__tests__/logger-factory.spec.ts
@@ -11,9 +11,13 @@ const mockConfigurationService = jest.mocked({
 } as jest.MockedObjectDeep<IConfigurationService>);
 
 describe('logger factory', () => {
+  let consoleSpy: jest.SpyInstance;
+  let logger: winston.Logger;
+
   beforeEach(() => {
     jest.resetAllMocks();
 
+    consoleSpy = jest.spyOn(winston.transports.Console.prototype, 'log');
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       switch (key) {
         case 'log.silent': {
@@ -30,13 +34,11 @@ describe('logger factory', () => {
         }
       }
     });
+    const transports = winstonTransportsFactory(mockConfigurationService);
+    logger = winstonFactory(transports, mockConfigurationService);
   });
 
-  const transports = winstonTransportsFactory(mockConfigurationService);
-  const logger = winstonFactory(transports, mockConfigurationService);
-
   it('logs string message', () => {
-    jest.spyOn(winston.transports.Console.prototype, 'log');
     const level = faker.helpers.arrayElement([
       'info',
       'warn',
@@ -47,8 +49,8 @@ describe('logger factory', () => {
 
     logger.log(level, { message });
 
-    expect(winston.transports.Console.prototype.log).toHaveBeenCalledTimes(1);
-    expect(winston.transports.Console.prototype.log).toHaveBeenNthCalledWith(
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
       1,
       {
         level,
@@ -64,7 +66,6 @@ describe('logger factory', () => {
   });
 
   it('logs Error message', () => {
-    jest.spyOn(winston.transports.Console.prototype, 'log');
     const level = faker.helpers.arrayElement([
       'info',
       'warn',
@@ -75,8 +76,8 @@ describe('logger factory', () => {
 
     logger.log(level, { message: new Error(message) });
 
-    expect(winston.transports.Console.prototype.log).toHaveBeenCalledTimes(1);
-    expect(winston.transports.Console.prototype.log).toHaveBeenNthCalledWith(
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
       1,
       {
         level,

--- a/src/logging/__tests__/logger-factory.spec.ts
+++ b/src/logging/__tests__/logger-factory.spec.ts
@@ -11,12 +11,9 @@ const mockConfigurationService = jest.mocked({
 } as jest.MockedObjectDeep<IConfigurationService>);
 
 describe('logger factory', () => {
-  let consoleSpy: jest.SpyInstance;
-
   beforeEach(() => {
     jest.resetAllMocks();
 
-    consoleSpy = jest.spyOn(winston.transports.Console.prototype, 'log');
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       switch (key) {
         case 'log.silent': {
@@ -39,6 +36,7 @@ describe('logger factory', () => {
   const logger = winstonFactory(transports, mockConfigurationService);
 
   it('logs string message', () => {
+    jest.spyOn(winston.transports.Console.prototype, 'log');
     const level = faker.helpers.arrayElement([
       'info',
       'warn',
@@ -49,8 +47,8 @@ describe('logger factory', () => {
 
     logger.log(level, { message });
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy).toHaveBeenNthCalledWith(
+    expect(winston.transports.Console.prototype.log).toHaveBeenCalledTimes(1);
+    expect(winston.transports.Console.prototype.log).toHaveBeenNthCalledWith(
       1,
       {
         level,
@@ -66,6 +64,7 @@ describe('logger factory', () => {
   });
 
   it('logs Error message', () => {
+    jest.spyOn(winston.transports.Console.prototype, 'log');
     const level = faker.helpers.arrayElement([
       'info',
       'warn',
@@ -76,8 +75,8 @@ describe('logger factory', () => {
 
     logger.log(level, { message: new Error(message) });
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy).toHaveBeenNthCalledWith(
+    expect(winston.transports.Console.prototype.log).toHaveBeenCalledTimes(1);
+    expect(winston.transports.Console.prototype.log).toHaveBeenNthCalledWith(
       1,
       {
         level,

--- a/src/logging/__tests__/logger-factory.spec.ts
+++ b/src/logging/__tests__/logger-factory.spec.ts
@@ -1,0 +1,95 @@
+import { faker } from '@faker-js/faker';
+import {
+  winstonFactory,
+  winstonTransportsFactory,
+} from '@/logging/logging.module';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import winston from 'winston';
+
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+describe('logger factory', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    consoleSpy = jest.spyOn(winston.transports.Console.prototype, 'log');
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      switch (key) {
+        case 'log.silent': {
+          return false;
+        }
+        case 'log.prettyColorize': {
+          return false;
+        }
+        case 'log.level': {
+          return 'debug';
+        }
+        default: {
+          throw Error(`No value set for key. key=${key}`);
+        }
+      }
+    });
+  });
+
+  const transports = winstonTransportsFactory(mockConfigurationService);
+  const logger = winstonFactory(transports, mockConfigurationService);
+
+  it('logs string message', () => {
+    const level = faker.helpers.arrayElement([
+      'info',
+      'warn',
+      'error',
+      'debug',
+    ]);
+    const message = faker.word.words();
+
+    logger.log(level, { message });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        level,
+        message,
+        [Symbol.for('level')]: level,
+        [Symbol.for('message')]: JSON.stringify({
+          level,
+          message,
+        }),
+      },
+      expect.any(Function),
+    );
+  });
+
+  it('logs Error message', () => {
+    const level = faker.helpers.arrayElement([
+      'info',
+      'warn',
+      'error',
+      'debug',
+    ]);
+    const message = faker.word.words();
+
+    logger.log(level, { message: new Error(message) });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        level,
+        // Error message is serialized to string
+        message,
+        [Symbol.for('level')]: level,
+        [Symbol.for('message')]: JSON.stringify({
+          level,
+          message,
+        }),
+      },
+      expect.any(Function),
+    );
+  });
+});

--- a/src/logging/logging.module.ts
+++ b/src/logging/logging.module.ts
@@ -11,7 +11,7 @@ import { RequestScopedLoggingService } from '@/logging/logging.service';
  * @param transports - the logger transports to be used in the winston instance
  * @param configurationService - the configuration service to retrieve service-level settings
  */
-function winstonFactory(
+export function winstonFactory(
   transports: Array<Transport> | Transport,
   configurationService: IConfigurationService,
 ): winston.Logger {
@@ -27,7 +27,7 @@ const LoggerTransports = Symbol('LoggerTransports');
  * Factory which provides a collection of transports to be used by the
  * logger instance
  */
-function winstonTransportsFactory(
+export function winstonTransportsFactory(
   configurationService: IConfigurationService,
 ): Array<Transport> | Transport {
   const prettyColorize =
@@ -36,7 +36,7 @@ function winstonTransportsFactory(
     level: configurationService.getOrThrow<string>('log.level'),
     format: prettyColorize
       ? winston.format.prettyPrint({ colorize: true })
-      : winston.format.json(),
+      : winston.format.combine(winston.format.errors(), winston.format.json()),
   });
 }
 


### PR DESCRIPTION
## Summary

We [pass `unknown` messages](https://github.com/safe-global/safe-client-gateway/blob/cf41694e757e32ab637fe28e1ae770cb0a40e0fc/src/logging/logging.service.ts#L56) to our logger.

Currently, winston only formats [using the `json`](https://github.com/safe-global/safe-client-gateway/blob/main/src/logging/logging.module.ts#L39) [formatter](https://github.com/winstonjs/logform?tab=readme-ov-file#json). This means that `Error` instances serialise to an empty object and are not shown in our logs. The [`error` formatter](https://github.com/winstonjs/logform?tab=readme-ov-file#errors) solves this, serialising the `message` of the instance and returning that instead of an empty object.

This combines the `json` and `error` formatters to successful log both JSON and `Error` instances.

## Changes

- Add `error` formatter to transport
- Add appropriate test coverage