### PR TITLE
fix: dedupe refinement error logs

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -1007,7 +1007,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'Invalid safeTxHash',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -1057,7 +1056,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'Duplicate owners in confirmations',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -1111,7 +1109,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'Duplicate signatures in confirmations',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -1166,7 +1163,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'Invalid signature',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -1221,7 +1217,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'Invalid signature',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -1288,7 +1283,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .expect(502)
       .expect({
         message: 'eth_sign is disabled',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -605,7 +605,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .expect(502)
       .expect({
         message: 'Invalid safeTxHash',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -678,7 +677,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .expect(502)
       .expect({
         message: 'Duplicate owners in confirmations',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -757,7 +755,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .expect(502)
       .expect({
         message: 'Duplicate signatures in confirmations',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -840,7 +837,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .expect(502)
       .expect({
         message: 'Invalid signature',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -921,7 +917,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .expect(502)
       .expect({
         message: 'Invalid signature',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });
@@ -1011,7 +1006,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .expect(502)
       .expect({
         message: 'eth_sign is disabled',
-        error: 'Bad Gateway',
         statusCode: 502,
       });
   });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -297,7 +297,6 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       .expect(422)
       .expect({
         message: 'eth_sign is disabled',
-        error: 'Unprocessable Entity',
         statusCode: 422,
       });
   });
@@ -373,7 +372,6 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       .expect(422)
       .expect({
         message: 'Delegate call is disabled',
-        error: 'Unprocessable Entity',
         statusCode: 422,
       });
   });

--- a/src/routes/transactions/errors/transaction-validity.error.ts
+++ b/src/routes/transactions/errors/transaction-validity.error.ts
@@ -1,0 +1,23 @@
+import { HttpException } from '@nestjs/common';
+import type { HttpStatus } from '@nestjs/common';
+
+enum TransactionValidityErrorType {
+  MalformedHash = 'Could not calculate safeTxHash',
+  HashMismatch = 'Invalid safeTxHash',
+  DuplicateOwners = 'Duplicate owners in confirmations',
+  DuplicateSignatures = 'Duplicate signatures in confirmations',
+  UnrecoverableAddress = 'Could not recover address',
+  InvalidSignature = 'Invalid signature',
+  BlockedAddress = 'Unauthorized address',
+  EthSignDisabled = 'eth_sign is disabled',
+  DelegateCallDisabled = 'Delegate call is disabled',
+}
+
+export class TransactionValidityError extends HttpException {
+  constructor(args: {
+    code: HttpStatus;
+    type: keyof typeof TransactionValidityErrorType;
+  }) {
+    super(TransactionValidityErrorType[args.type], args.code);
+  }
+}

--- a/src/routes/transactions/exception-filters/transaction-validity.exception-filter.spec.ts
+++ b/src/routes/transactions/exception-filters/transaction-validity.exception-filter.spec.ts
@@ -1,0 +1,200 @@
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/configuration';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { TransactionValidityError } from '@/routes/transactions/errors/transaction-validity.error';
+import { TransactionValidityExceptionFilter } from '@/routes/transactions/exception-filters/transaction-validity.exception-filter';
+import { faker } from '@faker-js/faker/.';
+import {
+  Body,
+  Controller,
+  HttpStatus,
+  INestApplication,
+  Post,
+} from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { TestingModule, Test } from '@nestjs/testing';
+import { Server } from 'net';
+import request from 'supertest';
+
+@Controller()
+class TestController {
+  @Post('transaction-valditity')
+  malformedHash(
+    @Body() body: ConstructorParameters<typeof TransactionValidityError>[0],
+  ): void {
+    throw new TransactionValidityError(body);
+  }
+}
+
+describe('TransactionValidityExceptionFilter', () => {
+  let app: INestApplication<Server>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+      providers: [
+        {
+          provide: APP_FILTER,
+          useClass: TransactionValidityExceptionFilter,
+        },
+      ],
+    }).compile();
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should catch MalformedHash', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'MalformedHash' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Could not calculate safeTxHash',
+      });
+  });
+
+  it('should catch HashMismatch', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'HashMismatch' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Invalid safeTxHash',
+      });
+  });
+
+  it('should catch DuplicateOwners', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'DuplicateOwners' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Duplicate owners in confirmations',
+      });
+  });
+
+  it('should catch DuplicateSignatures', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'DuplicateSignatures' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Duplicate signatures in confirmations',
+      });
+  });
+
+  it('should catch UnrecoverableAddress', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'UnrecoverableAddress' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Could not recover address',
+      });
+  });
+
+  it('should catch InvalidSignature', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'InvalidSignature' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Invalid signature',
+      });
+  });
+
+  it('should catch EthSignDisabled', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'EthSignDisabled' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'eth_sign is disabled',
+      });
+  });
+
+  it('should catch DelegateCallDisabled', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'DelegateCallDisabled' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Delegate call is disabled',
+      });
+  });
+
+  it('should catch BlockedAddress', async () => {
+    const code = faker.helpers.arrayElement([
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      HttpStatus.BAD_GATEWAY,
+    ]);
+
+    await request(app.getHttpServer())
+      .post('/transaction-valditity')
+      .send({ code, type: 'BlockedAddress' })
+      .expect(code)
+      .expect({
+        statusCode: code,
+        message: 'Unauthorized address',
+      });
+  });
+});

--- a/src/routes/transactions/exception-filters/transaction-validity.exception-filter.ts
+++ b/src/routes/transactions/exception-filters/transaction-validity.exception-filter.ts
@@ -1,0 +1,19 @@
+import { Catch, ExceptionFilter, ArgumentsHost } from '@nestjs/common';
+import { TransactionValidityError } from '@/routes/transactions/errors/transaction-validity.error';
+import type { Response } from 'express';
+
+@Catch(TransactionValidityError)
+export class TransactionValidityExceptionFilter implements ExceptionFilter {
+  constructor() {}
+
+  catch(exception: TransactionValidityError, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const statusCode = exception.getStatus();
+
+    response.status(statusCode).json({
+      statusCode,
+      message: exception.message,
+    });
+  }
+}

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -1,9 +1,4 @@
-import {
-  BadGatewayException,
-  Inject,
-  Injectable,
-  UnprocessableEntityException,
-} from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { recoverAddress, isAddressEqual, recoverMessageAddress } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import {
@@ -24,21 +19,9 @@ import {
   splitConcatenatedSignatures,
   splitSignature,
 } from '@/domain/common/utils/signatures';
-import { asError } from '@/logging/utils';
+import { TransactionValidityError } from '@/routes/transactions/errors/transaction-validity.error';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { LogType } from '@/domain/common/entities/log-type.entity';
-
-enum ErrorMessage {
-  // Logged:
-  MalformedHash = 'Could not calculate safeTxHash',
-  HashMismatch = 'Invalid safeTxHash',
-  DuplicateOwners = 'Duplicate owners in confirmations',
-  DuplicateSignatures = 'Duplicate signatures in confirmations',
-  UnrecoverableAddress = 'Could not recover address',
-  InvalidSignature = 'Invalid signature',
-  // Not logged:
-  EthSignDisabled = 'eth_sign is disabled',
-}
 
 @Injectable()
 export class TransactionVerifierHelper {
@@ -90,11 +73,13 @@ export class TransactionVerifierHelper {
     ) {
       return;
     }
+    const code = HttpStatus.BAD_GATEWAY;
+
     if (this.isApiHashVerificationEnabled) {
-      this.verifyApiSafeTxHash(args);
+      this.verifyApiSafeTxHash({ ...args, code });
     }
     if (this.isApiSignatureVerificationEnabled) {
-      await this.verifyApiSignatures(args);
+      await this.verifyApiSignatures({ ...args, code });
     }
   }
 
@@ -103,11 +88,13 @@ export class TransactionVerifierHelper {
     safe: Safe;
     proposal: ProposeTransactionDto;
   }): Promise<void> {
+    const code = HttpStatus.UNPROCESSABLE_ENTITY;
+
     if (this.isProposalHashVerificationEnabled) {
-      this.verifyProposalSafeTxHash(args);
+      this.verifyProposalSafeTxHash({ ...args, code });
     }
     if (this.isProposalSignatureVerificationEnabled) {
-      await this.verifyProposalSignature(args);
+      await this.verifyProposalSignature({ ...args, code });
     }
   }
 
@@ -117,11 +104,13 @@ export class TransactionVerifierHelper {
     transaction: MultisigTransaction;
     signature: `0x${string}`;
   }): Promise<void> {
+    const code = HttpStatus.UNPROCESSABLE_ENTITY;
+
     if (this.isProposalHashVerificationEnabled) {
-      this.verifyConfirmSafeTxHash(args);
+      this.verifyConfirmSafeTxHash({ ...args, code });
     }
     if (this.isProposalHashVerificationEnabled) {
-      await this.verifyConfirmationSignature(args);
+      await this.verifyConfirmationSignature({ ...args, code });
     }
   }
 
@@ -129,6 +118,7 @@ export class TransactionVerifierHelper {
     chainId: string;
     safe: Safe;
     transaction: MultisigTransaction;
+    code: HttpStatus;
   }): void {
     let safeTxHash: `0x${string}`;
     try {
@@ -138,7 +128,10 @@ export class TransactionVerifierHelper {
         ...args,
         safeTxHash: args.transaction.safeTxHash,
       });
-      throw new BadGatewayException(ErrorMessage.MalformedHash);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'MalformedHash',
+      });
     }
 
     if (safeTxHash !== args.transaction.safeTxHash) {
@@ -146,7 +139,10 @@ export class TransactionVerifierHelper {
         ...args,
         safeTxHash: args.transaction.safeTxHash,
       });
-      throw new BadGatewayException(ErrorMessage.HashMismatch);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'HashMismatch',
+      });
     }
   }
 
@@ -154,6 +150,7 @@ export class TransactionVerifierHelper {
     chainId: string;
     safe: Safe;
     proposal: ProposeTransactionDto;
+    code: HttpStatus;
   }): void {
     const transaction: BaseMultisigTransaction = {
       ...args.proposal,
@@ -174,7 +171,10 @@ export class TransactionVerifierHelper {
         transaction,
         safeTxHash: args.proposal.safeTxHash,
       });
-      throw new UnprocessableEntityException(ErrorMessage.MalformedHash);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'MalformedHash',
+      });
     }
 
     if (safeTxHash !== args.proposal.safeTxHash) {
@@ -183,7 +183,10 @@ export class TransactionVerifierHelper {
         transaction,
         safeTxHash: args.proposal.safeTxHash,
       });
-      throw new UnprocessableEntityException(ErrorMessage.HashMismatch);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'HashMismatch',
+      });
     }
   }
 
@@ -191,6 +194,7 @@ export class TransactionVerifierHelper {
     chainId: string;
     safe: Safe;
     transaction: MultisigTransaction;
+    code: HttpStatus;
   }): void {
     let safeTxHash: `0x${string}`;
     try {
@@ -201,7 +205,10 @@ export class TransactionVerifierHelper {
         transaction: args.transaction,
         safeTxHash: args.transaction.safeTxHash,
       });
-      throw new UnprocessableEntityException(ErrorMessage.MalformedHash);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'MalformedHash',
+      });
     }
 
     if (safeTxHash !== args.transaction.safeTxHash) {
@@ -209,7 +216,10 @@ export class TransactionVerifierHelper {
         ...args,
         safeTxHash: args.transaction.safeTxHash,
       });
-      throw new BadGatewayException(ErrorMessage.HashMismatch);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'HashMismatch',
+      });
     }
   }
 
@@ -217,6 +227,7 @@ export class TransactionVerifierHelper {
     chainId: string;
     safe: Safe;
     transaction: MultisigTransaction;
+    code: HttpStatus;
   }): Promise<void> {
     if (
       !args.transaction.confirmations ||
@@ -235,7 +246,10 @@ export class TransactionVerifierHelper {
         confirmations: args.transaction.confirmations,
         type: 'owners',
       });
-      throw new BadGatewayException(ErrorMessage.DuplicateOwners);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'DuplicateOwners',
+      });
     }
 
     const uniqueSignatures = new Set(
@@ -248,7 +262,10 @@ export class TransactionVerifierHelper {
         confirmations: args.transaction.confirmations,
         type: 'signatures',
       });
-      throw new BadGatewayException(ErrorMessage.DuplicateSignatures);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'DuplicateSignatures',
+      });
     }
 
     for (const confirmation of args.transaction.confirmations) {
@@ -256,20 +273,18 @@ export class TransactionVerifierHelper {
         continue;
       }
 
-      let address: `0x${string}` | null;
-      try {
-        address = await this.recoverAddress({
-          ...args,
-          safeTxHash: args.transaction.safeTxHash,
-          signature: confirmation.signature,
-        });
-      } catch (e) {
-        throw new BadGatewayException(asError(e).message);
-      }
+      const address = await this.recoverAddress({
+        ...args,
+        safeTxHash: args.transaction.safeTxHash,
+        signature: confirmation.signature,
+      });
 
       const isBlocked = address && this.blocklist.includes(address);
       if (isBlocked) {
-        throw new BadGatewayException('Unauthorized address');
+        throw new TransactionValidityError({
+          code: args.code,
+          type: 'BlockedAddress',
+        });
       }
 
       if (
@@ -281,10 +296,13 @@ export class TransactionVerifierHelper {
         this.logInvalidSignature({
           ...args,
           safeTxHash: args.transaction.safeTxHash,
-          signer: confirmation.owner,
+          signerAddress: confirmation.owner,
           signature: confirmation.signature,
         });
-        throw new BadGatewayException(ErrorMessage.InvalidSignature);
+        throw new TransactionValidityError({
+          code: args.code,
+          type: 'InvalidSignature',
+        });
       }
     }
   }
@@ -293,6 +311,7 @@ export class TransactionVerifierHelper {
     chainId: string;
     safe: Safe;
     proposal: ProposeTransactionDto;
+    code: HttpStatus;
   }): Promise<void> {
     if (!args.proposal.signature) {
       return;
@@ -308,22 +327,21 @@ export class TransactionVerifierHelper {
         safeTxHash: args.proposal.safeTxHash,
         signature: args.proposal.signature,
       });
-      throw new UnprocessableEntityException(ErrorMessage.UnrecoverableAddress);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'UnrecoverableAddress',
+      });
     }
 
     const recoveredAddresses: Array<`0x${string}`> = [];
     for (const signature of signatures) {
-      try {
-        const recoveredAddress = await this.recoverAddress({
-          ...args,
-          safeTxHash: args.proposal.safeTxHash,
-          signature,
-        });
-        if (recoveredAddress) {
-          recoveredAddresses.push(recoveredAddress);
-        }
-      } catch (e) {
-        throw new UnprocessableEntityException(asError(e).message);
+      const recoveredAddress = await this.recoverAddress({
+        ...args,
+        safeTxHash: args.proposal.safeTxHash,
+        signature,
+      });
+      if (recoveredAddress) {
+        recoveredAddresses.push(recoveredAddress);
       }
     }
 
@@ -331,7 +349,10 @@ export class TransactionVerifierHelper {
       return this.blocklist.includes(address);
     });
     if (hasBlockedAddresses) {
-      throw new UnprocessableEntityException('Unauthorized address');
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'BlockedAddress',
+      });
     }
 
     const isSender = recoveredAddresses.includes(args.proposal.sender);
@@ -339,33 +360,43 @@ export class TransactionVerifierHelper {
       this.logInvalidSignature({
         ...args,
         safeTxHash: args.proposal.safeTxHash,
-        signer: args.proposal.sender,
+        signerAddress: args.proposal.sender,
         signature: args.proposal.signature,
       });
-      throw new UnprocessableEntityException(ErrorMessage.InvalidSignature);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'InvalidSignature',
+      });
     }
 
     const areOwners = recoveredAddresses.every((address) =>
       args.safe.owners.includes(address),
     );
-    if (!areOwners) {
-      const delegates = await this.delegatesV2Repository.getDelegates({
-        chainId: args.chainId,
-        safeAddress: args.safe.address,
-      });
-      const isDelegate = delegates.results.some(({ delegate }) => {
-        return delegate === args.proposal.sender;
-      });
-      if (!isDelegate) {
-        this.logInvalidSignature({
-          ...args,
-          safeTxHash: args.proposal.safeTxHash,
-          signer: args.proposal.sender,
-          signature: args.proposal.signature,
-        });
-        throw new UnprocessableEntityException(ErrorMessage.InvalidSignature);
-      }
+    if (areOwners) {
+      return;
     }
+
+    const delegates = await this.delegatesV2Repository.getDelegates({
+      chainId: args.chainId,
+      safeAddress: args.safe.address,
+    });
+    const isDelegate = delegates.results.some(({ delegate }) => {
+      return delegate === args.proposal.sender;
+    });
+    if (isDelegate) {
+      return;
+    }
+
+    this.logInvalidSignature({
+      ...args,
+      safeTxHash: args.proposal.safeTxHash,
+      signerAddress: args.proposal.sender,
+      signature: args.proposal.signature,
+    });
+    throw new TransactionValidityError({
+      code: args.code,
+      type: 'InvalidSignature',
+    });
   }
 
   private async verifyConfirmationSignature(args: {
@@ -373,26 +404,25 @@ export class TransactionVerifierHelper {
     safe: Safe;
     transaction: MultisigTransaction;
     signature: `0x${string}`;
+    code: HttpStatus;
   }): Promise<void> {
-    let address: `0x${string}` | null;
-    try {
-      address = await this.recoverAddress({
-        ...args,
-        safeTxHash: args.transaction.safeTxHash,
-        signature: args.signature,
-      });
-    } catch (e) {
-      throw new UnprocessableEntityException(asError(e).message);
-    }
+    const address = await this.recoverAddress({
+      ...args,
+      safeTxHash: args.transaction.safeTxHash,
+      signature: args.signature,
+    });
 
     if (address && !args.safe.owners.includes(address)) {
       this.logInvalidSignature({
         ...args,
         safeTxHash: args.transaction.safeTxHash,
-        signer: address,
+        signerAddress: address,
         signature: args.signature,
       });
-      throw new UnprocessableEntityException(ErrorMessage.InvalidSignature);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'InvalidSignature',
+      });
     }
   }
 
@@ -401,11 +431,15 @@ export class TransactionVerifierHelper {
     chainId: string;
     safeTxHash: `0x${string}`;
     signature: `0x${string}`;
+    code: HttpStatus;
   }): Promise<`0x${string}` | null> {
     const { v } = splitSignature(args.signature);
 
     if (isEthSignV(v) && !this.isEthSignEnabled) {
-      throw new Error(ErrorMessage.EthSignDisabled);
+      throw new TransactionValidityError({
+        code: args.code,
+        type: 'EthSignDisabled',
+      });
     }
 
     try {
@@ -430,7 +464,10 @@ export class TransactionVerifierHelper {
       this.logUnrecoverableAddress(args);
     }
 
-    throw new Error(ErrorMessage.UnrecoverableAddress);
+    throw new TransactionValidityError({
+      code: args.code,
+      type: 'UnrecoverableAddress',
+    });
   }
 
   private logMalformedSafeTxHash(args: {
@@ -511,7 +548,7 @@ export class TransactionVerifierHelper {
     chainId: string;
     safe: Safe;
     safeTxHash: `0x${string}`;
-    signer: `0x${string}`;
+    signerAddress: `0x${string}`;
     signature: `0x${string}`;
   }): void {
     this.loggingService.error({
@@ -520,7 +557,7 @@ export class TransactionVerifierHelper {
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,
       safeTxHash: args.safeTxHash,
-      signer: args.signer,
+      signerAddress: args.signerAddress,
       signature: args.signature,
       type: LogType.TransactionValidity,
     });

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseIntPipe,
   Post,
   Query,
+  UseFilters,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
@@ -44,12 +45,14 @@ import { TimezoneSchema } from '@/validation/entities/schemas/timezone.schema';
 import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
 import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-multisig-transaction-page.entity';
 import { TXSCreationTransaction } from '@/routes/transactions/entities/txs-creation-transaction.entity';
+import { TransactionValidityExceptionFilter } from '@/routes/transactions/exception-filters/transaction-validity.exception-filter';
 
 @ApiTags('transactions')
 @Controller({
   path: '',
   version: '1',
 })
+@UseFilters(TransactionValidityExceptionFilter)
 export class TransactionsController {
   constructor(private readonly transactionsService: TransactionsService) {}
 


### PR DESCRIPTION
## Summary

We log any unhandled errors and our confirmation refiner both logs and throws errors. This means that we have duplicate logs for every case.

This adds a new custom exception and filter for it to prevent global error logging of them.

## Changes

- Add exception, replacing existing usage of `BadGatewayException` and `UnprocessableEntityException`
- Filter custom exception, returning given error message
- Add/update tests accordingly