### PR TITLE
Automatically remove database lock when migration fails

### DIFF
--- a/src/datasources/db/v2/database-migrator.service.ts
+++ b/src/datasources/db/v2/database-migrator.service.ts
@@ -152,14 +152,20 @@ export class DatabaseMigrator {
    * @returns {Promise<void>} An empty promise that resolves when the migration is complete.
    */
   private async runMigration(connection: DataSource): Promise<void> {
-    const migrations = await connection.runMigrations({ transaction: 'all' });
+    try {
+      const migrations = await connection.runMigrations({ transaction: 'all' });
 
-    if (migrations && migrations.length > 0) {
-      this.loggingService.info(
-        `Migrations: Successfully executed ${migrations.length} migrations.`,
-      );
-    } else {
-      this.loggingService.info('Migrations: No migrations to execute.');
+      if (migrations && migrations.length > 0) {
+        this.loggingService.info(
+          `Migrations: Successfully executed ${migrations.length} migrations.`,
+        );
+      } else {
+        this.loggingService.info('Migrations: No migrations to execute.');
+      }
+    } catch (error) {
+      await this.truncateLocks(connection);
+
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR introduces an automatic mechanism to remove database locks when a migration fails. Previously, failed migrations could leave the database in a locked state, requiring manual intervention. This enhancement ensures that the lock is cleaned up

## Changes
- Removes locks when the failure is confirmed.
- Adjusts tests