### PR TITLE
docs: update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Safe Ecosystem Foundation
+Copyright (c) 2022-2025 Safe Ecosystem Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Our license currently have the year 2022. This increases the span to 2025.

## Changes

- Add `-2025` to license year