### PR TITLE
fix: Rename UserOrganizationsDto to UserOrganizationDto

### DIFF
--- a/src/routes/organizations/entities/get-organization.dto.entity.ts
+++ b/src/routes/organizations/entities/get-organization.dto.entity.ts
@@ -18,7 +18,7 @@ class UserDto extends User {
   public status!: User['status'];
 }
 
-class UserOrganizationsDto {
+class UserOrganizationDto {
   @ApiProperty({ type: Number })
   public id!: UserOrganization['id'];
 
@@ -51,6 +51,6 @@ export class GetOrganizationResponse {
   @ApiProperty({ type: String, enum: getStringEnumKeys(OrganizationStatus) })
   public status!: keyof typeof OrganizationStatus;
 
-  @ApiProperty({ type: UserOrganizationsDto, isArray: true })
-  public userOrganizations!: Array<UserOrganizationsDto>;
+  @ApiProperty({ type: UserOrganizationDto, isArray: true })
+  public userOrganizations!: Array<UserOrganizationDto>;
 }


### PR DESCRIPTION
## Summary
This PR changes the name of `userOrganizationsDto` in https://github.com/safe-global/safe-client-gateway/blob/9d6191df34eddcb2f7ec328f9523468ca0778f3e/src/routes/organizations/entities/get-organization.dto.entity.ts

Since another exported class shares the same name, Swagger attempted to fetch the type from that class instead of the one defined in this file. To resolve the conflict, we renamed the class.

## Changes
- Renamed `UserOrganizationsDto`to `UserOrganizationDto`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised naming for organization user data to ensure a more coherent and consistent structure in system responses.
  - Clarified and standardized the presentation of organization details, enhancing predictability and uniformity.
  - These improvements promote clearer communication of organizational data in client interfaces and streamline backend integrations.
  - Overall adjustments yield a more reliable and understandable display of organization information, benefiting end users with improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->