### PR TITLE
fix: nest uses in entity for Swagger

### DIFF
--- a/src/routes/organizations/entities/invite-users.dto.entity.ts
+++ b/src/routes/organizations/entities/invite-users.dto.entity.ts
@@ -2,8 +2,9 @@ import { z } from 'zod';
 import { UserOrganizationRole } from '@/domain/users/entities/user-organization.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
+import { ApiProperty } from '@nestjs/swagger';
 
-export const InviteUsersDtoSchema = z
+const InviteUserDtoSchema = z
   .array(
     z.object({
       address: AddressSchema,
@@ -12,4 +13,24 @@ export const InviteUsersDtoSchema = z
   )
   .min(1);
 
-export type InviteUsersDto = z.infer<typeof InviteUsersDtoSchema>;
+export const InviteUsersDtoSchema = z.object({
+  users: InviteUserDtoSchema,
+});
+
+class InviteUserDto {
+  @ApiProperty()
+  public readonly address!: `0x${string}`;
+
+  @ApiProperty({
+    enum: getStringEnumKeys(UserOrganizationRole),
+  })
+  public readonly role!: keyof typeof UserOrganizationRole;
+}
+
+export class InviteUsersDto implements z.infer<typeof InviteUsersDtoSchema> {
+  @ApiProperty({
+    type: InviteUserDto,
+    isArray: true,
+  })
+  users!: Array<InviteUserDto>;
+}

--- a/src/routes/organizations/entities/invite-users.dto.entity.ts
+++ b/src/routes/organizations/entities/invite-users.dto.entity.ts
@@ -32,5 +32,5 @@ export class InviteUsersDto implements z.infer<typeof InviteUsersDtoSchema> {
     type: InviteUserDto,
     isArray: true,
   })
-  users!: Array<InviteUserDto>;
+  public readonly users!: Array<InviteUserDto>;
 }

--- a/src/routes/organizations/organization-safes.controller.spec.ts
+++ b/src/routes/organizations/organization-safes.controller.spec.ts
@@ -224,12 +224,14 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${adminAccessToken}`])
-        .send([
-          {
-            address: getAddress(memberAuthPayloadDto.signer_address),
-            role: 'MEMBER',
-          },
-        ]);
+        .send({
+          users: [
+            {
+              address: getAddress(memberAuthPayloadDto.signer_address),
+              role: 'MEMBER',
+            },
+          ],
+        });
 
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)

--- a/src/routes/organizations/organizations.controller.spec.ts
+++ b/src/routes/organizations/organizations.controller.spec.ts
@@ -633,12 +633,14 @@ describe('OrganizationController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${organizationId}/members/invite`)
         .set('Cookie', [`access_token=${adminAccessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: memberAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: memberAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -769,12 +771,14 @@ describe('OrganizationController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${organizationId}/members/invite`)
         .set('Cookie', [`access_token=${adminAccessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: memberAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: memberAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())

--- a/src/routes/organizations/user-organizations.controller.spec.ts
+++ b/src/routes/organizations/user-organizations.controller.spec.ts
@@ -124,16 +124,18 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(201)
         .expect(({ body }) =>
           expect(body).toEqual([
@@ -167,7 +169,7 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send(invites)
+        .send({ users: invites })
         .expect(409)
         .expect({
           message: 'Too many invites.',
@@ -197,16 +199,18 @@ describe('UserOrganizationsController', () => {
 
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(403)
         .expect({
           message: 'Forbidden resource',
@@ -235,7 +239,7 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([])
+        .send({ users: [] })
         .expect(422);
     });
 
@@ -263,16 +267,18 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${nonUserAccessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(404)
         .expect({
           message: 'User not found.',
@@ -299,16 +305,18 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(404)
         .expect({
           message: 'Organization not found.',
@@ -346,16 +354,18 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${nonUserOrgAccessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(404)
         .expect({
           message: 'Organization not found.',
@@ -387,23 +397,27 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: user,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: user,
+            },
+          ],
+        })
         .expect(404)
         .expect({
           message: 'Organization not found.',
@@ -436,12 +450,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -472,12 +488,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -572,12 +590,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: user,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: user,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -613,12 +633,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -662,12 +684,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -698,12 +722,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -798,12 +824,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: user,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: user,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -839,12 +867,14 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -888,16 +918,18 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -967,16 +999,18 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: user1,
-          },
-          {
-            role: 'MEMBER',
-            address: user2,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: user1,
+            },
+            {
+              role: 'MEMBER',
+              address: user2,
+            },
+          ],
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -1067,12 +1101,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 
@@ -1111,12 +1147,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 
@@ -1160,12 +1198,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 
@@ -1208,12 +1248,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 
@@ -1251,12 +1293,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 
@@ -1368,12 +1412,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 
@@ -1471,16 +1517,18 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'ADMIN',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-          {
-            role: 'MEMBER',
-            address: member,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'ADMIN',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+            {
+              role: 'MEMBER',
+              address: member,
+            },
+          ],
+        })
         .expect(201);
       const memberUserId = inviteUsersResponse.body[1].userId;
 
@@ -1517,12 +1565,14 @@ describe('UserOrganizationsController', () => {
       const inviteUsersResponse = await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            role: 'MEMBER',
-            address: inviteeAuthPayloadDto.signer_address,
-          },
-        ])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+            },
+          ],
+        })
         .expect(201);
       const userId = inviteUsersResponse.body[0].userId;
 

--- a/src/routes/organizations/user-organizations.service.ts
+++ b/src/routes/organizations/user-organizations.service.ts
@@ -26,14 +26,14 @@ export class UserOrganizationsService {
     orgId: Organization['id'];
     inviteUsersDto: InviteUsersDto;
   }): Promise<Array<Invitation>> {
-    if (args.inviteUsersDto.length > this.maxInvites) {
+    if (args.inviteUsersDto.users.length > this.maxInvites) {
       throw new ConflictException('Too many invites.');
     }
 
     return await this.usersOrgRepository.inviteUsers({
       authPayload: args.authPayload,
       orgId: args.orgId,
-      users: args.inviteUsersDto,
+      users: args.inviteUsersDto.users,
     });
   }
 


### PR DESCRIPTION
## Summary

`InviteUsersDto` was not a class and therefore incorrectly inferred by Swagger, breaking type generation client-side.

This adjusts the DTO to include the correct decorators. As it was an array, adding the correct decorators required it to have the array under a property. As such, this nests the invites under a new `users` property.

## Changes

- Change data structure
- Add correct decorators
- Update tests accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modified the invitation payload structure so that member invites are now sent as an object with a "users" property instead of a raw array.
  - Enhanced the invitation data schema for improved clarity, type safety, and API documentation.

- **Tests**
  - Updated tests for member invitation endpoints to verify the new request payload format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->