### PR TITLE
feat: forward TXS endpoints

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -729,6 +729,20 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async getMultisigTransactionWithNoCache(
+    safeTransactionHash: string,
+  ): Promise<Raw<MultisigTransaction>> {
+    try {
+      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}`;
+      const { data } = await this.networkService.get<Raw<MultisigTransaction>>({
+        url,
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(this.mapError(error));
+    }
+  }
+
   async deleteTransaction(args: {
     safeTxHash: string;
     signature: string;

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -701,6 +701,55 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async getMultisigTransactionsWithNoCache({
+    safeAddress,
+    ...params
+  }: {
+    safeAddress: `0x${string}`;
+    // Transaction Service parameters
+    failed?: boolean;
+    modified__lt?: string;
+    modified__gt?: string;
+    modified__lte?: string;
+    modified__gte?: string;
+    nonce__lt?: number;
+    nonce__gt?: number;
+    nonce__lte?: number;
+    nonce__gte?: number;
+    nonce?: number;
+    safe_tx_hash?: string;
+    to?: string;
+    value__lt?: number;
+    value__gt?: number;
+    value?: number;
+    executed?: boolean;
+    has_confirmations?: boolean;
+    trusted?: boolean;
+    execution_date__gte?: string;
+    execution_date__lte?: string;
+    submission_date__gte?: string;
+    submission_date__lte?: string;
+    transaction_hash?: string;
+    ordering?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<MultisigTransaction>>> {
+    try {
+      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const { data } = await this.networkService.get<Page<MultisigTransaction>>(
+        {
+          url,
+          networkRequest: {
+            params,
+          },
+        },
+      );
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(this.mapError(error));
+    }
+  }
+
   async clearMultisigTransactions(safeAddress: `0x${string}`): Promise<void> {
     const key = CacheRouter.getMultisigTransactionsCacheKey({
       chainId: this.chainId,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -150,6 +150,10 @@ export interface ITransactionApi {
     safeTransactionHash: string,
   ): Promise<Raw<MultisigTransaction>>;
 
+  getMultisigTransactionWithNoCache(
+    safeTransactionHash: string,
+  ): Promise<Raw<MultisigTransaction>>;
+
   deleteTransaction(args: {
     safeTxHash: string;
     signature: string;

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -176,6 +176,37 @@ export interface ITransactionApi {
     offset?: number;
   }): Promise<Raw<Page<MultisigTransaction>>>;
 
+  getMultisigTransactionsWithNoCache(args: {
+    safeAddress: `0x${string}`;
+    // Transaction Service parameters
+    failed?: boolean;
+    modified__lt?: string;
+    modified__gt?: string;
+    modified__lte?: string;
+    modified__gte?: string;
+    nonce__lt?: number;
+    nonce__gt?: number;
+    nonce__lte?: number;
+    nonce__gte?: number;
+    nonce?: number;
+    safe_tx_hash?: string;
+    to?: string;
+    value__lt?: number;
+    value__gt?: number;
+    value?: number;
+    executed?: boolean;
+    has_confirmations?: boolean;
+    trusted?: boolean;
+    execution_date__gte?: string;
+    execution_date__lte?: string;
+    submission_date__gte?: string;
+    submission_date__lte?: string;
+    transaction_hash?: string;
+    ordering?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<MultisigTransaction>>>;
+
   clearMultisigTransactions(safeAddress: `0x${string}`): Promise<void>;
 
   getCreationTransaction(

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -340,10 +340,9 @@ export class SafeRepository implements ISafeRepository {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-    const multiSigTransaction =
-      await transactionService.getMultisigTransactionWithNoCache(
-        args.safeTransactionHash,
-      );
+    const multiSigTransaction = await transactionService.getMultisigTransaction(
+      args.safeTransactionHash,
+    );
 
     return MultisigTransactionSchema.parse(multiSigTransaction);
   }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -340,9 +340,25 @@ export class SafeRepository implements ISafeRepository {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-    const multiSigTransaction = await transactionService.getMultisigTransaction(
-      args.safeTransactionHash,
+    const multiSigTransaction =
+      await transactionService.getMultisigTransactionWithNoCache(
+        args.safeTransactionHash,
+      );
+
+    return MultisigTransactionSchema.parse(multiSigTransaction);
+  }
+
+  async getMultiSigTransactionWithNoCache(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): Promise<MultisigTransaction> {
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
     );
+    const multiSigTransaction =
+      await transactionService.getMultisigTransactionWithNoCache(
+        args.safeTransactionHash,
+      );
 
     return MultisigTransactionSchema.parse(multiSigTransaction);
   }

--- a/src/routes/transactions/entities/txs-multisig-transaction-page.entity.ts
+++ b/src/routes/transactions/entities/txs-multisig-transaction-page.entity.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Page } from '@/routes/common/entities/page.entity';
+import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
+
+export class TXSMultisigTransactionPage extends Page<TXSMultisigTransaction> {
+  @ApiProperty({ type: TXSMultisigTransaction, isArray: true })
+  results!: Array<TXSMultisigTransaction>;
+}

--- a/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
@@ -1,0 +1,141 @@
+import { DataDecoded } from '@/domain/data-decoder/v1/entities/data-decoded.entity';
+import {
+  Confirmation,
+  MultisigTransaction as DomainMultisigTransaction,
+} from '@/domain/safe/entities/multisig-transaction.entity';
+import { Operation } from '@/domain/safe/entities/operation.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TXSMultisigTransaction implements DomainMultisigTransaction {
+  @ApiProperty()
+  safe: `0x${string}`;
+  @ApiProperty()
+  to: `0x${string}`;
+  @ApiProperty()
+  value: string;
+  @ApiProperty()
+  data: `0x${string}` | null;
+  @ApiProperty()
+  dataDecoded: DataDecoded | null;
+  @ApiProperty()
+  operation: Operation;
+  @ApiProperty()
+  gasToken: `0x${string}` | null;
+  @ApiProperty()
+  safeTxGas: number | null;
+  @ApiProperty()
+  baseGas: number | null;
+  @ApiProperty()
+  gasPrice: string | null;
+  @ApiProperty()
+  proposer: `0x${string}` | null;
+  @ApiProperty()
+  proposedByDelegate: `0x${string}` | null;
+  @ApiProperty()
+  refundReceiver: `0x${string}` | null;
+  @ApiProperty()
+  nonce: number;
+  @ApiProperty()
+  executionDate: Date | null;
+  @ApiProperty()
+  submissionDate: Date;
+  @ApiProperty()
+  modified: Date | null;
+  @ApiProperty()
+  blockNumber: number | null;
+  @ApiProperty()
+  transactionHash: `0x${string}` | null;
+  @ApiProperty()
+  safeTxHash: `0x${string}`;
+  @ApiProperty()
+  executor: `0x${string}` | null;
+  @ApiProperty()
+  isExecuted: boolean;
+  @ApiProperty()
+  isSuccessful: boolean | null;
+  @ApiProperty()
+  ethGasPrice: string | null;
+  @ApiProperty()
+  gasUsed: number | null;
+  @ApiProperty()
+  fee: string | null;
+  @ApiProperty()
+  origin: string | null;
+  @ApiProperty()
+  confirmationsRequired: number;
+  @ApiProperty()
+  confirmations: Array<Confirmation> | null;
+  @ApiProperty()
+  signatures: `0x${string}` | null;
+  @ApiProperty()
+  trusted: boolean;
+  @ApiProperty()
+  txType: 'MULTISIG_TRANSACTION';
+
+  constructor(args: {
+    safe: `0x${string}`;
+    to: `0x${string}`;
+    value: string;
+    data: `0x${string}` | null;
+    dataDecoded: DataDecoded | null;
+    operation: Operation;
+    gasToken: `0x${string}` | null;
+    safeTxGas: number | null;
+    baseGas: number | null;
+    gasPrice: string | null;
+    proposer: `0x${string}` | null;
+    proposedByDelegate: `0x${string}` | null;
+    refundReceiver: `0x${string}` | null;
+    nonce: number;
+    executionDate: Date | null;
+    submissionDate: Date;
+    modified: Date | null;
+    blockNumber: number | null;
+    transactionHash: `0x${string}` | null;
+    safeTxHash: `0x${string}`;
+    executor: `0x${string}` | null;
+    isExecuted: boolean;
+    isSuccessful: boolean | null;
+    ethGasPrice: string | null;
+    gasUsed: number | null;
+    fee: string | null;
+    origin: string | null;
+    confirmationsRequired: number;
+    confirmations: Array<Confirmation> | null;
+    signatures: `0x${string}` | null;
+    trusted: boolean;
+  }) {
+    this.safe = args.safe;
+    this.to = args.to;
+    this.value = args.value;
+    this.data = args.data;
+    this.dataDecoded = args.dataDecoded;
+    this.operation = args.operation;
+    this.gasToken = args.gasToken;
+    this.safeTxGas = args.safeTxGas;
+    this.baseGas = args.baseGas;
+    this.gasPrice = args.gasPrice;
+    this.proposer = args.proposer;
+    this.proposedByDelegate = args.proposedByDelegate;
+    this.refundReceiver = args.refundReceiver;
+    this.nonce = args.nonce;
+    this.executionDate = args.executionDate;
+    this.submissionDate = args.submissionDate;
+    this.modified = args.modified;
+    this.blockNumber = args.blockNumber;
+    this.transactionHash = args.transactionHash;
+    this.safeTxHash = args.safeTxHash;
+    this.executor = args.executor;
+    this.isExecuted = args.isExecuted;
+    this.isSuccessful = args.isSuccessful;
+    this.ethGasPrice = args.ethGasPrice;
+    this.gasUsed = args.gasUsed;
+    this.fee = args.fee;
+    this.origin = args.origin;
+    this.confirmationsRequired = args.confirmationsRequired;
+    this.confirmations = args.confirmations;
+    this.signatures = args.signatures;
+    this.trusted = args.trusted;
+    this.txType = 'MULTISIG_TRANSACTION';
+  }
+}

--- a/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
@@ -69,8 +69,6 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
   signatures: `0x${string}` | null;
   @ApiProperty()
   trusted: boolean;
-  @ApiProperty()
-  txType: 'MULTISIG_TRANSACTION';
 
   constructor(args: {
     safe: `0x${string}`;
@@ -136,6 +134,5 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
     this.confirmations = args.confirmations;
     this.signatures = args.signatures;
     this.trusted = args.trusted;
-    this.txType = 'MULTISIG_TRANSACTION';
   }
 }

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -41,6 +41,7 @@ import { DeleteTransactionDtoSchema } from '@/routes/transactions/entities/schem
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { CreationTransaction } from '@/routes/transactions/entities/creation-transaction.entity';
 import { TimezoneSchema } from '@/validation/entities/schemas/timezone.schema';
+import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
 
 @ApiTags('transactions')
 @Controller({
@@ -59,6 +60,18 @@ export class TransactionsController {
     return this.transactionsService.getById({
       chainId,
       txId: id,
+    });
+  }
+
+  @ApiOkResponse({ type: TXSMultisigTransaction })
+  @Get(`chains/:chainId/multisig-transactions/:safeTxHash`)
+  async getMultisigTransactionBySafeTxHash(
+    @Param('chainId') chainId: string,
+    @Param('safeTxHash') safeTxHash: string,
+  ): Promise<TXSMultisigTransaction> {
+    return this.transactionsService.getBySafeTxHash({
+      chainId,
+      safeTxHash,
     });
   }
 

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -42,6 +42,7 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { CreationTransaction } from '@/routes/transactions/entities/creation-transaction.entity';
 import { TimezoneSchema } from '@/validation/entities/schemas/timezone.schema';
 import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
+import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-multisig-transaction-page.entity';
 
 @ApiTags('transactions')
 @Controller({
@@ -64,14 +65,113 @@ export class TransactionsController {
   }
 
   @ApiOkResponse({ type: TXSMultisigTransaction })
-  @Get(`chains/:chainId/multisig-transactions/:safeTxHash`)
-  async getMultisigTransactionBySafeTxHash(
+  @Get('chains/:chainId/multisig-transactions/:safeTxHash/raw')
+  async getDomainMultisigTransactionBySafeTxHash(
     @Param('chainId') chainId: string,
     @Param('safeTxHash') safeTxHash: string,
   ): Promise<TXSMultisigTransaction> {
-    return this.transactionsService.getBySafeTxHash({
+    return this.transactionsService.getDomainMultisigTransactionBySafeTxHash({
       chainId,
       safeTxHash,
+    });
+  }
+
+  @ApiOkResponse({ type: TXSMultisigTransactionPage })
+  @ApiQuery({ name: 'failed', required: false, type: Boolean })
+  @ApiQuery({ name: 'modified__lt', required: false, type: String })
+  @ApiQuery({ name: 'modified__gt', required: false, type: String })
+  @ApiQuery({ name: 'modified__lte', required: false, type: String })
+  @ApiQuery({ name: 'modified__gte', required: false, type: String })
+  @ApiQuery({ name: 'nonce__lt', required: false, type: Number })
+  @ApiQuery({ name: 'nonce__gt', required: false, type: Number })
+  @ApiQuery({ name: 'nonce__lte', required: false, type: Number })
+  @ApiQuery({ name: 'nonce__gte', required: false, type: Number })
+  @ApiQuery({ name: 'nonce', required: false, type: Number })
+  @ApiQuery({ name: 'safe_tx_hash', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
+  @ApiQuery({ name: 'value__lt', required: false, type: Number })
+  @ApiQuery({ name: 'value__gt', required: false, type: Number })
+  @ApiQuery({ name: 'value', required: false, type: Number })
+  @ApiQuery({ name: 'executed', required: false, type: Boolean })
+  @ApiQuery({ name: 'has_confirmations', required: false, type: Boolean })
+  @ApiQuery({ name: 'trusted', required: false, type: Boolean })
+  @ApiQuery({ name: 'execution_date__gte', required: false, type: String })
+  @ApiQuery({ name: 'execution_date__lte', required: false, type: String })
+  @ApiQuery({ name: 'submission_date__gte', required: false, type: String })
+  @ApiQuery({ name: 'submission_date__lte', required: false, type: String })
+  @ApiQuery({ name: 'transaction_hash', required: false, type: String })
+  @ApiQuery({ name: 'ordering', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @Get('chains/:chainId/safes/:safeAddress/multisig-transactions/raw')
+  async getDomainMultisigTransactions(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+    @Param('failed', new ParseBoolPipe({ optional: true })) failed?: boolean,
+    @Query('modified__lt') modified__lt?: string,
+    @Query('modified__gt') modified__gt?: string,
+    @Query('modified__lte') modified__lte?: string,
+    @Query('modified__gte') modified__gte?: string,
+    @Query('nonce__lt', new ParseIntPipe({ optional: true }))
+    nonce__lt?: number,
+    @Query('nonce__gt', new ParseIntPipe({ optional: true }))
+    nonce__gt?: number,
+    @Query('nonce__lte', new ParseIntPipe({ optional: true }))
+    nonce__lte?: number,
+    @Query('nonce__gte', new ParseIntPipe({ optional: true }))
+    nonce__gte?: number,
+    @Query('nonce', new ParseIntPipe({ optional: true })) nonce?: number,
+    @Query('safe_tx_hash') safe_tx_hash?: string,
+    @Query('to', new ValidationPipe(AddressSchema)) to?: string,
+    @Query('value__lt', new ParseIntPipe({ optional: true }))
+    value__lt?: number,
+    @Query('value__gt', new ParseIntPipe({ optional: true }))
+    value__gt?: number,
+    @Query('value', new ParseIntPipe({ optional: true })) value?: number,
+    @Query('executed', new ParseBoolPipe({ optional: true }))
+    executed?: boolean,
+    @Query('has_confirmations', new ParseBoolPipe({ optional: true }))
+    has_confirmations?: boolean,
+    @Query('trusted', new ParseBoolPipe({ optional: true })) trusted?: boolean,
+    @Query('execution_date__gte') execution_date__gte?: string,
+    @Query('execution_date__lte') execution_date__lte?: string,
+    @Query('submission_date__gte') submission_date__gte?: string,
+    @Query('submission_date__lte') submission_date__lte?: string,
+    @Query('transaction_hash') transaction_hash?: string,
+    @Query('ordering') ordering?: string,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+    @Query('offset', new ParseIntPipe({ optional: true })) offset?: number,
+  ): Promise<TXSMultisigTransactionPage> {
+    return this.transactionsService.getDomainMultisigTransactions({
+      chainId,
+      safeAddress,
+      failed,
+      modified__lt,
+      modified__gt,
+      modified__lte,
+      modified__gte,
+      nonce__lt,
+      nonce__gt,
+      nonce__lte,
+      nonce__gte,
+      nonce,
+      safe_tx_hash,
+      to,
+      value__lt,
+      value__gt,
+      value,
+      executed,
+      has_confirmations,
+      trusted,
+      execution_date__gte,
+      execution_date__lte,
+      submission_date__gte,
+      submission_date__lte,
+      transaction_hash,
+      ordering,
+      limit,
+      offset,
     });
   }
 

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -41,6 +41,7 @@ import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { MultisigTransactionNoteMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper';
 import { LogType } from '@/domain/common/entities/log-type.entity';
 import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
+import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-multisig-transaction-page.entity';
 
 @Injectable()
 export class TransactionsService {
@@ -141,7 +142,7 @@ export class TransactionsService {
     }
   }
 
-  async getBySafeTxHash(args: {
+  async getDomainMultisigTransactionBySafeTxHash(args: {
     chainId: string;
     safeTxHash: string;
   }): Promise<TXSMultisigTransaction> {
@@ -202,6 +203,40 @@ export class TransactionsService {
       previous: previousURL?.toString() ?? null,
       results,
     };
+  }
+
+  async getDomainMultisigTransactions(args: {
+    safeAddress: `0x${string}`;
+    chainId: string;
+    // Transaction Service parameters
+    failed?: boolean;
+    modified__lt?: string;
+    modified__gt?: string;
+    modified__lte?: string;
+    modified__gte?: string;
+    nonce__lt?: number;
+    nonce__gt?: number;
+    nonce__lte?: number;
+    nonce__gte?: number;
+    nonce?: number;
+    safe_tx_hash?: string;
+    to?: string;
+    value__lt?: number;
+    value__gt?: number;
+    value?: number;
+    executed?: boolean;
+    has_confirmations?: boolean;
+    trusted?: boolean;
+    execution_date__gte?: string;
+    execution_date__lte?: string;
+    submission_date__gte?: string;
+    submission_date__lte?: string;
+    transaction_hash?: string;
+    ordering?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<TXSMultisigTransactionPage> {
+    return await this.safeRepository.getMultisigTransactionsWithNoCache(args);
   }
 
   async deleteTransaction(args: {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -40,6 +40,7 @@ import { getAddress, isAddress } from 'viem';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { MultisigTransactionNoteMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper';
 import { LogType } from '@/domain/common/entities/log-type.entity';
+import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
 
 @Injectable()
 export class TransactionsService {
@@ -138,6 +139,17 @@ export class TransactionsService {
         );
       }
     }
+  }
+
+  async getBySafeTxHash(args: {
+    chainId: string;
+    safeTxHash: string;
+  }): Promise<TXSMultisigTransaction> {
+    const tx = await this.safeRepository.getMultiSigTransactionWithNoCache({
+      chainId: args.chainId,
+      safeTransactionHash: args.safeTxHash,
+    });
+    return new TXSMultisigTransaction(tx);
   }
 
   async getMultisigTransactions(args: {


### PR DESCRIPTION
## Summary

This PR adds the code to forward the following endpoints from the Transaction Service:
- `/api/v1/chains/:chainId/multisig-transactions/:safeTxHash/raw` --> `/api/v1/multisig-transactions/:safeTransactionHash`
- `/api/v1/chains/:chainId/safes/:safeAddress/multisig-transactions/raw` --> `/api/v1/safes/:safeAddress/multisig-transactions`

## Changes
- Creates new endpoints to get a transaction by `safeTxHash` and the list of Multisig Transactions, without CGW-side caching.
- Adds route-layer definitions for OpenAPI
