### PR TITLE
Add and extend `BaseTransaction` entity

### DIFF
--- a/src/routes/transactions/entities/base-transaction.entity.ts
+++ b/src/routes/transactions/entities/base-transaction.entity.ts
@@ -1,0 +1,47 @@
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import { CreationTransactionInfo } from '@/routes/transactions/entities/creation-transaction-info.entity';
+import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
+import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
+import { NativeStakingValidatorsExitTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-validators-exit-info.entity';
+import { NativeStakingWithdrawTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-withdraw-info.entity';
+import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
+import { TwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/twap-order-info.entity';
+import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
+import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
+import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
+
+@ApiExtraModels(
+  TransactionInfo,
+  CreationTransactionInfo,
+  CustomTransactionInfo,
+  SettingsChangeTransaction,
+  TransferTransactionInfo,
+  SwapOrderTransactionInfo,
+  SwapTransferTransactionInfo,
+  TwapOrderTransactionInfo,
+  NativeStakingDepositTransactionInfo,
+  NativeStakingValidatorsExitTransactionInfo,
+  NativeStakingWithdrawTransactionInfo,
+)
+export class BaseTransaction {
+  @ApiProperty({
+    oneOf: [
+      { $ref: getSchemaPath(CreationTransactionInfo) },
+      { $ref: getSchemaPath(CustomTransactionInfo) },
+      { $ref: getSchemaPath(SettingsChangeTransaction) },
+      { $ref: getSchemaPath(TransferTransactionInfo) },
+      { $ref: getSchemaPath(SwapOrderTransactionInfo) },
+      { $ref: getSchemaPath(SwapTransferTransactionInfo) },
+      { $ref: getSchemaPath(TwapOrderTransactionInfo) },
+      { $ref: getSchemaPath(NativeStakingDepositTransactionInfo) },
+      { $ref: getSchemaPath(NativeStakingValidatorsExitTransactionInfo) },
+      { $ref: getSchemaPath(NativeStakingWithdrawTransactionInfo) },
+    ],
+  })
+  txInfo: TransactionInfo;
+
+  constructor(txInfo: TransactionInfo) {
+    this.txInfo = txInfo;
+  }
+}

--- a/src/routes/transactions/entities/transaction-details/transaction-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/transaction-details.entity.ts
@@ -8,17 +8,16 @@ import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity
 import { TransactionData } from '@/routes/transactions/entities/transaction-data.entity';
 import { ModuleExecutionDetails } from '@/routes/transactions/entities/transaction-details/module-execution-details.entity';
 import { MultisigExecutionDetails } from '@/routes/transactions/entities/transaction-details/multisig-execution-details.entity';
-import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
+import { BaseTransaction } from '@/routes/transactions/entities/base-transaction.entity';
 import { TransactionStatus } from '@/routes/transactions/entities/transaction-status.entity';
 
 @ApiExtraModels(
-  TransactionInfo,
   TransactionData,
   MultisigExecutionDetails,
   ModuleExecutionDetails,
   SafeAppInfo,
 )
-export class TransactionDetails {
+export class TransactionDetails extends BaseTransaction {
   @ApiProperty()
   safeAddress!: string;
   @ApiProperty()
@@ -27,8 +26,6 @@ export class TransactionDetails {
   executedAt!: number | null;
   @ApiProperty({ enum: TransactionStatus })
   txStatus!: TransactionStatus;
-  @ApiProperty({ type: TransactionInfo, nullable: true })
-  txInfo!: TransactionInfo;
   @ApiPropertyOptional({ type: TransactionData, nullable: true })
   txData!: TransactionData | null;
   @ApiPropertyOptional({

--- a/src/routes/transactions/entities/transaction-preview.entity.ts
+++ b/src/routes/transactions/entities/transaction-preview.entity.ts
@@ -1,47 +1,14 @@
-import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
-import { CreationTransactionInfo } from '@/routes/transactions/entities/creation-transaction-info.entity';
-import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
-import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseTransaction } from '@/routes/transactions/entities/base-transaction.entity';
 import { TransactionData } from '@/routes/transactions/entities/transaction-data.entity';
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
-import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
-import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
-import { TwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/twap-order-info.entity';
-import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
-import { NativeStakingWithdrawTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-withdraw-info.entity';
-import { NativeStakingValidatorsExitTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-validators-exit-info.entity';
 
-@ApiExtraModels(
-  CreationTransactionInfo,
-  CustomTransactionInfo,
-  SettingsChangeTransaction,
-  TransferTransactionInfo,
-  SwapOrderTransactionInfo,
-  TwapOrderTransactionInfo,
-  NativeStakingDepositTransactionInfo,
-  NativeStakingValidatorsExitTransactionInfo,
-  NativeStakingWithdrawTransactionInfo,
-)
-export class TransactionPreview {
-  @ApiProperty({
-    oneOf: [
-      { $ref: getSchemaPath(CreationTransactionInfo) },
-      { $ref: getSchemaPath(CustomTransactionInfo) },
-      { $ref: getSchemaPath(SettingsChangeTransaction) },
-      { $ref: getSchemaPath(TransferTransactionInfo) },
-      { $ref: getSchemaPath(SwapOrderTransactionInfo) },
-      { $ref: getSchemaPath(TwapOrderTransactionInfo) },
-      { $ref: getSchemaPath(NativeStakingDepositTransactionInfo) },
-      { $ref: getSchemaPath(NativeStakingValidatorsExitTransactionInfo) },
-      { $ref: getSchemaPath(NativeStakingWithdrawTransactionInfo) },
-    ],
-  })
-  txInfo: TransactionInfo;
+export class TransactionPreview extends BaseTransaction {
   @ApiProperty()
   txData: TransactionData;
 
   constructor(txInfo: TransactionInfo, txData: TransactionData) {
-    this.txInfo = txInfo;
+    super(txInfo);
     this.txData = txData;
   }
 }

--- a/src/routes/transactions/entities/transaction.entity.ts
+++ b/src/routes/transactions/entities/transaction.entity.ts
@@ -4,38 +4,16 @@ import {
   ApiPropertyOptional,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { CreationTransactionInfo } from '@/routes/transactions/entities/creation-transaction-info.entity';
-import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import { BaseTransaction } from '@/routes/transactions/entities/base-transaction.entity';
 import { ExecutionInfo } from '@/routes/transactions/entities/execution-info.entity';
 import { ModuleExecutionInfo } from '@/routes/transactions/entities/module-execution-info.entity';
 import { MultisigExecutionInfo } from '@/routes/transactions/entities/multisig-execution-info.entity';
 import { SafeAppInfo } from '@/routes/transactions/entities/safe-app-info.entity';
-import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
-import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
-import { SwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/swap-order-info.entity';
-import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
-import { TwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/twap-order-info.entity';
-import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
-import { NativeStakingValidatorsExitTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-validators-exit-info.entity';
-import { NativeStakingWithdrawTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-withdraw-info.entity';
 import { TransactionStatus } from '@/routes/transactions/entities/transaction-status.entity';
 
-@ApiExtraModels(
-  CreationTransactionInfo,
-  CustomTransactionInfo,
-  SettingsChangeTransaction,
-  TransferTransactionInfo,
-  ModuleExecutionInfo,
-  MultisigExecutionInfo,
-  SwapOrderTransactionInfo,
-  SwapTransferTransactionInfo,
-  TwapOrderTransactionInfo,
-  NativeStakingDepositTransactionInfo,
-  NativeStakingValidatorsExitTransactionInfo,
-  NativeStakingWithdrawTransactionInfo,
-)
-export class Transaction {
+@ApiExtraModels(ModuleExecutionInfo, MultisigExecutionInfo)
+export class Transaction extends BaseTransaction {
   @ApiProperty()
   id: string;
   @ApiPropertyOptional({ type: String, nullable: true })
@@ -44,21 +22,6 @@ export class Transaction {
   timestamp: number;
   @ApiProperty({ enum: TransactionStatus })
   txStatus: string;
-  @ApiProperty({
-    oneOf: [
-      { $ref: getSchemaPath(CreationTransactionInfo) },
-      { $ref: getSchemaPath(CustomTransactionInfo) },
-      { $ref: getSchemaPath(SettingsChangeTransaction) },
-      { $ref: getSchemaPath(SwapOrderTransactionInfo) },
-      { $ref: getSchemaPath(SwapTransferTransactionInfo) },
-      { $ref: getSchemaPath(TwapOrderTransactionInfo) },
-      { $ref: getSchemaPath(TransferTransactionInfo) },
-      { $ref: getSchemaPath(NativeStakingDepositTransactionInfo) },
-      { $ref: getSchemaPath(NativeStakingValidatorsExitTransactionInfo) },
-      { $ref: getSchemaPath(NativeStakingWithdrawTransactionInfo) },
-    ],
-  })
-  txInfo: TransactionInfo;
   @ApiPropertyOptional({
     oneOf: [
       { $ref: getSchemaPath(MultisigExecutionInfo) },
@@ -79,6 +42,7 @@ export class Transaction {
     safeAppInfo: SafeAppInfo | null = null,
     txHash: `0x${string}` | null = null,
   ) {
+    super(txInfo);
     this.id = id;
     this.timestamp = timestamp;
     this.txStatus = txStatus;


### PR DESCRIPTION
## Summary

Superseeds #2288.

Swagger does not correctly define the `txInfo` of `TransactionDetails`, and has duplicate definitions for `TransactionPreview` and `Transaction`.

All of the above have been simplified into a new `BaseTransaction` entity, which is extended from. It correctly implements and defines `txInfo`.

Below are screenshots from Swagger demonstrating the implementation (observe the correct `txInfo`):

![image](https://github.com/user-attachments/assets/7ad3b2d0-87ef-4c29-b3ee-4dcb15574dca)

![image](https://github.com/user-attachments/assets/6ec3dade-d05b-43b1-acd5-31ad59d4203d)

![image](https://github.com/user-attachments/assets/738c62c2-ef5c-4914-a13c-ced2e2c53f2b)

## Changes

- Add `BaseTransaction` entity
- Extend `TransactionDetails`, `TransactionPreview` and `Transaction` from it