### PR TITLE
fix: add tests for enum utils

### DIFF
--- a/src/domain/common/utils/__tests__/enum.spec.ts
+++ b/src/domain/common/utils/__tests__/enum.spec.ts
@@ -1,0 +1,127 @@
+import {
+  databaseEnumTransformer,
+  getEnumKey,
+  getStringEnumKeys,
+} from '@/domain/common/utils/enum';
+
+enum NumericEnum {
+  A,
+  B,
+}
+
+enum NumericEnumExplicit {
+  A = 0,
+  B = 1,
+}
+
+enum StringEnum {
+  A = 'A',
+  B = 'B',
+}
+
+describe('enum utils', () => {
+  describe('getEnumKey', () => {
+    it('should return the key of a numeric enum with no explicit values', () => {
+      const result = getEnumKey(NumericEnum, 1);
+
+      expect(result).toEqual('B');
+    });
+
+    it('should return the key of a numeric enum with explicit values', () => {
+      const result = getEnumKey(NumericEnumExplicit, 1);
+
+      expect(result).toEqual('B');
+    });
+
+    it('should throw for invalid enum values', () => {
+      expect(() => getEnumKey(NumericEnum, 2)).toThrow('Invalid enum value: 2');
+    });
+
+    it('should return the key of a string enum', () => {
+      // Function is inherently typed for number enums
+      const result = getEnumKey(StringEnum, 'B' as unknown as number);
+
+      expect(result).toEqual('B');
+    });
+  });
+
+  describe('databaseEnumTransformer', () => {
+    describe('to', () => {
+      it('should return the value of a numeric enum with no explicit values', () => {
+        const result = databaseEnumTransformer(NumericEnum).to('B');
+
+        expect(result).toEqual(1);
+      });
+
+      it('should return the value of a numeric enum with explicit values', () => {
+        const result = databaseEnumTransformer(NumericEnumExplicit).to('B');
+
+        expect(result).toEqual(1);
+      });
+
+      it('should throw for invalid enum keys', () => {
+        expect(() =>
+          databaseEnumTransformer(NumericEnumExplicit).to('C'),
+        ).toThrow('Invalid enum key: C');
+      });
+
+      it('should return the value of a string enum', () => {
+        // Function is inherently typed for number enums
+        const result = databaseEnumTransformer(StringEnum).to(
+          'B' as unknown as keyof typeof StringEnum,
+        );
+
+        expect(result).toEqual('B');
+      });
+    });
+
+    describe('from', () => {
+      it('should return the key of a numeric enum with no explicit values', () => {
+        const result = databaseEnumTransformer(NumericEnum).from(1);
+
+        expect(result).toEqual('B');
+      });
+
+      it('should return the key of a numeric enum with explicit values', () => {
+        const result = databaseEnumTransformer(NumericEnumExplicit).from(1);
+
+        expect(result).toEqual('B');
+      });
+
+      it('should throw for invalid enum values', () => {
+        expect(() =>
+          databaseEnumTransformer(NumericEnumExplicit).from(2),
+        ).toThrow('Invalid enum value: 2');
+      });
+
+      it('should return the key of a string enum', () => {
+        // Function is inherently typed for number enums
+        const result = databaseEnumTransformer(StringEnum).from(
+          'B' as unknown as number,
+        );
+
+        expect(result).toEqual('B');
+      });
+    });
+  });
+
+  describe('getStringEnumKeys', () => {
+    it('should return the key of a numeric enum with no explicit values', () => {
+      const result = getStringEnumKeys(NumericEnum);
+
+      expect(result).toEqual(['A', 'B']);
+    });
+
+    it('should return the key of a numeric enum with explicit values', () => {
+      const result = getStringEnumKeys(NumericEnumExplicit);
+
+      expect(result).toEqual(['A', 'B']);
+    });
+
+    it('should return all string keys of a string enum', () => {
+      const result = getStringEnumKeys(StringEnum);
+
+      expect(result).toEqual(['A', 'B']);
+    });
+  });
+});

--- a/src/domain/common/utils/__tests__/enum.spec.ts
+++ b/src/domain/common/utils/__tests__/enum.spec.ts
@@ -38,7 +38,6 @@ describe('enum utils', () => {
     });
 
     it('should return the key of a string enum', () => {
-      // Function is inherently typed for number enums
       const result = getEnumKey(StringEnum, 'B' as unknown as number);
 
       expect(result).toEqual('B');
@@ -66,7 +65,6 @@ describe('enum utils', () => {
       });
 
       it('should return the value of a string enum', () => {
-        // Function is inherently typed for number enums
         const result = databaseEnumTransformer(StringEnum).to(
           'B' as unknown as keyof typeof StringEnum,
         );
@@ -95,7 +93,6 @@ describe('enum utils', () => {
       });
 
       it('should return the key of a string enum', () => {
-        // Function is inherently typed for number enums
         const result = databaseEnumTransformer(StringEnum).from(
           'B' as unknown as number,
         );

--- a/src/domain/common/utils/enum.ts
+++ b/src/domain/common/utils/enum.ts
@@ -24,8 +24,24 @@ export const databaseEnumTransformer = <T extends NumericEnum>(
   enumObj: T,
 ): ValueTransformer => {
   return {
-    to: (value: keyof typeof enumObj) => enumObj[value],
-    from: (value: number): keyof T => getEnumKey(enumObj, value),
+    to: <K extends keyof T>(key: K): T[K] => {
+      const value = enumObj[key];
+
+      if (value === undefined) {
+        throw new Error(`Invalid enum key: ${String(key)}`);
+      }
+
+      return value;
+    },
+    from: (value: number): keyof T => {
+      const key = getEnumKey(enumObj, value);
+
+      if (key === undefined) {
+        throw new Error(`Invalid enum value: ${value}`);
+      }
+
+      return key;
+    },
   };
 };
 

--- a/src/domain/users/users.repository.integration.spec.ts
+++ b/src/domain/users/users.repository.integration.spec.ts
@@ -216,9 +216,7 @@ describe('UsersRepository', () => {
 
       await expect(
         usersRepository.createWithWallet({ status, authPayload }),
-      ).rejects.toThrow(
-        'null value in column "status" of relation "users" violates not-null constraint',
-      );
+      ).rejects.toThrow(`Invalid enum key: ${status}`);
     });
 
     it('should throw if an invalid wallet address is provided', async () => {
@@ -291,9 +289,7 @@ describe('UsersRepository', () => {
         postgresDatabaseService.transaction(async (entityManager) => {
           await usersRepository.create(status, entityManager);
         }),
-      ).rejects.toThrow(
-        'null value in column "status" of relation "users" violates not-null constraint',
-      );
+      ).rejects.toThrow(`Invalid enum key: ${status}`);
     });
   });
 


### PR DESCRIPTION
## Summary

We use numeric enums for performance reasons in our database entities, the values of which are stored as `integer`s. The values are converted to/from their respective keys when interacting with the database.

This adds relevant tests to the helpers, as well as fixing a small issue discovered when writing them.

## Changes

- Throw for `undefined` values in database enum transformer
- Add enum util tests