### PR TITLE
Revert: decimals nullability in Token type

### DIFF
--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -17,12 +17,12 @@ import { Chain } from '@/domain/chains/entities/chain.entity';
 import { rawify, type Raw } from '@/validation/entities/raw.entity';
 import { AssetPricesSchema } from '@/datasources/balances-api/entities/asset-price.entity';
 import { ZodError } from 'zod';
-import { DEFAULT_DECIMALS } from '@/domain/tokens/entities/schemas/token.schema';
 
 @Injectable()
 export class SafeBalancesApi implements IBalancesApi {
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
+  private static readonly DEFAULT_DECIMALS = 18;
   private static readonly HOLESKY_CHAIN_ID = '17000';
 
   constructor(
@@ -213,7 +213,7 @@ export class SafeBalancesApi implements IBalancesApi {
   ): number | null {
     return price !== null
       ? (price * Number(balance.balance)) /
-          10 ** (balance.token?.decimals ?? DEFAULT_DECIMALS)
+          10 ** (balance.token?.decimals ?? SafeBalancesApi.DEFAULT_DECIMALS)
       : null;
   }
 }

--- a/src/domain/tokens/entities/schemas/__tests__/token.schema.spec.ts
+++ b/src/domain/tokens/entities/schemas/__tests__/token.schema.spec.ts
@@ -26,15 +26,14 @@ describe('TokenSchema', () => {
     );
   });
 
-  it('should fallback to default decimals', () => {
-    const DEFAULT_DECIMALS = 18;
+  it('should allow undefined decimals', () => {
     const token = tokenBuilder().build();
     // @ts-expect-error - inferred type doesn't allow optional properties
     delete token.decimals;
 
     const result = TokenSchema.safeParse(token);
 
-    expect(result.success && result.data.decimals).toBe(DEFAULT_DECIMALS);
+    expect(result.success && result.data.decimals).toBe(null);
   });
 
   it.each<keyof Token>([

--- a/src/domain/tokens/entities/schemas/token.schema.ts
+++ b/src/domain/tokens/entities/schemas/token.schema.ts
@@ -3,11 +3,9 @@ import { TokenType } from '@/domain/tokens/entities/token.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
 
-export const DEFAULT_DECIMALS = 18;
-
 export const TokenSchema = z.object({
   address: AddressSchema,
-  decimals: z.number().default(DEFAULT_DECIMALS),
+  decimals: z.number().nullish().default(null),
   logoUri: z.string(),
   name: z.string(),
   symbol: z.string(),

--- a/src/routes/balances/entities/token.entity.ts
+++ b/src/routes/balances/entities/token.entity.ts
@@ -4,8 +4,8 @@ import { TokenType } from '@/routes/balances/entities/token-type.entity';
 export class Token {
   @ApiProperty()
   address!: `0x${string}`;
-  @ApiPropertyOptional({ type: Number })
-  decimals!: number;
+  @ApiPropertyOptional({ type: Number, nullable: true })
+  decimals!: number | null;
   @ApiProperty()
   logoUri?: string;
   @ApiProperty()

--- a/src/routes/balances/entities/token.entity.ts
+++ b/src/routes/balances/entities/token.entity.ts
@@ -1,10 +1,10 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { TokenType } from '@/routes/balances/entities/token-type.entity';
 
 export class Token {
   @ApiProperty()
   address!: `0x${string}`;
-  @ApiProperty()
+  @ApiPropertyOptional({ type: Number })
   decimals!: number;
   @ApiProperty()
   logoUri?: string;

--- a/src/routes/transactions/mappers/common/human-descriptions.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/human-descriptions.mapper.spec.ts
@@ -112,7 +112,7 @@ describe('Human descriptions mapper (Unit)', () => {
     );
 
     expect(humanDescription).toEqual(
-      `Send ${formatUnits(mockAmount, token.decimals)} ${token.symbol} to ${truncateAddress(mockAddress)}`,
+      `Send ${formatUnits(mockAmount, token.decimals!)} ${token.symbol} to ${truncateAddress(mockAddress)}`,
     );
   });
 
@@ -189,7 +189,7 @@ describe('Human descriptions mapper (Unit)', () => {
     );
 
     expect(humanDescription).toEqual(
-      `Send ${formatUnits(mockAmount, token.decimals)} ${token.symbol} to ${truncateAddress(mockAddress)} via ${mockSafeAppName}`,
+      `Send ${formatUnits(mockAmount, token.decimals!)} ${token.symbol} to ${truncateAddress(mockAddress)} via ${mockSafeAppName}`,
     );
   });
 });

--- a/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/swap-transfer-info.mapper.spec.ts
@@ -119,7 +119,7 @@ describe('SwapTransferInfoMapper', () => {
     mockSwapsRepository.getOrders.mockResolvedValue([order]);
     mockSwapOrderHelper.getToken.mockResolvedValue({
       ...token,
-      decimals: token.decimals,
+      decimals: token.decimals!,
     });
     mockSwapOrderHelper.getOrderExplorerUrl.mockReturnValue(
       new URL(explorerUrl),
@@ -202,7 +202,7 @@ describe('SwapTransferInfoMapper', () => {
     mockSwapsRepository.getOrders.mockResolvedValue([order]);
     mockSwapOrderHelper.getToken.mockResolvedValue({
       ...token,
-      decimals: token.decimals,
+      decimals: token.decimals!,
     });
     mockSwapOrderHelper.getOrderExplorerUrl.mockReturnValue(
       new URL(explorerUrl),
@@ -364,7 +364,7 @@ describe('SwapTransferInfoMapper', () => {
     mockSwapsRepository.getOrders.mockResolvedValue(orders);
     mockSwapOrderHelper.getToken.mockResolvedValue({
       ...token,
-      decimals: token.decimals,
+      decimals: token.decimals!,
     });
     mockSwapOrderHelper.getOrderExplorerUrl.mockReturnValue(
       new URL(explorerUrl),

--- a/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.imitation-transactions.controller.spec.ts
@@ -145,7 +145,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
         min: testValueBuffer,
         max: testValueBuffer + valueTolerance,
       }),
-      multisigToken.decimals,
+      multisigToken.decimals!,
     );
     const multisigTransfer = {
       ...erc20TransferBuilder()
@@ -1333,7 +1333,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
     describe('Intolerant value', () => {
       const intolerantDiff = parseUnits(
         valueTolerance * BigInt(2),
-        multisigToken.decimals,
+        multisigToken.decimals!,
       );
       const valueIntolerantIncomingTransaction = ((): EthereumTransaction => {
         const transaction = structuredClone(imitationIncomingTransaction);
@@ -2480,7 +2480,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
     });
 
     it('should detect imitation tokens using differing decimals', async () => {
-      const differentDecimals = multisigToken.decimals + 1;
+      const differentDecimals = multisigToken.decimals! + 1;
       const differentValue = multisigTransfer.value + '0';
       const imitationWithDifferentDecimalsAddress = getImitationAddress(
         multisigTransfer.to,
@@ -2676,7 +2676,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
           parseUnits(
             // Value vastly above echo limit for testing flagging
             (echoLimit * faker.number.bigInt({ min: 3, max: 9 })).toString(),
-            multisigToken.decimals,
+            multisigToken.decimals!,
           ).toString(),
         )
         .build(),
@@ -2806,7 +2806,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
             'value',
             parseUnits(
               faker.number.bigInt({ min: 1, max: echoLimit }).toString(),
-              multisigToken.decimals,
+              multisigToken.decimals!,
             ).toString(),
           )
           .with('executionDate', imitationExecutionDate)
@@ -3587,7 +3587,7 @@ describe('Transactions History Controller (Unit) - Imitation Transactions', () =
             'value',
             parseUnits(
               faker.number.bigInt({ min: echoLimit }).toString(),
-              multisigToken.decimals,
+              multisigToken.decimals!,
             ).toString(),
           )
           .with('executionDate', aboveLimitExecutionDate)


### PR DESCRIPTION
## Summary

Revert #2291 and #2293 because they broke NFT decoding (ERC721 have `decimals: null`).