### PR TITLE
feat: proxy creation transaction endpoint

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -839,6 +839,20 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async getCreationTransactionWithNoCache(
+    safeAddress: `0x${string}`,
+  ): Promise<Raw<CreationTransaction>> {
+    try {
+      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
+      const { data } = await this.networkService.get({
+        url,
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(this.mapError(error));
+    }
+  }
+
   async getAllTransactions(args: {
     safeAddress: `0x${string}`;
     ordering?: string;

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -213,6 +213,10 @@ export interface ITransactionApi {
     safeAddress: `0x${string}`,
   ): Promise<Raw<CreationTransaction>>;
 
+  getCreationTransactionWithNoCache(
+    safeAddress: `0x${string}`,
+  ): Promise<Raw<CreationTransaction>>;
+
   getAllTransactions(args: {
     safeAddress: `0x${string}`;
     ordering?: string;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -300,6 +300,20 @@ export class SafeRepository implements ISafeRepository {
     return CreationTransactionSchema.parse(createTransaction);
   }
 
+  async getCreationTransactionWithNoCache(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<CreationTransaction> {
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
+    );
+    const createTransaction =
+      await transactionService.getCreationTransactionWithNoCache(
+        args.safeAddress,
+      );
+    return CreationTransactionSchema.parse(createTransaction);
+  }
+
   async getTransactionHistory(args: {
     chainId: string;
     safeAddress: `0x${string}`;

--- a/src/routes/transactions/entities/txs-creation-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-creation-transaction.entity.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DataDecoded } from '@/domain/data-decoder/v1/entities/data-decoded.entity';
+import { CreationTransaction as DomainCreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
+
+export class TXSCreationTransaction implements DomainCreationTransaction {
+  @ApiProperty()
+  created: Date;
+  @ApiProperty()
+  creator: `0x${string}`;
+  @ApiProperty()
+  transactionHash: `0x${string}`;
+  @ApiProperty()
+  factoryAddress: `0x${string}`;
+  @ApiProperty()
+  masterCopy: `0x${string}` | null;
+  @ApiProperty()
+  setupData: `0x${string}` | null;
+  @ApiProperty()
+  saltNonce: string | null;
+  @ApiProperty()
+  dataDecoded: DataDecoded | null;
+
+  constructor(args: {
+    created: Date;
+    creator: `0x${string}`;
+    transactionHash: `0x${string}`;
+    factoryAddress: `0x${string}`;
+    masterCopy: `0x${string}` | null;
+    setupData: `0x${string}` | null;
+    saltNonce: string | null;
+    dataDecoded: DataDecoded | null;
+  }) {
+    this.created = args.created;
+    this.creator = args.creator;
+    this.transactionHash = args.transactionHash;
+    this.factoryAddress = args.factoryAddress;
+    this.masterCopy = args.masterCopy;
+    this.setupData = args.setupData;
+    this.saltNonce = args.saltNonce;
+    this.dataDecoded = args.dataDecoded;
+  }
+}

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -421,7 +421,7 @@ export class TransactionsController {
 
   @HttpCode(200)
   @ApiOkResponse({ type: TXSCreationTransaction })
-  @Get('chains/:chainId/safes/:safeAddress/transactions/creation')
+  @Get('chains/:chainId/safes/:safeAddress/transactions/creation/raw')
   async getDomainCreationTransaction(
     @Param('chainId') chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -43,6 +43,7 @@ import { CreationTransaction } from '@/routes/transactions/entities/creation-tra
 import { TimezoneSchema } from '@/validation/entities/schemas/timezone.schema';
 import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
 import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-multisig-transaction-page.entity';
+import { TXSCreationTransaction } from '@/routes/transactions/entities/txs-creation-transaction.entity';
 
 @ApiTags('transactions')
 @Controller({
@@ -413,6 +414,20 @@ export class TransactionsController {
     safeAddress: `0x${string}`,
   ): Promise<CreationTransaction> {
     return this.transactionsService.getCreationTransaction({
+      chainId,
+      safeAddress,
+    });
+  }
+
+  @HttpCode(200)
+  @ApiOkResponse({ type: TXSCreationTransaction })
+  @Get('chains/:chainId/safes/:safeAddress/transactions/creation')
+  async getDomainCreationTransaction(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: `0x${string}`,
+  ): Promise<TXSCreationTransaction> {
+    return this.transactionsService.getDomainCreationTransaction({
       chainId,
       safeAddress,
     });

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -421,7 +421,7 @@ export class TransactionsController {
 
   @HttpCode(200)
   @ApiOkResponse({ type: TXSCreationTransaction })
-  @Get('chains/:chainId/safes/:safeAddress/transactions/creation/raw')
+  @Get('chains/:chainId/safes/:safeAddress/creation/raw')
   async getDomainCreationTransaction(
     @Param('chainId') chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -42,6 +42,7 @@ import { MultisigTransactionNoteMapper } from '@/routes/transactions/mappers/mul
 import { LogType } from '@/domain/common/entities/log-type.entity';
 import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
 import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-multisig-transaction-page.entity';
+import { TXSCreationTransaction } from '@/routes/transactions/entities/txs-creation-transaction.entity';
 
 @Injectable()
 export class TransactionsService {
@@ -511,6 +512,14 @@ export class TransactionsService {
     safeAddress: `0x${string}`;
   }): Promise<CreationTransaction> {
     return this.safeRepository.getCreationTransaction(args);
+  }
+
+  async getDomainCreationTransaction(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): Promise<TXSCreationTransaction> {
+    const tx = await this.safeRepository.getCreationTransaction(args);
+    return new TXSCreationTransaction(tx);
   }
 
   /**


### PR DESCRIPTION
## Summary

This adds a proxy of the Transaction Service's creation transaction endpoint: `GET` `/v1/chains/:chainId/safes/:safeAddress/creation/raw`.

## Changes

- Add cacheless method for retrieving the creation transaction from the Transaction Service
- Propagate method to controller