### PR TITLE
fix: invite/role user org request bodies of Swagger

### DIFF
--- a/src/routes/organizations/entities/invite-users.dto.entity.ts
+++ b/src/routes/organizations/entities/invite-users.dto.entity.ts
@@ -17,7 +17,7 @@ export const InviteUsersDtoSchema = z.object({
   users: InviteUserDtoSchema,
 });
 
-class InviteUserDto {
+export class InviteUserDto {
   @ApiProperty()
   public readonly address!: `0x${string}`;
 

--- a/src/routes/organizations/entities/update-role.dto.entity.ts
+++ b/src/routes/organizations/entities/update-role.dto.entity.ts
@@ -1,9 +1,16 @@
 import { z } from 'zod';
 import { UserOrganizationRole } from '@/domain/users/entities/user-organization.entity';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 export const UpdateRoleDtoSchema = z.object({
   role: z.enum(getStringEnumKeys(UserOrganizationRole)),
 });
 
-export type UpdateRoleDto = z.infer<typeof UpdateRoleDtoSchema>;
+export class UpdateRoleDto implements z.infer<typeof UpdateRoleDtoSchema> {
+  @ApiProperty({
+    type: String,
+    enum: getStringEnumKeys(UserOrganizationRole),
+  })
+  public readonly role!: keyof typeof UserOrganizationRole;
+}

--- a/src/routes/organizations/user-organizations.controller.ts
+++ b/src/routes/organizations/user-organizations.controller.ts
@@ -22,14 +22,16 @@ import { UserOrganizationsService } from '@/routes/organizations/user-organizati
 import { Auth } from '@/routes/auth/decorators/auth.decorator';
 import { AuthGuard } from '@/routes/auth/guards/auth.guard';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
-import { InviteUsersDtoSchema } from '@/routes/organizations/entities/invite-users.dto.entity';
+import {
+  InviteUsersDto,
+  InviteUsersDtoSchema,
+} from '@/routes/organizations/entities/invite-users.dto.entity';
 import { UpdateRoleDtoSchema } from '@/routes/organizations/entities/update-role.dto.entity';
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import { UserOrganizationsDto } from '@/routes/organizations/entities/user-organizations.dto.entity';
 import { Invitation } from '@/routes/organizations/entities/invitation.entity';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
-import type { InviteUsersDto } from '@/routes/organizations/entities/invite-users.dto.entity';
-import type { UpdateRoleDto } from '@/routes/organizations/entities/update-role.dto.entity';
+import { UpdateRoleDto } from '@/routes/organizations/entities/update-role.dto.entity';
 
 @ApiTags('organizations')
 @Controller({ path: 'organizations', version: '1' })


### PR DESCRIPTION
## Summary

The Swagger definitions for the request bodies of inviting users to `UserOrganization`s or updating their roles were missing. Both of theses were pure types and, as such, classes were created for them.

When importing an entity class, even if used as a `type`, it must be imported "normally" to be parsed by Swagger. This was the required fix for the `InviteUsersDto`.

## Changes

- Create classes for both types
- Remove `type` from import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the invitation workflow and role update process for improved integration and consistency.
  
- **Documentation**
  - Enhanced API metadata for role updates, providing clearer public reference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->