### PR TITLE
feat: add feature flag for `eth_sign` refinement

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -167,6 +167,7 @@ export default (): ReturnType<typeof configuration> => ({
       api: true,
       proposal: true,
     },
+    ethSign: true,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -256,6 +256,7 @@ export default () => ({
         process.env.FF_SIGNATURE_VERIFICATION_PROPOSAL?.toLowerCase() ===
         'true',
     },
+    ethSign: process.env.FF_ETH_SIGN?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -54,11 +54,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
   let safeConfigUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
 
-  beforeEach(async () => {
-    jest.resetAllMocks();
-
+  async function initApp(config: typeof configuration): Promise<void> {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(config)],
     })
       .overrideModule(PostgresDatabaseModule)
       .useModule(TestPostgresDatabaseModule)
@@ -84,6 +82,21 @@ describe('Get by id - Transactions Controller (Unit)', () => {
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
+  }
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        ethSign: true,
+      },
+    });
+
+    await initApp(testConfiguration);
   });
 
   afterAll(async () => {
@@ -1203,6 +1216,72 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'Invalid signature',
+        error: 'Bad Gateway',
+        statusCode: 502,
+      });
+  });
+
+  it('should block eth_sign', async () => {
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        ethSign: false,
+      },
+    });
+    await initApp(testConfiguration);
+
+    const chain = chainBuilder().build();
+    const signers = Array.from(
+      { length: faker.number.int({ min: 1, max: 5 }) },
+      () => {
+        const privateKey = generatePrivateKey();
+        return privateKeyToAccount(privateKey);
+      },
+    );
+    const safe = safeBuilder()
+      .with(
+        'owners',
+        signers.map((signer) => signer.address),
+      )
+      .build();
+    const multisigTransaction = await multisigTransactionBuilder()
+      .with('safe', safe.address)
+      .with('nonce', safe.nonce)
+      .with('isExecuted', false)
+      .buildWithConfirmations({
+        signers: signers,
+        chainId: chain.chainId,
+        safe,
+        signatureType: SignatureType.EthSign,
+      });
+    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+    const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${multisigTransaction.safeTxHash}/`;
+    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === getChainUrl) {
+        return Promise.resolve({ data: rawify(chain), status: 200 });
+      }
+      if (url === getMultisigTransactionUrl) {
+        return Promise.resolve({
+          data: rawify(multisigToJson(multisigTransaction)),
+          status: 200,
+        });
+      }
+      if (url === getSafeUrl) {
+        return Promise.resolve({ data: rawify(safe), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/transactions/multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+      )
+      .expect(502)
+      .expect({
+        message: 'eth_sign is disabled',
         error: 'Bad Gateway',
         statusCode: 502,
       });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -17,6 +17,7 @@ import type { IConfigurationService } from '@/config/configuration.service.inter
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
 import type { DelegatesV2Repository } from '@/domain/delegate/v2/delegates.v2.repository';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -58,15 +59,14 @@ const mockDelegatesRepository = jest.mocked({
 describe('MultisigTransactionDetails mapper (Unit)', () => {
   let mapper: MultisigTransactionDetailsMapper;
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-
+  function initTarget(ethSign: boolean): void {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       return [
         'features.hashVerification.api',
         'features.signatureVerification.api',
         'features.hashVerification.proposal',
         'features.signatureVerification.proposal',
+        ethSign ? 'features.ethSign' : null,
       ].includes(key);
     });
     mapper = new MultisigTransactionDetailsMapper(
@@ -82,6 +82,12 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
         mockDelegatesRepository,
       ),
     );
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    initTarget(true);
   });
 
   it('should return a TransactionDetails object with null addressInfoIndex', async () => {
@@ -190,5 +196,27 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
       detailedExecutionInfo: multisigExecutionDetails,
       safeAppInfo,
     });
+  });
+
+  it('should block eth_sign', async () => {
+    initTarget(false);
+
+    const chainId = faker.string.numeric();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const safe = safeBuilder().with('owners', [signer.address]).build();
+    const transaction = await multisigTransactionBuilder()
+      .with('safe', safe.address)
+      .with('isExecuted', false)
+      .buildWithConfirmations({
+        chainId,
+        safe,
+        signers: [signer],
+        signatureType: SignatureType.EthSign,
+      });
+
+    await expect(mapper.mapDetails(chainId, transaction, safe)).rejects.toThrow(
+      'eth_sign is disabled',
+    );
   });
 });


### PR DESCRIPTION
## Summary

This adds a new feature flag for `eth_sign` refinement which, when off, throws accordingly.

## Changes

- Add feature flag, throwing if disabled when confirmations are refined.
- Add/update tests accordingly.