### PR TITLE
fix: only try to recover EOA or ETH_SIGN signatures

### DIFF
--- a/src/domain/common/utils/signatures.ts
+++ b/src/domain/common/utils/signatures.ts
@@ -73,10 +73,18 @@ export function normalizeEthSignSignature(
   return `0x${r.slice(2)}${s.slice(2)}${(v - ETH_SIGN_V_ADJUSTMENT).toString(16)}`;
 }
 
+export function isContractSignatureV(v: Signature['v']): boolean {
+  return v === 0;
+}
+
+export function isApprovedHashV(v: Signature['v']): boolean {
+  return v === 1;
+}
+
 export function isEoaV(v: Signature['v']): boolean {
   return v === 27 || v === 28;
 }
 
 export function isEthSignV(v: Signature['v']): boolean {
-  return v === 31 || v === 32;
+  return v > 30;
 }

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -16,6 +16,8 @@ import { Safe } from '@/domain/safe/entities/safe.entity';
 import { ProposeTransactionDto } from '@/domain/transactions/entities/propose-transaction.dto.entity';
 import { IDelegatesV2Repository } from '@/domain/delegate/v2/delegates.v2.repository.interface';
 import {
+  isApprovedHashV,
+  isContractSignatureV,
   isEoaV,
   isEthSignV,
   normalizeEthSignSignature,
@@ -251,6 +253,12 @@ export class TransactionVerifierHelper {
 
     for (const confirmation of args.transaction.confirmations) {
       if (!confirmation.signature) {
+        continue;
+      }
+
+      const { v } = splitSignature(confirmation.signature);
+      // We cannot verify contract signatures or approved hashes on-chain
+      if (isContractSignatureV(v) || isApprovedHashV(v)) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

Removal of [`eth_sign` refinement](https://github.com/safe-global/safe-client-gateway/pull/2412) also removed [validity of contract signatures and approved hashes](https://github.com/safe-global/safe-client-gateway/pull/2412/files#diff-fd50b28d584750207bc45137e511987d0d3e938f2b8ae7ca49788d06654591aeL424-L428). This adds the relevant checks for them again.

## Changes

- If a confirmation is an approved hash or contract signature, don't try to recover the address from it