### PR TITLE
feat: return `User` wallet addresses when getting `Organization`s

### DIFF
--- a/src/routes/organizations/entities/get-organization.dto.entity.ts
+++ b/src/routes/organizations/entities/get-organization.dto.entity.ts
@@ -10,12 +10,15 @@ import {
 import { UserStatus } from '@/domain/users/entities/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
-class UserDto extends User {
+class UserDto implements Pick<User, 'id' | 'status'> {
   @ApiProperty({ type: Number })
   public id!: User['id'];
 
   @ApiProperty({ type: String, enum: getStringEnumKeys(UserStatus) })
   public status!: User['status'];
+
+  @ApiProperty({ type: String, isArray: true })
+  public wallets!: Array<`0x${string}`>;
 }
 
 class UserOrganizationsDto {

--- a/src/routes/organizations/organizations.controller.spec.ts
+++ b/src/routes/organizations/organizations.controller.spec.ts
@@ -326,6 +326,7 @@ describe('OrganizationController', () => {
                   user: {
                     id: expect.any(Number),
                     status: getEnumKey(UserStatus, UserStatus.ACTIVE),
+                    wallets: [authPayloadDto.signer_address],
                   },
                 },
               ],
@@ -350,6 +351,7 @@ describe('OrganizationController', () => {
                   user: {
                     id: expect.any(Number),
                     status: getEnumKey(UserStatus, UserStatus.ACTIVE),
+                    wallets: [authPayloadDto.signer_address],
                   },
                 },
               ],
@@ -446,6 +448,7 @@ describe('OrganizationController', () => {
                 user: {
                   id: userId,
                   status: getEnumKey(UserStatus, UserStatus.ACTIVE),
+                  wallets: [authPayloadDto.signer_address],
                 },
               },
             ],

--- a/src/routes/organizations/organizations.module.ts
+++ b/src/routes/organizations/organizations.module.ts
@@ -6,12 +6,14 @@ import { AuthRepositoryModule } from '@/domain/auth/auth.repository.interface';
 import { UserRepositoryModule } from '@/domain/users/users.repository.module';
 import { OrganizationSafesController } from '@/routes/organizations/organization-safes.controller';
 import { OrganizationSafesService } from '@/routes/organizations/organization-safes.service';
+import { WalletsRepositoryModule } from '@/domain/wallets/wallets.repository.module';
 
 @Module({
   imports: [
     OrganizationsRepositoryModule,
     AuthRepositoryModule,
     UserRepositoryModule,
+    WalletsRepositoryModule,
   ],
   controllers: [OrganizationsController, OrganizationSafesController],
   providers: [OrganizationsService, OrganizationSafesService],


### PR DESCRIPTION
## Summary

We currently return details of the `User` when fetching `Organization`(s) but not the assocated `Wallet['address']`es.

This adds a new `userOrganizations[number]['user']['wallets']` array property under the `GetOrganizationResponse` entity, containing an array of strings - wallet addresses of the associated `User`.

## Changes

- Map `Wallet['address']` to `GetOrganizationResponse`
- Update tests accordingly