### PR TITLE
fix: add decorator options to `GetOrganizationResponse['userOrganizations']`

### DIFF
--- a/src/routes/organizations/entities/get-organization.dto.entity.ts
+++ b/src/routes/organizations/entities/get-organization.dto.entity.ts
@@ -47,6 +47,6 @@ export class GetOrganizationResponse {
   @ApiProperty({ type: String, enum: OrganizationStatus })
   public status!: keyof typeof OrganizationStatus;
 
-  @ApiProperty()
+  @ApiProperty({ type: UserOrganizationsDto, isArray: true })
   public userOrganizations!: Array<UserOrganizationsDto>;
 }


### PR DESCRIPTION
## Summary

As the clients generate types based on our Swagger scheme, we must explicitly define the decorator `type` as the TypeScript type is not correctly inferred.

`GetOrganizationResponse['userOrganizations']` is currently inferred as a `string` by default. This adds the relevant `type`, marking it as an array in accordance with the response.

## Changes

- Add `type` and `isArray` to `GetOrganizationResponse['userOrganizations']`