### PR TITLE
Remove `sdk` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,14 +182,3 @@ jobs:
           AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
           AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
           TARGET_ENV: 'staging'
-
-  sdk:
-    runs-on: ubuntu-latest
-    needs: [autodeploy]
-    steps:
-      - run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GH_ACCESS_TOKEN_CGW_SDK }}" \
-            https://api.github.com/repos/safe-global/safe-client-gateway-sdk/dispatches \
-            -d '{"event_type":"Dispatched by safe-client-gateway"}'


### PR DESCRIPTION
## Summary

Clients are now [generating their own SDK](https://github.com/safe-global/safe-wallet-monorepo/tree/dev/packages/store), based on appropriate [adjustments to our Swagger definitions](https://github.com/safe-global/safe-client-gateway/pull/2129).

As such, we no longer need to run the `sdk` job. This removes the step from our workflow.

## Changes

- Remove `sdk` step from our workflow.