### PR TITLE
fix: compare Safe addresses of a transaction ID

### DIFF
--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -36,7 +36,7 @@ import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transact
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
-import { getAddress, isAddress } from 'viem';
+import { getAddress, isAddress, isAddressEqual } from 'viem';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { MultisigTransactionNoteMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper';
 import { LogType } from '@/domain/common/entities/log-type.entity';
@@ -117,6 +117,11 @@ export class TransactionsService {
             address: getAddress(safeAddress),
           }),
         ]);
+
+        if (!isAddressEqual(tx.safe, safe.address)) {
+          throw new BadRequestException('Invalid transaction ID');
+        }
+
         return this.multisigTransactionDetailsMapper.mapDetails(
           args.chainId,
           tx,


### PR DESCRIPTION
## Summary

Multisig transactions fetched by their ID assume that the provided Safe and `safeTxHash` are the same. If an ID is malformed, the mismatched Safes are trusted "as is". This causes issues with things such as confirmation refinement.

This adds a check to ensure the Safe and Safe of the transaction match.

## Changes

- Compare Safe and Safe of the transaction, throwing if they don't match
- Add appropriate test coverage