### PR TITLE
feat: Add name field to user organization invitation and acceptance

### DIFF
--- a/migrations/1740129969003-user-organization-name.ts
+++ b/migrations/1740129969003-user-organization-name.ts
@@ -1,0 +1,22 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserOrganizationName1740129969003 implements MigrationInterface {
+  name = 'UserOrganizationName1740129969003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE user_organizations
+        SET name = 'OrganizationUser_' || "user_organizations"."userId"
+        WHERE name IS NULL;`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_organizations" ALTER COLUMN "name" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_organizations" ALTER COLUMN "name" DROP NOT NULL`,
+    );
+  }
+}

--- a/src/datasources/users/entities/user-organizations.entity.db.ts
+++ b/src/datasources/users/entities/user-organizations.entity.db.ts
@@ -48,8 +48,8 @@ export class UserOrganization implements DomainUserOrganization {
   })
   organization!: Organization;
 
-  @Column({ type: 'varchar', length: 255, nullable: true })
-  name!: string | null;
+  @Column({ type: 'varchar', length: 255 })
+  name!: string;
 
   // Postgres enums are string therefore we use integer
   @Column({

--- a/src/domain/organizations/organizations.repository.ts
+++ b/src/domain/organizations/organizations.repository.ts
@@ -41,7 +41,6 @@ export class OrganizationsRepository implements IOrganizationsRepository {
 
     // @todo Move to UserOrganizationsRepository
     const userOrganization = new UserOrganization();
-    // @todo We should remove name
     userOrganization.name = args.name;
     userOrganization.role = getEnumKey(
       UserOrganizationRole,

--- a/src/domain/users/entities/invitation.entity.ts
+++ b/src/domain/users/entities/invitation.entity.ts
@@ -6,5 +6,6 @@ export type Invitation = {
   userId: User['id'];
   orgId: Organization['id'];
   role: UserOrganization['role'];
+  name: UserOrganization['name'];
   status: UserOrganization['status'];
 };

--- a/src/domain/users/entities/user-organization.entity.ts
+++ b/src/domain/users/entities/user-organization.entity.ts
@@ -22,14 +22,14 @@ export const UserOrganizationSchema: z.ZodType<
   z.infer<typeof RowSchema> & {
     user: User;
     organization: Organization;
-    name: string | null;
+    name: string;
     role: keyof typeof UserOrganizationRole;
     status: keyof typeof UserOrganizationStatus;
   }
 > = RowSchema.extend({
   user: z.lazy(() => UserSchema),
   organization: z.lazy(() => OrganizationSchema),
-  name: z.string().nullable(),
+  name: z.string(),
   role: z.enum(getStringEnumKeys(UserOrganizationRole)),
   status: z.enum(getStringEnumKeys(UserOrganizationStatus)),
 });

--- a/src/domain/users/user-organizations.repository.integration.spec.ts
+++ b/src/domain/users/user-organizations.repository.integration.spec.ts
@@ -155,6 +155,7 @@ describe('UserOrganizationsRepository', () => {
       const userOrg = await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: faker.person.firstName(),
         status: faker.helpers.arrayElement(UserOrgStatusKeys),
         role: faker.helpers.arrayElement(UserOrgRoleKeys),
       });
@@ -191,6 +192,7 @@ describe('UserOrganizationsRepository', () => {
       const prevUserOrg = await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: faker.person.firstName(),
         status: 'ACTIVE',
         role: faker.helpers.arrayElement(UserOrgRoleKeys),
       });
@@ -457,6 +459,7 @@ describe('UserOrganizationsRepository', () => {
     it('should invite users to an organization and return the user organizations', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminOrgName = faker.person.firstName();
       const owner = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -472,6 +475,7 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: owner.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminOrgName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
@@ -480,6 +484,7 @@ describe('UserOrganizationsRepository', () => {
           return {
             address: getAddress(faker.finance.ethereumAddress()),
             role: faker.helpers.arrayElement(UserOrgRoleKeys),
+            name: faker.person.firstName(),
           };
         },
         { count: { min: 2, max: 5 } },
@@ -496,6 +501,7 @@ describe('UserOrganizationsRepository', () => {
           return {
             userId: expect.any(Number),
             orgId,
+            name: user.name,
             role: user.role,
             status: 'INVITED',
           };
@@ -506,6 +512,7 @@ describe('UserOrganizationsRepository', () => {
     it('should not create PENDING users for existing ones', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminOrgName = faker.person.firstName();
       const owner = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -521,6 +528,7 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: owner.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminOrgName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
@@ -533,6 +541,7 @@ describe('UserOrganizationsRepository', () => {
         address: memberWallet,
       });
       const memberRole = faker.helpers.arrayElement(UserOrgRoleKeys);
+      const memberName = faker.person.firstName();
 
       await userOrgRepo.inviteUsers({
         authPayload: new AuthPayload(authPayloadDto),
@@ -541,6 +550,7 @@ describe('UserOrganizationsRepository', () => {
           {
             address: memberWallet,
             role: memberRole,
+            name: memberName,
           },
         ],
       });
@@ -579,6 +589,7 @@ describe('UserOrganizationsRepository', () => {
       const users: Array<{
         address: `0x${string}`;
         role: keyof typeof UserOrganizationRole;
+        name: string;
       }> = [];
 
       await expect(
@@ -599,6 +610,7 @@ describe('UserOrganizationsRepository', () => {
       const users: Array<{
         address: `0x${string}`;
         role: keyof typeof UserOrganizationRole;
+        name: string;
       }> = [];
 
       await expect(
@@ -613,6 +625,7 @@ describe('UserOrganizationsRepository', () => {
     it('should not allow inviting users if the user is not an ADMIN', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
       const owner = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -628,6 +641,7 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: owner.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -636,6 +650,7 @@ describe('UserOrganizationsRepository', () => {
           return {
             address: getAddress(faker.finance.ethereumAddress()),
             role: faker.helpers.arrayElement(UserOrgRoleKeys),
+            name: faker.person.firstName(),
           };
         },
         { count: { min: 2, max: 5 } },
@@ -666,6 +681,7 @@ describe('UserOrganizationsRepository', () => {
       const users: Array<{
         address: `0x${string}`;
         role: keyof typeof UserOrganizationRole;
+        name: string;
       }> = [];
 
       await expect(
@@ -681,6 +697,7 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const pendingAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -703,18 +720,21 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: invitedAdmin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'INVITED',
       });
       const users: Array<{
         address: `0x${string}`;
         role: keyof typeof UserOrganizationRole;
+        name: string;
       }> = [];
 
       await expect(
@@ -731,6 +751,8 @@ describe('UserOrganizationsRepository', () => {
     it('should accept an invite to an organization, setting the user organization and user to ACTIVE', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -755,12 +777,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       const userOrg = await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: 'INVITED',
       });
@@ -769,6 +793,9 @@ describe('UserOrganizationsRepository', () => {
       await userOrgRepo.acceptInvite({
         authPayload: new AuthPayload(authPayloadDto),
         orgId,
+        payload: {
+          name: userOrgName,
+        },
       });
 
       await expect(
@@ -778,7 +805,7 @@ describe('UserOrganizationsRepository', () => {
       ).resolves.toEqual({
         createdAt: expect.any(Date),
         id: userOrgId,
-        name: null,
+        name: userOrgName,
         role: userOrgRole,
         status: 'ACTIVE',
         updatedAt: expect.any(Date),
@@ -799,6 +826,7 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -822,6 +850,7 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: userOrgRole,
         status: 'ACTIVE',
       });
@@ -830,6 +859,9 @@ describe('UserOrganizationsRepository', () => {
         userOrgRepo.acceptInvite({
           authPayload: new AuthPayload(memberAuthPayloadDto),
           orgId,
+          payload: {
+            name: adminName,
+          },
         }),
       ).rejects.toThrow('Organization not found.');
     });
@@ -842,11 +874,15 @@ describe('UserOrganizationsRepository', () => {
         min: 69420,
         max: DB_MAX_SAFE_INTEGER,
       });
+      const userOrgName = faker.person.firstName();
 
       await expect(
         userOrgRepo.acceptInvite({
           authPayload: new AuthPayload(authPayloadDto),
           orgId,
+          payload: {
+            name: userOrgName,
+          },
         }),
       ).rejects.toThrow('Signer address not provided.');
     });
@@ -857,17 +893,22 @@ describe('UserOrganizationsRepository', () => {
         min: 69420,
         max: DB_MAX_SAFE_INTEGER,
       });
+      const userOrgName = faker.person.firstName();
 
       await expect(
         userOrgRepo.acceptInvite({
           authPayload: new AuthPayload(authPayloadDto),
           orgId,
+          payload: {
+            name: userOrgName,
+          },
         }),
       ).rejects.toThrow('User not found.');
     });
 
     it('should throw an error if the organization does not exist', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
+      const userOrgName = faker.person.firstName();
       const user = await dbUserRepo.insert({
         status: 'PENDING',
       });
@@ -884,6 +925,9 @@ describe('UserOrganizationsRepository', () => {
         userOrgRepo.acceptInvite({
           authPayload: new AuthPayload(authPayloadDto),
           orgId,
+          payload: {
+            name: userOrgName,
+          },
         }),
       ).rejects.toThrow('Organization not found.');
     });
@@ -892,6 +936,8 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -915,12 +961,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: 'ACTIVE',
       });
@@ -929,6 +977,7 @@ describe('UserOrganizationsRepository', () => {
         userOrgRepo.acceptInvite({
           authPayload: new AuthPayload(memberAuthPayloadDto),
           orgId,
+          payload: { name: userOrgName },
         }),
       ).rejects.toThrow('Organization not found.');
     });
@@ -936,6 +985,8 @@ describe('UserOrganizationsRepository', () => {
     it('should throw an error if the user is not INVITED to the organization', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -959,12 +1010,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: 'ACTIVE',
       });
@@ -973,6 +1026,9 @@ describe('UserOrganizationsRepository', () => {
         userOrgRepo.acceptInvite({
           authPayload: new AuthPayload(authPayloadDto),
           orgId,
+          payload: {
+            name: userOrgName,
+          },
         }),
       ).rejects.toThrow('Organization not found.');
     });
@@ -982,6 +1038,8 @@ describe('UserOrganizationsRepository', () => {
     it('should accept an invite to an organization, setting the user organization to DECLINED', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1006,12 +1064,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       const userOrg = await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: 'INVITED',
       });
@@ -1029,7 +1089,7 @@ describe('UserOrganizationsRepository', () => {
       ).resolves.toEqual({
         createdAt: expect.any(Date),
         id: userOrgId,
-        name: null,
+        name: userOrgName,
         role: userOrgRole,
         status: 'DECLINED',
         updatedAt: expect.any(Date),
@@ -1050,6 +1110,7 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1073,6 +1134,7 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: userOrgRole,
         status: 'ACTIVE',
       });
@@ -1143,6 +1205,8 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1166,12 +1230,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: 'ACTIVE',
       });
@@ -1187,6 +1253,8 @@ describe('UserOrganizationsRepository', () => {
     it('should throw an error if the user is not INVITED to the organization', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1210,12 +1278,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: 'ACTIVE',
       });
@@ -1233,6 +1303,7 @@ describe('UserOrganizationsRepository', () => {
     it('should find user organizations by organization id', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
       const userStatus = faker.helpers.arrayElement(UserStatusKeys);
       const user = await dbUserRepo.insert({
         status: userStatus,
@@ -1251,6 +1322,7 @@ describe('UserOrganizationsRepository', () => {
       const userOrg = await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: userOrgRole,
         status: userOrgStatus,
       });
@@ -1265,7 +1337,7 @@ describe('UserOrganizationsRepository', () => {
         {
           createdAt: expect.any(Date),
           id: userOrgId,
-          name: null,
+          name: userOrgName,
           role: userOrgRole,
           status: userOrgStatus,
           updatedAt: expect.any(Date),
@@ -1339,6 +1411,8 @@ describe('UserOrganizationsRepository', () => {
     it('should update the role of a user organization', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const userOrgName = faker.person.firstName();
       const owner = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1362,12 +1436,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: owner.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -1386,6 +1462,8 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
+      const memberName = faker.person.firstName();
       const userToUpdate = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1409,12 +1487,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: userToUpdate.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: memberName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -1433,6 +1513,8 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
+      const memberName = faker.person.firstName();
       const userToUpdate = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1456,12 +1538,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: userToUpdate.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: memberName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -1523,6 +1607,8 @@ describe('UserOrganizationsRepository', () => {
     it('should throw an error if user does not have access to upgrade to ADMIN', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
+      const memberName = faker.person.firstName();
       const owner = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1546,12 +1632,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: owner.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: memberName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -1569,6 +1657,7 @@ describe('UserOrganizationsRepository', () => {
     it('should throw an error if downgrading the last ACTIVE ADMIN', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
       const user = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1585,6 +1674,7 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
@@ -1604,6 +1694,8 @@ describe('UserOrganizationsRepository', () => {
     it('should remove the user', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
+      const memberName = faker.person.firstName();
       const owner = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1627,12 +1719,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: owner.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       const memberUserOrg = await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: memberName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -1656,6 +1750,8 @@ describe('UserOrganizationsRepository', () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
+      const memberName = faker.person.firstName();
       const admin = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1679,12 +1775,14 @@ describe('UserOrganizationsRepository', () => {
       await dbUserOrgRepo.insert({
         user: admin.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: userOrgName,
         role: 'ADMIN',
         status: 'ACTIVE',
       });
       await dbUserOrgRepo.insert({
         user: member.generatedMaps[0],
         organization: org.generatedMaps[0],
+        name: memberName,
         role: 'MEMBER',
         status: 'ACTIVE',
       });
@@ -1743,6 +1841,7 @@ describe('UserOrganizationsRepository', () => {
     it('should throw an error if removing the last ACTIVE ADMIN', async () => {
       const authPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const userOrgName = faker.person.firstName();
       const user = await dbUserRepo.insert({
         status: 'ACTIVE',
       });
@@ -1758,6 +1857,7 @@ describe('UserOrganizationsRepository', () => {
       const orgId = org.generatedMaps[0].id;
       await dbUserOrgRepo.insert({
         user: user.generatedMaps[0],
+        name: userOrgName,
         organization: org.generatedMaps[0],
         role: 'ADMIN',
         status: 'ACTIVE',

--- a/src/domain/users/user-organizations.repository.interface.ts
+++ b/src/domain/users/user-organizations.repository.interface.ts
@@ -43,12 +43,14 @@ export interface IUsersOrganizationsRepository {
     users: Array<{
       address: `0x${string}`;
       role: UserOrganization['role'];
+      name: UserOrganization['name'];
     }>;
   }): Promise<Array<Invitation>>;
 
   acceptInvite(args: {
     authPayload: AuthPayload;
     orgId: Organization['id'];
+    payload: Pick<UserOrganization, 'name'>;
   }): Promise<void>;
 
   declineInvite(args: {

--- a/src/domain/users/user-organizations.repository.ts
+++ b/src/domain/users/user-organizations.repository.ts
@@ -94,6 +94,7 @@ export class UsersOrganizationsRepository
     authPayload: AuthPayload;
     orgId: Organization['id'];
     users: Array<{
+      name: UserOrganization['name'];
       address: `0x${string}`;
       role: UserOrganization['role'];
     }>;
@@ -154,6 +155,7 @@ export class UsersOrganizationsRepository
         await entityManager.insert(DbUserOrganization, {
           user: { id: invitedUserId },
           organization: org,
+          name: userToInvite.name,
           role: userToInvite.role,
           status: 'INVITED',
         });
@@ -161,6 +163,7 @@ export class UsersOrganizationsRepository
         invitations.push({
           userId: invitedUserId,
           orgId: org.id,
+          name: userToInvite.name,
           role: userToInvite.role,
           status: 'INVITED',
         });
@@ -173,6 +176,7 @@ export class UsersOrganizationsRepository
   public async acceptInvite(args: {
     authPayload: AuthPayload;
     orgId: Organization['id'];
+    payload: Pick<UserOrganization, 'name'>;
   }): Promise<void> {
     this.assertSignerAddress(args.authPayload);
 
@@ -190,6 +194,7 @@ export class UsersOrganizationsRepository
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
       await this.updateStatus({
+        name: args.payload.name,
         userOrgId: userOrg.id,
         status: 'ACTIVE',
         entityManager,
@@ -234,6 +239,7 @@ export class UsersOrganizationsRepository
     userOrgId: UserOrganization['id'];
     status: UserOrganization['status'];
     entityManager: EntityManager;
+    name?: UserOrganization['name'];
   }): Promise<void> {
     await args.entityManager.update(DbUserOrganization, args.userOrgId, {
       status: args.status,

--- a/src/routes/organizations/entities/accept-invite.dto.entity.ts
+++ b/src/routes/organizations/entities/accept-invite.dto.entity.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { z } from 'zod';
+
+export const AcceptInviteDtoSchema = z.object({
+  name: z.string().max(255),
+});
+
+export class AcceptInviteDto implements z.infer<typeof AcceptInviteDtoSchema> {
+  @ApiProperty({ type: String })
+  public readonly name!: string;
+}

--- a/src/routes/organizations/entities/get-organization.dto.entity.ts
+++ b/src/routes/organizations/entities/get-organization.dto.entity.ts
@@ -25,6 +25,9 @@ class UserOrganizationDto {
   @ApiProperty({ type: String, enum: getStringEnumKeys(UserOrganizationRole) })
   public role!: UserOrganization['role'];
 
+  @ApiProperty({ type: String })
+  public name!: UserOrganization['name'];
+
   @ApiProperty({
     type: String,
     enum: getStringEnumKeys(UserOrganizationStatus),

--- a/src/routes/organizations/entities/invite-users.dto.entity.ts
+++ b/src/routes/organizations/entities/invite-users.dto.entity.ts
@@ -9,6 +9,7 @@ const InviteUserDtoSchema = z
     z.object({
       address: AddressSchema,
       role: z.enum(getStringEnumKeys(UserOrganizationRole)),
+      name: z.string().max(255),
     }),
   )
   .min(1);
@@ -20,6 +21,9 @@ export const InviteUsersDtoSchema = z.object({
 export class InviteUserDto {
   @ApiProperty()
   public readonly address!: `0x${string}`;
+
+  @ApiProperty({ type: String })
+  public readonly name!: string;
 
   @ApiProperty({
     enum: getStringEnumKeys(UserOrganizationRole),

--- a/src/routes/organizations/organization-safes.controller.spec.ts
+++ b/src/routes/organizations/organization-safes.controller.spec.ts
@@ -215,6 +215,7 @@ describe('OrganizationSafeController', () => {
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const memberAccessToken = jwtService.sign(memberAuthPayloadDto);
       const orgName = faker.company.name();
+      const orgMemberName = faker.person.firstName();
       const chain = chainBuilder().build();
 
       await request(app.getHttpServer())
@@ -234,6 +235,7 @@ describe('OrganizationSafeController', () => {
           users: [
             {
               address: getAddress(memberAuthPayloadDto.signer_address),
+              name: orgMemberName,
               role: 'MEMBER',
             },
           ],

--- a/src/routes/organizations/organizations.controller.spec.ts
+++ b/src/routes/organizations/organizations.controller.spec.ts
@@ -313,6 +313,7 @@ describe('OrganizationController', () => {
               userOrganizations: [
                 {
                   id: expect.any(Number),
+                  name: expect.any(String),
                   role: getEnumKey(
                     UserOrganizationRole,
                     UserOrganizationRole.ADMIN,
@@ -337,6 +338,7 @@ describe('OrganizationController', () => {
               userOrganizations: [
                 {
                   id: expect.any(Number),
+                  name: expect.any(String),
                   role: getEnumKey(
                     UserOrganizationRole,
                     UserOrganizationRole.ADMIN,
@@ -433,6 +435,7 @@ describe('OrganizationController', () => {
             userOrganizations: [
               {
                 id: expect.any(Number),
+                name: expect.any(String),
                 status: getEnumKey(
                   UserOrganizationStatus,
                   UserOrganizationStatus.ACTIVE,
@@ -619,6 +622,7 @@ describe('OrganizationController', () => {
       const memberAccessToken = jwtService.sign(memberAuthPayloadDto);
       const previousOrganizationName = faker.company.name();
       const newOrganizationName = faker.company.name();
+      const organizationMemberName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -637,6 +641,7 @@ describe('OrganizationController', () => {
           users: [
             {
               role: 'MEMBER',
+              name: organizationMemberName,
               address: memberAuthPayloadDto.signer_address,
             },
           ],
@@ -757,6 +762,7 @@ describe('OrganizationController', () => {
       const memberAuthPayloadDto = authPayloadDtoBuilder().build();
       const memberAccessToken = jwtService.sign(memberAuthPayloadDto);
       const organizationName = faker.company.name();
+      const organizationMemberName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -776,6 +782,7 @@ describe('OrganizationController', () => {
             {
               role: 'MEMBER',
               address: memberAuthPayloadDto.signer_address,
+              name: organizationMemberName,
             },
           ],
         })

--- a/src/routes/organizations/organizations.service.ts
+++ b/src/routes/organizations/organizations.service.ts
@@ -82,6 +82,7 @@ export class OrganizationsService {
         userOrganizations: {
           id: true,
           role: true,
+          name: true,
           status: true,
           createdAt: true,
           updatedAt: true,
@@ -121,6 +122,7 @@ export class OrganizationsService {
         userOrganizations: {
           id: true,
           role: true,
+          name: true,
           status: true,
           createdAt: true,
           updatedAt: true,

--- a/src/routes/organizations/user-organizations.controller.spec.ts
+++ b/src/routes/organizations/user-organizations.controller.spec.ts
@@ -107,7 +107,9 @@ describe('UserOrganizationsController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const orgName = faker.word.noun();
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -129,10 +131,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -142,12 +146,14 @@ describe('UserOrganizationsController', () => {
             {
               userId: expect.any(Number),
               orgId,
+              name: user1Name,
               role: 'ADMIN',
               status: 'INVITED',
             },
             {
               userId: expect.any(Number),
               orgId,
+              name: user2Name,
               role: 'MEMBER',
               status: 'INVITED',
             },
@@ -163,6 +169,7 @@ describe('UserOrganizationsController', () => {
         return {
           role: faker.helpers.arrayElement(['ADMIN', 'MEMBER']),
           address: getAddress(faker.finance.ethereumAddress()),
+          name: faker.person.firstName(),
         };
       });
 
@@ -183,7 +190,9 @@ describe('UserOrganizationsController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const orgName = faker.word.noun();
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -204,10 +213,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -250,7 +261,9 @@ describe('UserOrganizationsController', () => {
       const nonUserAccessToken = jwtService.sign(nonUserAuthPayloadDto);
       const orgName = faker.word.noun();
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -272,10 +285,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -295,7 +310,9 @@ describe('UserOrganizationsController', () => {
         max: DB_MAX_SAFE_INTEGER,
       });
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -310,10 +327,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -332,7 +351,9 @@ describe('UserOrganizationsController', () => {
       const nonUserOrgAccessToken = jwtService.sign(nonUserOrgAuthPayloadDto);
       const orgName = faker.word.noun();
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -359,10 +380,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -381,6 +404,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
       const user = getAddress(faker.finance.ethereumAddress());
+      const userName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -402,6 +426,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: userName,
             },
           ],
         })
@@ -415,6 +440,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: user,
+              name: userName,
             },
           ],
         })
@@ -434,6 +460,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -455,6 +482,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -463,6 +491,54 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
+        .expect(201)
+        .expect({});
+    });
+
+    it('should accept an invite for a user, changing name', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
+      const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
+      const orgName = faker.word.noun();
+      const orgInvitedUserName = faker.person.firstName();
+      const orgAcceptedUserName = faker.person.firstName();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(201);
+
+      const createOrganizationResponse = await request(app.getHttpServer())
+        .post('/v1/organizations')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: orgName })
+        .expect(201);
+      const orgId = createOrganizationResponse.body.id;
+
+      await request(app.getHttpServer())
+        .post(`/v1/organizations/${orgId}/members/invite`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+              name: orgInvitedUserName,
+            },
+          ],
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/v1/organizations/${orgId}/members/accept`)
+        .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgAcceptedUserName,
+        })
         .expect(201)
         .expect({});
     });
@@ -472,6 +548,7 @@ describe('UserOrganizationsController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -493,6 +570,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -500,6 +578,9 @@ describe('UserOrganizationsController', () => {
 
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
+        .send({
+          name: orgUserName,
+        })
         .expect(403)
         .expect({
           message: 'Forbidden resource',
@@ -514,6 +595,7 @@ describe('UserOrganizationsController', () => {
       const nonUserAuthPayloadDto = authPayloadDtoBuilder().build();
       const nonUserAccessToken = jwtService.sign(nonUserAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -530,6 +612,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${nonUserAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(404)
         .expect({
           message: 'User not found.',
@@ -545,6 +630,7 @@ describe('UserOrganizationsController', () => {
         min: 69420,
         max: DB_MAX_SAFE_INTEGER,
       });
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -554,6 +640,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(404)
         .expect({
           message: 'Organization not found.',
@@ -569,6 +658,7 @@ describe('UserOrganizationsController', () => {
       const nonUserOrgAuthPayload = jwtService.sign(nonUserOrgAuthPayloadDto);
       const orgName = faker.word.noun();
       const user = getAddress(faker.finance.ethereumAddress());
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -595,6 +685,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: user,
+              name: orgUserName,
             },
           ],
         })
@@ -603,6 +694,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${nonUserOrgAuthPayload}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(404)
         .expect({
           message: 'Organization not found.',
@@ -617,6 +711,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -638,6 +733,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -646,17 +742,72 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201)
         .expect({});
 
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(404)
         .expect({
           message: 'Organization not found.',
           error: 'Not Found',
           statusCode: 404,
+        });
+    });
+
+    it('should throw a 422 if the user name is not provided', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
+      const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
+      const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(201);
+
+      const createOrganizationResponse = await request(app.getHttpServer())
+        .post('/v1/organizations')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: orgName })
+        .expect(201);
+      const orgId = createOrganizationResponse.body.id;
+
+      await request(app.getHttpServer())
+        .post(`/v1/organizations/${orgId}/members/invite`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
+            },
+          ],
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/v1/organizations/${orgId}/members/accept`)
+        .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send()
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'invalid_type',
+          expected: 'object',
+          received: 'undefined',
+          path: [],
+          message: 'Required',
         });
     });
   });
@@ -668,6 +819,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -689,6 +841,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -706,6 +859,7 @@ describe('UserOrganizationsController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -727,6 +881,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -802,6 +957,7 @@ describe('UserOrganizationsController', () => {
       const nonUserOrgAuthPayloadDto = authPayloadDtoBuilder().build();
       const nonUserOrgAuthPayload = jwtService.sign(nonUserOrgAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
       const user = getAddress(faker.finance.ethereumAddress());
 
       await request(app.getHttpServer())
@@ -829,6 +985,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: user,
+              name: orgUserName,
             },
           ],
         })
@@ -851,6 +1008,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -872,6 +1030,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -901,7 +1060,9 @@ describe('UserOrganizationsController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const orgName = faker.word.noun();
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -923,10 +1084,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -982,7 +1145,9 @@ describe('UserOrganizationsController', () => {
       const accessToken = jwtService.sign(authPayloadDto);
       const orgName = faker.word.noun();
       const user1 = getAddress(faker.finance.ethereumAddress());
+      const user1Name = faker.person.firstName();
       const user2 = getAddress(faker.finance.ethereumAddress());
+      const user2Name = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1004,10 +1169,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: user1,
+              name: user1Name,
             },
             {
               role: 'MEMBER',
               address: user2,
+              name: user2Name,
             },
           ],
         })
@@ -1085,6 +1252,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1106,6 +1274,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1115,6 +1284,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -1131,6 +1303,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1152,6 +1325,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1161,6 +1335,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -1182,6 +1359,7 @@ describe('UserOrganizationsController', () => {
       const nonUserAuthPayloadDto = authPayloadDtoBuilder().build();
       const nonUserAccessToken = jwtService.sign(nonUserAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1203,6 +1381,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1212,6 +1391,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -1232,6 +1414,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1253,6 +1436,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1277,6 +1461,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1298,6 +1483,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1307,6 +1493,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -1396,6 +1585,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1417,6 +1607,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1426,6 +1617,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201);
 
       await request(app.getHttpServer())
@@ -1501,6 +1695,8 @@ describe('UserOrganizationsController', () => {
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const member = getAddress(faker.finance.ethereumAddress());
       const orgName = faker.word.noun();
+      const adminName = faker.person.firstName();
+      const memberName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1522,10 +1718,12 @@ describe('UserOrganizationsController', () => {
             {
               role: 'ADMIN',
               address: inviteeAuthPayloadDto.signer_address,
+              name: adminName,
             },
             {
               role: 'MEMBER',
               address: member,
+              name: memberName,
             },
           ],
         })
@@ -1549,6 +1747,7 @@ describe('UserOrganizationsController', () => {
       const inviteeAuthPayloadDto = authPayloadDtoBuilder().build();
       const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
       const orgName = faker.word.noun();
+      const orgUserName = faker.person.firstName();
 
       await request(app.getHttpServer())
         .post('/v1/users/wallet')
@@ -1570,6 +1769,7 @@ describe('UserOrganizationsController', () => {
             {
               role: 'MEMBER',
               address: inviteeAuthPayloadDto.signer_address,
+              name: orgUserName,
             },
           ],
         })
@@ -1579,6 +1779,9 @@ describe('UserOrganizationsController', () => {
       await request(app.getHttpServer())
         .post(`/v1/organizations/${orgId}/members/accept`)
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .send({
+          name: orgUserName,
+        })
         .expect(201);
 
       await request(app.getHttpServer())

--- a/src/routes/organizations/user-organizations.controller.ts
+++ b/src/routes/organizations/user-organizations.controller.ts
@@ -32,6 +32,10 @@ import { UserOrganizationsDto } from '@/routes/organizations/entities/user-organ
 import { Invitation } from '@/routes/organizations/entities/invitation.entity';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { UpdateRoleDto } from '@/routes/organizations/entities/update-role.dto.entity';
+import {
+  AcceptInviteDto,
+  AcceptInviteDtoSchema,
+} from '@/routes/organizations/entities/accept-invite.dto.entity';
 
 @ApiTags('organizations')
 @Controller({ path: 'organizations', version: '1' })
@@ -80,10 +84,13 @@ export class UserOrganizationsController {
     @Auth() authPayload: AuthPayload,
     @Param('orgId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     orgId: number,
+    @Body(new ValidationPipe(AcceptInviteDtoSchema))
+    acceptInviteDto: AcceptInviteDto,
   ): Promise<void> {
     return await this.userOrgService.acceptInvite({
       authPayload,
       orgId,
+      acceptInviteDto,
     });
   }
 

--- a/src/routes/organizations/user-organizations.service.ts
+++ b/src/routes/organizations/user-organizations.service.ts
@@ -8,6 +8,7 @@ import type { InviteUsersDto } from '@/routes/organizations/entities/invite-user
 import type { Invitation } from '@/routes/organizations/entities/invitation.entity';
 import type { UserOrganizationsDto } from '@/routes/organizations/entities/user-organizations.dto.entity';
 import type { UpdateRoleDto } from '@/routes/organizations/entities/update-role.dto.entity';
+import { AcceptInviteDto } from '@/routes/organizations/entities/accept-invite.dto.entity';
 
 export class UserOrganizationsService {
   private readonly maxInvites: number;
@@ -40,8 +41,13 @@ export class UserOrganizationsService {
   public async acceptInvite(args: {
     authPayload: AuthPayload;
     orgId: Organization['id'];
+    acceptInviteDto: AcceptInviteDto;
   }): Promise<void> {
-    return await this.usersOrgRepository.acceptInvite(args);
+    return await this.usersOrgRepository.acceptInvite({
+      authPayload: args.authPayload,
+      orgId: args.orgId,
+      payload: args.acceptInviteDto,
+    });
   }
 
   public async declineInvite(args: {


### PR DESCRIPTION
## Summary

This PR Introduces a name field in the user organization invitation and acceptance process, ensuring that the name is required and properly handled throughout the related services and data transfer objects.

## Changes
- Changed `UserOrganization` datababe column `name` to `non-nullable`.
- Added `name` to the invite endpoint of `User Oganization`.
- Added a name field to the accept endpoint of `User Organization`
- Adjusted tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization invitations and membership processes now require a member name, which is displayed in organization details across the platform.

- **Chores**
  - Updated system data structures to enforce a mandatory member name for improved data consistency and quality.

- **Tests**
  - Enhanced validations to verify that the member name is correctly included and handled during invitations and acceptance flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->