### PR TITLE
fix: don't compare all confirmations against sender

### DIFF
--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -289,10 +289,10 @@ export class TransactionVerifierHelper {
     );
 
     if (!recoveredAddresses.includes(args.proposal.sender)) {
-      const couldNotRecover = recoveredAddresses.some((address) => {
-        return address === null;
+      const recoveredAll = recoveredAddresses.every((address) => {
+        return address !== null;
       });
-      if (!couldNotRecover) {
+      if (recoveredAll) {
         throw new UnprocessableEntityException('Invalid signature');
       }
     }


### PR DESCRIPTION
## Summary

Refinement of incoming proposal confirmations were being compared against the same sender. This instead compares the presences in recovered addresses.

## Changes

- Check for presence of sender instead of match