### PR TITLE
fix: use `number` type for `outreachId` `Param`

### DIFF
--- a/src/routes/targeted-messaging/targeted-messaging.controller.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.controller.ts
@@ -49,7 +49,7 @@ export class TargetedMessagingController {
       ParseIntPipe,
       new ValidationPipe(TargetedSafeSchema.shape.outreachId),
     )
-    outreachId: DomainTargetedSafe['outreachId'],
+    outreachId: TargetedSafe['outreachId'],
     @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: `0x${string}`,

--- a/src/routes/targeted-messaging/targeted-messaging.controller.ts
+++ b/src/routes/targeted-messaging/targeted-messaging.controller.ts
@@ -1,7 +1,4 @@
-import {
-  TargetedSafe as DomainTargetedSafe,
-  TargetedSafeSchema,
-} from '@/domain/targeted-messaging/entities/targeted-safe.entity';
+import { TargetedSafeSchema } from '@/domain/targeted-messaging/entities/targeted-safe.entity';
 import { TargetedSafeNotFoundError } from '@/domain/targeted-messaging/errors/targeted-safe-not-found.error';
 import {
   CreateSubmissionDto,
@@ -49,7 +46,7 @@ export class TargetedMessagingController {
       ParseIntPipe,
       new ValidationPipe(TargetedSafeSchema.shape.outreachId),
     )
-    outreachId: TargetedSafe['outreachId'],
+    outreachId: number,
     @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: `0x${string}`,


### PR DESCRIPTION
## Summary

Store generation was broken client-side because: "path parameter outreachId does not seem to be defined".

The endpoint in question was inferring types from the domain entity, which has no decorators. Inferring the type from the route entity, which does have decorators does not work, however as there is no way to specify the `type` in `Param` decorators of a controller.

This converts the `Param` type to use a native `number` - confirmed working locally.

## Changes

- Change `outreachId` `Param` type to be `number`