### PR TITLE
feat: optimize trusted contracts retrieval

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -175,6 +175,7 @@ export default (): ReturnType<typeof configuration> => ({
     messageVerification: true,
     ethSign: true,
     trustedDelegateCall: false,
+    trustedForDelegateCallContractsList: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -263,6 +263,10 @@ export default () => ({
     ethSign: process.env.FF_ETH_SIGN?.toLowerCase() === 'true',
     trustedDelegateCall:
       process.env.FF_TRUSTED_DELEGATE_CALL?.toLowerCase() === 'true',
+    // TODO: Remove this feature flag once the feature is established.
+    trustedForDelegateCallContractsList:
+      process.env.FF_TRUSTED_FOR_DELEGATE_CALL_CONTRACTS_LIST?.toLowerCase() ===
+      'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -11,6 +11,8 @@ export class CacheRouter {
   private static readonly CHAIN_KEY = 'chain';
   private static readonly CHAINS_KEY = 'chains';
   private static readonly CONTRACT_KEY = 'contract';
+  private static readonly TRUSTED_FOR_DELEGATE_CALL_CONTRACTS_KEY =
+    'trusted_contracts';
   private static readonly COUNTERFACTUAL_SAFE_KEY = 'counterfactual_safe';
   private static readonly COUNTERFACTUAL_SAFES_KEY = 'counterfactual_safes';
   private static readonly CREATION_TRANSACTION_KEY = 'creation_transaction';
@@ -166,6 +168,17 @@ export class CacheRouter {
   }): CacheDir {
     return new CacheDir(
       `${args.chainId}_${CacheRouter.CONTRACT_KEY}_${args.contractAddress}`,
+      '',
+    );
+  }
+
+  static getTrustedForDelegateCallContractsCacheKey(chainId: string): string {
+    return `${chainId}_${CacheRouter.TRUSTED_FOR_DELEGATE_CALL_CONTRACTS_KEY}`;
+  }
+
+  static getTrustedForDelegateCallContractsCacheDir(chainId: string): CacheDir {
+    return new CacheDir(
+      CacheRouter.getTrustedForDelegateCallContractsCacheKey(chainId),
       '',
     );
   }

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -526,7 +526,10 @@ describe('TransactionApi', () => {
   describe('getTrustedForDelegateCallContracts', () => {
     it('should return the trusted for delegate call contracts received', async () => {
       const contractPage = pageBuilder()
-        .with('results', [contractBuilder().build(), contractBuilder().build()])
+        .with('results', [
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+        ])
         .build();
       const getTrustedForDelegateCallContractsUrl = `${baseUrl}/api/v1/contracts/`;
       const cacheDir = new CacheDir(`${chainId}_trusted_contracts`, '');

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -523,6 +523,72 @@ describe('TransactionApi', () => {
     });
   });
 
+  describe('getTrustedForDelegateCallContracts', () => {
+    it('should return the trusted for delegate call contracts received', async () => {
+      const contractPage = pageBuilder()
+        .with('results', [contractBuilder().build(), contractBuilder().build()])
+        .build();
+      const getTrustedForDelegateCallContractsUrl = `${baseUrl}/api/v1/contracts/`;
+      const cacheDir = new CacheDir(`${chainId}_trusted_contracts`, '');
+      mockDataSource.get.mockResolvedValueOnce(rawify(contractPage));
+
+      const actual = await service.getTrustedForDelegateCallContracts();
+
+      expect(actual).toBe(contractPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getTrustedForDelegateCallContractsUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            trusted_for_delegate_call: true,
+          },
+        },
+      });
+    });
+
+    const errorMessage = faker.word.words();
+    it.each([
+      ['Transaction Service', { nonFieldErrors: [errorMessage] }],
+      ['standard', new Error(errorMessage)],
+    ])(`should forward a %s error`, async (_, error) => {
+      const getTrustedForDelegateCallContractsUrl = `${baseUrl}/api/v1/contracts/`;
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+      const expected = new DataSourceError(errorMessage, statusCode);
+      const cacheDir = new CacheDir(`${chainId}_trusted_contracts`, '');
+      mockDataSource.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          new URL(getTrustedForDelegateCallContractsUrl),
+          {
+            status: statusCode,
+          } as Response,
+          error,
+        ),
+      );
+
+      await expect(
+        service.getTrustedForDelegateCallContracts(),
+      ).rejects.toThrow(expected);
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getTrustedForDelegateCallContractsUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            trusted_for_delegate_call: true,
+          },
+        },
+      });
+    });
+  });
+
   describe('getContract', () => {
     it('should return retrieved contract', async () => {
       const contract = contractBuilder().build();

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -270,6 +270,30 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
+  async getTrustedForDelegateCallContracts(): Promise<Raw<Page<Contract>>> {
+    try {
+      const cacheDir = CacheRouter.getTrustedForDelegateCallContractsCacheDir(
+        this.chainId,
+      );
+      const url = `${this.baseUrl}/api/v1/contracts/`;
+      return await this.dataSource.get<Page<Contract>>({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            trusted_for_delegate_call: true,
+          },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(this.mapError(error));
+    }
+  }
+
   async getDelegates(args: {
     safeAddress?: `0x${string}`;
     delegate?: `0x${string}`;

--- a/src/domain/contracts/contracts.repository.interface.ts
+++ b/src/domain/contracts/contracts.repository.interface.ts
@@ -2,7 +2,6 @@ import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { Module } from '@nestjs/common';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
-import { Page } from '@/domain/entities/page.entity';
 
 export const IContractsRepository = Symbol('IContractsRepository');
 
@@ -16,9 +15,12 @@ export interface IContractsRepository {
   }): Promise<Contract>;
 
   /**
-   * Gets the {@link Contract}s that are trusted for delegate call for the {@link chainId}.
+   * Determines if the contract at the {@link contractAddress} is trusted for delegate calls.
    */
-  getTrustedForDelegateCallContracts(chainId: string): Promise<Page<Contract>>;
+  isTrustedForDelegateCall(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<boolean>;
 }
 
 @Module({

--- a/src/domain/contracts/contracts.repository.interface.ts
+++ b/src/domain/contracts/contracts.repository.interface.ts
@@ -2,6 +2,7 @@ import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { Module } from '@nestjs/common';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
+import { Page } from '@/domain/entities/page.entity';
 
 export const IContractsRepository = Symbol('IContractsRepository');
 
@@ -13,6 +14,11 @@ export interface IContractsRepository {
     chainId: string;
     contractAddress: `0x${string}`;
   }): Promise<Contract>;
+
+  /**
+   * Gets the {@link Contract}s that are trusted for delegate call for the {@link chainId}.
+   */
+  getTrustedForDelegateCallContracts(chainId: string): Promise<Page<Contract>>;
 }
 
 @Module({

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -2,7 +2,11 @@ import { Inject, Injectable } from '@nestjs/common';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
-import { ContractSchema } from '@/domain/contracts/entities/schemas/contract.schema';
+import {
+  ContractPageSchema,
+  ContractSchema,
+} from '@/domain/contracts/entities/schemas/contract.schema';
+import { Page } from '@/domain/entities/page.entity';
 
 @Injectable()
 export class ContractsRepository implements IContractsRepository {
@@ -18,5 +22,13 @@ export class ContractsRepository implements IContractsRepository {
     const api = await this.transactionApiManager.getApi(args.chainId);
     const data = await api.getContract(args.contractAddress);
     return ContractSchema.parse(data);
+  }
+
+  async getTrustedForDelegateCallContracts(args: {
+    chainId: string;
+  }): Promise<Page<Contract>> {
+    const api = await this.transactionApiManager.getApi(args.chainId);
+    const contracts = await api.getTrustedForDelegateCallContracts();
+    return ContractPageSchema.parse(contracts);
   }
 }

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -24,10 +24,10 @@ export class ContractsRepository implements IContractsRepository {
     return ContractSchema.parse(data);
   }
 
-  async getTrustedForDelegateCallContracts(args: {
-    chainId: string;
-  }): Promise<Page<Contract>> {
-    const api = await this.transactionApiManager.getApi(args.chainId);
+  async getTrustedForDelegateCallContracts(
+    chainId: string,
+  ): Promise<Page<Contract>> {
+    const api = await this.transactionApiManager.getApi(chainId);
     const contracts = await api.getTrustedForDelegateCallContracts();
     return ContractPageSchema.parse(contracts);
   }

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -7,13 +7,24 @@ import {
   ContractSchema,
 } from '@/domain/contracts/entities/schemas/contract.schema';
 import { Page } from '@/domain/entities/page.entity';
+import { isAddressEqual } from 'viem';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 
 @Injectable()
 export class ContractsRepository implements IContractsRepository {
+  private readonly isTrustedForDelegateCallContractsListEnabled: boolean;
+
   constructor(
     @Inject(ITransactionApiManager)
     private readonly transactionApiManager: ITransactionApiManager,
-  ) {}
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.isTrustedForDelegateCallContractsListEnabled =
+      this.configurationService.getOrThrow(
+        'features.trustedForDelegateCallContractsList',
+      );
+  }
 
   async getContract(args: {
     chainId: string;
@@ -24,11 +35,49 @@ export class ContractsRepository implements IContractsRepository {
     return ContractSchema.parse(data);
   }
 
-  async getTrustedForDelegateCallContracts(
+  async isTrustedForDelegateCall(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<boolean> {
+    return this.isTrustedForDelegateCallContractsListEnabled
+      ? await this.isIncludedInTrustedForDelegateCallContractsList({
+          chainId: args.chainId,
+          contractAddress: args.contractAddress,
+        })
+      : await this.isTrustedForDelegateCallContract({
+          chainId: args.chainId,
+          contractAddress: args.contractAddress,
+        });
+  }
+
+  private async getTrustedForDelegateCallContracts(
     chainId: string,
   ): Promise<Page<Contract>> {
     const api = await this.transactionApiManager.getApi(chainId);
     const contracts = await api.getTrustedForDelegateCallContracts();
     return ContractPageSchema.parse(contracts);
+  }
+
+  private async isIncludedInTrustedForDelegateCallContractsList(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<boolean> {
+    const trustedContracts = await this.getTrustedForDelegateCallContracts(
+      args.chainId,
+    );
+    return trustedContracts.results.some((contract) =>
+      isAddressEqual(contract.address, args.contractAddress),
+    );
+  }
+
+  private async isTrustedForDelegateCallContract(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<boolean> {
+    const contract = await this.getContract({
+      chainId: args.chainId,
+      contractAddress: args.contractAddress,
+    });
+    return contract.trustedForDelegateCall;
   }
 }

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -65,8 +65,10 @@ export class ContractsRepository implements IContractsRepository {
     const trustedContracts = await this.getTrustedForDelegateCallContracts(
       args.chainId,
     );
-    return trustedContracts.results.some((contract) =>
-      isAddressEqual(contract.address, args.contractAddress),
+    return trustedContracts.results.some(
+      (contract) =>
+        isAddressEqual(contract.address, args.contractAddress) &&
+        contract.trustedForDelegateCall,
     );
   }
 

--- a/src/domain/contracts/entities/schemas/contract.schema.ts
+++ b/src/domain/contracts/entities/schemas/contract.schema.ts
@@ -1,3 +1,4 @@
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
 
@@ -9,3 +10,5 @@ export const ContractSchema = z.object({
   contractAbi: z.record(z.unknown()).nullish().default(null),
   trustedForDelegateCall: z.boolean(),
 });
+
+export const ContractPageSchema = buildPageSchema(ContractSchema);

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -43,6 +43,8 @@ export interface ITransactionApi {
 
   getContract(contractAddress: `0x${string}`): Promise<Raw<Contract>>;
 
+  getTrustedForDelegateCallContracts(): Promise<Raw<Page<Contract>>>;
+
   getDelegates(args: {
     safeAddress?: `0x${string}`;
     delegate?: `0x${string}`;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -36,10 +36,12 @@ import { IContractsRepository } from '@/domain/contracts/contracts.repository.in
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import { HttpExceptionNoLog } from '@/domain/common/errors/http-exception-no-log.error';
+import { getAddress } from 'viem';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
   private readonly isTrustedDelegateCallEnabled: boolean;
+  private readonly isTrustedForDelegateCallContractsListEnabled: boolean;
 
   constructor(
     @Inject(ITransactionApiManager)
@@ -56,6 +58,10 @@ export class SafeRepository implements ISafeRepository {
     this.isTrustedDelegateCallEnabled = this.configurationService.getOrThrow(
       'features.trustedDelegateCall',
     );
+    this.isTrustedForDelegateCallContractsListEnabled =
+      this.configurationService.getOrThrow(
+        'features.trustedForDelegateCallContractsList',
+      );
   }
 
   async getSafe(args: {
@@ -648,13 +654,16 @@ export class SafeRepository implements ISafeRepository {
         throw error;
       }
       try {
-        // TODO: FF
-        // TODO: contractRepository.getTrustedForDelegateCallContracts, check it's included.
-        const contract = await this.contractsRepository.getContract({
-          chainId: args.chainId,
-          contractAddress: args.proposeTransactionDto.to,
-        });
-        if (!contract.trustedForDelegateCall) {
+        const isTrusted = this.isTrustedForDelegateCallContractsListEnabled
+          ? await this.isIncludedInTrustedForDelegateCallContractsList({
+              chainId: args.chainId,
+              contractAddress: args.proposeTransactionDto.to,
+            })
+          : await this.isTrustedForDelegateCallContract({
+              chainId: args.chainId,
+              contractAddress: args.proposeTransactionDto.to,
+            });
+        if (!isTrusted) {
           throw error;
         }
       } catch {
@@ -677,6 +686,31 @@ export class SafeRepository implements ISafeRepository {
       address: args.safeAddress,
       data: args.proposeTransactionDto,
     });
+  }
+
+  private async isIncludedInTrustedForDelegateCallContractsList(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<boolean> {
+    const trustedContracts =
+      await this.contractsRepository.getTrustedForDelegateCallContracts(
+        args.chainId,
+      );
+    return trustedContracts.results.some(
+      (contract) =>
+        getAddress(contract.address) === getAddress(args.contractAddress),
+    );
+  }
+
+  private async isTrustedForDelegateCallContract(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<boolean> {
+    const contract = await this.contractsRepository.getContract({
+      chainId: args.chainId,
+      contractAddress: args.contractAddress,
+    });
+    return contract.trustedForDelegateCall;
   }
 
   async getNonces(args: {

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -648,6 +648,8 @@ export class SafeRepository implements ISafeRepository {
         throw error;
       }
       try {
+        // TODO: FF
+        // TODO: contractRepository.getTrustedForDelegateCallContracts, check it's included.
         const contract = await this.contractsRepository.getContract({
           chainId: args.chainId,
           contractAddress: args.proposeTransactionDto.to,

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -551,4 +551,228 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         ),
       );
   });
+
+  it('should allow delegate calls if the contract is included in the list of trusted contracts', async () => {
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        ethSign: true,
+        trustedDelegateCall: true,
+        trustedForDelegateCallContractsList: true,
+      },
+    });
+    await initApp(testConfiguration);
+
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const safe = safeBuilder()
+      .with('address', safeAddress)
+      .with('owners', [signer.address])
+      .build();
+    const safeApps = [safeAppBuilder().build()];
+    const transaction = await multisigTransactionBuilder()
+      .with('safe', safeAddress)
+      .with('nonce', safe.nonce)
+      .with('operation', Operation.DELEGATE)
+      .buildWithConfirmations({
+        chainId,
+        safe,
+        signers: [signer],
+      });
+    const contractPage = pageBuilder()
+      .with('results', [
+        contractBuilder().with('trustedForDelegateCall', true).build(),
+        contractBuilder()
+          .with('trustedForDelegateCall', true)
+          .with('address', transaction.to) // transaction.to address is a trusted contract
+          .build(),
+        contractBuilder().with('trustedForDelegateCall', true).build(),
+      ])
+      .build();
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with('to', transaction.to)
+      .with('value', transaction.value)
+      .with('data', transaction.data)
+      .with('nonce', transaction.nonce.toString())
+      .with('operation', transaction.operation)
+      .with('safeTxGas', transaction.safeTxGas!.toString())
+      .with('baseGas', transaction.baseGas!.toString())
+      .with('gasPrice', transaction.gasPrice!)
+      .with('gasToken', transaction.gasToken!)
+      .with('refundReceiver', transaction.refundReceiver)
+      .with('safeTxHash', transaction.safeTxHash)
+      .with('sender', transaction.confirmations![0].owner)
+      .with('signature', transaction.confirmations![0].signature)
+      .build();
+    const transactions = pageBuilder().build();
+    const token = tokenBuilder().build();
+    const gasToken = tokenBuilder().build();
+    networkService.get.mockImplementation(({ url }) => {
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
+      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
+      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+      const getContractsUrl = `${chain.transactionService}/api/v1/contracts/`;
+      const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
+      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        case getMultisigTransactionUrl:
+          return Promise.resolve({
+            data: rawify(multisigToJson(transaction)),
+            status: 200,
+          });
+        case getMultisigTransactionsUrl:
+          return Promise.resolve({ data: rawify(transactions), status: 200 });
+        case getSafeUrl:
+          return Promise.resolve({ data: rawify(safe), status: 200 });
+        case getSafeAppsUrl:
+          return Promise.resolve({ data: rawify(safeApps), status: 200 });
+        case getContractsUrl:
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
+        case getTokenUrl:
+          return Promise.resolve({ data: rawify(token), status: 200 });
+        case getGasTokenContractUrl:
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    networkService.post.mockImplementation(({ url }) => {
+      const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      switch (url) {
+        case proposeTransactionUrl:
+          return Promise.resolve({ data: rawify({}), status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
+      .send(proposeTransactionDto)
+      .expect(200)
+      .expect(({ body }) =>
+        expect(body).toEqual(
+          expect.objectContaining({
+            txId: `multisig_${safeAddress}_${transaction.safeTxHash}`,
+          }),
+        ),
+      );
+  });
+
+  it('should disallow delegate calls if the contract is not included in the list of trusted contracts', async () => {
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        ethSign: true,
+        trustedDelegateCall: true,
+        trustedForDelegateCallContractsList: true,
+      },
+    });
+    await initApp(testConfiguration);
+
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const chain = chainBuilder().with('chainId', chainId).build();
+    const privateKey = generatePrivateKey();
+    const signer = privateKeyToAccount(privateKey);
+    const safe = safeBuilder()
+      .with('address', safeAddress)
+      .with('owners', [signer.address])
+      .build();
+    const safeApps = [safeAppBuilder().build()];
+    const transaction = await multisigTransactionBuilder()
+      .with('safe', safeAddress)
+      .with('nonce', safe.nonce)
+      .with('operation', Operation.DELEGATE)
+      .buildWithConfirmations({
+        chainId,
+        safe,
+        signers: [signer],
+      });
+    const contractPage = pageBuilder()
+      .with('results', [
+        // transaction.to address is not in the list of trusted contracts
+        contractBuilder().with('trustedForDelegateCall', true).build(),
+        contractBuilder().with('trustedForDelegateCall', true).build(),
+      ])
+      .build();
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with('to', transaction.to)
+      .with('value', transaction.value)
+      .with('data', transaction.data)
+      .with('nonce', transaction.nonce.toString())
+      .with('operation', transaction.operation)
+      .with('safeTxGas', transaction.safeTxGas!.toString())
+      .with('baseGas', transaction.baseGas!.toString())
+      .with('gasPrice', transaction.gasPrice!)
+      .with('gasToken', transaction.gasToken!)
+      .with('refundReceiver', transaction.refundReceiver)
+      .with('safeTxHash', transaction.safeTxHash)
+      .with('sender', transaction.confirmations![0].owner)
+      .with('signature', transaction.confirmations![0].signature)
+      .build();
+    const transactions = pageBuilder().build();
+    const token = tokenBuilder().build();
+    const gasToken = tokenBuilder().build();
+    networkService.get.mockImplementation(({ url }) => {
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
+      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
+      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+      const getContractsUrl = `${chain.transactionService}/api/v1/contracts/`;
+      const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
+      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+      switch (url) {
+        case getChainUrl:
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        case getMultisigTransactionUrl:
+          return Promise.resolve({
+            data: rawify(multisigToJson(transaction)),
+            status: 200,
+          });
+        case getMultisigTransactionsUrl:
+          return Promise.resolve({ data: rawify(transactions), status: 200 });
+        case getSafeUrl:
+          return Promise.resolve({ data: rawify(safe), status: 200 });
+        case getSafeAppsUrl:
+          return Promise.resolve({ data: rawify(safeApps), status: 200 });
+        case getContractsUrl:
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
+        case getTokenUrl:
+          return Promise.resolve({ data: rawify(token), status: 200 });
+        case getGasTokenContractUrl:
+          return Promise.resolve({ data: rawify(gasToken), status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    networkService.post.mockImplementation(({ url }) => {
+      const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      switch (url) {
+        case proposeTransactionUrl:
+          return Promise.resolve({ data: rawify({}), status: 200 });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
+      .send(proposeTransactionDto)
+      .expect(422)
+      .expect({
+        message: 'Delegate call is disabled',
+        statusCode: 422,
+      });
+  });
 });

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -79,6 +79,9 @@ export class TransactionDataMapper {
   ): Promise<boolean | null> {
     if (operation !== Operation.DELEGATE) return null;
 
+    // TODO: FF
+    // TODO: contractRepository.getTrustedForDelegateCallContracts, check it's included.
+
     let contract: Contract;
     try {
       contract = await this.contractRepository.getContract({

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -3,7 +3,6 @@ import isEmpty from 'lodash/isEmpty';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Operation } from '@/domain/safe/entities/operation.entity';
-import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { DataDecoded } from '@/domain/data-decoder/v1/entities/data-decoded.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import { NULL_ADDRESS } from '@/routes/common/constants';
@@ -79,15 +78,13 @@ export class TransactionDataMapper {
   ): Promise<boolean | null> {
     if (operation !== Operation.DELEGATE) return null;
 
-    // TODO: FF
-    // TODO: contractRepository.getTrustedForDelegateCallContracts, check it's included.
-
-    let contract: Contract;
+    let isTrustedForDelegateCall: boolean;
     try {
-      contract = await this.contractRepository.getContract({
-        chainId,
-        contractAddress: to,
-      });
+      isTrustedForDelegateCall =
+        await this.contractRepository.isTrustedForDelegateCall({
+          chainId,
+          contractAddress: to,
+        });
     } catch {
       return false;
     }
@@ -96,7 +93,7 @@ export class TransactionDataMapper {
       ? this.dataDecodedParamHelper.hasNestedDelegate(dataDecoded)
       : false;
 
-    return contract.trustedForDelegateCall && !hasNestedDelegate;
+    return isTrustedForDelegateCall && !hasNestedDelegate;
   }
 
   /**


### PR DESCRIPTION
## Summary
After [the addition of a new filter](https://github.com/safe-global/safe-transaction-service/pull/2448) that makes it possible to get the complete list of trusted for delegate call contracts in the Transaction Service API, the Client Gateway can take advantage of it by caching that list and comparing proposals and transaction mappings against the list, instead of checking each contract on demand.

This PR adds a new function to retrieve the list, and checks against that list instead of calling `ContractRepository.getContract` in both `TransactionDataMapper` and `SafeRepository`.

## Changes
- Adds the `ContractRepository['isTrustedForDelegateCall']` function.
- Adds an `FF_TRUSTED_FOR_DELEGATE_CALL_CONTRACTS_LIST` feature flag.
- Adjusts the related tests.
