### PR TITLE
fix: validate/coerce multisig `safeTxGas`,`baseGas` and `nonce` values to numbers

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.entity.spec.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.entity.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@/domain/safe/entities/multisig-transaction.entity';
 import { faker } from '@faker-js/faker/.';
 import { getAddress } from 'viem';
+import { ZodError } from 'zod';
 
 describe('MultisigTransaction', () => {
   describe('ConfirmationSchema', () => {
@@ -251,11 +252,29 @@ describe('MultisigTransaction', () => {
           received: 'undefined',
         },
         {
-          code: 'invalid_type',
-          expected: 'number',
-          message: 'Required',
+          code: 'invalid_union',
+          message: 'Invalid input',
           path: ['nonce'],
-          received: 'undefined',
+          unionErrors: [
+            new ZodError([
+              {
+                code: 'invalid_type',
+                expected: 'number',
+                received: 'undefined',
+                path: ['nonce'],
+                message: 'Required',
+              },
+            ]),
+            new ZodError([
+              {
+                code: 'invalid_type',
+                expected: 'string',
+                received: 'undefined',
+                path: ['nonce'],
+                message: 'Required',
+              },
+            ]),
+          ],
         },
         {
           code: 'invalid_date',
@@ -347,11 +366,29 @@ describe('MultisigTransaction', () => {
           received: 'undefined',
         },
         {
-          code: 'invalid_type',
-          expected: 'number',
-          message: 'Required',
+          code: 'invalid_union',
+          message: 'Invalid input',
           path: ['nonce'],
-          received: 'undefined',
+          unionErrors: [
+            new ZodError([
+              {
+                code: 'invalid_type',
+                expected: 'number',
+                received: 'undefined',
+                path: ['nonce'],
+                message: 'Required',
+              },
+            ]),
+            new ZodError([
+              {
+                code: 'invalid_type',
+                expected: 'string',
+                received: 'undefined',
+                path: ['nonce'],
+                message: 'Required',
+              },
+            ]),
+          ],
         },
         {
           code: 'invalid_date',

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -6,6 +6,7 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
+import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
 
 export type Confirmation = z.infer<typeof ConfirmationSchema>;
 
@@ -27,13 +28,13 @@ export const MultisigTransactionSchema = z.object({
   dataDecoded: DataDecodedSchema.nullish().default(null),
   operation: z.nativeEnum(Operation),
   gasToken: AddressSchema.nullish().default(null),
-  safeTxGas: z.number().nullish().default(null),
-  baseGas: z.number().nullish().default(null),
+  safeTxGas: CoercedNumberSchema.nullish().default(null),
+  baseGas: CoercedNumberSchema.nullish().default(null),
   gasPrice: NumericStringSchema.nullish().default(null),
   proposer: AddressSchema.nullish().default(null),
   proposedByDelegate: AddressSchema.nullish().default(null),
   refundReceiver: AddressSchema.nullish().default(null),
-  nonce: z.number(),
+  nonce: CoercedNumberSchema,
   executionDate: z.coerce.date().nullish().default(null),
   submissionDate: z.coerce.date(),
   modified: z.coerce.date().nullish().default(null),

--- a/src/domain/safe/entities/schemas/safe.schema.ts
+++ b/src/domain/safe/entities/schemas/safe.schema.ts
@@ -1,12 +1,10 @@
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
 import { z } from 'zod';
 
 export const SafeSchema = z.object({
   address: AddressSchema,
-  // nonce was changed from a number to string on the the Transaction Service
-  // @see https://github.com/safe-global/safe-transaction-service/pull/2367
-  // TODO: only allow strings after Transaction Service is on prod.
-  nonce: z.union([z.number(), z.string()]).pipe(z.coerce.number()),
+  nonce: CoercedNumberSchema,
   threshold: z.number(),
   owners: z.array(AddressSchema),
   masterCopy: AddressSchema,

--- a/src/validation/entities/schemas/__tests__/coerced-number.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/coerced-number.schema.spec.ts
@@ -1,0 +1,20 @@
+import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
+import { faker } from '@faker-js/faker';
+
+describe('CoercedNumberSchema', () => {
+  it('should return a number as is', () => {
+    const value = faker.number.int();
+
+    const result = CoercedNumberSchema.safeParse(value);
+
+    expect(result.success && result.data).toBe(value);
+  });
+
+  it('should coerce a numeric string to a number', () => {
+    const value = faker.string.numeric();
+
+    const result = CoercedNumberSchema.safeParse(value);
+
+    expect(result.success && result.data).toBe(Number(value));
+  });
+});

--- a/src/validation/entities/schemas/coerced-number.schema.ts
+++ b/src/validation/entities/schemas/coerced-number.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/**
+ * TODO: After Transaction Service is released, use z.coerce.number instead
+ *
+ * Several numeric values were changed to strings, breaking validation:
+ * @see https://github.com/safe-global/safe-transaction-service/pull/2367
+ * @see https://github.com/safe-global/safe-transaction-service/pull/2402
+ */
+export const CoercedNumberSchema = z
+  .union([z.number(), z.string()])
+  .pipe(z.coerce.number());


### PR DESCRIPTION
## Summary

A [recent change to the Transaction Service](https://github.com/safe-global/safe-transaction-service/pull/2402
), changed `safeTxGas`,`baseGas` and `nonce` values of multisig transactions to strings. This therefore broke validation.

This adjusts validation of the above fields, allowing both string/number and coerces the value to a string to not affect types client-side.

## Changes

- Abstract previous schema change to [related change on the Transaction Service](https://github.com/safe-global/safe-transaction-service/pull/2367) to `CoercedNumberSchema`
- Use schema for `safeTxGas`, `baseGas` and `nonce` of multisig transactions
- Add appropriate test coverage