### PR TITLE
feat: only allow adding wallets with signature

### DIFF
--- a/src/domain/siwe/entities/siwe-message.entity.ts
+++ b/src/domain/siwe/entities/siwe-message.entity.ts
@@ -1,0 +1,71 @@
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { parseSiweMessage } from 'viem/siwe';
+import { z } from 'zod';
+
+/**
+ * viem provides both parseSiweMessage (used here) and validatedSiweMessage
+ * functions but the former returns a Partial<SiweMessage> and the latter
+ * does not validate issuedAt as of writing this.
+ *
+ * @see https://github.com/wevm/viem/blob/main/src/utils/siwe/parseSiweMessage.ts
+ * @see https://github.com/wevm/viem/blob/main/src/utils/siwe/validateSiweMessage.ts
+ *
+ * We define our own schema to parse, validate and refine the message to ensure
+ * compliance with EIP-4361 according to our requirements, with custom error
+ * messages and strict types.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-4361
+ */
+export const SiweMessageSchema = z
+  .string()
+  .transform(parseSiweMessage)
+  .pipe(
+    // We only validate primitives as parseSiweMessage ensures compliance,
+    // e.g. scheme, domain and uri should be RFC 3986 compliant.
+    z.object({
+      scheme: z.string().optional(),
+      domain: z.string(),
+      address: AddressSchema,
+      statement: z.string().optional(),
+      uri: z.string(),
+      version: z.literal('1'),
+      chainId: z.coerce.number(),
+      nonce: z.string(),
+      issuedAt: z.coerce.date(),
+      expirationTime: z.coerce.date().optional(),
+      notBefore: z.coerce.date().optional(),
+      requestId: z.string().optional(),
+      resources: z.array(z.string()).optional(),
+    }),
+  )
+  .superRefine((message, ctx) => {
+    /**
+     * According to the spec., we should also compare the scheme, domain and uri
+     * of the message against the request but as our API is often used either
+     * locally or across environments, those checks would fail.
+     */
+    const now = new Date();
+
+    if (!message.issuedAt || message.issuedAt > now) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Message yet issued',
+      });
+    }
+
+    if (message.expirationTime && message.expirationTime <= now) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Message has expired',
+      });
+    }
+
+    if (message.notBefore && message.notBefore > now) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Message yet valid',
+      });
+    }
+
+    return z.NEVER;
+  });

--- a/src/domain/siwe/siwe.repository.interface.ts
+++ b/src/domain/siwe/siwe.repository.interface.ts
@@ -2,11 +2,17 @@ import { SiweApiModule } from '@/datasources/siwe-api/siwe-api.module';
 import { BlockchainApiManagerModule } from '@/domain/interfaces/blockchain-api.manager.interface';
 import { SiweRepository } from '@/domain/siwe/siwe.repository';
 import { Module } from '@nestjs/common';
+import type { SiweMessage } from 'viem/siwe';
 
 export const ISiweRepository = Symbol('ISiweRepository');
 
 export interface ISiweRepository {
   generateNonce(): Promise<{ nonce: string }>;
+
+  getValidatedSiweMessage(args: {
+    message: string;
+    signature: `0x${string}`;
+  }): Promise<SiweMessage>;
 
   getMaxValidityDate(): Date;
 

--- a/src/domain/siwe/siwe.repository.ts
+++ b/src/domain/siwe/siwe.repository.ts
@@ -67,7 +67,7 @@ export class SiweRepository implements ISiweRepository {
       message: args.message,
       signature: args.signature,
       address: result.data.address,
-    });
+    }).catch(() => false);
 
     if (!isValidSignature) {
       throw new UnauthorizedException('Invalid signature');

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -6,6 +6,7 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import {
+  Body,
   Controller,
   Delete,
   Get,
@@ -21,6 +22,8 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { UserWithWallets } from '@/routes/users/entities/user-with-wallets.entity';
 import { CreatedUserWithWallet } from '@/routes/users/entities/created-user-with-wallet.entity';
 import { WalletAddedToUser } from '@/routes/users/entities/wallet-added-to-user.entity';
+import { SiweDtoSchema } from '@/routes/auth/entities/siwe.dto.entity';
+import type { SiweDto } from '@/routes/auth/entities/siwe.dto.entity';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 
 @ApiTags('users')
@@ -61,19 +64,21 @@ export class UsersController {
   }
 
   @ApiOkResponse({ type: WalletAddedToUser })
-  @ApiUnauthorizedResponse({ description: 'Signer address not provided' })
+  @ApiUnauthorizedResponse({
+    description: 'Signer address not provided OR invalid message/signature',
+  })
   @ApiConflictResponse({ description: 'Wallet already exists' })
   @ApiNotFoundResponse({ description: 'User not found' })
-  @Post('/wallet/:walletAddress')
+  @Post('/wallet/add')
   @UseGuards(AuthGuard)
   public async addWalletToUser(
-    @Param('walletAddress', new ValidationPipe(AddressSchema))
-    walletAddress: `0x${string}`,
     @Auth() authPayload: AuthPayload,
+    @Body(new ValidationPipe(SiweDtoSchema))
+    siweDto: SiweDto,
   ): Promise<WalletAddedToUser> {
     return await this.usersService.addWalletToUser({
       authPayload,
-      walletAddress,
+      siweDto,
     });
   }
 

--- a/src/routes/users/users.module.ts
+++ b/src/routes/users/users.module.ts
@@ -4,12 +4,14 @@ import { UsersController } from '@/routes/users/users.controller';
 import { UsersService } from '@/routes/users/users.service';
 import { AuthRepositoryModule } from '@/domain/auth/auth.repository.interface';
 import { WalletsRepositoryModule } from '@/domain/wallets/wallets.repository.module';
+import { SiweRepositoryModule } from '@/domain/siwe/siwe.repository.interface';
 
 @Module({
   imports: [
     UserRepositoryModule,
     WalletsRepositoryModule,
     AuthRepositoryModule,
+    SiweRepositoryModule,
   ],
   controllers: [UsersController],
   providers: [UsersService],

--- a/src/routes/users/users.service.ts
+++ b/src/routes/users/users.service.ts
@@ -1,17 +1,21 @@
 import { Inject } from '@nestjs/common';
 import { IUsersRepository } from '@/domain/users/users.repository.interface';
 import { UserStatus } from '@/domain/users/entities/user.entity';
+import { ISiweRepository } from '@/domain/siwe/siwe.repository.interface';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import type { UsersRepository } from '@/domain/users/users.repository';
 import type { UserWithWallets } from '@/routes/users/entities/user-with-wallets.entity';
 import type { CreatedUserWithWallet } from '@/routes/users/entities/created-user-with-wallet.entity';
 import type { WalletAddedToUser } from '@/routes/users/entities/wallet-added-to-user.entity';
 import { getEnumKey } from '@/domain/common/utils/enum';
+import type { SiweDto } from '@/routes/auth/entities/siwe.dto.entity';
 
 export class UsersService {
   public constructor(
     @Inject(IUsersRepository)
     private readonly usersRepository: UsersRepository,
+    @Inject(ISiweRepository)
+    private readonly siweRepository: ISiweRepository,
   ) {}
 
   public async createWithWallet(
@@ -31,9 +35,16 @@ export class UsersService {
 
   public async addWalletToUser(args: {
     authPayload: AuthPayload;
-    walletAddress: `0x${string}`;
+    siweDto: SiweDto;
   }): Promise<WalletAddedToUser> {
-    return await this.usersRepository.addWalletToUser(args);
+    const message = await this.siweRepository.getValidatedSiweMessage(
+      args.siweDto,
+    );
+
+    return await this.usersRepository.addWalletToUser({
+      authPayload: args.authPayload,
+      walletAddress: message.address,
+    });
   }
 
   public async delete(authPayload: AuthPayload): Promise<void> {


### PR DESCRIPTION
## Summary

This modifies the current endpoint for adding a `Wallet` to a `User` to expect a SiWe `message` and `signature`, which must pass validation in order to succeed.

The `POST` `/v1/wallet/:walletAddress` endpoint now becomes `/v1/wallet/add`, which requires the original access token cookie, as well as the following request:

```ts
type Request = {
  message: string;
  signature: `0x${string}`
}
```

The `message` is parsed according to EIP-4362 (Sign-In with Ethereum) and the `signature` validated accordingly. The recovered address is that which a `Wallet` is created for.

As with other endpoints, the access token cookie is responsible for finding the `User` - the `address` of the token.

## Changes

- Rename `POST` `/v1/wallet/:walletAddress` to `/v1/wallet/add`, and expect/validate payload
- Add `SiweMessageSchema`, responsible for parsing a string `message` to an object
- Add `ISiweRepository['getValidatedSiweMessage']`, responsible for returning a parsed/validated string `message` as an object
- Add/update tests accordingly