### PR TITLE
fix: only show string keys on Swagger

### DIFF
--- a/src/routes/organizations/entities/get-organization.dto.entity.ts
+++ b/src/routes/organizations/entities/get-organization.dto.entity.ts
@@ -1,6 +1,7 @@
 import { Organization } from '@/datasources/organizations/entities/organizations.entity.db';
 import { UserOrganization } from '@/datasources/users/entities/user-organizations.entity.db';
 import { User } from '@/datasources/users/entities/users.entity.db';
+import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { OrganizationStatus } from '@/domain/organizations/entities/organization.entity';
 import {
   UserOrganizationRole,
@@ -13,7 +14,7 @@ class UserDto extends User {
   @ApiProperty({ type: Number })
   public id!: User['id'];
 
-  @ApiProperty({ type: String, enum: UserStatus })
+  @ApiProperty({ type: String, enum: getStringEnumKeys(UserStatus) })
   public status!: User['status'];
 }
 
@@ -21,10 +22,13 @@ class UserOrganizationsDto {
   @ApiProperty({ type: Number })
   public id!: UserOrganization['id'];
 
-  @ApiProperty({ type: String, enum: UserOrganizationRole })
+  @ApiProperty({ type: String, enum: getStringEnumKeys(UserOrganizationRole) })
   public role!: UserOrganization['role'];
 
-  @ApiProperty({ type: String, enum: UserOrganizationStatus })
+  @ApiProperty({
+    type: String,
+    enum: getStringEnumKeys(UserOrganizationStatus),
+  })
   public status!: UserOrganization['status'];
 
   @ApiProperty({ type: Date })
@@ -44,7 +48,7 @@ export class GetOrganizationResponse {
   @ApiProperty({ type: String })
   public name!: Organization['name'];
 
-  @ApiProperty({ type: String, enum: OrganizationStatus })
+  @ApiProperty({ type: String, enum: getStringEnumKeys(OrganizationStatus) })
   public status!: keyof typeof OrganizationStatus;
 
   @ApiProperty({ type: UserOrganizationsDto, isArray: true })

--- a/src/routes/organizations/entities/invitation.entity.ts
+++ b/src/routes/organizations/entities/invitation.entity.ts
@@ -3,6 +3,7 @@ import {
   UserOrganizationRole,
   UserOrganizationStatus,
 } from '@/domain/users/entities/user-organization.entity';
+import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { Organization } from '@/domain/organizations/entities/organization.entity';
 import type { User } from '@/domain/users/entities/user.entity';
 
@@ -13,9 +14,9 @@ export class Invitation {
   @ApiProperty({ type: Number })
   orgId!: Organization['id'];
 
-  @ApiProperty({ enum: Object.keys(UserOrganizationRole) })
+  @ApiProperty({ enum: getStringEnumKeys(UserOrganizationRole) })
   role!: keyof typeof UserOrganizationRole;
 
-  @ApiProperty({ enum: Object.keys(UserOrganizationStatus) })
+  @ApiProperty({ enum: getStringEnumKeys(UserOrganizationStatus) })
   status!: keyof typeof UserOrganizationStatus;
 }

--- a/src/routes/organizations/entities/update-organization.dto.entity.ts
+++ b/src/routes/organizations/entities/update-organization.dto.entity.ts
@@ -16,7 +16,7 @@ export class UpdateOrganizationDto
   public readonly name?: Organization['name'];
 
   @ApiPropertyOptional({
-    enum: OrganizationStatus,
+    enum: getStringEnumKeys(OrganizationStatus),
   })
   public readonly status?: keyof typeof OrganizationStatus;
 }

--- a/src/routes/organizations/entities/user-organizations.dto.entity.ts
+++ b/src/routes/organizations/entities/user-organizations.dto.entity.ts
@@ -1,3 +1,4 @@
+import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import {
   UserOrganizationRole,
   UserOrganizationStatus,
@@ -10,7 +11,7 @@ class UserOrganizationUser implements Pick<User, 'id'> {
   @ApiProperty({ type: Number })
   id!: User['id'];
 
-  @ApiProperty({ enum: Object.keys(UserStatus) })
+  @ApiProperty({ enum: getStringEnumKeys(UserStatus) })
   status!: keyof typeof UserStatus;
 }
 
@@ -18,10 +19,10 @@ class UserOrganization {
   @ApiProperty({ type: Number })
   id!: DomainUserOrganization['id'];
 
-  @ApiProperty({ enum: Object.keys(UserOrganizationRole) })
+  @ApiProperty({ enum: getStringEnumKeys(UserOrganizationRole) })
   role!: keyof typeof UserOrganizationRole;
 
-  @ApiProperty({ enum: Object.keys(UserOrganizationStatus) })
+  @ApiProperty({ enum: getStringEnumKeys(UserOrganizationStatus) })
   status!: keyof typeof UserOrganizationStatus;
 
   @ApiProperty()


### PR DESCRIPTION
## Summary

As we are using numeric enums for statuses/roles of org. onboarding entities, we have to be careful when extracting the string keys - numeric enums have forward/reverse lookups.

This wraps reference of: `UserStatus`, `UserOrganizationRole`, `UserOrganizationStatus` and `OrganizationStatus` in our `getStringEnumKeys` helper to correctly return the keys.

## Changes

- Update entity decorators to use helper.