### PR TITLE
fix: allow confirmation DTOs signatures under `signedSafeTxHash` property

### DIFF
--- a/src/routes/transactions/entities/schemas/__tests__/add-confirmation.dto.schema.spec.ts
+++ b/src/routes/transactions/entities/schemas/__tests__/add-confirmation.dto.schema.spec.ts
@@ -10,22 +10,52 @@ describe('AddConfirmationDtoSchema', () => {
     const result = AddConfirmationDtoSchema.safeParse({ signature });
 
     expect(result.success).toBe(true);
+    expect(result.success && 'signature' in result.data).toBe(true);
+    expect(result.success && 'signedSafeTxHash' in result.data).toBe(false);
+  });
+
+  it('supports the signedSafeTxHash property', () => {
+    const signedSafeTxHash = faker.string.hexadecimal({
+      length: 130,
+    }) as `0x${string}`;
+
+    const result = AddConfirmationDtoSchema.safeParse({ signedSafeTxHash });
+
+    expect(result.success).toBe(true);
+    expect(result.success && 'signature' in result.data).toBe(true);
+    expect(result.success && 'signedSafeTxHash' in result.data).toBe(false);
   });
 
   it('should not validate a non-signature', () => {
-    const value = faker.number.int();
+    const value = { invalid: 'addConfirmationDto' };
     const result = AddConfirmationDtoSchema.safeParse(value);
 
-    expect(!result.success && result.error).toStrictEqual(
-      new ZodError([
-        {
-          code: 'invalid_type',
-          expected: 'object',
-          received: 'number',
-          path: [],
-          message: 'Expected object, received number',
-        },
-      ]),
-    );
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_union',
+        message: 'Invalid input',
+        path: [],
+        unionErrors: [
+          new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              received: 'undefined',
+              path: ['signature'],
+              message: 'Required',
+            },
+          ]),
+          new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              received: 'undefined',
+              path: ['signedSafeTxHash'],
+              message: 'Required',
+            },
+          ]),
+        ],
+      },
+    ]);
   });
 });

--- a/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
@@ -1,6 +1,18 @@
 import { z } from 'zod';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 
-export const AddConfirmationDtoSchema = z.object({
-  signature: HexSchema,
-});
+export const AddConfirmationDtoSchema = z
+  .object({
+    signature: HexSchema,
+  })
+  .or(
+    z.object({
+      // Note: mobile proposes signatures under the signedSafeTxHash property
+      signedSafeTxHash: HexSchema,
+    }),
+  )
+  .transform((data) => {
+    return {
+      signature: 'signature' in data ? data.signature : data.signedSafeTxHash,
+    };
+  });

--- a/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
@@ -6,13 +6,14 @@ export const AddConfirmationDtoSchema = z
     signature: HexSchema,
   })
   .or(
-    z.object({
-      // Note: mobile proposes signatures under the signedSafeTxHash property
-      signedSafeTxHash: HexSchema,
-    }),
-  )
-  .transform((data) => {
-    return {
-      signature: 'signature' in data ? data.signature : data.signedSafeTxHash,
-    };
-  });
+    // Note: mobile proposes signatures under the signedSafeTxHash property
+    z
+      .object({
+        signedSafeTxHash: HexSchema,
+      })
+      .transform((data) => {
+        return {
+          signature: data.signedSafeTxHash,
+        };
+      }),
+  );

--- a/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
@@ -6,14 +6,13 @@ export const AddConfirmationDtoSchema = z
     signature: HexSchema,
   })
   .or(
-    // Note: mobile proposes signatures under the signedSafeTxHash property
-    z
-      .object({
-        signedSafeTxHash: HexSchema,
-      })
-      .transform((data) => {
-        return {
-          signature: data.signedSafeTxHash,
-        };
-      }),
-  );
+    z.object({
+      // Note: mobile proposes signatures under the signedSafeTxHash property
+      signedSafeTxHash: HexSchema,
+    }),
+  )
+  .transform((data) => {
+    return {
+      signature: 'signature' in data ? data.signature : data.signedSafeTxHash,
+    };
+  });


### PR DESCRIPTION
## Summary

When adding [refinement of confirmations](https://github.com/safe-global/safe-client-gateway/pull/2382), we wrongly assumed only web used the confirmation endpoint. As such, we aligned the property name to match that of the Transaction Service.

Since then, we've confirmed that the property was correct. This allows both the new and previous name.

## Changes

- Allow `signature` and `signedSafeTxHash` property, transforming the latter to `signature`
- Add appropriate test coverage