### PR TITLE
fix: explicitly type params of user org. controller

### DIFF
--- a/src/routes/organizations/user-organizations.controller.ts
+++ b/src/routes/organizations/user-organizations.controller.ts
@@ -31,7 +31,6 @@ import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import type { Organization } from '@/domain/organizations/entities/organization.entity';
 import type { InviteUsersDto } from '@/routes/organizations/entities/invite-users.dto.entity';
 import type { UpdateRoleDto } from '@/routes/organizations/entities/update-role.dto.entity';
-import type { User } from '@/domain/users/entities/user.entity';
 
 @ApiTags('organizations')
 @Controller({ path: 'organizations', version: '1' })
@@ -57,7 +56,7 @@ export class UserOrganizationsController {
   public async inviteUser(
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    orgId: Organization['id'],
+    orgId: number,
     @Body(new ValidationPipe(InviteUsersDtoSchema))
     inviteUsersDto: InviteUsersDto,
   ): Promise<Array<Invitation>> {
@@ -79,7 +78,7 @@ export class UserOrganizationsController {
   public async acceptInvite(
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    orgId: Organization['id'],
+    orgId: number,
   ): Promise<void> {
     return await this.userOrgService.acceptInvite({
       authPayload,
@@ -98,7 +97,7 @@ export class UserOrganizationsController {
   public async declineInvite(
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    orgId: Organization['id'],
+    orgId: number,
   ): Promise<void> {
     return await this.userOrgService.declineInvite({
       authPayload,
@@ -119,7 +118,7 @@ export class UserOrganizationsController {
   public async getUsers(
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    orgId: Organization['id'],
+    orgId: number,
   ): Promise<UserOrganizationsDto> {
     return await this.userOrgService.get({
       authPayload,
@@ -140,9 +139,9 @@ export class UserOrganizationsController {
   public async updateRole(
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    orgId: Organization['id'],
+    orgId: number,
     @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    userId: User['id'],
+    userId: number,
     @Body(new ValidationPipe(UpdateRoleDtoSchema))
     updateRoleDto: UpdateRoleDto,
   ): Promise<void> {
@@ -166,9 +165,9 @@ export class UserOrganizationsController {
   public async removeUser(
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    orgId: Organization['id'],
+    orgId: number,
     @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    userId: User['id'],
+    userId: number,
   ): Promise<void> {
     return await this.userOrgService.removeUser({
       authPayload,

--- a/src/routes/organizations/user-organizations.controller.ts
+++ b/src/routes/organizations/user-organizations.controller.ts
@@ -28,7 +28,6 @@ import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import { UserOrganizationsDto } from '@/routes/organizations/entities/user-organizations.dto.entity';
 import { Invitation } from '@/routes/organizations/entities/invitation.entity';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
-import type { Organization } from '@/domain/organizations/entities/organization.entity';
 import type { InviteUsersDto } from '@/routes/organizations/entities/invite-users.dto.entity';
 import type { UpdateRoleDto } from '@/routes/organizations/entities/update-role.dto.entity';
 


### PR DESCRIPTION
## Summary

Similarly to https://github.com/safe-global/safe-client-gateway/pull/2346, we were using inferred types for the `Param`s of `UserOrganizationsController`. In turn, this prevented clients from generating types.

This explicitly types all `Param`s of `UserOrganizationsController`.

## Changes

- Don't infer `Param`s of `UserOrganizationsController`