### PR TITLE
fix: only refine queued transactions above Safe nonce

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -979,6 +979,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const multisigTransaction = multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .build();
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
@@ -1024,6 +1025,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         safe,
@@ -1073,6 +1075,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         safe,
@@ -1127,6 +1130,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         signers: [signer],
@@ -1181,6 +1185,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         signers: [signer],
@@ -1250,6 +1255,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .with('safe', safe.address)
       .with('nonce', safe.nonce)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         signers: signers,
         chainId: chain.chainId,

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -541,7 +541,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
   it('should return a 502 if there is a safeTxHash mismatch', async () => {
     const chain = chainBuilder().build();
-    const safe = safeBuilder().build();
+    const safe = safeBuilder().with('nonce', 1).build();
     const getTransaction = (nonce: number): MultisigTransaction => {
       const transaction = multisigTransactionBuilder()
         .with('safe', safe.address)
@@ -618,6 +618,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         safe,
@@ -627,6 +628,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       await multisigTransactionBuilder()
         .with('safe', safe.address)
         .with('isExecuted', false)
+        .with('nonce', safe.nonce)
         .buildWithConfirmations({
           chainId: chain.chainId,
           safe,
@@ -689,6 +691,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         safe,
@@ -698,6 +701,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       await multisigTransactionBuilder()
         .with('safe', safe.address)
         .with('isExecuted', false)
+        .with('nonce', safe.nonce)
         .buildWithConfirmations({
           chainId: chain.chainId,
           safe,
@@ -773,6 +777,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         signers,
@@ -781,6 +786,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const invalidEoaMultisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         signers: [signers[0]],
@@ -847,6 +853,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         signers: [signer],
@@ -856,6 +863,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     const invalidEthSignMultisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId: chain.chainId,
         signers: [signer],

--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -76,6 +76,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -108,6 +109,44 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', true)
+          .with('nonce', safe.nonce)
+          .buildWithConfirmations({
+            chainId,
+            signers: faker.helpers.arrayElements(signers, {
+              min: 1,
+              max: signers.length,
+            }),
+            safe,
+          });
+        // @ts-expect-error - data is hex
+        transaction.data = faker.number.int();
+
+        await expect(
+          target.verifyApiTransaction({ chainId, safe, transaction }),
+        ).resolves.not.toThrow();
+      });
+
+      it('should not validate queued transactions with a nonce lower than the Safe', async () => {
+        const chainId = faker.string.numeric();
+        const signers = Array.from(
+          { length: faker.number.int({ min: 1, max: 5 }) },
+          () => {
+            const privateKey = generatePrivateKey();
+            return privateKeyToAccount(privateKey);
+          },
+        );
+        const nonce = faker.number.int({ min: 1, max: 5 });
+        const safe = safeBuilder()
+          .with(
+            'owners',
+            signers.map((s) => s.address),
+          )
+          .with('nonce', nonce)
+          .build();
+        const transaction = await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('isExecuted', true)
+          .with('nonce', nonce - 1)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -142,6 +181,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -200,6 +240,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -249,6 +290,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [signer],
@@ -271,6 +313,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [signer],
@@ -301,6 +344,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -321,6 +365,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [],
@@ -339,6 +384,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [],
@@ -359,6 +405,32 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', true)
+          .with('nonce', safe.nonce)
+          .buildWithConfirmations({
+            chainId,
+            // Duplicate owners
+            signers: [signer, signer],
+            safe,
+          });
+
+        await expect(
+          target.verifyApiTransaction({ chainId, safe, transaction }),
+        ).resolves.not.toThrow();
+      });
+
+      it('should not validate queued transactions with a nonce lower than the Safe', async () => {
+        const chainId = faker.string.numeric();
+        const privateKey = generatePrivateKey();
+        const signer = privateKeyToAccount(privateKey);
+        const nonce = faker.number.int({ min: 1, max: 5 });
+        const safe = safeBuilder()
+          .with('owners', [signer.address])
+          .with('nonce', nonce)
+          .build();
+        const transaction = await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('isExecuted', true)
+          .with('nonce', nonce - 1)
           .buildWithConfirmations({
             chainId,
             // Duplicate owners
@@ -379,6 +451,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [signer, signer],
@@ -418,6 +491,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers,
@@ -454,6 +528,7 @@ describe('TransactionVerifierHelper', () => {
           const transaction = await multisigTransactionBuilder()
             .with('safe', safe.address)
             .with('isExecuted', false)
+            .with('nonce', safe.nonce)
             .buildWithConfirmations({
               chainId,
               signers: [signer],
@@ -491,6 +566,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [signer],
@@ -525,6 +601,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [signer],
@@ -559,6 +636,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: [signer],

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -80,7 +80,10 @@ export class TransactionVerifierHelper {
     safe: Safe;
     transaction: MultisigTransaction;
   }): Promise<void> {
-    if (args.transaction.isExecuted) {
+    if (
+      args.transaction.isExecuted ||
+      args.transaction.nonce < args.safe.nonce
+    ) {
       return;
     }
     if (this.isApiHashVerificationEnabled) {

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -104,6 +104,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const transaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId,
         safe,
@@ -155,6 +156,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const transaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId,
         safe,
@@ -214,6 +216,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const transaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('isExecuted', false)
+      .with('nonce', safe.nonce)
       .buildWithConfirmations({
         chainId,
         safe,


### PR DESCRIPTION
## Summary

We current refine the queue according to the `isExecuted` status of a transaction. This extends the flag to only refine those with a nonce higher than the Safe nonce.

## Changes

- Add `nonce` comparison to refinement