### PR TITLE
fix: fix TransactionVerifierHelper test

### DIFF
--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -675,6 +675,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
+          .with('nonce', faker.number.int({ min: safe.nonce }))
           .buildWithConfirmations({
             chainId,
             signers: [blockedSigner, legitSigner],

--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -1920,7 +1920,7 @@ describe('TransactionVerifierHelper', () => {
       });
 
       it('should block eth_sign', async () => {
-        initTarget(false);
+        initTarget({ ethSign: false, blocklist: [] });
 
         const chainId = faker.string.numeric();
         const signers = Array.from(


### PR DESCRIPTION
## Changes
- Fixes invalid `initTarget` call in `TransactionVerifierHelper` unit tests.
- Fixes a flaky test with a bad transaction nonce.
