### PR TITLE
Scaffold org entity, domain, route and service

### DIFF
--- a/migrations/1737988522192-create_organisations.ts
+++ b/migrations/1737988522192-create_organisations.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrganisations1737988522192 implements MigrationInterface {
+  name = 'CreateOrganisations1737988522192';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "organisations" ("id" SERIAL NOT NULL, "name" character varying(255) NOT NULL, "status" integer NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_org_id" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_org_status" ON "organisations" ("status") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_org_status"`);
+    await queryRunner.query(`DROP TABLE "organisations"`);
+  }
+}

--- a/migrations/1737988602722-update_organisations_timestamp_trigger.ts
+++ b/migrations/1737988602722-update_organisations_timestamp_trigger.ts
@@ -1,0 +1,22 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateOrganisationsTimestampTrigger1737988602722
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+                    CREATE TRIGGER update_organisations_updated_at
+                        BEFORE UPDATE
+                        ON
+                            organisations
+                        FOR EACH ROW
+                    EXECUTE PROCEDURE update_updated_at();
+            `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS update_organisations_updated_at ON organisations;`,
+    );
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -59,6 +59,7 @@ import {
   type ILoggingService,
 } from '@/logging/logging.interface';
 import { UsersModule } from '@/routes/users/users.module';
+import { OrganisationsModule } from '@/routes/organisations/organisations.module';
 
 @Module({})
 export class AppModule implements NestModule {
@@ -103,6 +104,7 @@ export class AppModule implements NestModule {
           : [HooksModule]),
         MessagesModule,
         NotificationsModule,
+        ...(isUsersFeatureEnabled ? [OrganisationsModule] : []),
         OwnersModule,
         RelayControllerModule,
         RootModule,

--- a/src/datasources/organisations/entities/organisations.entity.db.ts
+++ b/src/datasources/organisations/entities/organisations.entity.db.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  OrganisationStatus,
+  Organisation as DomainOrganisation,
+} from '@/domain/organisations/entities/organisation.entity';
+
+@Entity('organisations')
+export class Organisations implements DomainOrganisation {
+  @PrimaryGeneratedColumn({ primaryKeyConstraintName: 'PK_org_id' })
+  id!: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  name!: string;
+
+  @Index('idx_org_status')
+  @Column({
+    type: 'integer',
+  })
+  status!: OrganisationStatus;
+
+  @Column({
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  created_at!: Date;
+
+  @Column({
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  updated_at!: Date;
+}

--- a/src/domain/organisations/entities/organisation.entity.ts
+++ b/src/domain/organisations/entities/organisation.entity.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
+
+export enum OrganisationStatus {
+  ACTIVE = 1,
+  INACTIVE = 2,
+}
+
+export type Organisation = z.infer<typeof OrganisationSchema>;
+
+export const OrganisationSchema = RowSchema.extend({
+  status: z.nativeEnum(OrganisationStatus),
+});

--- a/src/domain/organisations/organisations.repository.interface.ts
+++ b/src/domain/organisations/organisations.repository.interface.ts
@@ -1,0 +1,4 @@
+export const IOrganisationsRepository = Symbol('IOrganisationsRepository');
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface IOrganisationsRepository {}

--- a/src/domain/organisations/organisations.repository.module.ts
+++ b/src/domain/organisations/organisations.repository.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Organisations } from '@/datasources/organisations/entities/organisations.entity.db';
+import { IOrganisationsRepository } from '@/domain/organisations/organisations.repository.interface';
+import { OrganisationsRepository } from '@/domain/organisations/organisations.repository';
+
+@Module({
+  imports: [
+    PostgresDatabaseModuleV2,
+    TypeOrmModule.forFeature([Organisations]),
+  ],
+  providers: [
+    {
+      provide: IOrganisationsRepository,
+      useClass: OrganisationsRepository,
+    },
+  ],
+  exports: [IOrganisationsRepository],
+})
+export class OrganisationsRepositoryModule {}

--- a/src/domain/organisations/organisations.repository.ts
+++ b/src/domain/organisations/organisations.repository.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { IOrganisationsRepository } from '@/domain/organisations/organisations.repository.interface';
+
+@Injectable()
+export class OrganisationsRepository implements IOrganisationsRepository {}

--- a/src/routes/organisations/organisations.controller.spec.ts
+++ b/src/routes/organisations/organisations.controller.spec.ts
@@ -1,0 +1,3 @@
+describe('OrganisationsController', () => {
+  it.todo('OrganisationsController');
+});

--- a/src/routes/organisations/organisations.controller.ts
+++ b/src/routes/organisations/organisations.controller.ts
@@ -1,0 +1,6 @@
+import { ApiTags } from '@nestjs/swagger';
+import { Controller } from '@nestjs/common';
+
+@ApiTags('organisations')
+@Controller({ path: 'organisations', version: '1' })
+export class OrganisationsController {}

--- a/src/routes/organisations/organisations.module.ts
+++ b/src/routes/organisations/organisations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OrganisationsRepositoryModule } from '@/domain/organisations/organisations.repository.module';
+import { OrganisationsController } from '@/routes/organisations/organisations.controller';
+import { OrganisationsService } from '@/routes/organisations/organisations.service';
+
+@Module({
+  imports: [OrganisationsRepositoryModule],
+  controllers: [OrganisationsController],
+  providers: [OrganisationsService],
+})
+export class OrganisationsModule {}

--- a/src/routes/organisations/organisations.service.ts
+++ b/src/routes/organisations/organisations.service.ts
@@ -1,0 +1,1 @@
+export class OrganisationsService {}


### PR DESCRIPTION
## Summary

Scaffolds the organisations entity datasource, migrations, repository, route and service and includes the module on the app level with a feature flag.

## Changes

- Create `organisations.entity.db.ts` TypeORM entity
- Create `organisation.entity.ts` domain entity
- Create empty `organisations.repository.ts` and `organisations.repository.interface.ts`
- Create empty `organisations.controller.ts` and `organisations.service.ts`
- Create `organisations.repository.module.ts` and `organisations.module.ts`
- Import `organisations.module.ts` in `app.module.ts`
- Create `create_organisations` and `update_organisations_timestamp_trigger` migrations