### PR TITLE
Update ORM configuration for dynamic migrations table name

### DIFF
--- a/src/config/entities/orm.config.ts
+++ b/src/config/entities/orm.config.ts
@@ -2,10 +2,12 @@ import { DataSource } from 'typeorm';
 import configuration from '@/config/entities/configuration';
 import { postgresConfig } from '@/config/entities/postgres.config';
 
+const dbConfig = configuration().db;
 export default new DataSource({
+  migrationsTableName: dbConfig.orm.migrationsTableName,
   entities: ['dist/src/**/entities/*.entity.db.js'],
   ...postgresConfig({
-    ...configuration().db.connection.postgres,
+    ...dbConfig.connection.postgres,
     type: 'postgres',
   }),
 });


### PR DESCRIPTION
## Summary
Configure the ORM to use a dynamic migrations table name based on the database configuration. Since we have two database modules, we modify the migration table name in TypeORM accordingly. When running the `migration:run` command, the `orm.config.ts` file is executed. Without specifying the table name, migrations would be written to the default migration table.

## Changes
- Uses a dynamic migrations table name based on the database configuration in Postgresql migrations.