### PR TITLE
Add max redis queue limit

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -216,6 +216,7 @@ export default (): ReturnType<typeof configuration> => ({
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',
     timeout: process.env.REDIS_TIMEOUT || 1 * 1_000, // Milliseconds
+    queueMaxLength: process.env.REDIS_COMMANDS_QUEUE_MAX_LENGTH || 1000,
   },
   relay: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -320,6 +320,7 @@ export default () => ({
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',
     timeout: process.env.REDIS_TIMEOUT || 2 * 1_000, // Milliseconds
+    queueMaxLength: process.env.REDIS_COMMANDS_QUEUE_MAX_LENGTH || 1000,
   },
   relay: {
     baseUri:

--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -21,6 +21,9 @@ async function redisClientFactory(
   const redisPass = configurationService.get<string>('redis.pass');
   const redisHost = configurationService.getOrThrow<string>('redis.host');
   const redisPort = configurationService.getOrThrow<string>('redis.port');
+  const redisQueueMaxLength = configurationService.getOrThrow<number>(
+    'redis.queueMaxLength',
+  );
   const redisTimeout = configurationService.getOrThrow<number>('redis.timeout');
   const client: RedisClientType = createClient({
     socket: {
@@ -29,7 +32,9 @@ async function redisClientFactory(
     },
     username: redisUser,
     password: redisPass,
+    commandsQueueMaxLength: redisQueueMaxLength,
   });
+  client.on('ready', () => loggingService.debug('Redis server is ready.'));
   client.on('error', (err) =>
     loggingService.error(`Redis client error: ${err}`),
   );

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -188,10 +188,7 @@ export class RedisCacheService
       return await promiseWithTimeout(queryObject, timeout);
     } catch (error) {
       if (error instanceof PromiseTimeoutError) {
-        /**
-         * @todo: Uncomment this line after the issue on Redis is fixed.
-         */
-        // this.loggingService.error('Redis Query Timed out!');
+        throw new PromiseTimeoutError('Redis Query Timed Out!`');
       }
 
       throw error;


### PR DESCRIPTION
## Summary
This PR implements a maximum queue limit for Redis to prevent excessive memory usage and ensure system stability. It ensures that when the `Redis` server is down, messages exceeding a defined threshold are not queued, preventing memory exhaustion.

For example, with a `10KB` object, the maximum memory usage is limited to approximately `10MB`, based on the calculation:
` 10 * 1000 / 1024 ~= 9.77  Mb`

## Changes
- Added a configurable max queue limit for Redis.