### PR TITLE
fix: only refine queue

### DIFF
--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -49,6 +49,9 @@ export class TransactionVerifierHelper {
     safe: Safe;
     transaction: MultisigTransaction;
   }): Promise<void> {
+    if (args.transaction.isExecuted) {
+      return;
+    }
     if (this.isApiHashVerificationEnabled) {
       this.verifyApiSafeTxHash(args);
     }


### PR DESCRIPTION
## Summary

We only have access to the current Safe version and can therefore not reliably generate the `safeTxHash` for already executed transactions. This adds a relevant check to only refine the queue.

## Changes

- Only refine transactions that are `!isExecuted`