### PR TITLE
Disable Redis offline queue

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -216,6 +216,8 @@ export default (): ReturnType<typeof configuration> => ({
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',
     timeout: process.env.REDIS_TIMEOUT || 1 * 1_000, // Milliseconds
+    disableOfflineQueue:
+      process.env.REDIS_DISABLE_OFFLINE_QUEUE?.toString() === 'true',
   },
   relay: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -320,6 +320,8 @@ export default () => ({
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',
     timeout: process.env.REDIS_TIMEOUT || 2 * 1_000, // Milliseconds
+    disableOfflineQueue:
+      process.env.REDIS_DISABLE_OFFLINE_QUEUE?.toString() === 'true',
   },
   relay: {
     baseUri:

--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -22,6 +22,9 @@ async function redisClientFactory(
   const redisHost = configurationService.getOrThrow<string>('redis.host');
   const redisPort = configurationService.getOrThrow<string>('redis.port');
   const redisTimeout = configurationService.getOrThrow<number>('redis.timeout');
+  const redisDisableOfflineQueue = configurationService.getOrThrow<boolean>(
+    'redis.disableOfflineQueue',
+  );
   const client: RedisClientType = createClient({
     socket: {
       host: redisHost,
@@ -29,6 +32,7 @@ async function redisClientFactory(
     },
     username: redisUser,
     password: redisPass,
+    disableOfflineQueue: redisDisableOfflineQueue,
   });
   client.on('error', (err) =>
     loggingService.error(`Redis client error: ${err}`),


### PR DESCRIPTION
## Summary
This PR disables the Redis offline queue to prevent messages from accumulating when the Redis server is down.

Currently, `node-redis` does not provide a way to configure the offline queue size. Since we use Redis solely as a cache server with a low TTL, there is no benefit in queuing messages while the server is unavailable.

## Changes
- Disables Redis offline queue