### PR TITLE
feat: Add create organization endpoint with user handling

### DIFF
--- a/src/domain/users/users.repository.interface.ts
+++ b/src/domain/users/users.repository.interface.ts
@@ -29,4 +29,6 @@ export interface IUsersRepository {
   }): Promise<void>;
 
   findByWalletAddressOrFail(address: `0x${string}`): Promise<User>;
+
+  findByWalletAddress(address: `0x${string}`): Promise<User | undefined>;
 }

--- a/src/domain/users/users.repository.ts
+++ b/src/domain/users/users.repository.ts
@@ -147,18 +147,23 @@ export class UsersRepository implements IUsersRepository {
   public async findByWalletAddressOrFail(
     address: `0x${string}`,
   ): Promise<User> {
-    try {
-      const { user } = await this.walletsRepository.findOneByAddressOrFail(
-        address,
-        { user: true },
-      );
-      return user;
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw new NotFoundException('User not found.');
-      }
-      throw error;
+    const user = await this.findByWalletAddress(address);
+
+    if (!user) {
+      throw new NotFoundException('User not found.');
     }
+
+    return user;
+  }
+
+  public async findByWalletAddress(
+    address: `0x${string}`,
+  ): Promise<User | undefined> {
+    const wallet = await this.walletsRepository.findOneByAddress(address, {
+      user: true,
+    });
+
+    return wallet?.user;
   }
 
   private assertSignerAddress(

--- a/src/routes/organizations/organizations.controller.ts
+++ b/src/routes/organizations/organizations.controller.ts
@@ -38,6 +38,7 @@ import {
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import { getEnumKey } from '@/domain/common/utils/enum';
+import { UserStatus } from '@/domain/users/entities/user.entity';
 
 @ApiTags('organizations')
 @UseGuards(AuthGuard)
@@ -66,6 +67,26 @@ export class OrganizationsController {
       authPayload,
       name: body.name,
       status: getEnumKey(OrganizationStatus, OrganizationStatus.ACTIVE),
+    });
+  }
+
+  @Post('/create-with-user')
+  @ApiOkResponse({
+    description: 'Organizations created',
+    type: CreateOrganizationResponse,
+  })
+  @ApiForbiddenResponse({ description: 'Forbidden resource' })
+  @ApiUnauthorizedResponse({ description: 'Signer address not provided' })
+  public async createWithUser(
+    @Body(new ValidationPipe(CreateOrganizationSchema))
+    body: CreateOrganizationDto,
+    @Auth() authPayload: AuthPayload,
+  ): Promise<CreateOrganizationResponse> {
+    return await this.organizationsService.createWithUser({
+      authPayload,
+      name: body.name,
+      status: getEnumKey(OrganizationStatus, OrganizationStatus.ACTIVE),
+      userStatuus: getEnumKey(UserStatus, UserStatus.ACTIVE),
     });
   }
 

--- a/src/routes/organizations/organizations.controller.ts
+++ b/src/routes/organizations/organizations.controller.ts
@@ -86,7 +86,7 @@ export class OrganizationsController {
       authPayload,
       name: body.name,
       status: getEnumKey(OrganizationStatus, OrganizationStatus.ACTIVE),
-      userStatuus: getEnumKey(UserStatus, UserStatus.ACTIVE),
+      userStatus: getEnumKey(UserStatus, UserStatus.ACTIVE),
     });
   }
 

--- a/src/routes/organizations/organizations.service.ts
+++ b/src/routes/organizations/organizations.service.ts
@@ -1,9 +1,9 @@
 import type { Organization } from '@/datasources/organizations/entities/organizations.entity.db';
-import { User } from '@/datasources/users/entities/users.entity.db';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { getEnumKey } from '@/domain/common/utils/enum';
 import { IOrganizationsRepository } from '@/domain/organizations/organizations.repository.interface';
 import { UserOrganizationRole } from '@/domain/users/entities/user-organization.entity';
+import { User } from '@/domain/users/entities/user.entity';
 import { IUsersRepository } from '@/domain/users/users.repository.interface';
 import { CreateOrganizationResponse } from '@/routes/organizations/entities/create-organization.dto.entity';
 import type { GetOrganizationResponse } from '@/routes/organizations/entities/get-organization.dto.entity';
@@ -37,7 +37,7 @@ export class OrganizationsService {
   public async createWithUser(args: {
     name: Organization['name'];
     status: Organization['status'];
-    userStatuus: User['status'];
+    userStatus: User['status'];
     authPayload: AuthPayload;
   }): Promise<CreateOrganizationResponse> {
     this.assertSignerAddress(args.authPayload);
@@ -51,7 +51,7 @@ export class OrganizationsService {
       userId = user.id;
     } else {
       const user = await this.userRepository.createWithWallet({
-        status: args.userStatuus,
+        status: args.userStatus,
         authPayload: args.authPayload,
       });
 


### PR DESCRIPTION
## Summary
This PR introduces an endpoint to create an organization, handling cases where the user exists or not. Implement user retrieval and creation logic within the organization service.

## Changes
- Introduced a new endpoint to create a user if they don’t already exist when a new organization is created.
- Added unit tests for the new endpoint
- Added a new `findByWallet` method to `UserRepository`