### PR TITLE
Fix openapi

### DIFF
--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -9,7 +9,7 @@ import {
 export class MultisigConfirmationDetails {
   @ApiProperty()
   signer: AddressInfo;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   signature: string | null;
   @ApiProperty()
   submittedAt: number;

--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -46,7 +46,7 @@ export class MultisigExecutionDetails extends ExecutionDetails {
   safeTxHash: string;
   @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   executor: AddressInfo | null;
-  @ApiProperty()
+  @ApiProperty({ type: AddressInfo, isArray: true })
   signers: Array<AddressInfo>;
   @ApiProperty()
   confirmationsRequired: number;


### PR DESCRIPTION
## Summary
- fix wrong return type for signers
- fix wrong signature type

The endpoint was returning different data than the one claimed by the openAPI spec. Now they should match.

## Changes
