### PR TITLE
fix: default `gasToken`/`refundReceiver` to zero address

### DIFF
--- a/src/domain/common/utils/__tests__/safe.spec.ts
+++ b/src/domain/common/utils/__tests__/safe.spec.ts
@@ -223,8 +223,6 @@ describe('Safe', () => {
       'safeTxGas',
       'baseGas',
       'gasPrice',
-      'gasToken',
-      'refundReceiver',
     ])('should throw if the %s is not present', (key) => {
       const chainId = faker.string.numeric();
       const safe = safeBuilder().build();
@@ -304,12 +302,29 @@ describe('Safe', () => {
       expect(result.message.data).toEqual('0x');
     });
 
+    it.each<keyof BaseMultisigTransaction>(['gasToken', 'refundReceiver'])(
+      'should default a missing %s to a zero address if not present',
+      (key) => {
+        const transaction = safeTxHashMultisigTransactionBuilder()
+          .with(key, null)
+          .build();
+        const version = faker.helpers.arrayElement(TYPES_WITH_BASEGAS_VERSIONS);
+
+        const result = _getSafeTxTypesAndMessage({
+          transaction,
+          version,
+        });
+
+        expect(result.message[key]).toEqual(
+          '0x0000000000000000000000000000000000000000',
+        );
+      },
+    );
+
     it.each<keyof BaseMultisigTransaction>([
       'safeTxGas',
       'baseGas',
       'gasPrice',
-      'gasToken',
-      'refundReceiver',
     ])('should throw if %s is not present', (key) => {
       const transaction = safeTxHashMultisigTransactionBuilder()
         .with(key, null)

--- a/src/domain/common/utils/safe.ts
+++ b/src/domain/common/utils/safe.ts
@@ -1,5 +1,10 @@
 import semverSatisfies from 'semver/functions/satisfies';
-import { hashMessage, hashTypedData, type TypedDataDefinition } from 'viem';
+import {
+  hashMessage,
+  hashTypedData,
+  zeroAddress,
+  type TypedDataDefinition,
+} from 'viem';
 import { MessageSchema } from '@/domain/messages/entities/message.entity';
 import type { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import type { Safe } from '@/domain/safe/entities/safe.entity';
@@ -132,28 +137,15 @@ export function _getSafeTxTypesAndMessage(args: {
   transaction: BaseMultisigTransaction;
   version: NonNullable<Safe['version']>;
 }) {
-  const {
-    to,
-    value,
-    operation,
-    safeTxGas,
-    baseGas,
-    gasPrice,
-    gasToken,
-    refundReceiver,
-    nonce,
-  } = args.transaction;
+  const { to, value, operation, safeTxGas, baseGas, gasPrice, nonce } =
+    args.transaction;
 
   // Transfer of funds has no data
   const data = args.transaction.data || '0x';
+  const gasToken = args.transaction.gasToken || zeroAddress;
+  const refundReceiver = args.transaction.refundReceiver || zeroAddress;
 
-  if (
-    safeTxGas === null ||
-    baseGas === null ||
-    gasPrice === null ||
-    gasToken === null ||
-    refundReceiver === null
-  ) {
+  if (safeTxGas === null || baseGas === null || gasPrice === null) {
     throw new Error('Transaction data is incomplete');
   }
 


### PR DESCRIPTION
## Summary

Should the `gasToken` or `refundReceiver` not be present, generating the `safeTxHash` is not possible and refinement throws. This defaults both to a zero address if not present.

## Changes

- Default respective values
- Add/update tests accordingly