### PR TITLE
feat: add `GET` `/v1/targeted-messaging/:outreachId/chains/:chainId/safes/:safeAddress`

### DIFF
--- a/src/routes/targeted-messaging/entities/targeted-safe.entity.ts
+++ b/src/routes/targeted-messaging/entities/targeted-safe.entity.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { TargetedSafe as DomainTargetedSafe } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+
+export class TargetedSafe
+  implements Pick<DomainTargetedSafe, 'outreachId' | 'address'>
+{
+  @ApiProperty()
+  outreachId: number;
+
+  @ApiProperty()
+  address: `0x${string}`;
+
+  constructor({
+    outreachId,
+    address,
+  }: Pick<DomainTargetedSafe, 'outreachId' | 'address'>) {
+    this.outreachId = outreachId;
+    this.address = address;
+  }
+}

--- a/src/routes/targeted-messaging/entities/targeted-safe.entity.ts
+++ b/src/routes/targeted-messaging/entities/targeted-safe.entity.ts
@@ -4,17 +4,9 @@ import type { TargetedSafe as DomainTargetedSafe } from '@/domain/targeted-messa
 export class TargetedSafe
   implements Pick<DomainTargetedSafe, 'outreachId' | 'address'>
 {
-  @ApiProperty()
-  outreachId: number;
+  @ApiProperty({ type: Number })
+  outreachId!: DomainTargetedSafe['outreachId'];
 
-  @ApiProperty()
-  address: `0x${string}`;
-
-  constructor({
-    outreachId,
-    address,
-  }: Pick<DomainTargetedSafe, 'outreachId' | 'address'>) {
-    this.outreachId = outreachId;
-    this.address = address;
-  }
+  @ApiProperty({ type: String })
+  address!: DomainTargetedSafe['address'];
 }

--- a/src/routes/targeted-messaging/targeted-messaging.controller.spec.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.controller.spec.ts
@@ -79,6 +79,45 @@ describe('TargetedMessagingController', () => {
     await app.close();
   });
 
+  describe('GET targeted Safe', () => {
+    it('should get a targeted Safe', async () => {
+      const outreachId = faker.number.int();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const targetedSafe = targetedSafeBuilder()
+        .with('address', safe.address)
+        .build();
+      targetedMessagingDatasource.getTargetedSafe.mockResolvedValue(
+        targetedSafe,
+      );
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/targeted-messaging/outreaches/${outreachId}/chains/${chain.chainId}/safes/${safe.address}`,
+        )
+        .expect(200)
+        .expect({
+          outreachId: targetedSafe.outreachId,
+          address: targetedSafe.address,
+        });
+    });
+
+    it('should return 404 Not Found if the Safe is not targeted', async () => {
+      const outreachId = faker.number.int();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      targetedMessagingDatasource.getTargetedSafe.mockRejectedValue(
+        new TargetedSafeNotFoundError(),
+      );
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/targeted-messaging/outreaches/${outreachId}/chains/${chain.chainId}/safes/${safe.address}`,
+        )
+        .expect(404);
+    });
+  });
+
   describe('GET submissions', () => {
     it('should get a completed submission', async () => {
       const outreachId = faker.number.int();

--- a/src/routes/targeted-messaging/targeted-messaging.controller.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.controller.ts
@@ -1,9 +1,11 @@
+import { TargetedSafeSchema } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
 import { TargetedSafeNotFoundError } from '@/domain/targeted-messaging/errors/targeted-safe-not-found.error';
 import {
   CreateSubmissionDto,
   CreateSubmissionDtoSchema,
 } from '@/routes/targeted-messaging/entities/create-submission.dto.entity';
 import { Submission } from '@/routes/targeted-messaging/entities/submission.entity';
+import { TargetedSafe } from '@/routes/targeted-messaging/entities/targeted-safe.entity';
 import { TargetedMessagingService } from '@/routes/targeted-messaging/targeted-messaging.service';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
@@ -29,6 +31,22 @@ import { Response } from 'express';
 })
 export class TargetedMessagingController {
   constructor(private readonly service: TargetedMessagingService) {}
+
+  @ApiOkResponse({ type: TargetedSafe })
+  @Get(':outreachId/chains/:chainId/safes/:safeAddress')
+  async getTargetedSafe(
+    @Param(
+      'outreachId',
+      ParseIntPipe,
+      new ValidationPipe(TargetedSafeSchema.shape.outreachId),
+    )
+    outreachId: number,
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+  ): Promise<TargetedSafe> {
+    return this.service.getTargetedSafe({ outreachId, chainId, safeAddress });
+  }
 
   @ApiOkResponse({ type: Submission })
   @Get(

--- a/src/routes/targeted-messaging/targeted-messaging.controller.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.controller.ts
@@ -1,4 +1,7 @@
-import { TargetedSafeSchema } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+import {
+  TargetedSafe as DomainTargetedSafe,
+  TargetedSafeSchema,
+} from '@/domain/targeted-messaging/entities/targeted-safe.entity';
 import { TargetedSafeNotFoundError } from '@/domain/targeted-messaging/errors/targeted-safe-not-found.error';
 import {
   CreateSubmissionDto,
@@ -21,7 +24,12 @@ import {
   Post,
   Res,
 } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Response } from 'express';
 
 @ApiTags('targeted-messaging')
@@ -33,6 +41,7 @@ export class TargetedMessagingController {
   constructor(private readonly service: TargetedMessagingService) {}
 
   @ApiOkResponse({ type: TargetedSafe })
+  @ApiNotFoundResponse({ description: 'Safe not targeted.' })
   @Get(':outreachId/chains/:chainId/safes/:safeAddress')
   async getTargetedSafe(
     @Param(
@@ -40,7 +49,7 @@ export class TargetedMessagingController {
       ParseIntPipe,
       new ValidationPipe(TargetedSafeSchema.shape.outreachId),
     )
-    outreachId: number,
+    outreachId: DomainTargetedSafe['outreachId'],
     @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: `0x${string}`,

--- a/src/routes/targeted-messaging/targeted-messaging.service.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.service.ts
@@ -14,15 +14,15 @@ export class TargetedMessagingService {
   ) {}
 
   async getTargetedSafe(args: {
-    outreachId: number;
+    outreachId: TargetedSafe['outreachId'];
     chainId: string;
     safeAddress: `0x${string}`;
   }): Promise<RouteTargetedSafe> {
     const targetedSafe = await this.repository.getTargetedSafe(args);
-    return new RouteTargetedSafe({
+    return {
       outreachId: targetedSafe.outreachId,
       address: targetedSafe.address,
-    });
+    };
   }
 
   async getSubmission(args: {

--- a/src/routes/targeted-messaging/targeted-messaging.service.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.service.ts
@@ -3,6 +3,7 @@ import { SubmissionNotFoundError } from '@/domain/targeted-messaging/errors/subm
 import { ITargetedMessagingRepository } from '@/domain/targeted-messaging/targeted-messaging.repository.interface';
 import { CreateSubmissionDto } from '@/routes/targeted-messaging/entities/create-submission.dto.entity';
 import { Submission } from '@/routes/targeted-messaging/entities/submission.entity';
+import { TargetedSafe as RouteTargetedSafe } from '@/routes/targeted-messaging/entities/targeted-safe.entity';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
@@ -11,6 +12,18 @@ export class TargetedMessagingService {
     @Inject(ITargetedMessagingRepository)
     private readonly repository: ITargetedMessagingRepository,
   ) {}
+
+  async getTargetedSafe(args: {
+    outreachId: number;
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<RouteTargetedSafe> {
+    const targetedSafe = await this.repository.getTargetedSafe(args);
+    return new RouteTargetedSafe({
+      outreachId: targetedSafe.outreachId,
+      address: targetedSafe.address,
+    });
+  }
 
   async getSubmission(args: {
     outreachId: number;


### PR DESCRIPTION
Partially resolves #2323

## Summary

Targeted messaging currently targets Safes and signers (that have yet submitted responses).

This adds a new (`GET` `/v1/targeted-messaging/:outreachId/chains/:chainId/safes/:safeAddress`) route, returning a response should a `safeAddress` be targeted by a given `outreachId`.

```ts
type Response = {
  outreachId: number;
  address: `0x${string}`;
}
```

## Changes

- Add `GET` `/v1/targeted-messaging/:outreachId/chains/:chainId/safes/:safeAddress` route
- Add new route-level `TargetedSafe` entity
- Add appropriate test coverage