### PR TITLE
fix: categorize propose  errors

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -538,15 +538,11 @@ export class SafeRepository implements ISafeRepository {
       if (!this.isTrustedDelegateCallEnabled) {
         throw new UnprocessableEntityException('Delegate call is disabled');
       }
-      try {
-        const contract = await this.contractsRepository.getContract({
-          chainId: args.chainId,
-          contractAddress: args.proposeTransactionDto.to,
-        });
-        if (!contract.trustedForDelegateCall) {
-          throw new Error('Delegate call is disabled');
-        }
-      } catch {
+      const contract = await this.contractsRepository.getContract({
+        chainId: args.chainId,
+        contractAddress: args.proposeTransactionDto.to,
+      });
+      if (contract && !contract.trustedForDelegateCall) {
         throw new UnprocessableEntityException('Delegate call is disabled');
       }
     }


### PR DESCRIPTION
## Summary

This PR unmasks errors incoming from the Transaction Service when `this.contractsRepository.getContract` throws an error during delegate calls trustability tests.

## Changes
- Removes _catch-all_ block from `SafeRepository.proposeTransaction`.
- Adds related tests.
