### PR TITLE
fix: refine ownership of all split signatures

### DIFF
--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -1213,13 +1213,10 @@ describe('TransactionVerifierHelper', () => {
 
       it('should throw it not all individual signatures, after being split, are from owners or delegates', async () => {
         const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 2, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
+        const signers = Array.from({ length: 4 }, () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        });
         const safe = safeBuilder()
           .with(
             'owners',
@@ -1230,10 +1227,7 @@ describe('TransactionVerifierHelper', () => {
           .with('safe', safe.address)
           .buildWithConfirmations({
             chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
+            signers,
             safe,
           });
         if (
@@ -1263,6 +1257,9 @@ describe('TransactionVerifierHelper', () => {
           .with('sender', sender)
           .with('signature', signature)
           .build();
+        mockDelegatesRepository.getDelegates.mockResolvedValue(
+          pageBuilder<Delegate>().with('results', []).build(),
+        );
 
         await expect(
           target.verifyProposal({ chainId, safe, proposal }),

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -270,8 +270,8 @@ export class TransactionVerifierHelper {
       throw new UnprocessableEntityException('Invalid signature');
     }
 
-    const isOwner = args.safe.owners.includes(args.proposal.sender);
-    if (!isOwner) {
+    const areOwners = recoveredAddresses.every(args.safe.owners.includes);
+    if (!areOwners) {
       const delegates = await this.delegatesV2Repository.getDelegates({
         chainId: args.chainId,
         safeAddress: args.safe.address,

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -274,7 +274,9 @@ export class TransactionVerifierHelper {
       throw new UnprocessableEntityException('Invalid signature');
     }
 
-    const areOwners = recoveredAddresses.every(args.safe.owners.includes);
+    const areOwners = recoveredAddresses.every((address) =>
+      args.safe.owners.includes(address),
+    );
     if (!areOwners) {
       const delegates = await this.delegatesV2Repository.getDelegates({
         chainId: args.chainId,


### PR DESCRIPTION
## Summary

This adds ownership refinement of all components of a concatenated signature.

## Changes

- Compare every component
- Add/update test coverage