### PR TITLE
fix: remove refinement of `eth_sign` API signatures

### DIFF
--- a/src/domain/common/utils/signatures.ts
+++ b/src/domain/common/utils/signatures.ts
@@ -73,14 +73,6 @@ export function normalizeEthSignSignature(
   return `0x${r.slice(2)}${s.slice(2)}${(v - ETH_SIGN_V_ADJUSTMENT).toString(16)}`;
 }
 
-export function isApprovedHashV(v: Signature['v']): boolean {
-  return v === 1;
-}
-
-export function isContractSignatureV(v: Signature['v']): boolean {
-  return v === 0;
-}
-
 export function isEoaV(v: Signature['v']): boolean {
   return v === 27 || v === 28;
 }

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -1226,7 +1226,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       });
   });
 
-  it('should block eth_sign', async () => {
+  it('should not block eth_sign', async () => {
     const baseConfiguration = configuration();
     const testConfiguration = (): typeof baseConfiguration => ({
       ...baseConfiguration,
@@ -1238,19 +1238,17 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     await initApp(testConfiguration);
 
     const chain = chainBuilder().build();
-    const signers = Array.from(
-      { length: faker.number.int({ min: 1, max: 5 }) },
-      () => {
-        const privateKey = generatePrivateKey();
-        return privateKeyToAccount(privateKey);
-      },
-    );
+    const signers = Array.from({ length: 2 }, () => {
+      const privateKey = generatePrivateKey();
+      return privateKeyToAccount(privateKey);
+    });
     const safe = safeBuilder()
       .with(
         'owners',
         signers.map((signer) => signer.address),
       )
       .build();
+    const contract = contractBuilder().build();
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
       .with('nonce', safe.nonce)
@@ -1262,34 +1260,69 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         safe,
         signatureType: SignatureType.EthSign,
       });
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${multisigTransaction.safeTxHash}/`;
+    const rejectionTx = multisigTransactionBuilder().build();
+    const rejectionTxsPage = pageBuilder()
+      .with('results', [multisigToJson(rejectionTx)])
+      .build();
+    const safeAppsResponse = [
+      safeAppBuilder()
+        .with('url', faker.internet.url({ appendSlash: false }))
+        .with('iconUrl', faker.internet.url({ appendSlash: false }))
+        .with('name', faker.word.words())
+        .build(),
+    ];
+    const gasToken = tokenBuilder().build();
+    const token = tokenBuilder().build();
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
+    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+    const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${multisigTransaction.safeTxHash}/`;
+    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+    const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.gasToken}`;
+    const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${multisigTransaction.to}`;
+    const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
     networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        case getMultisigTransactionUrl:
+          return Promise.resolve({
+            data: rawify(multisigToJson(multisigTransaction)),
+            status: 200,
+          });
+        case getMultisigTransactionsUrl:
+          return Promise.resolve({
+            data: rawify(rejectionTxsPage),
+            status: 200,
+          });
+        case getSafeUrl:
+          return Promise.resolve({ data: rawify(safe), status: 200 });
+        case getGasTokenContractUrl:
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
+        case getToContractUrl:
+          return Promise.resolve({ data: rawify(contract), status: 200 });
+        case getToTokenUrl:
+          return Promise.resolve({ data: rawify(token), status: 200 });
+        case getSafeAppsUrl:
+          return Promise.resolve({
+            data: rawify(safeAppsResponse),
+            status: 200,
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
       }
-      if (url === getMultisigTransactionUrl) {
-        return Promise.resolve({
-          data: rawify(multisigToJson(multisigTransaction)),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
     });
 
     await request(app.getHttpServer())
       .get(
         `/v1/chains/${chain.chainId}/transactions/multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
       )
-      .expect(502)
-      .expect({
-        message: 'eth_sign is disabled',
-        error: 'Bad Gateway',
-        statusCode: 502,
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          safeAddress: safe.address,
+          txId: `multisig_${safe.address}_${multisigTransaction.safeTxHash}`,
+        });
       });
   });
 });

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -926,7 +926,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       });
   });
 
-  it('should block eth_sign', async () => {
+  it('should not block eth_sign', async () => {
     const baseConfiguration = configuration();
     const testConfiguration = (): typeof baseConfiguration => ({
       ...baseConfiguration,
@@ -1008,11 +1008,26 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .get(
         `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
       )
-      .expect(502)
-      .expect({
-        message: 'eth_sign is disabled',
-        error: 'Bad Gateway',
-        statusCode: 502,
+      .expect(200)
+      .then(({ body }) => {
+        expect(body).toEqual({
+          count: 2,
+          next: null,
+          previous: null,
+          results: [
+            {
+              type: 'LABEL',
+              label: 'Next',
+            },
+            {
+              type: 'TRANSACTION',
+              transaction: expect.objectContaining({
+                id: `multisig_${safe.address}_${transactions[0].safeTxHash}`,
+              }),
+              conflictType: 'None',
+            },
+          ],
+        });
       });
   });
 });

--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -630,7 +630,7 @@ describe('TransactionVerifierHelper', () => {
         });
       });
 
-      it('should block eth_sign', async () => {
+      it('should not block eth_sign', async () => {
         initTarget({ ethSign: false, blocklist: [] });
 
         const chainId = faker.string.numeric();
@@ -650,7 +650,7 @@ describe('TransactionVerifierHelper', () => {
 
         await expect(
           target.verifyApiTransaction({ chainId, safe, transaction }),
-        ).rejects.toThrow(new BadGatewayException('eth_sign is disabled'));
+        ).resolves.not.toThrow();
 
         expect(mockLoggingRepository.error).not.toHaveBeenCalled();
       });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -210,7 +210,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     });
   });
 
-  it('should block eth_sign', async () => {
+  it('should not block eth_sign', async () => {
     initTarget({ ethSign: false, blocklist: [] });
 
     const chainId = faker.string.numeric();
@@ -228,8 +228,13 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
         signatureType: SignatureType.EthSign,
       });
 
-    await expect(mapper.mapDetails(chainId, transaction, safe)).rejects.toThrow(
-      'eth_sign is disabled',
+    await expect(
+      mapper.mapDetails(chainId, transaction, safe),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        safeAddress: safe.address,
+        txId: `multisig_${safe.address}_${transaction.safeTxHash}`,
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary

This removes refinement of `eth_sign` signatures from the API, whilst continuing to disable it on proposal/confirmation.

## Changes

- Remove refinement on API
- Update tests appropriately