### PR TITLE
feat: only allow trusted delegate calls

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -168,7 +168,7 @@ export default (): ReturnType<typeof configuration> => ({
       proposal: true,
     },
     ethSign: true,
-    delegateCall: false,
+    trustedDelegateCall: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -168,6 +168,7 @@ export default (): ReturnType<typeof configuration> => ({
       proposal: true,
     },
     ethSign: true,
+    delegateCall: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -257,6 +257,7 @@ export default () => ({
         'true',
     },
     ethSign: process.env.FF_ETH_SIGN?.toLowerCase() === 'true',
+    delegateCall: process.env.FF_DELEGATE_CALL?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -257,7 +257,8 @@ export default () => ({
         'true',
     },
     ethSign: process.env.FF_ETH_SIGN?.toLowerCase() === 'true',
-    delegateCall: process.env.FF_DELEGATE_CALL?.toLowerCase() === 'true',
+    trustedDelegateCall:
+      process.env.FF_TRUSTED_DELEGATE_CALL?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -14,6 +14,7 @@ import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interf
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
 import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.repository.interface';
+import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
 
 export const ISafeRepository = Symbol('ISafeRepository');
 
@@ -222,6 +223,7 @@ export interface ISafeRepository {
     ChainsRepositoryModule,
     TransactionApiManagerModule,
     DelegatesV2RepositoryModule,
+    ContractsRepositoryModule,
   ],
   providers: [
     {

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -536,7 +536,6 @@ export class SafeRepository implements ISafeRepository {
 
     if (args.proposeTransactionDto.operation === Operation.DELEGATE) {
       if (!this.isTrustedDelegateCallEnabled) {
-        console.log('==> disabled');
         throw new UnprocessableEntityException('Delegate call is disabled');
       }
       try {
@@ -544,12 +543,10 @@ export class SafeRepository implements ISafeRepository {
           chainId: args.chainId,
           contractAddress: args.proposeTransactionDto.to,
         });
-        console.log('==>', contract.trustedForDelegateCall);
         if (!contract.trustedForDelegateCall) {
           throw new Error('Delegate call is disabled');
         }
       } catch {
-        console.log('==> no contract');
         throw new UnprocessableEntityException('Delegate call is disabled');
       }
     }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -534,19 +534,22 @@ export class SafeRepository implements ISafeRepository {
       args.chainId,
     );
 
-    if (
-      this.isTrustedDelegateCallEnabled &&
-      args.proposeTransactionDto.operation === Operation.DELEGATE
-    ) {
+    if (args.proposeTransactionDto.operation === Operation.DELEGATE) {
+      if (!this.isTrustedDelegateCallEnabled) {
+        console.log('==> disabled');
+        throw new UnprocessableEntityException('Delegate call is disabled');
+      }
       try {
         const contract = await this.contractsRepository.getContract({
           chainId: args.chainId,
           contractAddress: args.proposeTransactionDto.to,
         });
+        console.log('==>', contract.trustedForDelegateCall);
         if (!contract.trustedForDelegateCall) {
           throw new Error('Delegate call is disabled');
         }
       } catch {
+        console.log('==> no contract');
         throw new UnprocessableEntityException('Delegate call is disabled');
       }
     }

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -134,6 +134,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           appendSlash: false,
         })}", "name": "${faker.word.words()}", "note": "<script>document.write('<img src=s onerror=alert(Hello World)>')</script>"}`,
       )
+      .with('operation', Operation.CALL)
       .buildWithConfirmations({
         chainId,
         safe,
@@ -247,6 +248,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       .build();
     const transaction = await multisigTransactionBuilder()
       .with('safe', safeAddress)
+      .with('operation', Operation.CALL)
       .buildWithConfirmations({
         chainId,
         safe,
@@ -307,7 +309,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       features: {
         ...baseConfiguration.features,
         ethSign: true,
-        trustedDelegateCall: true,
+        trustedDelegateCall: false,
       },
     });
     await initApp(testConfiguration);
@@ -315,7 +317,9 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     const chainId = faker.string.numeric();
     const safeAddress = getAddress(faker.finance.ethereumAddress());
     const chain = chainBuilder().with('chainId', chainId).build();
-    const contract = contractBuilder().build();
+    const contract = contractBuilder()
+      .with('trustedForDelegateCall', false)
+      .build();
     const privateKey = generatePrivateKey();
     const signer = privateKeyToAccount(privateKey);
     const safe = safeBuilder()
@@ -349,19 +353,19 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
     const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
     networkService.get.mockImplementation(({ url }) => {
-      switch (url) {
-        case getChainUrl:
-          return Promise.resolve({ data: rawify(chain), status: 200 });
-        case getMultisigTransactionUrl:
-          return Promise.resolve({
-            data: rawify(multisigToJson(transaction)),
-            status: 200,
-          });
-        case getContractUrlPattern:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
+      if (url === getChainUrl) {
+        return Promise.resolve({ data: rawify(chain), status: 200 });
       }
+      if (url === getMultisigTransactionUrl) {
+        return Promise.resolve({
+          data: rawify(multisigToJson(transaction)),
+          status: 200,
+        });
+      }
+      if (url.includes(getContractUrlPattern)) {
+        return Promise.resolve({ data: rawify(contract), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
     });
     await request(app.getHttpServer())
       .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
@@ -372,5 +376,111 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         error: 'Unprocessable Entity',
         statusCode: 422,
       });
+  });
+
+  it('should allow trusted delegate calls', async () => {
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        ethSign: true,
+        trustedDelegateCall: true,
+      },
+    });
+    await initApp(testConfiguration);
+
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const safe = safeBuilder()
+      .with('address', safeAddress)
+      .with('owners', [signer.address])
+      .build();
+    const safeApps = [safeAppBuilder().build()];
+    const contract = contractBuilder()
+      .with('trustedForDelegateCall', true)
+      .build();
+    const transaction = await multisigTransactionBuilder()
+      .with('safe', safeAddress)
+      .with('operation', Operation.DELEGATE)
+      .buildWithConfirmations({
+        chainId,
+        safe,
+        signers: [signer],
+      });
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with('to', transaction.to)
+      .with('value', transaction.value)
+      .with('data', transaction.data)
+      .with('nonce', transaction.nonce.toString())
+      .with('operation', transaction.operation)
+      .with('safeTxGas', transaction.safeTxGas!.toString())
+      .with('baseGas', transaction.baseGas!.toString())
+      .with('gasPrice', transaction.gasPrice!)
+      .with('gasToken', transaction.gasToken!)
+      .with('refundReceiver', transaction.refundReceiver)
+      .with('safeTxHash', transaction.safeTxHash)
+      .with('sender', transaction.confirmations![0].owner)
+      .with('signature', transaction.confirmations![0].signature)
+      .build();
+    const transactions = pageBuilder().build();
+    const token = tokenBuilder().build();
+    const gasToken = tokenBuilder().build();
+    networkService.get.mockImplementation(({ url }) => {
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
+      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
+      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+      const getContractUrl = `${chain.transactionService}/api/v1/contracts/${transaction.to}`;
+      const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
+      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        case getMultisigTransactionUrl:
+          return Promise.resolve({
+            data: rawify(multisigToJson(transaction)),
+            status: 200,
+          });
+        case getMultisigTransactionsUrl:
+          return Promise.resolve({ data: rawify(transactions), status: 200 });
+        case getSafeUrl:
+          return Promise.resolve({ data: rawify(safe), status: 200 });
+        case getSafeAppsUrl:
+          return Promise.resolve({ data: rawify(safeApps), status: 200 });
+        case getContractUrl:
+          return Promise.resolve({ data: rawify(contract), status: 200 });
+        case getTokenUrl:
+          return Promise.resolve({ data: rawify(token), status: 200 });
+        case getGasTokenContractUrl:
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    networkService.post.mockImplementation(({ url }) => {
+      const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      switch (url) {
+        case proposeTransactionUrl:
+          return Promise.resolve({ data: rawify({}), status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
+      .send(proposeTransactionDto)
+      .expect(200)
+      .expect(({ body }) =>
+        expect(body).toEqual(
+          expect.objectContaining({
+            txId: `multisig_${safeAddress}_${transaction.safeTxHash}`,
+          }),
+        ),
+      );
   });
 });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -39,6 +39,7 @@ import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messag
 import { rawify } from '@/validation/entities/raw.entity';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
 
 describe('Propose transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -84,7 +85,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       features: {
         ...baseConfiguration.features,
         ethSign: true,
-        delegateCall: true,
+        trustedDelegateCall: true,
       },
     });
 
@@ -229,7 +230,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       features: {
         ...baseConfiguration.features,
         ethSign: false,
-        delegateCall: true,
+        trustedDelegateCall: false,
       },
     });
     await initApp(testConfiguration);
@@ -306,7 +307,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       features: {
         ...baseConfiguration.features,
         ethSign: true,
-        delegateCall: false,
+        trustedDelegateCall: true,
       },
     });
     await initApp(testConfiguration);
@@ -323,6 +324,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       .build();
     const transaction = await multisigTransactionBuilder()
       .with('safe', safeAddress)
+      .with('operation', Operation.DELEGATE)
       .buildWithConfirmations({
         chainId,
         safe,


### PR DESCRIPTION
## Summary

This adds a new feature flag that, if enable, ensures that proposed delegate call transactions are only allowed with trusted contracts.

## Changes

- Add new check of operation against trust flag
- Add appropriate test coverage