### PR TITLE
fix: nest Safes in entity for Swagger

### DIFF
--- a/src/routes/organizations/entities/create-organization-safe.dto.entity.ts
+++ b/src/routes/organizations/entities/create-organization-safe.dto.entity.ts
@@ -5,14 +5,14 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { z } from 'zod';
 
-export const CreateOrganizationSafeSchema = z.object({
+const CreateOrganizationSafeSchema = z.object({
   chainId: ChainIdSchema,
   address: AddressSchema,
 });
 
-export const CreateOrganizationSafesSchema = z
-  .array(CreateOrganizationSafeSchema)
-  .nonempty();
+export const CreateOrganizationSafesSchema = z.object({
+  safes: z.array(CreateOrganizationSafeSchema).nonempty(),
+});
 
 export class CreateOrganizationSafeDto
   implements z.infer<typeof CreateOrganizationSafeSchema>
@@ -22,4 +22,14 @@ export class CreateOrganizationSafeDto
 
   @ApiProperty({ type: String })
   public readonly address!: OrganizationSafe['address'];
+}
+
+export class CreateOrganizationSafesDto
+  implements z.infer<typeof CreateOrganizationSafesSchema>
+{
+  @ApiProperty({ type: CreateOrganizationSafeDto, isArray: true })
+  public readonly safes!: [
+    CreateOrganizationSafeDto,
+    ...Array<CreateOrganizationSafeDto>,
+  ];
 }

--- a/src/routes/organizations/entities/delete-organization-safe.dto.entity.ts
+++ b/src/routes/organizations/entities/delete-organization-safe.dto.entity.ts
@@ -4,14 +4,14 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
 
-export const DeleteOrganizationSafeSchema = z.object({
+const DeleteOrganizationSafeSchema = z.object({
   chainId: ChainIdSchema,
   address: AddressSchema,
 });
 
-export const DeleteOrganizationSafesSchema = z
-  .array(DeleteOrganizationSafeSchema)
-  .nonempty();
+export const DeleteOrganizationSafesSchema = z.object({
+  safes: z.array(DeleteOrganizationSafeSchema).nonempty(),
+});
 
 export class DeleteOrganizationSafeDto
   implements z.infer<typeof DeleteOrganizationSafeSchema>
@@ -21,4 +21,14 @@ export class DeleteOrganizationSafeDto
 
   @ApiProperty({ type: String })
   public readonly address!: OrganizationSafe['address'];
+}
+
+export class DeleteOrganizationSafesDto
+  implements z.infer<typeof DeleteOrganizationSafesSchema>
+{
+  @ApiProperty({ type: DeleteOrganizationSafeDto, isArray: true })
+  public readonly safes!: [
+    DeleteOrganizationSafeDto,
+    ...Array<DeleteOrganizationSafeDto>,
+  ];
 }

--- a/src/routes/organizations/organization-safes.controller.spec.ts
+++ b/src/routes/organizations/organization-safes.controller.spec.ts
@@ -115,12 +115,14 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(201);
     });
 
@@ -145,20 +147,22 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain3.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain3.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(201);
     });
 
@@ -187,12 +191,14 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${userAccessToken}`])
-        .send([
-          {
-            chainId: chain.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(401)
         .expect({
           error: 'Unauthorized',
@@ -241,12 +247,14 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${memberAccessToken}`])
-        .send([
-          {
-            chainId: chain.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(401)
         .expect({
           error: 'Unauthorized',
@@ -296,12 +304,14 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(404)
         .expect({
           statusCode: 404,
@@ -318,7 +328,7 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([])
+        .send({ safes: [] })
         .expect(422)
         .expect({
           statusCode: 422,
@@ -341,16 +351,18 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: 111,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: 111,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(422)
         .expect({
           statusCode: 422,
@@ -372,16 +384,18 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: 'invalid-address',
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: 'invalid-address',
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(422)
         .expect({
           statusCode: 422,
@@ -406,16 +420,18 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(422)
         .expect({
           statusCode: 422,
@@ -435,16 +451,18 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(400)
         .expect({
           message: 'Validation failed (numeric string is expected)',

--- a/src/routes/organizations/organization-safes.controller.spec.ts
+++ b/src/routes/organizations/organization-safes.controller.spec.ts
@@ -338,7 +338,7 @@ describe('OrganizationSafeController', () => {
           inclusive: true,
           exact: false,
           message: 'Array must contain at least 1 element(s)',
-          path: [],
+          path: ['safes'],
         });
     });
 
@@ -369,7 +369,7 @@ describe('OrganizationSafeController', () => {
           code: 'invalid_type',
           expected: 'string',
           received: 'number',
-          path: [0, 'chainId'],
+          path: ['safes', 0, 'chainId'],
           message: 'Expected string, received number',
         });
     });
@@ -401,7 +401,7 @@ describe('OrganizationSafeController', () => {
           statusCode: 422,
           code: 'custom',
           message: 'Invalid address',
-          path: [0, 'address'],
+          path: ['safes', 0, 'address'],
         });
     });
 
@@ -437,7 +437,7 @@ describe('OrganizationSafeController', () => {
           statusCode: 422,
           code: 'custom',
           message: 'Value must be less than or euqal to 78',
-          path: [0, 'chainId'],
+          path: ['safes', 0, 'chainId'],
         });
     });
 
@@ -483,20 +483,22 @@ describe('OrganizationSafeController', () => {
       const chain2 = chainBuilder()
         .with('chainId', faker.string.numeric({ length: { min: 3, max: 4 } }))
         .build();
-      const createOrgSafePayload = [
-        {
-          chainId: chain1.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-        {
-          chainId: chain2.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-        {
-          chainId: chain2.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-      ];
+      const createOrgSafePayload = {
+        safes: [
+          {
+            chainId: chain1.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+          {
+            chainId: chain2.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+          {
+            chainId: chain2.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+        ],
+      };
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -519,10 +521,10 @@ describe('OrganizationSafeController', () => {
         .expect(200)
         .expect({
           safes: {
-            [chain1.chainId]: [createOrgSafePayload[0].address],
+            [chain1.chainId]: [createOrgSafePayload.safes[0].address],
             [chain2.chainId]: [
-              createOrgSafePayload[1].address,
-              createOrgSafePayload[2].address,
+              createOrgSafePayload.safes[1].address,
+              createOrgSafePayload.safes[2].address,
             ],
           },
         });
@@ -631,12 +633,14 @@ describe('OrganizationSafeController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const orgName = faker.company.name();
       const chain = chainBuilder().build();
-      const orgSafes = [
-        {
-          chainId: chain.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-      ];
+      const orgSafes = {
+        safes: [
+          {
+            chainId: chain.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+        ],
+      };
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -656,7 +660,7 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send(orgSafes)
+        .send(orgSafes.safes)
         .expect(204);
     });
 
@@ -667,20 +671,22 @@ describe('OrganizationSafeController', () => {
       const chain1 = chainBuilder().build();
       const chain2 = chainBuilder().build();
       const chain3 = chainBuilder().build();
-      const orgSafes = [
-        {
-          chainId: chain1.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-        {
-          chainId: chain2.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-        {
-          chainId: chain3.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-      ];
+      const orgSafes = {
+        safes: [
+          {
+            chainId: chain1.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+          {
+            chainId: chain2.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+          {
+            chainId: chain3.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+        ],
+      };
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -700,7 +706,7 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send(orgSafes)
+        .send(orgSafes.safes)
         .expect(204);
     });
 

--- a/src/routes/organizations/organization-safes.controller.spec.ts
+++ b/src/routes/organizations/organization-safes.controller.spec.ts
@@ -660,7 +660,7 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send(orgSafes.safes)
+        .send(orgSafes)
         .expect(204);
     });
 
@@ -706,7 +706,7 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send(orgSafes.safes)
+        .send(orgSafes)
         .expect(204);
     });
 
@@ -719,20 +719,22 @@ describe('OrganizationSafeController', () => {
       const chain1 = chainBuilder().build();
       const chain2 = chainBuilder().build();
       const chain3 = chainBuilder().build();
-      const orgSafes = [
-        {
-          chainId: chain1.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-        {
-          chainId: chain2.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-        {
-          chainId: chain3.chainId,
-          address: getAddress(faker.finance.ethereumAddress()),
-        },
-      ];
+      const orgSafes = {
+        safes: [
+          {
+            chainId: chain1.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+          {
+            chainId: chain2.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+          {
+            chainId: chain3.chainId,
+            address: getAddress(faker.finance.ethereumAddress()),
+          },
+        ],
+      };
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -806,12 +808,14 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(404)
         .expect({
           statusCode: 404,
@@ -828,7 +832,7 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([])
+        .send({ safes: [] })
         .expect(422)
         .expect({
           statusCode: 422,
@@ -838,7 +842,7 @@ describe('OrganizationSafeController', () => {
           inclusive: true,
           exact: false,
           message: 'Array must contain at least 1 element(s)',
-          path: [],
+          path: ['safes'],
         });
     });
 
@@ -851,23 +855,25 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: 111,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: 111,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(422)
         .expect({
           statusCode: 422,
           code: 'invalid_type',
           expected: 'string',
           received: 'number',
-          path: [0, 'chainId'],
+          path: ['safes', 0, 'chainId'],
           message: 'Expected string, received number',
         });
     });
@@ -882,22 +888,24 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: 'invalid-address',
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: 'invalid-address',
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(422)
         .expect({
           statusCode: 422,
           code: 'custom',
           message: 'Invalid address',
-          path: [0, 'address'],
+          path: ['safes', 0, 'address'],
         });
     });
 
@@ -916,22 +924,24 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(422)
         .expect({
           statusCode: 422,
           code: 'custom',
           message: 'Value must be less than or euqal to 78',
-          path: [0, 'chainId'],
+          path: ['safes', 0, 'chainId'],
         });
     });
 
@@ -945,16 +955,18 @@ describe('OrganizationSafeController', () => {
       await request(app.getHttpServer())
         .delete(`/v1/organizations/${orgId}/safes`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .send([
-          {
-            chainId: chain1.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-          {
-            chainId: chain2.chainId,
-            address: getAddress(faker.finance.ethereumAddress()),
-          },
-        ])
+        .send({
+          safes: [
+            {
+              chainId: chain1.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+            {
+              chainId: chain2.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
         .expect(400)
         .expect({
           message: 'Validation failed (numeric string is expected)',

--- a/src/routes/organizations/organization-safes.controller.ts
+++ b/src/routes/organizations/organization-safes.controller.ts
@@ -3,7 +3,7 @@ import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { Auth } from '@/routes/auth/decorators/auth.decorator';
 import { AuthGuard } from '@/routes/auth/guards/auth.guard';
 import {
-  CreateOrganizationSafeDto,
+  CreateOrganizationSafesDto,
   CreateOrganizationSafesSchema,
 } from '@/routes/organizations/entities/create-organization-safe.dto.entity';
 import {
@@ -49,14 +49,14 @@ export class OrganizationSafesController {
 
   @Post()
   @ApiCreatedResponse({ description: 'Safes created successfully' })
-  @ApiBody({ type: CreateOrganizationSafeDto, isArray: true })
+  @ApiBody({ type: CreateOrganizationSafesDto })
   @ApiUnauthorizedResponse({
     description: 'User unauthorize OR signer address not provided',
   })
   @ApiNotFoundResponse({ description: 'User not found.' })
   public async create(
     @Body(new ValidationPipe(CreateOrganizationSafesSchema))
-    body: Array<CreateOrganizationSafeDto>,
+    body: CreateOrganizationSafesDto,
     @Param(
       'organizationId',
       ParseIntPipe,
@@ -68,7 +68,7 @@ export class OrganizationSafesController {
     return await this.organizationSafesService.create({
       organizationId,
       authPayload,
-      payload: body,
+      payload: body.safes,
     });
   }
 

--- a/src/routes/organizations/organization-safes.controller.ts
+++ b/src/routes/organizations/organization-safes.controller.ts
@@ -7,7 +7,7 @@ import {
   CreateOrganizationSafesSchema,
 } from '@/routes/organizations/entities/create-organization-safe.dto.entity';
 import {
-  DeleteOrganizationSafeDto,
+  DeleteOrganizationSafesDto,
   DeleteOrganizationSafesSchema,
 } from '@/routes/organizations/entities/delete-organization-safe.dto.entity';
 import { GetOrganizationSafeResponse } from '@/routes/organizations/entities/get-organization-safe.dto.entity';
@@ -106,7 +106,7 @@ export class OrganizationSafesController {
   })
   public async delete(
     @Body(new ValidationPipe(DeleteOrganizationSafesSchema))
-    body: Array<DeleteOrganizationSafeDto>,
+    body: DeleteOrganizationSafesDto,
     @Param(
       'organizationId',
       ParseIntPipe,
@@ -117,7 +117,7 @@ export class OrganizationSafesController {
   ): Promise<void> {
     return await this.organizationSafesService.delete({
       authPayload,
-      payload: body,
+      payload: body.safes,
       organizationId,
     });
   }


### PR DESCRIPTION
## Summary

Similarly to https://github.com/safe-global/safe-client-gateway/pull/2366, Swagger struggles with having top-level arrays as entities. This then causes issues with client-side generation of types.

This moves the Safe(s)-to-be-created inside a nested property to solve the above for `CreateOrganizationSafesDto`.

## Changes

- Move Safe(s)-to-be-created under `safes` property in `CreateOrganizationSafesDto`.
- Propagate changes and update tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the API for creating and deleting organization safes by standardizing the input structure. Safes must now be submitted within an object containing a non-empty array, improving consistency and validation.
	- Updated data transfer objects for organization safes to reflect a plural naming convention, aligning with the new payload structure.

- **Tests**
	- Updated test cases for the safe creation and deletion endpoints to reflect the new payload format, ensuring proper handling of valid requests as well as error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->