### PR TITLE
fix(openapi): returned schema type

### DIFF
--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -50,7 +50,7 @@ export class MultisigExecutionDetails extends ExecutionDetails {
   signers: Array<AddressInfo>;
   @ApiProperty()
   confirmationsRequired: number;
-  @ApiProperty()
+  @ApiProperty({ type: MultisigConfirmationDetails, isArray: true })
   confirmations: Array<MultisigConfirmationDetails>;
   @ApiProperty({ type: AddressInfo, isArray: true })
   rejectors: Array<AddressInfo>;


### PR DESCRIPTION
The confirmations on a TX were specified as an array of strings in the openAPI spec. In reality we return an array of MultisigConfirmationDetails objects.
