### PR TITLE
chore: disable dependency scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.1.1.cjs


### PR DESCRIPTION
## Summary

When installing dependencies, `postinstall` scripts can run. This disables them via the [`enableScripts` configuration of yarn](https://yarnpkg.com/configuration/yarnrc#enableScripts).

## Changes

- Set `enableScripts` to `false`