### PR TITLE
fix: flakey test for getting transactions by id

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -463,7 +463,14 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         safe,
         signers,
       });
-    const rejectionTx = multisigTransactionBuilder().build();
+    const rejectionTx = await multisigTransactionBuilder()
+      .with('safe', safe.address)
+      .with('nonce', tx.nonce)
+      .buildWithConfirmations({
+        chainId,
+        safe,
+        signers: [signers[0]],
+      });
     const rejectionTxsPage = pageBuilder()
       .with('results', [multisigToJson(rejectionTx)])
       .build();


### PR DESCRIPTION
## Summary

We were seeing consistent [flakey test results](https://github.com/safe-global/safe-client-gateway/actions/runs/13650190622/job/38156792995) in the "Get by id - Transactions Controller (Unit)" test suite.

This fixes the issue by ensuring at least one `confirmations` element is present in the offending test. (It [can be 0-5](https://github.com/safe-global/safe-client-gateway/blob/67bbe29da2afbe65b464a971da995495df9889c1/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts#L128) by default.)

## Changes

- Ensure `confirmations` is populated