### PR TITLE
fix: increase refinement test coverage

### DIFF
--- a/src/domain/common/entities/safe-signature.spec.ts
+++ b/src/domain/common/entities/safe-signature.spec.ts
@@ -139,7 +139,11 @@ describe('SafeSignature', () => {
       const privateKey = generatePrivateKey();
       const signer = privateKeyToAccount(privateKey);
       const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
-      const signatureType = faker.helpers.enumValue(SignatureType);
+      // Recovered via encodeAbiParameters
+      const signatureType = faker.helpers.arrayElement([
+        SignatureType.ApprovedHash,
+        SignatureType.ContractSignature,
+      ]);
       const signature = await getSignature({
         signer,
         hash,

--- a/src/domain/common/entities/safe-signature.spec.ts
+++ b/src/domain/common/entities/safe-signature.spec.ts
@@ -3,10 +3,7 @@ import * as viem from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { SafeSignature } from '@/domain/common/entities/safe-signature';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
-import {
-  getContractSignature,
-  getApprovedHashSignature,
-} from '@/domain/common/utils/__tests__/signatures.builder';
+import { getSignature } from '@/domain/common/utils/__tests__/signatures.builder';
 
 describe('SafeSignature', () => {
   it('should create an instance', () => {
@@ -118,76 +115,57 @@ describe('SafeSignature', () => {
   });
 
   describe('owner', () => {
-    it('should recover the address of contract signatures', () => {
-      const owner = viem.getAddress(faker.finance.ethereumAddress());
-      const signature = getContractSignature(owner);
-      const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
+    it.each(Object.values(SignatureType))(
+      'should recover the address of a %s signature',
+      async (signatureType) => {
+        const privateKey = generatePrivateKey();
+        const signer = privateKeyToAccount(privateKey);
+        const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
+        const signature = await getSignature({
+          signer,
+          hash,
+          signatureType,
+        });
 
-      const safeSignature = new SafeSignature({ signature, hash });
+        const safeSignature = new SafeSignature({ signature, hash });
 
-      expect(safeSignature.owner).toBe(owner);
-    });
+        expect(safeSignature.owner).toBe(signer.address);
+      },
+    );
 
-    it('should recover the address of an approved hash', () => {
-      const owner = viem.getAddress(faker.finance.ethereumAddress());
-      const signature = getApprovedHashSignature(owner);
-      const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
-
-      const safeSignature = new SafeSignature({ signature, hash });
-
-      expect(safeSignature.owner).toBe(owner);
-    });
-
-    it('should recover the address of an eth_sign signature', async () => {
-      const privateKey = generatePrivateKey();
-      const signer = privateKeyToAccount(privateKey);
-      const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
-      const signature = await signer.signMessage({ message: { raw: hash } });
-      const v = parseInt(signature.slice(-2), 16) + 4;
-
-      const safeSignature = new SafeSignature({
-        signature:
-          `${signature.slice(0, 130)}${v.toString(16)}` as `0x${string}`,
-        hash,
-      });
-
-      expect(safeSignature.owner).toBe(signer.address);
-    });
-
-    it('should recover the address of an EOA signature', async () => {
-      const privateKey = generatePrivateKey();
-      const signer = privateKeyToAccount(privateKey);
-      const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
-      const signature = await signer.sign({ hash });
-
-      const safeSignature = new SafeSignature({
-        signature,
-        hash,
-      });
-
-      expect(safeSignature.owner).toBe(signer.address);
-    });
-
-    it('should memoize the owner', () => {
+    it('should memoize the owner', async () => {
       const encodeApiParametersSpy = jest.spyOn(viem, 'encodeAbiParameters');
 
-      const owner = viem.getAddress(faker.finance.ethereumAddress());
-      const signature = getContractSignature(owner);
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
       const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
+      const signatureType = faker.helpers.enumValue(SignatureType);
+      const signature = await getSignature({
+        signer,
+        hash,
+        signatureType,
+      });
 
       const safeSignature = new SafeSignature({ signature, hash });
 
-      expect(safeSignature.owner).toBe(owner);
-      expect(encodeApiParametersSpy).toHaveBeenCalledTimes(1);
-      expect(safeSignature.owner).toBe(owner);
+      expect(safeSignature.owner).toBe(signer.address);
       expect(encodeApiParametersSpy).toHaveBeenCalledTimes(1);
 
-      const newOwner = viem.getAddress(faker.finance.ethereumAddress());
-      safeSignature.signature = getContractSignature(newOwner);
+      expect(safeSignature.owner).toBe(signer.address);
+      expect(encodeApiParametersSpy).toHaveBeenCalledTimes(1);
 
-      expect(safeSignature.owner).toBe(newOwner);
+      const newPrivateKey = generatePrivateKey();
+      const newSigner = privateKeyToAccount(newPrivateKey);
+      safeSignature.signature = await getSignature({
+        signer: newSigner,
+        hash,
+        signatureType,
+      });
+
+      expect(safeSignature.owner).toBe(newSigner.address);
       expect(encodeApiParametersSpy).toHaveBeenCalledTimes(2);
-      expect(safeSignature.owner).toBe(newOwner);
+
+      expect(safeSignature.owner).toBe(newSigner.address);
       expect(encodeApiParametersSpy).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/domain/common/utils/__tests__/signatures.builder.ts
+++ b/src/domain/common/utils/__tests__/signatures.builder.ts
@@ -1,20 +1,64 @@
-export function getApprovedHashSignature(owner: `0x${string}`): `0x${string}` {
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import type { PrivateKeyAccount } from 'viem';
+
+export async function getSignature(args: {
+  signer: PrivateKeyAccount;
+  hash: `0x${string}`;
+  signatureType: SignatureType;
+}): Promise<`0x${string}`> {
+  switch (args.signatureType) {
+    case SignatureType.ContractSignature: {
+      return getContractSignature(args.signer.address);
+    }
+    case SignatureType.ApprovedHash: {
+      return getApprovedHashSignature(args.signer.address);
+    }
+    case SignatureType.Eoa: {
+      return await getEoaSignature({ signer: args.signer, hash: args.hash });
+    }
+    case SignatureType.EthSign: {
+      return await getEthSignSignature({
+        signer: args.signer,
+        hash: args.hash,
+      });
+    }
+    default: {
+      throw new Error(`Unknown signature type: ${args.signatureType}`);
+    }
+  }
+}
+
+function getApprovedHashSignature(owner: `0x${string}`): `0x${string}` {
   return ('0x000000000000000000000000' +
     owner.slice(2) +
     '0000000000000000000000000000000000000000000000000000000000000000' +
     '01') as `0x${string}`;
 }
 
-export function getContractSignature(owner: `0x${string}`): `0x${string}` {
+function getContractSignature(owner: `0x${string}`): `0x${string}` {
   return ('0x000000000000000000000000' +
     owner.slice(2) +
     '0000000000000000000000000000000000000000000000000000000000000000' +
     '00') as `0x${string}`;
 }
 
-export function adjustEthSignSignature(
-  signature: `0x${string}`,
-): `0x${string}` {
+async function getEoaSignature(args: {
+  signer: PrivateKeyAccount;
+  hash: `0x${string}`;
+}): Promise<`0x${string}`> {
+  return await args.signer.sign({ hash: args.hash });
+}
+
+async function getEthSignSignature(args: {
+  signer: PrivateKeyAccount;
+  hash: `0x${string}`;
+}): Promise<`0x${string}`> {
+  const signature = await args.signer.signMessage({
+    message: { raw: args.hash },
+  });
+
+  // To differentiate signature types, eth_sign signatures have v value increased by 4
+  // @see https://docs.safe.global/advanced/smart-account-signatures#eth_sign-signature
   const v = parseInt(signature.slice(-2), 16);
   return (signature.slice(0, 130) + (v + 4).toString(16)) as `0x${string}`;
 }

--- a/src/domain/messages/helpers/message-verifier.helper.spec.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.spec.ts
@@ -252,7 +252,7 @@ describe('MessageVerifierHelper', () => {
             safe,
             message: message.message,
             messageHash: message.messageHash,
-            signature: `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
+            signature: `0x${'-'.repeat(128)}${v}`,
           });
         }).toThrow(new HttpExceptionNoLog('Could not recover address', 422));
 
@@ -610,7 +610,7 @@ describe('MessageVerifierHelper', () => {
             safe,
             message: message.message,
             messageHash: message.messageHash,
-            signature: `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
+            signature: `0x${'-'.repeat(128)}${v}`,
           });
         }).toThrow(new HttpExceptionNoLog('Could not recover address', 422));
 

--- a/src/domain/messages/helpers/message-verifier.helper.spec.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.spec.ts
@@ -1,13 +1,15 @@
+import { faker } from '@faker-js/faker';
+import { get } from 'lodash';
+import { getAddress } from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { MessageVerifierHelper } from '@/domain/messages/helpers/message-verifier.helper';
-import type { IConfigurationService } from '@/config/configuration.service.interface';
-import type { ILoggingService } from '@/logging/logging.interface';
 import { messageBuilder } from '@/domain/messages/entities/__tests__/message.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
-import { faker } from '@faker-js/faker/.';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { HttpExceptionNoLog } from '@/domain/common/errors/http-exception-no-log.error';
-import { getAddress } from 'viem';
+import configuration from '@/config/entities/__tests__/configuration';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
 
 const mockConfigurationService = jest.mocked({
   getOrThrow: jest.fn(),
@@ -20,16 +22,9 @@ const mockLoggingRepository = jest.mocked({
 describe('MessageVerifierHelper', () => {
   let target: MessageVerifierHelper;
 
-  function initTarget(args: {
-    ethSign: boolean;
-    blocklist: Array<`0x${string}`>;
-  }): void {
+  function initTarget(config: typeof configuration): void {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
-      if (key === 'blockchain.blocklist') return args.blocklist;
-      return [
-        'features.messageVerification',
-        args.ethSign ? 'features.ethSign' : null,
-      ].includes(key);
+      return get(config(), key);
     });
 
     target = new MessageVerifierHelper(
@@ -41,7 +36,7 @@ describe('MessageVerifierHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    initTarget({ ethSign: true, blocklist: [] });
+    initTarget(configuration);
   });
 
   describe('verifyCreation', () => {
@@ -79,6 +74,8 @@ describe('MessageVerifierHelper', () => {
           signature: message.confirmations[0].signature,
         });
       }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
 
     it('should throw and log if the messageHash could not be generated', async () => {
@@ -131,8 +128,17 @@ describe('MessageVerifierHelper', () => {
     });
 
     it('should throw if eth_sign is disabled', async () => {
-      initTarget({ ethSign: false, blocklist: [] });
-
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          features: {
+            ...defaultConfiguration.features,
+            ethSign: false,
+          },
+        };
+      };
+      initTarget(testConfiguration);
       const chainId = faker.string.numeric();
       const signers = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
@@ -167,9 +173,11 @@ describe('MessageVerifierHelper', () => {
           signature: message.confirmations[0].signature,
         });
       }).toThrow(new HttpExceptionNoLog('eth_sign is disabled', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
 
-    it('should throw if the signature is an invalid length', async () => {
+    it('should throw if the signature length is invalid', async () => {
       const chainId = faker.string.numeric();
       const signers = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
@@ -194,16 +202,18 @@ describe('MessageVerifierHelper', () => {
           }),
           safe,
         });
-      message.confirmations[0].signature += 'extra';
 
       expect(() => {
         return target.verifyCreation({
           chainId,
           safe,
           message: message.message,
-          signature: message.confirmations[0].signature,
+          signature: (message.confirmations[0].signature +
+            'deadbeef') as `0x${string}`,
         });
       }).toThrow(new Error('Invalid signature length'));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
 
     it.each(Object.values(SignatureType))(
@@ -235,7 +245,6 @@ describe('MessageVerifierHelper', () => {
             signatureType,
           });
         const v = message.confirmations[0].signature?.slice(-2);
-        message.confirmations[0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
 
         expect(() => {
           return target.verifyUpdate({
@@ -243,9 +252,11 @@ describe('MessageVerifierHelper', () => {
             safe,
             message: message.message,
             messageHash: message.messageHash,
-            signature: message.confirmations[0].signature,
+            signature: `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
           });
         }).toThrow(new HttpExceptionNoLog('Could not recover address', 422));
+
+        expect(mockLoggingRepository.error).not.toHaveBeenCalled();
       },
     );
 
@@ -253,10 +264,17 @@ describe('MessageVerifierHelper', () => {
       const chainId = faker.string.numeric();
       const privateKey = generatePrivateKey();
       const signer = privateKeyToAccount(privateKey);
-      initTarget({
-        ethSign: true,
-        blocklist: [signer.address],
-      });
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          blockchain: {
+            ...defaultConfiguration.blockchain,
+            blocklist: [signer.address],
+          },
+        };
+      };
+      initTarget(testConfiguration);
       const safe = safeBuilder().with('owners', [signer.address]).build();
       const message = await messageBuilder()
         .with('safe', safe.address)
@@ -360,6 +378,8 @@ describe('MessageVerifierHelper', () => {
           signature: message.confirmations[0].signature,
         });
       }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
 
     it('should throw and log if the messageHash could not be generated', async () => {
@@ -464,8 +484,17 @@ describe('MessageVerifierHelper', () => {
     });
 
     it('should throw if eth_sign is disabled', async () => {
-      initTarget({ ethSign: false, blocklist: [] });
-
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          features: {
+            ...defaultConfiguration.features,
+            ethSign: false,
+          },
+        };
+      };
+      initTarget(testConfiguration);
       const chainId = faker.string.numeric();
       const signers = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
@@ -501,9 +530,11 @@ describe('MessageVerifierHelper', () => {
           signature: message.confirmations[0].signature,
         });
       }).toThrow(new HttpExceptionNoLog('eth_sign is disabled', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
 
-    it('should throw if the signature is an invalid length', async () => {
+    it('should throw if the signature length is invalid', async () => {
       const chainId = faker.string.numeric();
       const signers = Array.from(
         { length: faker.number.int({ min: 1, max: 5 }) },
@@ -528,7 +559,6 @@ describe('MessageVerifierHelper', () => {
           }),
           safe,
         });
-      message.confirmations[0].signature += 'extra';
 
       expect(() => {
         return target.verifyUpdate({
@@ -536,9 +566,12 @@ describe('MessageVerifierHelper', () => {
           safe,
           message: message.message,
           messageHash: message.messageHash,
-          signature: message.confirmations[0].signature,
+          signature: (message.confirmations[0].signature +
+            'deadbeef') as `0x${string}`,
         });
       }).toThrow(new Error('Invalid signature length'));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
 
     it.each(Object.values(SignatureType))(
@@ -570,7 +603,6 @@ describe('MessageVerifierHelper', () => {
             signatureType,
           });
         const v = message.confirmations[0].signature?.slice(-2);
-        message.confirmations[0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
 
         expect(() => {
           return target.verifyUpdate({
@@ -578,9 +610,11 @@ describe('MessageVerifierHelper', () => {
             safe,
             message: message.message,
             messageHash: message.messageHash,
-            signature: message.confirmations[0].signature,
+            signature: `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
           });
         }).toThrow(new HttpExceptionNoLog('Could not recover address', 422));
+
+        expect(mockLoggingRepository.error).not.toHaveBeenCalled();
       },
     );
 
@@ -588,10 +622,21 @@ describe('MessageVerifierHelper', () => {
       const chainId = faker.string.numeric();
       const privateKey = generatePrivateKey();
       const signer = privateKeyToAccount(privateKey);
-      initTarget({
-        ethSign: true,
-        blocklist: [signer.address],
-      });
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          features: {
+            ...defaultConfiguration.features,
+            ethSign: true,
+          },
+          blockchain: {
+            ...defaultConfiguration.blockchain,
+            blocklist: [signer.address],
+          },
+        };
+      };
+      initTarget(testConfiguration);
       const safe = safeBuilder().with('owners', [signer.address]).build();
       const message = await messageBuilder()
         .with('safe', safe.address)

--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -141,16 +141,6 @@ export class MessageVerifierHelper {
       signature: args.signature,
     });
 
-    if (
-      !this.isEthSignEnabled &&
-      signature.signatureType === SignatureType.EthSign
-    ) {
-      throw new HttpExceptionNoLog(
-        'eth_sign is disabled',
-        MessageVerifierHelper.StatusCode,
-      );
-    }
-
     const isBlocked = this.blocklist.includes(signature.owner);
     if (isBlocked) {
       this.logBlockedAddress({
@@ -159,6 +149,16 @@ export class MessageVerifierHelper {
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.BlockedAddress,
+        MessageVerifierHelper.StatusCode,
+      );
+    }
+
+    if (
+      !this.isEthSignEnabled &&
+      signature.signatureType === SignatureType.EthSign
+    ) {
+      throw new HttpExceptionNoLog(
+        'eth_sign is disabled',
         MessageVerifierHelper.StatusCode,
       );
     }

--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -9,7 +9,7 @@ import { Safe } from '@/domain/safe/entities/safe.entity';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { CreateMessageDto } from '@/routes/messages/entities/create-message.dto.entity';
 import { HttpStatus, Inject, Injectable } from '@nestjs/common';
-import { TypedDataDefinition } from 'viem';
+import { isAddressEqual, TypedDataDefinition } from 'viem';
 
 enum ErrorMessage {
   MalformedHash = 'Could not calculate messageHash',
@@ -141,7 +141,9 @@ export class MessageVerifierHelper {
       signature: args.signature,
     });
 
-    const isBlocked = this.blocklist.includes(signature.owner);
+    const isBlocked = this.blocklist.some((blockedAddress) => {
+      return isAddressEqual(signature.owner, blockedAddress);
+    });
     if (isBlocked) {
       this.logBlockedAddress({
         ...args,
@@ -163,7 +165,9 @@ export class MessageVerifierHelper {
       );
     }
 
-    const isOwner = args.safe.owners.includes(signature.owner);
+    const isOwner = args.safe.owners.some((owner) => {
+      return isAddressEqual(signature.owner, owner);
+    });
     if (!isOwner) {
       this.logInvalidSignature({
         ...args,

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -7,6 +7,7 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
 
 export type Confirmation = z.infer<typeof ConfirmationSchema>;
 
@@ -17,7 +18,7 @@ export const ConfirmationSchema = z.object({
   submissionDate: z.coerce.date(),
   transactionHash: HexSchema.nullish().default(null),
   signatureType: z.nativeEnum(SignatureType),
-  signature: HexSchema.nullish().default(null),
+  signature: SignatureSchema.nullish().default(null),
 });
 
 export const MultisigTransactionSchema = z.object({

--- a/src/routes/messages/entities/__tests__/update-message-signature.dto.builder.ts
+++ b/src/routes/messages/entities/__tests__/update-message-signature.dto.builder.ts
@@ -6,6 +6,6 @@ import type { UpdateMessageSignatureDto } from '@/routes/messages/entities/updat
 export function updateMessageSignatureDtoBuilder(): IBuilder<UpdateMessageSignatureDto> {
   return new Builder<UpdateMessageSignatureDto>().with(
     'signature',
-    faker.string.hexadecimal({ length: 32 }) as `0x${string}`,
+    faker.string.hexadecimal({ length: 130 }) as `0x${string}`,
   );
 }

--- a/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
@@ -149,6 +149,29 @@ describe('CreateMessageDtoSchema', () => {
   });
 
   describe('signature', () => {
+    it('should not validate a non-hex signature', () => {
+      const createMessageDto = createMessageDtoBuilder()
+        .with('signature', faker.string.numeric() as `0x${string}`)
+        .build();
+
+      const result = CreateMessageDtoSchema.safeParse(createMessageDto);
+
+      expect(!result.success && result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'custom',
+            message: 'Invalid "0x" notated hex string',
+            path: ['signature'],
+          },
+          {
+            code: 'custom',
+            message: 'Invalid signature',
+            path: ['signature'],
+          },
+        ]),
+      );
+    });
+
     it('should not validate without a signature', () => {
       const createMessageDto = createMessageDtoBuilder().build();
       // @ts-expect-error - inferred type doesn't allow optional properties

--- a/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
@@ -31,6 +31,34 @@ describe('UpdateMessageSignatureDtoSchema', () => {
           message: 'Invalid "0x" notated hex string',
           path: ['signature'],
         },
+        {
+          code: 'custom',
+          message: 'Invalid signature',
+          path: ['signature'],
+        },
+      ]),
+    );
+  });
+
+  it('should not allow non-signature length hex strings', () => {
+    const updateMessageSignatureDto = updateMessageSignatureDtoBuilder()
+      .with(
+        'signature',
+        faker.string.hexadecimal({ length: 129 }) as `0x${string}`,
+      )
+      .build();
+
+    const result = UpdateMessageSignatureDtoSchema.safeParse(
+      updateMessageSignatureDto,
+    );
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'custom',
+          message: 'Invalid signature',
+          path: ['signature'],
+        },
       ]),
     );
   });

--- a/src/routes/messages/entities/schemas/create-message.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/create-message.dto.schema.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
 
 export const CreateMessageDtoSchema = z.object({
   message: z.union([z.record(z.unknown()), z.string()]),
   safeAppId: z.number().int().gte(0).nullish().default(null),
-  signature: z.string(),
+  signature: SignatureSchema,
   origin: z.string().nullish().default(null),
 });

--- a/src/routes/messages/entities/schemas/update-message-signature.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/update-message-signature.dto.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
 
 export const UpdateMessageSignatureDtoSchema = z.object({
-  signature: HexSchema,
+  signature: SignatureSchema,
 });

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -1035,10 +1035,7 @@ describe('Messages controller', () => {
             .send(
               createMessageDtoBuilder()
                 .with('message', message.message)
-                .with(
-                  'signature',
-                  `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
-                )
+                .with('signature', `0x${'-'.repeat(128)}${v}`)
                 .build(),
             )
             .expect(422)
@@ -1568,10 +1565,7 @@ describe('Messages controller', () => {
             )
             .send(
               updateMessageSignatureDtoBuilder()
-                .with(
-                  'signature',
-                  `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
-                )
+                .with('signature', `0x${'-'.repeat(128)}${v}`)
                 .build(),
             )
             .expect(422)

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -30,22 +30,28 @@ import { rawify } from '@/validation/entities/raw.entity';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { GlobalErrorFilter } from '@/routes/common/filters/global-error.filter';
 import { APP_FILTER } from '@nestjs/core';
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import { ZodErrorFilter } from '@/routes/common/filters/zod-error.filter';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import { getAddress } from 'viem';
 
 describe('Add transaction confirmations - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
+  let loggingService: jest.MockedObjectDeep<ILoggingService>;
 
-  beforeEach(async () => {
-    jest.resetAllMocks();
-
+  async function initApp(config: typeof configuration): Promise<void> {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         // feature
         TransactionsModule,
         // common
         TestCacheModule,
-        ConfigurationModule.register(configuration),
+        ConfigurationModule.register(config),
         TestLoggingModule,
         TestNetworkModule,
       ],
@@ -55,6 +61,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
           provide: APP_FILTER,
           useClass: GlobalErrorFilter,
         },
+        { provide: APP_FILTER, useClass: ZodErrorFilter },
       ],
     }).compile();
 
@@ -63,9 +70,28 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
+    loggingService = moduleFixture.get(LoggingService);
+
+    // TODO: Override module to avoid spying
+    jest.spyOn(loggingService, 'error');
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
+  }
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        ethSign: true,
+      },
+    });
+
+    await initApp(testConfiguration);
   });
 
   afterAll(async () => {
@@ -75,196 +101,621 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
   it('should throw a validation error', async () => {
     await request(app.getHttpServer())
       .post(
-        `/v1/chains/${faker.string.numeric()}/transactions/${faker.string.hexadecimal()}/confirmations`,
+        `/v1/chains/${faker.string.numeric()}/transactions/${faker.finance.ethereumAddress()}/confirmations`,
       )
-      .send({ signature: 1 });
+      .send({ signature: 1 })
+      .expect(422)
+      .expect({
+        statusCode: 422,
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'number',
+        path: ['signature'],
+        message: 'Expected string, received number',
+      });
   });
 
-  it('should create a confirmation and return the updated transaction', async () => {
-    const chain = chainBuilder().build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const safeApps = [safeAppBuilder().build()];
-    const contract = contractBuilder().build();
-    const transaction = multisigToJson(
-      await multisigTransactionBuilder()
-        .with('safe', safe.address)
-        .with('nonce', safe.nonce)
-        .with('isExecuted', false)
-        .buildWithConfirmations({
-          signers: [signer],
-          chainId: chain.chainId,
-          safe,
-        }),
-    ) as MultisigTransaction;
-    const addConfirmationDto = addConfirmationDtoBuilder()
-      .with('signature', transaction.confirmations![0].signature!)
-      .build();
-    const gasToken = tokenBuilder().build();
-    const token = tokenBuilder().build();
-    const rejectionTxsPage = pageBuilder().with('results', []).build();
-    networkService.get.mockImplementation(({ url }) => {
+  it.each(Object.values(SignatureType))(
+    'should confirm a transaction with a %s signature and return the updated transaction',
+    async (signatureType) => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const safeApps = [safeAppBuilder().build()];
+      const contract = contractBuilder().build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+            signatureType,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      const gasToken = tokenBuilder().build();
+      const token = tokenBuilder().build();
+      const rejectionTxsPage = pageBuilder().with('results', []).build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+        const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+        const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${transaction.to}`;
+        const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getMultisigTransactionsUrl:
+            return Promise.resolve({
+              data: rawify(rejectionTxsPage),
+              status: 200,
+            });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          case getSafeAppsUrl:
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
+          case getGasTokenContractUrl:
+            return Promise.resolve({ data: rawify(gasToken), status: 200 });
+          case getToContractUrl:
+            return Promise.resolve({ data: rawify(contract), status: 200 });
+          case getToTokenUrl:
+            return Promise.resolve({ data: rawify(token), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+      networkService.post.mockImplementation(({ url }) => {
+        const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/confirmations/`;
+        switch (url) {
+          case postConfirmationUrl:
+            return Promise.resolve({ data: rawify({}), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toMatchObject({
+            safeAddress: safe.address,
+            txId: `multisig_${transaction.safe}_${transaction.safeTxHash}`,
+            executedAt: expect.any(Number),
+            txStatus: expect.any(String),
+            txInfo: expect.any(Object),
+            txData: expect.any(Object),
+            txHash: transaction.transactionHash,
+            detailedExecutionInfo: expect.any(Object),
+            safeAppInfo: expect.any(Object),
+          }),
+        );
+    },
+  );
+
+  describe('Verification', () => {
+    it('should throw for executed transactions', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', true)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
-      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
-      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
-      const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${transaction.to}`;
-      const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
-      switch (url) {
-        case getChainUrl:
-          return Promise.resolve({ data: rawify(chain), status: 200 });
-        case getMultisigTransactionUrl:
-          return Promise.resolve({ data: rawify(transaction), status: 200 });
-        case getMultisigTransactionsUrl:
-          return Promise.resolve({
-            data: rawify(rejectionTxsPage),
-            status: 200,
-          });
-        case getSafeUrl:
-          return Promise.resolve({ data: rawify(safe), status: 200 });
-        case getSafeAppsUrl:
-          return Promise.resolve({ data: rawify(safeApps), status: 200 });
-        case getGasTokenContractUrl:
-          return Promise.resolve({ data: rawify(gasToken), status: 200 });
-        case getToContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
-        case getToTokenUrl:
-          return Promise.resolve({ data: rawify(token), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-    networkService.post.mockImplementation(({ url }) => {
-      const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/confirmations/`;
-      switch (url) {
-        case postConfirmationUrl:
-          return Promise.resolve({ data: rawify({}), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-
-    await request(app.getHttpServer())
-      .post(
-        `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
-      )
-      .send(addConfirmationDto)
-      .expect(200)
-      .expect(({ body }) =>
-        expect(body).toMatchObject({
-          safeAddress: safe.address,
-          txId: `multisig_${transaction.safe}_${transaction.safeTxHash}`,
-          executedAt: expect.any(Number),
-          txStatus: expect.any(String),
-          txInfo: expect.any(Object),
-          txData: expect.any(Object),
-          txHash: transaction.transactionHash,
-          detailedExecutionInfo: expect.any(Object),
-          safeAppInfo: expect.any(Object),
-        }),
-      );
-  });
-
-  it('should throw for historical transactions', async () => {
-    const chain = chainBuilder().build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const transaction = multisigToJson(
-      await multisigTransactionBuilder()
-        .with('safe', safe.address)
-        .with('nonce', safe.nonce)
-        .with('isExecuted', true)
-        .buildWithConfirmations({
-          signers: [signer],
-          chainId: chain.chainId,
-          safe,
-        }),
-    ) as MultisigTransaction;
-    const addConfirmationDto = addConfirmationDtoBuilder()
-      .with('signature', transaction.confirmations![0].signature!)
-      .build();
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
-    networkService.get.mockImplementation(({ url }) => {
-      switch (url) {
-        case getChainUrl:
-          return Promise.resolve({ data: rawify(chain), status: 200 });
-        case getMultisigTransactionUrl:
-          return Promise.resolve({
-            data: rawify(transaction),
-            status: 200,
-          });
-        case getSafeUrl:
-          return Promise.resolve({ data: rawify(safe), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-
-    await request(app.getHttpServer())
-      .post(
-        `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
-      )
-      .send(addConfirmationDto)
-      .expect(422)
-      .expect({
-        message: 'Invalid nonce',
-        statusCode: 422,
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
       });
-  });
 
-  it('should throw if the nonce is below that of the Safe', async () => {
-    const chain = chainBuilder().build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const transaction = multisigToJson(
-      await multisigTransactionBuilder()
-        .with('safe', safe.address)
-        .with('nonce', safe.nonce - 1)
-        .with('isExecuted', false)
-        .buildWithConfirmations({
-          signers: [signer],
-          chainId: chain.chainId,
-          safe,
-        }),
-    ) as MultisigTransaction;
-    const addConfirmationDto = addConfirmationDtoBuilder()
-      .with('signature', transaction.confirmations![0].signature!)
-      .build();
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
-    networkService.get.mockImplementation(({ url }) => {
-      switch (url) {
-        case getChainUrl:
-          return Promise.resolve({ data: rawify(chain), status: 200 });
-        case getMultisigTransactionUrl:
-          return Promise.resolve({
-            data: rawify(transaction),
-            status: 200,
-          });
-        case getSafeUrl:
-          return Promise.resolve({ data: rawify(safe), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(422)
+        .expect({
+          message: 'Invalid nonce',
+          statusCode: 422,
+        });
+
+      expect(loggingService.error).not.toHaveBeenCalled();
     });
 
-    await request(app.getHttpServer())
-      .post(
-        `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
-      )
-      .send(addConfirmationDto)
-      .expect(422)
-      .expect({
-        message: 'Invalid nonce',
-        statusCode: 422,
+    it('should throw if the nonce is below that of the Safe', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce - 1)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
       });
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(422)
+        .expect({
+          message: 'Invalid nonce',
+          statusCode: 422,
+        });
+
+      expect(loggingService.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw and log if the safeTxHash could not be calculated', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      safe.version = null;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(502)
+        .expect({
+          statusCode: 502,
+          message: 'Could not calculate safeTxHash',
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Could not calculate safeTxHash',
+        chainId: chain.chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if the safeTxHash does not match', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+      transaction.data = faker.string.hexadecimal({
+        length: 64,
+      }) as `0x${string}`;
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(502)
+        .expect({
+          statusCode: 502,
+          message: 'Invalid safeTxHash',
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'safeTxHash does not match',
+        chainId: chain.chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw if the signature length is invalid', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce - 1)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with(
+          'signature',
+          (transaction.confirmations![0].signature +
+            'deadbeef') as `0x${string}`,
+        )
+        .build();
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'Invalid signature',
+          path: ['signature'],
+        });
+
+      expect(loggingService.error).not.toHaveBeenCalled();
+    });
+
+    it.each(Object.values(SignatureType))(
+      'should throw and log if a %s signature is invalid',
+      async (signatureType) => {
+        const chain = chainBuilder().build();
+        const privateKey = generatePrivateKey();
+        const signer = privateKeyToAccount(privateKey);
+        const safe = safeBuilder().with('owners', [signer.address]).build();
+        const transaction = multisigToJson(
+          await multisigTransactionBuilder()
+            .with('safe', safe.address)
+            .with('nonce', safe.nonce)
+            .with('isExecuted', false)
+            .buildWithConfirmations({
+              signers: [signer],
+              chainId: chain.chainId,
+              safe,
+              signatureType,
+            }),
+        ) as MultisigTransaction;
+        const v = transaction.confirmations![0].signature?.slice(-2);
+        const addConfirmationDto = addConfirmationDtoBuilder()
+          .with(
+            'signature',
+            `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
+          )
+          .build();
+
+        await request(app.getHttpServer())
+          .post(
+            `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+          )
+          .send(addConfirmationDto)
+          .expect(422)
+          .expect({
+            statusCode: 422,
+            code: 'custom',
+            message: 'Invalid "0x" notated hex string',
+            path: ['signature'],
+          });
+
+        expect(loggingService.error).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should throw and log if a signer is blocked', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => ({
+        ...defaultConfiguration,
+        blockchain: {
+          ...defaultConfiguration.blockchain,
+          blocklist: [signer.address],
+        },
+      });
+      await initApp(testConfiguration);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(502)
+        .expect({
+          message: 'Unauthorized address',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Unauthorized address',
+        chainId: chain.chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        blockedAddress: signer.address,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw if eth_sign is disabled', async () => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => ({
+        ...defaultConfiguration,
+        features: {
+          ...defaultConfiguration.features,
+          ethSign: false,
+        },
+      });
+      await initApp(testConfiguration);
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+            signatureType: SignatureType.EthSign,
+          }),
+      ) as MultisigTransaction;
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(422)
+        .expect({
+          message: 'eth_sign is disabled',
+          statusCode: 422,
+        });
+
+      expect(loggingService.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw and log if the signer is not an owner', async () => {
+      const chain = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = multisigToJson(
+        await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('isExecuted', false)
+          .buildWithConfirmations({
+            signers: [signer],
+            chainId: chain.chainId,
+            safe,
+          }),
+      ) as MultisigTransaction;
+      safe.owners = [getAddress(faker.finance.ethereumAddress())];
+      const addConfirmationDto = addConfirmationDtoBuilder()
+        .with('signature', transaction.confirmations![0].signature!)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${transaction.safeTxHash}/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({ data: rawify(transaction), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .post(
+          `/v1/chains/${chain.chainId}/transactions/${transaction.safeTxHash}/confirmations`,
+        )
+        .send(addConfirmationDto)
+        .expect(502)
+        .expect({
+          message: 'Invalid signature',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Recovered address does not match signer',
+        chainId: chain.chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        signerAddress: transaction.confirmations![0].owner,
+        signature: transaction.confirmations![0].signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
   });
 });

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -509,10 +509,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         ) as MultisigTransaction;
         const v = transaction.confirmations![0].signature?.slice(-2);
         const addConfirmationDto = addConfirmationDtoBuilder()
-          .with(
-            'signature',
-            `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
-          )
+          .with('signature', `0x${'-'.repeat(128)}${v}`)
           .build();
 
         await request(app.getHttpServer())

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -1392,7 +1392,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             signatureType,
           });
         const v = multisigTransaction.confirmations![0].signature?.slice(-2);
-        multisigTransaction.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
+        multisigTransaction.confirmations![0].signature = `0x${'-'.repeat(128)}${v}`;
 
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
         const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -1077,7 +1077,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         };
         const nonce1 = await getTransaction(1);
         const v = nonce1.confirmations![0].signature?.slice(-2);
-        nonce1.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
+        nonce1.confirmations![0].signature = `0x${'-'.repeat(128)}${v}`;
         const nonce2 = await getTransaction(2);
         const transactions: Array<MultisigTransaction> = [
           multisigToJson(nonce1) as MultisigTransaction,

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -20,7 +20,6 @@ import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-me
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
-import { getSafeTxHash } from '@/domain/common/utils/safe';
 import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { safeAppBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app.builder';
@@ -31,6 +30,10 @@ import {
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import type { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { rawify } from '@/validation/entities/raw.entity';
 import { faker } from '@faker-js/faker';
@@ -46,6 +49,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
+  let loggingService: jest.MockedObjectDeep<ILoggingService>;
 
   async function initApp(config: typeof configuration): Promise<void> {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -74,6 +78,10 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     networkService = moduleFixture.get(NetworkService);
+    loggingService = moduleFixture.get(LoggingService);
+
+    // TODO: Override module to avoid spying
+    jest.spyOn(loggingService, 'error');
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -99,12 +107,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
   });
 
   it('Failure: data page validation fails', async () => {
-    const chainId = faker.string.numeric();
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
     const page = pageBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       if (url === getChainUrl) {
@@ -123,18 +130,27 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     });
 
     await request(app.getHttpServer())
-      .get(`/v1/chains/${chainId}/safes/${safe.address}/transactions/queued`)
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
+      )
       .expect(502)
       .expect({ statusCode: 502, message: 'Bad gateway' });
   });
 
   it('should get a transactions queue with labels and conflict headers', async () => {
-    const chainId = faker.string.numeric();
     const chainResponse = chainBuilder().build();
+    const signers = Array.from({ length: 3 }, () => {
+      const privateKey = generatePrivateKey();
+      return privateKeyToAccount(privateKey);
+    });
     const safeAddress = getAddress(faker.finance.ethereumAddress());
     const safeResponse = safeBuilder()
       .with('address', safeAddress)
       .with('nonce', 1)
+      .with(
+        'owners',
+        signers.map((signer) => signer.address),
+      )
       .build();
     const safeAppsResponse = [
       safeAppBuilder()
@@ -144,25 +160,27 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         .build(),
     ];
     const contractResponse = contractBuilder().build();
-    const getTransaction = (nonce: number): MultisigTransaction => {
-      const transaction = multisigTransactionBuilder()
+    const getTransaction = async (
+      nonce: number,
+    ): Promise<MultisigTransaction> => {
+      return multisigTransactionBuilder()
         .with('safe', safeAddress)
         .with('isExecuted', false)
         .with('nonce', nonce)
         .with('dataDecoded', null)
-        .with('confirmations', [])
-        .build();
-      transaction.safeTxHash = getSafeTxHash({
-        transaction,
-        safe: safeResponse,
-        chainId,
-      });
-      return transaction;
+        .buildWithConfirmations({
+          safe: safeResponse,
+          chainId: chainResponse.chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+        });
     };
-    const nonce1 = getTransaction(1);
-    const nonce2 = getTransaction(2);
-    const nonce3 = getTransaction(3);
-    const nonce4 = getTransaction(4);
+    const nonce1 = await getTransaction(1);
+    const nonce2 = await getTransaction(2);
+    const nonce3 = await getTransaction(3);
+    const nonce4 = await getTransaction(4);
     const transactions: Array<MultisigTransaction> = [
       multisigToJson(nonce1) as MultisigTransaction,
       multisigToJson(nonce1) as MultisigTransaction,
@@ -173,7 +191,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     ];
 
     networkService.get.mockImplementation(({ url }) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -205,7 +223,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
     });
 
     await request(app.getHttpServer())
-      .get(`/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued`)
+      .get(
+        `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+      )
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual({
@@ -277,13 +297,20 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
   });
 
   it('should get a transactions queue with labels and conflict headers for a multi-page queue', async () => {
-    const chainId = faker.string.numeric();
     const safeAddress = getAddress(faker.finance.ethereumAddress());
     const chainResponse = chainBuilder().build();
+    const signers = Array.from({ length: 3 }, () => {
+      const privateKey = generatePrivateKey();
+      return privateKeyToAccount(privateKey);
+    });
     const contractResponse = contractBuilder().build();
     const safeResponse = safeBuilder()
       .with('address', safeAddress)
       .with('nonce', 1)
+      .with(
+        'owners',
+        signers.map((signer) => signer.address),
+      )
       .build();
     const safeAppsResponse = [
       safeAppBuilder()
@@ -292,24 +319,26 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         .with('name', faker.word.words())
         .build(),
     ];
-    const getTransaction = (nonce: number): MultisigTransaction => {
-      const transaction = multisigTransactionBuilder()
+    const getTransaction = async (
+      nonce: number,
+    ): Promise<MultisigTransaction> => {
+      return multisigTransactionBuilder()
         .with('safe', safeAddress)
         .with('isExecuted', false)
         .with('nonce', nonce)
         .with('dataDecoded', null)
-        .with('confirmations', [])
-        .build();
-      transaction.safeTxHash = getSafeTxHash({
-        transaction,
-        safe: safeResponse,
-        chainId,
-      });
-      return transaction;
+        .buildWithConfirmations({
+          safe: safeResponse,
+          chainId: chainResponse.chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+        });
     };
-    const nonce1 = getTransaction(1);
-    const nonce2 = getTransaction(2);
-    const nonce3 = getTransaction(3);
+    const nonce1 = await getTransaction(1);
+    const nonce2 = await getTransaction(2);
+    const nonce3 = await getTransaction(3);
     const transactions: Array<MultisigTransaction> = [
       multisigToJson(nonce1) as MultisigTransaction,
       multisigToJson(nonce1) as MultisigTransaction,
@@ -321,7 +350,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       multisigToJson(nonce3) as MultisigTransaction,
     ];
     networkService.get.mockImplementation(({ url }) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -358,7 +387,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
     await request(app.getHttpServer())
       .get(
-        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued/?cursor=limit%3D10%26offset%3D2`,
+        `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued/?cursor=limit%3D10%26offset%3D2`,
       )
       .expect(200)
       .then(({ body }) => {
@@ -434,38 +463,47 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
   });
 
   it('should get an "untrusted" queue', async () => {
-    const chainId = faker.string.numeric();
     const safeAddress = getAddress(faker.finance.ethereumAddress());
     const chainResponse = chainBuilder().build();
+    const signers = Array.from({ length: 3 }, () => {
+      const privateKey = generatePrivateKey();
+      return privateKeyToAccount(privateKey);
+    });
     const contractResponse = contractBuilder().build();
     const safeResponse = safeBuilder()
       .with('address', safeAddress)
       .with('nonce', 1)
+      .with(
+        'owners',
+        signers.map((signer) => signer.address),
+      )
       .build();
     const safeAppsResponse = [safeAppBuilder().build()];
-    const getTransaction = (nonce: number): MultisigTransaction => {
-      const transaction = multisigTransactionBuilder()
+    const getTransaction = async (
+      nonce: number,
+    ): Promise<MultisigTransaction> => {
+      return multisigTransactionBuilder()
         .with('safe', safeAddress)
         .with('isExecuted', false)
         .with('nonce', nonce)
         .with('dataDecoded', null)
-        .with('confirmations', [])
-        .build();
-      transaction.safeTxHash = getSafeTxHash({
-        transaction,
-        safe: safeResponse,
-        chainId,
-      });
-      return transaction;
+        .buildWithConfirmations({
+          safe: safeResponse,
+          chainId: chainResponse.chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+        });
     };
-    const nonce1 = getTransaction(1);
-    const nonce2 = getTransaction(2);
+    const nonce1 = await getTransaction(1);
+    const nonce2 = await getTransaction(2);
     const transactions: Array<MultisigTransaction> = [
       multisigToJson(nonce1) as MultisigTransaction,
       multisigToJson(nonce2) as MultisigTransaction,
     ];
     networkService.get.mockImplementation(({ url, networkRequest }) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -503,7 +541,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
     await request(app.getHttpServer())
       .get(
-        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued/?trusted=false`,
+        `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued/?trusted=false`,
       )
       .expect(200)
       .then(({ body }) => {
@@ -539,490 +577,825 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       });
   });
 
-  it('should return a 502 if there is a safeTxHash mismatch', async () => {
-    const chain = chainBuilder().build();
-    const safe = safeBuilder().with('nonce', 1).build();
-    const getTransaction = (nonce: number): MultisigTransaction => {
-      const transaction = multisigTransactionBuilder()
-        .with('safe', safe.address)
-        .with('isExecuted', false)
-        .with('nonce', nonce)
-        .with('dataDecoded', null)
-        .with('confirmations', [])
-        .build();
-      transaction.safeTxHash = getSafeTxHash({
-        transaction,
-        safe,
-        chainId: chain.chainId,
-      });
-      return transaction;
-    };
-    const nonce1 = getTransaction(1);
-    const nonce2 = getTransaction(2);
-    nonce1.safeTxHash = faker.string.hexadecimal({
-      length: 64,
-    }) as `0x${string}`;
-    const transactions: Array<MultisigTransaction> = [
-      multisigToJson(nonce1) as MultisigTransaction,
-      multisigToJson(nonce2) as MultisigTransaction,
-    ];
-    const contract = contractBuilder().build();
-
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-    const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      if (url === getMultisigTransactionsUrl) {
-        return Promise.resolve({
-          data: rawify(pageBuilder().with('results', transactions).build()),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: rawify([]), status: 200 });
-      }
-      if (url.startsWith(getContractUrlPattern)) {
-        return Promise.resolve({
-          data: rawify(contract),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
-      )
-      .expect(502)
-      .expect({
-        message: 'Invalid safeTxHash',
-        statusCode: 502,
-      });
-  });
-
-  it('should return a 502 if confirmations contain duplicate owners', async () => {
-    const chain = chainBuilder().build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const multisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId: chain.chainId,
-        safe,
-        signers: [signer],
-      });
-    const duplicateOwnersMultisigTransaction =
-      await multisigTransactionBuilder()
-        .with('safe', safe.address)
-        .with('isExecuted', false)
-        .with('nonce', safe.nonce)
-        .buildWithConfirmations({
-          chainId: chain.chainId,
-          safe,
-          signers: [signer, signer],
-        });
-    const transactions: Array<MultisigTransaction> = [
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-      multisigToJson(duplicateOwnersMultisigTransaction) as MultisigTransaction,
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-    ];
-    const contract = contractBuilder().build();
-
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-    const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      if (url === getMultisigTransactionsUrl) {
-        return Promise.resolve({
-          data: rawify(pageBuilder().with('results', transactions).build()),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: rawify([]), status: 200 });
-      }
-      if (url.startsWith(getContractUrlPattern)) {
-        return Promise.resolve({
-          data: rawify(contract),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
-      )
-      .expect(502)
-      .expect({
-        message: 'Duplicate owners in confirmations',
-        statusCode: 502,
-      });
-  });
-
-  it('should return a 502 if confirmations contain duplicate signers', async () => {
-    const chain = chainBuilder().build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const multisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId: chain.chainId,
-        safe,
-        signers: [signer],
-      });
-    const duplicateSignaturesMultisigTransaction =
-      await multisigTransactionBuilder()
-        .with('safe', safe.address)
-        .with('isExecuted', false)
-        .with('nonce', safe.nonce)
-        .buildWithConfirmations({
-          chainId: chain.chainId,
-          safe,
-          signers: [signer],
-        });
-    duplicateSignaturesMultisigTransaction.confirmations!.push({
-      ...duplicateSignaturesMultisigTransaction.confirmations![0],
-      owner: getAddress(faker.finance.ethereumAddress()),
-    });
-    const transactions: Array<MultisigTransaction> = [
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-      multisigToJson(
-        duplicateSignaturesMultisigTransaction,
-      ) as MultisigTransaction,
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-    ];
-    const contract = contractBuilder().build();
-
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-    const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      if (url === getMultisigTransactionsUrl) {
-        return Promise.resolve({
-          data: rawify(pageBuilder().with('results', transactions).build()),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: rawify([]), status: 200 });
-      }
-      if (url.startsWith(getContractUrlPattern)) {
-        return Promise.resolve({
-          data: rawify(contract),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
-      )
-      .expect(502)
-      .expect({
-        message: 'Duplicate signatures in confirmations',
-        statusCode: 502,
-      });
-  });
-
-  it('should return a 502 if confirmations contain an invalid EOA confirmation', async () => {
-    const chain = chainBuilder().build();
-    const signers = Array.from({ length: 2 }, () => {
-      const privateKey = generatePrivateKey();
-      return privateKeyToAccount(privateKey);
-    });
-    const safe = safeBuilder()
-      .with(
-        'owners',
-        signers.map((signer) => signer.address),
-      )
-      .build();
-    const multisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId: chain.chainId,
-        signers,
-        safe,
-      });
-    const invalidEoaMultisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId: chain.chainId,
-        signers: [signers[0]],
-        safe,
-        signatureType: SignatureType.Eoa,
-      });
-    multisigTransaction.confirmations![0].owner = getAddress(
-      faker.finance.ethereumAddress(),
-    );
-    const transactions: Array<MultisigTransaction> = [
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-      multisigToJson(invalidEoaMultisigTransaction) as MultisigTransaction,
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-    ];
-    const contract = contractBuilder().build();
-
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-    const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      if (url === getMultisigTransactionsUrl) {
-        return Promise.resolve({
-          data: rawify(pageBuilder().with('results', transactions).build()),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: rawify([]), status: 200 });
-      }
-      if (url.startsWith(getContractUrlPattern)) {
-        return Promise.resolve({
-          data: rawify(contract),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
-      )
-      .expect(502)
-      .expect({
-        message: 'Invalid signature',
-        statusCode: 502,
-      });
-  });
-
-  it('should return a 502 if confirmations contain an invalid invalid ETH_SIGN confirmation', async () => {
-    const chain = chainBuilder().build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const multisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId: chain.chainId,
-        signers: [signer],
-        safe,
-        signatureType: SignatureType.Eoa,
-      });
-    const invalidEthSignMultisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId: chain.chainId,
-        signers: [signer],
-        safe,
-        signatureType: SignatureType.EthSign,
-      });
-    invalidEthSignMultisigTransaction.confirmations![0].owner = getAddress(
-      faker.finance.ethereumAddress(),
-    );
-    const transactions: Array<MultisigTransaction> = [
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-      multisigToJson(invalidEthSignMultisigTransaction) as MultisigTransaction,
-    ];
-    const contract = contractBuilder().build();
-
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-    const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      if (url === getMultisigTransactionsUrl) {
-        return Promise.resolve({
-          data: rawify(
-            pageBuilder()
-              .with('next', null) // avoid slicing the results
-              .with('results', transactions)
-              .build(),
-          ),
-          status: 200,
-        });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: rawify([]), status: 200 });
-      }
-      if (url.startsWith(getContractUrlPattern)) {
-        return Promise.resolve({
-          data: rawify(contract),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
-      )
-      .expect(502)
-      .expect({
-        message: 'Invalid signature',
-        statusCode: 502,
-      });
-  });
-
-  it('should not block eth_sign', async () => {
-    const baseConfiguration = configuration();
-    const testConfiguration = (): typeof baseConfiguration => ({
-      ...baseConfiguration,
-      features: {
-        ...baseConfiguration.features,
-        ethSign: false,
-      },
-    });
-    await initApp(testConfiguration);
-
-    const chain = chainBuilder().build();
-    const signers = Array.from(
-      { length: faker.number.int({ min: 1, max: 5 }) },
-      () => {
+  describe('Verification', () => {
+    it('should throw and log if the safeTxHash could not be calculated', async () => {
+      const chainResponse = chainBuilder().build();
+      const signers = Array.from({ length: 3 }, () => {
         const privateKey = generatePrivateKey();
         return privateKeyToAccount(privateKey);
-      },
-    );
-    const safe = safeBuilder()
-      .with(
-        'owners',
-        signers.map((signer) => signer.address),
-      )
-      .build();
-    const multisigTransaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('nonce', safe.nonce)
-      .with('isExecuted', false)
-      .buildWithConfirmations({
-        signers: signers,
-        chainId: chain.chainId,
-        safe,
-        signatureType: SignatureType.EthSign,
       });
-    const transactions: Array<MultisigTransaction> = [
-      multisigToJson(multisigTransaction) as MultisigTransaction,
-    ];
-    const contract = contractBuilder().build();
-    const safeApps = [
-      safeAppBuilder()
-        .with('url', faker.internet.url({ appendSlash: false }))
-        .with('iconUrl', faker.internet.url({ appendSlash: false }))
-        .with('name', faker.word.words())
-        .build(),
-    ];
-    const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-    const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-    const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-    const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-    const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === getChainUrl) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: rawify(contract), status: 200 });
-      }
-      if (url === getMultisigTransactionsUrl) {
-        return Promise.resolve({
-          data: rawify({
-            count: 6,
-            next: null,
-            previous: null,
-            results: transactions,
-          }),
-          status: 200,
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with(
+          'owners',
+          signers.map((signer) => signer.address),
+        )
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: faker.helpers.arrayElements(signers, {
+              min: 1,
+              max: signers.length,
+            }),
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      const nonce2 = await getTransaction(2);
+      safeResponse.version = null;
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({ data: rawify(safeResponse), status: 200 });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Could not calculate safeTxHash',
+          statusCode: 502,
         });
-      }
-      if (url === getSafeUrl) {
-        return Promise.resolve({ data: rawify(safe), status: 200 });
-      }
-      if (url === getSafeAppsUrl) {
-        return Promise.resolve({ data: rawify(safeApps), status: 200 });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Could not calculate safeTxHash',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        transaction: {
+          to: nonce1.to,
+          value: nonce1.value,
+          data: nonce1.data,
+          operation: nonce1.operation,
+          safeTxGas: nonce1.safeTxGas,
+          baseGas: nonce1.baseGas,
+          gasPrice: nonce1.gasPrice,
+          gasToken: nonce1.gasToken,
+          refundReceiver: nonce1.refundReceiver,
+          nonce: nonce1.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
     });
 
-    await request(app.getHttpServer())
-      .get(
-        `/v1/chains/${chain.chainId}/safes/${safe.address}/transactions/queued`,
-      )
-      .expect(200)
-      .then(({ body }) => {
-        expect(body).toEqual({
-          count: 2,
-          next: null,
-          previous: null,
-          results: [
-            {
-              type: 'LABEL',
-              label: 'Next',
-            },
-            {
-              type: 'TRANSACTION',
-              transaction: expect.objectContaining({
-                id: `multisig_${safe.address}_${transactions[0].safeTxHash}`,
-              }),
-              conflictType: 'None',
-            },
-          ],
-        });
+    it('should throw and log if the safeTxHash does not match', async () => {
+      const chainResponse = chainBuilder().build();
+      const signers = Array.from({ length: 3 }, () => {
+        const privateKey = generatePrivateKey();
+        return privateKeyToAccount(privateKey);
       });
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with(
+          'owners',
+          signers.map((signer) => signer.address),
+        )
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: faker.helpers.arrayElements(signers, {
+              min: 1,
+              max: signers.length,
+            }),
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      const nonce2 = await getTransaction(2);
+      nonce1.data = faker.string.hexadecimal({ length: 64 }) as `0x${string}`;
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Invalid safeTxHash',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'safeTxHash does not match',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        transaction: {
+          to: nonce1.to,
+          value: nonce1.value,
+          data: nonce1.data,
+          operation: nonce1.operation,
+          safeTxGas: nonce1.safeTxGas,
+          baseGas: nonce1.baseGas,
+          gasPrice: nonce1.gasPrice,
+          gasToken: nonce1.gasToken,
+          refundReceiver: nonce1.refundReceiver,
+          nonce: nonce1.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if confirmations contain duplicate owners', async () => {
+      const chainResponse = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with('owners', [signer.address])
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: [signer, signer],
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      const nonce2 = await getTransaction(2);
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Duplicate owners in confirmations',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Duplicate owners in confirmations',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        confirmations: nonce1.confirmations,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if confirmations contain duplicate signatures', async () => {
+      const chainResponse = chainBuilder().build();
+      const signers = Array.from({ length: 2 }, () => {
+        const privateKey = generatePrivateKey();
+        return privateKeyToAccount(privateKey);
+      });
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with(
+          'owners',
+          signers.map((signer) => signer.address),
+        )
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers,
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      nonce1.confirmations![1].signature = nonce1.confirmations![0].signature;
+      const nonce2 = await getTransaction(2);
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Duplicate signatures in confirmations',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Duplicate signatures in confirmations',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        confirmations: nonce1.confirmations,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw if a signature length is invalid', async () => {
+      const chainResponse = chainBuilder().build();
+      const signers = Array.from({ length: 3 }, () => {
+        const privateKey = generatePrivateKey();
+        return privateKeyToAccount(privateKey);
+      });
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with(
+          'owners',
+          signers.map((signer) => signer.address),
+        )
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: faker.helpers.arrayElements(signers, {
+              min: 1,
+              max: signers.length,
+            }),
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      nonce1.confirmations![0].signature = '0xdeadbeef';
+      const nonce2 = await getTransaction(2);
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Bad gateway',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'TRANSACTION_VALIDITY',
+        }),
+      );
+    });
+
+    it.each(Object.values(SignatureType))(
+      'should throw if a confirmation contains an invalid %s signature',
+      async (signatureType) => {
+        const chainResponse = chainBuilder().build();
+        const signers = Array.from({ length: 3 }, () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        });
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const safeResponse = safeBuilder()
+          .with('address', safeAddress)
+          .with('nonce', 1)
+          .with(
+            'owners',
+            signers.map((signer) => signer.address),
+          )
+          .build();
+        const getTransaction = async (
+          nonce: number,
+        ): Promise<MultisigTransaction> => {
+          return multisigTransactionBuilder()
+            .with('safe', safeAddress)
+            .with('isExecuted', false)
+            .with('nonce', nonce)
+            .with('dataDecoded', null)
+            .buildWithConfirmations({
+              safe: safeResponse,
+              chainId: chainResponse.chainId,
+              signers: faker.helpers.arrayElements(signers, {
+                min: 1,
+                max: signers.length,
+              }),
+              signatureType,
+            });
+        };
+        const nonce1 = await getTransaction(1);
+        const v = nonce1.confirmations![0].signature?.slice(-2);
+        nonce1.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
+        const nonce2 = await getTransaction(2);
+        const transactions: Array<MultisigTransaction> = [
+          multisigToJson(nonce1) as MultisigTransaction,
+          multisigToJson(nonce2) as MultisigTransaction,
+        ];
+
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+        const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+        const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+        networkService.get.mockImplementation(({ url }) => {
+          if (url === getChainUrl) {
+            return Promise.resolve({
+              data: rawify(chainResponse),
+              status: 200,
+            });
+          }
+          if (url === getMultisigTransactionsUrl) {
+            return Promise.resolve({
+              data: rawify({
+                count: 6,
+                next: null,
+                previous: null,
+                results: transactions,
+              }),
+              status: 200,
+            });
+          }
+          if (url === getSafeUrl) {
+            return Promise.resolve({
+              data: rawify(safeResponse),
+              status: 200,
+            });
+          }
+          return Promise.reject(new Error(`Could not match ${url}`));
+        });
+
+        await request(app.getHttpServer())
+          .get(
+            `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+          )
+          .expect(502)
+          .expect({
+            message: 'Bad gateway',
+            statusCode: 502,
+          });
+
+        expect(loggingService.error).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'TRANSACTION_VALIDITY',
+          }),
+        );
+      },
+    );
+
+    it('should throw and log if a signer is blocked', async () => {
+      const chainResponse = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          blockchain: {
+            ...defaultConfiguration.blockchain,
+            blocklist: [signer.address],
+          },
+        };
+      };
+      await initApp(testConfiguration);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with('owners', [signer.address])
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: [signer],
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      const nonce2 = await getTransaction(2);
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Unauthorized address',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Unauthorized address',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        blockedAddress: signer.address,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if a signer does not match the confirmation owner', async () => {
+      const chainResponse = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with('owners', [signer.address])
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: [signer],
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      nonce1.confirmations![0].owner = getAddress(
+        faker.finance.ethereumAddress(),
+      );
+      const nonce2 = await getTransaction(2);
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Invalid signature',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Recovered address does not match signer',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        signerAddress: nonce1.confirmations![0].owner,
+        signature: nonce1.confirmations![0].signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if a signer is not an owner of the Safe', async () => {
+      const chainResponse = chainBuilder().build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeResponse = safeBuilder()
+        .with('address', safeAddress)
+        .with('nonce', 1)
+        .with('owners', [signer.address])
+        .build();
+      const getTransaction = async (
+        nonce: number,
+      ): Promise<MultisigTransaction> => {
+        return multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('nonce', nonce)
+          .with('dataDecoded', null)
+          .buildWithConfirmations({
+            safe: safeResponse,
+            chainId: chainResponse.chainId,
+            signers: [signer],
+          });
+      };
+      const nonce1 = await getTransaction(1);
+      const nonce2 = await getTransaction(2);
+      const transactions: Array<MultisigTransaction> = [
+        multisigToJson(nonce1) as MultisigTransaction,
+        multisigToJson(nonce2) as MultisigTransaction,
+      ];
+      safeResponse.owners = [getAddress(faker.finance.ethereumAddress())];
+
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === getChainUrl) {
+          return Promise.resolve({
+            data: rawify(chainResponse),
+            status: 200,
+          });
+        }
+        if (url === getMultisigTransactionsUrl) {
+          return Promise.resolve({
+            data: rawify({
+              count: 6,
+              next: null,
+              previous: null,
+              results: transactions,
+            }),
+            status: 200,
+          });
+        }
+        if (url === getSafeUrl) {
+          return Promise.resolve({
+            data: rawify(safeResponse),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainResponse.chainId}/safes/${safeAddress}/transactions/queued`,
+        )
+        .expect(502)
+        .expect({
+          message: 'Invalid signature',
+          statusCode: 502,
+        });
+
+      expect(loggingService.error).toHaveBeenCalledWith({
+        message: 'Recovered address does not match signer',
+        chainId: chainResponse.chainId,
+        safeAddress: safeResponse.address,
+        safeVersion: safeResponse.version,
+        safeTxHash: nonce1.safeTxHash,
+        signerAddress: nonce1.confirmations![0].owner,
+        signature: nonce1.confirmations![0].signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
   });
 });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -801,10 +801,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           .with('refundReceiver', transaction.refundReceiver)
           .with('safeTxHash', transaction.safeTxHash)
           .with('sender', transaction.confirmations![0].owner)
-          .with(
-            'signature',
-            `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
-          )
+          .with('signature', `0x${'-'.repeat(128)}${v}`)
           .build();
         const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
@@ -1171,229 +1168,230 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         source: 'PROPOSAL',
       });
     });
-    
+
     // TODO: Move to TODOs further up
-  it('should allow delegate calls if the contract is included in the list of trusted contracts', async () => {
-    const baseConfiguration = configuration();
-    const testConfiguration = (): typeof baseConfiguration => ({
-      ...baseConfiguration,
-      features: {
-        ...baseConfiguration.features,
-        ethSign: true,
-        trustedDelegateCall: true,
-        trustedForDelegateCallContractsList: true,
-      },
-    });
-    await initApp(testConfiguration);
-
-    const chainId = faker.string.numeric();
-    const safeAddress = getAddress(faker.finance.ethereumAddress());
-    const chain = chainBuilder().with('chainId', chainId).build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder()
-      .with('address', safeAddress)
-      .with('owners', [signer.address])
-      .build();
-    const safeApps = [safeAppBuilder().build()];
-    const transaction = await multisigTransactionBuilder()
-      .with('safe', safeAddress)
-      .with('nonce', safe.nonce)
-      .with('operation', Operation.DELEGATE)
-      .buildWithConfirmations({
-        chainId,
-        safe,
-        signers: [signer],
+    it('should allow delegate calls if the contract is included in the list of trusted contracts', async () => {
+      const baseConfiguration = configuration();
+      const testConfiguration = (): typeof baseConfiguration => ({
+        ...baseConfiguration,
+        features: {
+          ...baseConfiguration.features,
+          ethSign: true,
+          trustedDelegateCall: true,
+          trustedForDelegateCallContractsList: true,
+        },
       });
-    const contractPage = pageBuilder()
-      .with('results', [
-        contractBuilder().with('trustedForDelegateCall', true).build(),
-        contractBuilder()
-          .with('trustedForDelegateCall', true)
-          .with('address', transaction.to) // transaction.to address is a trusted contract
-          .build(),
-        contractBuilder().with('trustedForDelegateCall', true).build(),
-      ])
-      .build();
-    const proposeTransactionDto = proposeTransactionDtoBuilder()
-      .with('to', transaction.to)
-      .with('value', transaction.value)
-      .with('data', transaction.data)
-      .with('nonce', transaction.nonce.toString())
-      .with('operation', transaction.operation)
-      .with('safeTxGas', transaction.safeTxGas!.toString())
-      .with('baseGas', transaction.baseGas!.toString())
-      .with('gasPrice', transaction.gasPrice!)
-      .with('gasToken', transaction.gasToken!)
-      .with('refundReceiver', transaction.refundReceiver)
-      .with('safeTxHash', transaction.safeTxHash)
-      .with('sender', transaction.confirmations![0].owner)
-      .with('signature', transaction.confirmations![0].signature)
-      .build();
-    const transactions = pageBuilder().build();
-    const token = tokenBuilder().build();
-    const gasToken = tokenBuilder().build();
-    networkService.get.mockImplementation(({ url }) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
-      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
-      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-      const getContractsUrl = `${chain.transactionService}/api/v1/contracts/`;
-      const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
-      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
-      switch (url) {
-        case getChainUrl:
-          return Promise.resolve({ data: rawify(chain), status: 200 });
-        case getMultisigTransactionUrl:
-          return Promise.resolve({
-            data: rawify(multisigToJson(transaction)),
-            status: 200,
-          });
-        case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rawify(transactions), status: 200 });
-        case getSafeUrl:
-          return Promise.resolve({ data: rawify(safe), status: 200 });
-        case getSafeAppsUrl:
-          return Promise.resolve({ data: rawify(safeApps), status: 200 });
-        case getContractsUrl:
-          return Promise.resolve({ data: rawify(contractPage), status: 200 });
-        case getTokenUrl:
-          return Promise.resolve({ data: rawify(token), status: 200 });
-        case getGasTokenContractUrl:
-          return Promise.resolve({ data: rawify(gasToken), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-    networkService.post.mockImplementation(({ url }) => {
-      const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
-      switch (url) {
-        case proposeTransactionUrl:
-          return Promise.resolve({ data: rawify({}), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-    await request(app.getHttpServer())
-      .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
-      .send(proposeTransactionDto)
-      .expect(200)
-      .expect(({ body }) =>
-        expect(body).toEqual(
-          expect.objectContaining({
-            txId: `multisig_${safeAddress}_${transaction.safeTxHash}`,
-          }),
-        ),
-      );
-  });
+      await initApp(testConfiguration);
 
-  it('should disallow delegate calls if the contract is not included in the list of trusted contracts', async () => {
-    const baseConfiguration = configuration();
-    const testConfiguration = (): typeof baseConfiguration => ({
-      ...baseConfiguration,
-      features: {
-        ...baseConfiguration.features,
-        ethSign: true,
-        trustedDelegateCall: true,
-        trustedForDelegateCallContractsList: true,
-      },
+      const chainId = faker.string.numeric();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().with('chainId', chainId).build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder()
+        .with('address', safeAddress)
+        .with('owners', [signer.address])
+        .build();
+      const safeApps = [safeAppBuilder().build()];
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.DELEGATE)
+        .buildWithConfirmations({
+          chainId,
+          safe,
+          signers: [signer],
+        });
+      const contractPage = pageBuilder()
+        .with('results', [
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+          contractBuilder()
+            .with('trustedForDelegateCall', true)
+            .with('address', transaction.to) // transaction.to address is a trusted contract
+            .build(),
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+        ])
+        .build();
+      const proposeTransactionDto = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+      const transactions = pageBuilder().build();
+      const token = tokenBuilder().build();
+      const gasToken = tokenBuilder().build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
+        const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
+        const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+        const getContractsUrl = `${chain.transactionService}/api/v1/contracts/`;
+        const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
+        const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({
+              data: rawify(multisigToJson(transaction)),
+              status: 200,
+            });
+          case getMultisigTransactionsUrl:
+            return Promise.resolve({ data: rawify(transactions), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          case getSafeAppsUrl:
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
+          case getContractsUrl:
+            return Promise.resolve({ data: rawify(contractPage), status: 200 });
+          case getTokenUrl:
+            return Promise.resolve({ data: rawify(token), status: 200 });
+          case getGasTokenContractUrl:
+            return Promise.resolve({ data: rawify(gasToken), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+      networkService.post.mockImplementation(({ url }) => {
+        const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+        switch (url) {
+          case proposeTransactionUrl:
+            return Promise.resolve({ data: rawify({}), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+      await request(app.getHttpServer())
+        .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
+        .send(proposeTransactionDto)
+        .expect(200)
+        .expect(({ body }) =>
+          expect(body).toEqual(
+            expect.objectContaining({
+              txId: `multisig_${safeAddress}_${transaction.safeTxHash}`,
+            }),
+          ),
+        );
     });
-    await initApp(testConfiguration);
 
-    const chainId = faker.string.numeric();
-    const safeAddress = getAddress(faker.finance.ethereumAddress());
-    const chain = chainBuilder().with('chainId', chainId).build();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder()
-      .with('address', safeAddress)
-      .with('owners', [signer.address])
-      .build();
-    const safeApps = [safeAppBuilder().build()];
-    const transaction = await multisigTransactionBuilder()
-      .with('safe', safeAddress)
-      .with('nonce', safe.nonce)
-      .with('operation', Operation.DELEGATE)
-      .buildWithConfirmations({
-        chainId,
-        safe,
-        signers: [signer],
+    it('should disallow delegate calls if the contract is not included in the list of trusted contracts', async () => {
+      const baseConfiguration = configuration();
+      const testConfiguration = (): typeof baseConfiguration => ({
+        ...baseConfiguration,
+        features: {
+          ...baseConfiguration.features,
+          ethSign: true,
+          trustedDelegateCall: true,
+          trustedForDelegateCallContractsList: true,
+        },
       });
-    const contractPage = pageBuilder()
-      .with('results', [
-        // transaction.to address is not in the list of trusted contracts
-        contractBuilder().with('trustedForDelegateCall', true).build(),
-        contractBuilder().with('trustedForDelegateCall', true).build(),
-      ])
-      .build();
-    const proposeTransactionDto = proposeTransactionDtoBuilder()
-      .with('to', transaction.to)
-      .with('value', transaction.value)
-      .with('data', transaction.data)
-      .with('nonce', transaction.nonce.toString())
-      .with('operation', transaction.operation)
-      .with('safeTxGas', transaction.safeTxGas!.toString())
-      .with('baseGas', transaction.baseGas!.toString())
-      .with('gasPrice', transaction.gasPrice!)
-      .with('gasToken', transaction.gasToken!)
-      .with('refundReceiver', transaction.refundReceiver)
-      .with('safeTxHash', transaction.safeTxHash)
-      .with('sender', transaction.confirmations![0].owner)
-      .with('signature', transaction.confirmations![0].signature)
-      .build();
-    const transactions = pageBuilder().build();
-    const token = tokenBuilder().build();
-    const gasToken = tokenBuilder().build();
-    networkService.get.mockImplementation(({ url }) => {
-      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-      const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
-      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
-      const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
-      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-      const getContractsUrl = `${chain.transactionService}/api/v1/contracts/`;
-      const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
-      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
-      switch (url) {
-        case getChainUrl:
-          return Promise.resolve({ data: rawify(chain), status: 200 });
-        case getMultisigTransactionUrl:
-          return Promise.resolve({
-            data: rawify(multisigToJson(transaction)),
-            status: 200,
-          });
-        case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: rawify(transactions), status: 200 });
-        case getSafeUrl:
-          return Promise.resolve({ data: rawify(safe), status: 200 });
-        case getSafeAppsUrl:
-          return Promise.resolve({ data: rawify(safeApps), status: 200 });
-        case getContractsUrl:
-          return Promise.resolve({ data: rawify(contractPage), status: 200 });
-        case getTokenUrl:
-          return Promise.resolve({ data: rawify(token), status: 200 });
-        case getGasTokenContractUrl:
-          return Promise.resolve({ data: rawify(gasToken), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-    networkService.post.mockImplementation(({ url }) => {
-      const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
-      switch (url) {
-        case proposeTransactionUrl:
-          return Promise.resolve({ data: rawify({}), status: 200 });
-        default:
-          return Promise.reject(new Error(`Could not match ${url}`));
-      }
-    });
-    await request(app.getHttpServer())
-      .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
-      .send(proposeTransactionDto)
-      .expect(422)
-      .expect({
-        message: 'Delegate call is disabled',
-        statusCode: 422,
+      await initApp(testConfiguration);
+
+      const chainId = faker.string.numeric();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().with('chainId', chainId).build();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder()
+        .with('address', safeAddress)
+        .with('owners', [signer.address])
+        .build();
+      const safeApps = [safeAppBuilder().build()];
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.DELEGATE)
+        .buildWithConfirmations({
+          chainId,
+          safe,
+          signers: [signer],
+        });
+      const contractPage = pageBuilder()
+        .with('results', [
+          // transaction.to address is not in the list of trusted contracts
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+        ])
+        .build();
+      const proposeTransactionDto = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+      const transactions = pageBuilder().build();
+      const token = tokenBuilder().build();
+      const gasToken = tokenBuilder().build();
+      networkService.get.mockImplementation(({ url }) => {
+        const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+        const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
+        const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+        const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
+        const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+        const getContractsUrl = `${chain.transactionService}/api/v1/contracts/`;
+        const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
+        const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+        switch (url) {
+          case getChainUrl:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case getMultisigTransactionUrl:
+            return Promise.resolve({
+              data: rawify(multisigToJson(transaction)),
+              status: 200,
+            });
+          case getMultisigTransactionsUrl:
+            return Promise.resolve({ data: rawify(transactions), status: 200 });
+          case getSafeUrl:
+            return Promise.resolve({ data: rawify(safe), status: 200 });
+          case getSafeAppsUrl:
+            return Promise.resolve({ data: rawify(safeApps), status: 200 });
+          case getContractsUrl:
+            return Promise.resolve({ data: rawify(contractPage), status: 200 });
+          case getTokenUrl:
+            return Promise.resolve({ data: rawify(token), status: 200 });
+          case getGasTokenContractUrl:
+            return Promise.resolve({ data: rawify(gasToken), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
       });
+      networkService.post.mockImplementation(({ url }) => {
+        const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+        switch (url) {
+          case proposeTransactionUrl:
+            return Promise.resolve({ data: rawify({}), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+      await request(app.getHttpServer())
+        .post(`/v1/chains/${chainId}/transactions/${safeAddress}/propose`)
+        .send(proposeTransactionDto)
+        .expect(422)
+        .expect({
+          message: 'Delegate call is disabled',
+          statusCode: 422,
+        });
+    });
   });
 });

--- a/src/routes/transactions/entities/__tests__/propose-transaction.dto.builder.ts
+++ b/src/routes/transactions/entities/__tests__/propose-transaction.dto.builder.ts
@@ -24,7 +24,7 @@ export function proposeTransactionDtoBuilder(): IBuilder<ProposeTransactionDto> 
     .with('sender', getAddress(faker.finance.ethereumAddress()))
     .with(
       'signature',
-      faker.string.hexadecimal({ length: 32 }) as `0x${string}`,
+      faker.string.hexadecimal({ length: 130 }) as `0x${string}`,
     )
     .with('origin', faker.word.sample());
 }

--- a/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
+++ b/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
@@ -92,38 +92,69 @@ describe('ProposeTransactionDtoSchema', () => {
       );
     });
   });
-  ['safeTxHash' as const, 'signature' as const].forEach((field) => {
-    it(`should validate if ${field} is hex`, () => {
-      const proposeTransactionDto = proposeTransactionDtoBuilder()
-        .with(field, faker.string.hexadecimal() as `0x${string}`)
-        .build();
 
-      const result = ProposeTransactionDtoSchema.safeParse(
-        proposeTransactionDto,
-      );
+  it('should validate if safeTxHash is hex', () => {
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with('safeTxHash', faker.string.hexadecimal() as `0x${string}`)
+      .build();
 
-      expect(result.success).toBe(true);
-    });
+    const result = ProposeTransactionDtoSchema.safeParse(proposeTransactionDto);
 
-    it(`should not allow non-hex ${field}`, () => {
-      const proposeTransactionDto = proposeTransactionDtoBuilder()
-        .with(field, faker.string.alphanumeric() as `0x${string}`)
-        .build();
+    expect(result.success).toBe(true);
+  });
 
-      const result = ProposeTransactionDtoSchema.safeParse(
-        proposeTransactionDto,
-      );
+  it('should not allow non-hex safeTxHash', () => {
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with('safeTxHash', faker.string.alphanumeric() as `0x${string}`)
+      .build();
 
-      expect(!result.success && result.error).toStrictEqual(
-        new ZodError([
-          {
-            code: 'custom',
-            message: 'Invalid "0x" notated hex string',
-            path: [field],
-          },
-        ]),
-      );
-    });
+    const result = ProposeTransactionDtoSchema.safeParse(proposeTransactionDto);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'custom',
+          message: 'Invalid "0x" notated hex string',
+          path: ['safeTxHash'],
+        },
+      ]),
+    );
+  });
+
+  it('should validate if signature is hex', () => {
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with(
+        'signature',
+        faker.string.hexadecimal({ length: 130 }) as `0x${string}`,
+      )
+      .build();
+
+    const result = ProposeTransactionDtoSchema.safeParse(proposeTransactionDto);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not allow non-hex signature', () => {
+    const proposeTransactionDto = proposeTransactionDtoBuilder()
+      .with('signature', faker.string.alphanumeric() as `0x${string}`)
+      .build();
+
+    const result = ProposeTransactionDtoSchema.safeParse(proposeTransactionDto);
+
+    expect(!result.success && result.error).toStrictEqual(
+      new ZodError([
+        {
+          code: 'custom',
+          message: 'Invalid "0x" notated hex string',
+          path: ['signature'],
+        },
+        {
+          code: 'custom',
+          message: 'Invalid signature',
+          path: ['signature'],
+        },
+      ]),
+    );
   });
 
   it.each([

--- a/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
-import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
 
 export const AddConfirmationDtoSchema = z
   .object({
-    signature: HexSchema,
+    signature: SignatureSchema,
   })
   .or(
     z.object({
       // Note: mobile proposes signatures under the signedSafeTxHash property
-      signedSafeTxHash: HexSchema,
+      signedSafeTxHash: SignatureSchema,
     }),
   )
   .transform((data) => {

--- a/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
@@ -3,6 +3,7 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { Operation } from '@/domain/safe/entities/operation.entity';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
 
 export const ProposeTransactionDtoSchema = z.object({
   to: AddressSchema,
@@ -17,6 +18,6 @@ export const ProposeTransactionDtoSchema = z.object({
   refundReceiver: AddressSchema.nullish().default(null),
   safeTxHash: HexSchema,
   sender: AddressSchema,
-  signature: HexSchema.nullish().default(null),
+  signature: SignatureSchema.nullish().default(null),
   origin: z.string().nullish().default(null),
 });

--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { HttpStatus } from '@nestjs/common';
+import { get } from 'lodash';
 import { concat, getAddress } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
@@ -10,6 +10,9 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { proposeTransactionDtoBuilder } from '@/routes/transactions/entities/__tests__/propose-transaction.dto.builder';
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
 import { HttpExceptionNoLog } from '@/domain/common/errors/http-exception-no-log.error';
+import { Operation } from '@/domain/safe/entities/operation.entity';
+import configuration from '@/config/entities/__tests__/configuration';
+import { getSignature } from '@/domain/common/utils/__tests__/signatures.builder';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import type { DelegatesV2Repository } from '@/domain/delegate/v2/delegates.v2.repository';
 import type { ILoggingService } from '@/logging/logging.interface';
@@ -30,19 +33,9 @@ const mockLoggingRepository = jest.mocked({
 describe('TransactionVerifierHelper', () => {
   let target: TransactionVerifierHelper;
 
-  function initTarget(args: {
-    ethSign: boolean;
-    blocklist: Array<`0x${string}`>;
-  }): void {
+  function initTarget(config: typeof configuration): void {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
-      if (key === 'blockchain.blocklist') return args.blocklist;
-      return [
-        'features.hashVerification.api',
-        'features.signatureVerification.api',
-        'features.hashVerification.proposal',
-        'features.signatureVerification.proposal',
-        args.ethSign ? 'features.ethSign' : null,
-      ].includes(key);
+      return get(config(), key);
     });
 
     target = new TransactionVerifierHelper(
@@ -55,12 +48,13 @@ describe('TransactionVerifierHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    initTarget({ ethSign: true, blocklist: [] });
+    initTarget(configuration);
   });
 
   describe('verifyApiTransaction', () => {
-    describe('safeTxHash verification', () => {
-      it('should validate a valid safeTxHash', async () => {
+    it.each(Object.values(SignatureType))(
+      'should allow a transaction with %s signature',
+      async (signatureType) => {
         const chainId = faker.string.numeric();
         const signers = Array.from(
           { length: faker.number.int({ min: 1, max: 5 }) },
@@ -86,551 +80,7 @@ describe('TransactionVerifierHelper', () => {
               max: signers.length,
             }),
             safe,
-          });
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should not validate historical transactions', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', true)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        // @ts-expect-error - data is hex
-        transaction.data = faker.number.int();
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should not validate queued transactions with a nonce lower than the Safe', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const nonce = faker.number.int({ min: 1, max: 5 });
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .with('nonce', nonce)
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', true)
-          .with('nonce', nonce - 1)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        // @ts-expect-error - data is hex
-        transaction.data = faker.number.int();
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should throw if safeTxHash could not be calculated', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        // @ts-expect-error - data is hex
-        transaction.data = faker.number.int();
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Could not calculate safeTxHash',
-            HttpStatus.BAD_GATEWAY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Could not calculate safeTxHash',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          transaction: {
-            to: transaction.to,
-            value: transaction.value,
-            data: transaction.data,
-            operation: transaction.operation,
-            safeTxGas: transaction.safeTxGas,
-            baseGas: transaction.baseGas,
-            gasPrice: transaction.gasPrice,
-            gasToken: transaction.gasToken,
-            refundReceiver: transaction.refundReceiver,
-            nonce: transaction.nonce,
-          },
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
-        });
-      });
-
-      it('should throw if safeTxHash is invalid', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        transaction.data = faker.string.hexadecimal({
-          length: 64,
-        }) as `0x${string}`;
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog('Invalid safeTxHash', HttpStatus.BAD_GATEWAY),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenCalledWith({
-          message: 'safeTxHash does not match',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          transaction: {
-            to: transaction.to,
-            value: transaction.value,
-            data: transaction.data,
-            operation: transaction.operation,
-            safeTxGas: transaction.safeTxGas,
-            baseGas: transaction.baseGas,
-            gasPrice: transaction.gasPrice,
-            gasToken: transaction.gasToken,
-            refundReceiver: transaction.refundReceiver,
-            nonce: transaction.nonce,
-          },
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
-        });
-      });
-    });
-
-    describe('signature verification', () => {
-      it('should validate a confirmation', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [signer],
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should validate multiple confirmations', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 2, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 2,
-              max: signers.length,
-            }),
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should not validate confirmations if there are none', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [],
-            safe,
-          });
-        transaction.confirmations = null;
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should not validate confirmations if they are empty', async () => {
-        const chainId = faker.string.numeric();
-        const safe = safeBuilder().build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [],
-            safe,
-          });
-        transaction.confirmations = [];
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should not validate historical transactions', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', true)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            // Duplicate owners
-            signers: [signer, signer],
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should not validate queued transactions with a nonce lower than the Safe', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const nonce = faker.number.int({ min: 1, max: 5 });
-        const safe = safeBuilder()
-          .with('owners', [signer.address])
-          .with('nonce', nonce)
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', true)
-          .with('nonce', nonce - 1)
-          .buildWithConfirmations({
-            chainId,
-            // Duplicate owners
-            signers: [signer, signer],
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).not.toThrow();
-      });
-
-      it('should throw if there are duplicate owners in confirmations', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [signer, signer],
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Duplicate owners in confirmations',
-            HttpStatus.BAD_GATEWAY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Duplicate owners in confirmations',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          confirmations: transaction.confirmations,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
-        });
-      });
-
-      it('should throw if there are duplicate signatures in confirmations', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from({ length: 2 }, () => {
-          const privateKey = generatePrivateKey();
-          return privateKeyToAccount(privateKey);
-        });
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((signer) => signer.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers,
-            safe,
-          });
-        transaction.confirmations![1].signature =
-          transaction.confirmations![0].signature;
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Duplicate signatures in confirmations',
-            HttpStatus.BAD_GATEWAY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Duplicate signatures in confirmations',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          confirmations: transaction.confirmations,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
-        });
-      });
-
-      it.each(Object.values(SignatureType))(
-        'should throw if an address cannot be recovered from an %s signature',
-        async (signatureType) => {
-          const chainId = faker.string.numeric();
-          const privateKey = generatePrivateKey();
-          const signer = privateKeyToAccount(privateKey);
-          const safe = safeBuilder().with('owners', [signer.address]).build();
-          const transaction = await multisigTransactionBuilder()
-            .with('safe', safe.address)
-            .with('isExecuted', false)
-            .with('nonce', safe.nonce)
-            .buildWithConfirmations({
-              chainId,
-              signers: [signer],
-              safe,
-              signatureType,
-            });
-          const v = transaction.confirmations![0].signature?.slice(-2);
-          transaction.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
-          expect(() => {
-            return target.verifyApiTransaction({ chainId, safe, transaction });
-          }).toThrow(
-            new HttpExceptionNoLog(
-              'Could not recover address',
-              HttpStatus.BAD_GATEWAY,
-            ),
-          );
-        },
-      );
-
-      it('should throw if the signature does not match the confirmation owner', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [signer],
-            safe,
-          });
-        transaction.confirmations![0].owner = getAddress(
-          faker.finance.ethereumAddress(),
-        );
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog('Invalid signature', HttpStatus.BAD_GATEWAY),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Recovered address does not match signer',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          signerAddress: transaction.confirmations![0].owner,
-          signature: transaction.confirmations![0].signature,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
-        });
-      });
-
-      it('should throw if the signature is not of a Safe owner', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [signer],
-            safe,
-          });
-        safe.owners = [getAddress(faker.finance.ethereumAddress())];
-
-        expect(() => {
-          return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog('Invalid signature', HttpStatus.BAD_GATEWAY),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Recovered address does not match signer',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          signerAddress: transaction.confirmations![0].owner,
-          signature: transaction.confirmations![0].signature,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
-        });
-      });
-
-      it('should not block eth_sign', async () => {
-        initTarget({ ethSign: false, blocklist: [] });
-
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('isExecuted', false)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: [signer],
-            safe,
-            signatureType: SignatureType.EthSign,
+            signatureType,
           });
 
         expect(() => {
@@ -638,62 +88,567 @@ describe('TransactionVerifierHelper', () => {
         }).not.toThrow();
 
         expect(mockLoggingRepository.error).not.toHaveBeenCalled();
-      });
+      },
+    );
 
-      it('should block addresses in the blocklist', async () => {
-        const chainId = faker.string.numeric();
-        const blockedPrivateKey = generatePrivateKey();
-        const blockedSigner = privateKeyToAccount(blockedPrivateKey);
-        const legitPrivateKey = generatePrivateKey();
-        const legitSigner = privateKeyToAccount(legitPrivateKey);
-        initTarget({
-          ethSign: true,
-          blocklist: [
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(blockedSigner.address),
-          ],
+    it('should allow a transaction with a mixture of signature type confirmations', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
         });
-        const safe = safeBuilder()
-          .with('owners', [blockedSigner.address, legitSigner.address])
-          .build();
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should not validate executed transactions', async () => {
+      const chainId = faker.string.numeric();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', true)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: [signer],
+          safe,
+        });
+      transaction.confirmations![0].signature = faker.string.hexadecimal({
+        length: 130,
+      }) as `0x${string}`;
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should not validate transactions with a nonce lower than the Safe', async () => {
+      const chainId = faker.string.numeric();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce - 1)
+        .buildWithConfirmations({
+          chainId,
+          signers: [signer],
+          safe,
+        });
+      transaction.confirmations![0].signature = faker.string.hexadecimal({
+        length: 130,
+      }) as `0x${string}`;
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw and log if the safeTxHash could not be calculated', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      // @ts-expect-error - data is hex
+      transaction.data = faker.number.int();
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(new HttpExceptionNoLog('Could not calculate safeTxHash', 502));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Could not calculate safeTxHash',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if the safeTxHash does not match', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      transaction.data = faker.string.hexadecimal({
+        length: 64,
+      }) as `0x${string}`;
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(new HttpExceptionNoLog('Invalid safeTxHash', 502));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'safeTxHash does not match',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should allow a transaction with no confirmations', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      transaction.confirmations = null;
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should allow a transaction with empty confirmations', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      transaction.confirmations = [];
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw and log if confirmations contain duplicate owners', async () => {
+      const chainId = faker.string.numeric();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: [signer, signer],
+          safe,
+        });
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(
+        new HttpExceptionNoLog('Duplicate owners in confirmations', 502),
+      );
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Duplicate owners in confirmations',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        confirmations: transaction.confirmations,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw and log if confirmations contain duplicate signatures', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from({ length: 2 }, () => {
+        const privateKey = generatePrivateKey();
+        return privateKeyToAccount(privateKey);
+      });
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((signer) => signer.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers,
+          safe,
+        });
+      transaction.confirmations![1].signature =
+        transaction.confirmations![0].signature;
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(
+        new HttpExceptionNoLog('Duplicate signatures in confirmations', 502),
+      );
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Duplicate signatures in confirmations',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        confirmations: transaction.confirmations,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw if a signature length is invalid', async () => {
+      const chainId = faker.string.numeric();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: [signer],
+          safe,
+        });
+      transaction.confirmations![0].signature += 'invalid';
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(new Error('Invalid signature length'));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it.each(Object.values(SignatureType))(
+      'should throw if a confirmation contains an invalid %s signature',
+      async (signatureType) => {
+        const chainId = faker.string.numeric();
+        const privateKey = generatePrivateKey();
+        const signer = privateKeyToAccount(privateKey);
+        const safe = safeBuilder().with('owners', [signer.address]).build();
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('isExecuted', false)
-          .with('nonce', faker.number.int({ min: safe.nonce }))
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
-            signers: [blockedSigner, legitSigner],
+            signers: [signer],
             safe,
+            signatureType,
           });
+        const v = transaction.confirmations![0].signature?.slice(-2);
+        transaction.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
 
         expect(() => {
           return target.verifyApiTransaction({ chainId, safe, transaction });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Unauthorized address',
-            HttpStatus.BAD_GATEWAY,
-          ),
-        );
+        }).toThrow(new Error('Could not recover address'));
 
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Unauthorized address',
+        expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should throw and log if a signer is blocked', async () => {
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          blockchain: {
+            ...defaultConfiguration.blockchain,
+            blocklist: [signer.address],
+          },
+        };
+      };
+      initTarget(testConfiguration);
+      const chainId = faker.string.numeric();
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
           chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          blockedAddress: blockedSigner.address,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'API',
+          signers: [signer],
+          safe,
         });
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(new HttpExceptionNoLog('Unauthorized address', 502));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Unauthorized address',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        blockedAddress: signer.address,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
       });
+    });
+
+    it('should throw and log if a signer does not match the confirmation owner', async () => {
+      const chainId = faker.string.numeric();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: [signer],
+          safe,
+        });
+      transaction.confirmations![0].owner = getAddress(
+        faker.finance.ethereumAddress(),
+      );
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).toThrow(new HttpExceptionNoLog('Invalid signature', 502));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Recovered address does not match signer',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        signerAddress: transaction.confirmations![0].owner,
+        signature: transaction.confirmations![0].signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should not block eth_sign', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+          signatureType: SignatureType.EthSign,
+        });
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should not block delegate calls', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.DELEGATE)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+
+      expect(() => {
+        return target.verifyApiTransaction({ chainId, safe, transaction });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
   });
 
   describe('verifyProposal', () => {
-    describe('safeTxHash verification', () => {
-      it('should validate a valid safeTxHash', async () => {
+    it.each(Object.values(SignatureType))(
+      'should allow a transaction with %s signature',
+      async (signatureType) => {
         const chainId = faker.string.numeric();
         const signers = Array.from(
           { length: faker.number.int({ min: 1, max: 5 }) },
@@ -711,6 +666,7 @@ describe('TransactionVerifierHelper', () => {
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
           .with('nonce', safe.nonce)
+          .with('operation', Operation.CALL)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -718,6 +674,7 @@ describe('TransactionVerifierHelper', () => {
               max: signers.length,
             }),
             safe,
+            signatureType,
           });
         const proposal = proposeTransactionDtoBuilder()
           .with('to', transaction.to)
@@ -733,901 +690,77 @@ describe('TransactionVerifierHelper', () => {
           .with('safeTxHash', transaction.safeTxHash)
           .with('sender', transaction.confirmations![0].owner)
           .with('signature', transaction.confirmations![0].signature)
-          .build();
-
-        expect(() => {
-          return target.verifyProposal({ chainId, safe, proposal });
-        }).not.toThrow();
-      });
-
-      it('should throw if the nonce is below that of the Safe', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce - 1)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', transaction.confirmations![0].owner)
-          .with('signature', transaction.confirmations![0].signature)
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Invalid nonce',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-      });
-
-      it('should throw if safeTxHash could not be calculated', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', faker.number.int() as unknown as `0x${string}`)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', transaction.confirmations![0].owner)
-          .with('signature', transaction.confirmations![0].signature)
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Could not calculate safeTxHash',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Could not calculate safeTxHash',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          transaction: {
-            to: transaction.to,
-            value: transaction.value,
-            data: proposal.data,
-            operation: transaction.operation,
-            safeTxGas: transaction.safeTxGas,
-            baseGas: transaction.baseGas,
-            gasPrice: transaction.gasPrice,
-            gasToken: transaction.gasToken,
-            refundReceiver: transaction.refundReceiver,
-            nonce: transaction.nonce,
-          },
-          type: 'TRANSACTION_VALIDITY',
-          source: 'PROPOSAL',
-        });
-      });
-
-      it('should throw if safeTxHash is invalid', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with(
-            'safeTxHash',
-            faker.string.hexadecimal({
-              length: 64,
-            }) as `0x${string}`,
-          )
-          .with('sender', transaction.confirmations![0].owner)
-          .with('signature', transaction.confirmations![0].signature)
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Invalid safeTxHash',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'safeTxHash does not match',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: proposal.safeTxHash,
-          transaction: {
-            to: transaction.to,
-            value: transaction.value,
-            data: transaction.data,
-            operation: transaction.operation,
-            safeTxGas: transaction.safeTxGas,
-            baseGas: transaction.baseGas,
-            gasPrice: transaction.gasPrice,
-            gasToken: transaction.gasToken,
-            refundReceiver: transaction.refundReceiver,
-            nonce: transaction.nonce,
-          },
-          type: 'TRANSACTION_VALIDITY',
-          source: 'PROPOSAL',
-        });
-      });
-    });
-
-    describe('signature verification', () => {
-      it('should validate an owner signature', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const confirmation = faker.helpers.arrayElement(
-          transaction.confirmations,
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', confirmation.owner)
-          .with('signature', confirmation.signature)
           .build();
 
         await expect(
           target.verifyProposal({ chainId, safe, proposal }),
         ).resolves.not.toThrow();
-      });
 
-      it('should throw if the nonce is below that of the Safe', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce - 1)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const confirmation = faker.helpers.arrayElement(
-          transaction.confirmations,
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', confirmation.owner)
-          .with('signature', confirmation.signature)
-          .build();
+        expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+      },
+    );
 
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Invalid nonce',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-      });
-
-      it('should validate a delegate signature', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const confirmation = faker.helpers.arrayElement(
-          transaction.confirmations,
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', confirmation.owner)
-          .with('signature', confirmation.signature)
-          .build();
-        safe.owners = [getAddress(faker.finance.ethereumAddress())];
-        mockDelegatesRepository.getDelegates.mockResolvedValue(
-          pageBuilder<Delegate>()
-            .with('results', [
-              delegateBuilder().with('delegate', confirmation.owner).build(),
-            ])
-            .build(),
-        );
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).resolves.not.toThrow();
-      });
-
-      it('should validate concatenated signatures', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 2, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 2,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length < 2
-        ) {
-          throw new Error('Transaction must have at least 2 confirmations');
-        }
-        const sender = transaction.confirmations[1].owner;
-        const signature = concat(
-          transaction.confirmations.map(({ signature }) => signature!),
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', sender)
-          .with('signature', signature)
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).resolves.not.toThrow();
-      });
-
-      it('should throw if the signature is an invalid length', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const confirmation = faker.helpers.arrayElement(
-          transaction.confirmations,
-        );
-        confirmation.signature = '0xinvalid';
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', confirmation.owner)
-          .with('signature', confirmation.signature)
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(new Error('Invalid signature length'));
-      });
-
-      it.each(Object.values(SignatureType))(
-        'should throw if an an address cannot be recovered from an %s signature',
-        async (signatureType) => {
-          const chainId = faker.string.numeric();
-          const signers = Array.from(
-            { length: faker.number.int({ min: 1, max: 5 }) },
-            () => {
-              const privateKey = generatePrivateKey();
-              return privateKeyToAccount(privateKey);
-            },
-          );
-          const safe = safeBuilder()
-            .with(
-              'owners',
-              signers.map((s) => s.address),
-            )
-            .build();
-          const transaction = await multisigTransactionBuilder()
-            .with('safe', safe.address)
-            .with('nonce', safe.nonce)
-            .buildWithConfirmations({
-              chainId,
-              signers: faker.helpers.arrayElements(signers, {
-                min: 1,
-                max: signers.length,
-              }),
-              safe,
-              signatureType,
-            });
-          if (
-            !transaction.confirmations ||
-            transaction.confirmations.length === 0
-          ) {
-            throw new Error('Transaction must have at least 1 confirmation');
-          }
-          const confirmation = faker.helpers.arrayElement(
-            transaction.confirmations,
-          );
-          const v = confirmation.signature!.slice(-2);
-          confirmation.signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
-          const proposal = proposeTransactionDtoBuilder()
-            .with('to', transaction.to)
-            .with('value', transaction.value)
-            .with('data', transaction.data)
-            .with('nonce', transaction.nonce.toString())
-            .with('operation', transaction.operation)
-            .with('safeTxGas', transaction.safeTxGas!.toString())
-            .with('baseGas', transaction.baseGas!.toString())
-            .with('gasPrice', transaction.gasPrice!)
-            .with('gasToken', transaction.gasToken!)
-            .with('refundReceiver', transaction.refundReceiver)
-            .with('safeTxHash', transaction.safeTxHash)
-            .with('sender', confirmation.owner)
-            .with('signature', confirmation.signature)
-            .build();
-
-          await expect(
-            target.verifyProposal({ chainId, safe, proposal }),
-          ).rejects.toThrow(
-            new HttpExceptionNoLog(
-              'Could not recover address',
-              HttpStatus.UNPROCESSABLE_ENTITY,
-            ),
-          );
-        },
-      );
-
-      it('should throw if the signature does not match the sender', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const confirmation = faker.helpers.arrayElement(
-          transaction.confirmations,
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', getAddress(faker.finance.ethereumAddress()))
-          .with('signature', confirmation.signature)
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Invalid signature',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Recovered address does not match signer',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          signerAddress: proposal.sender,
-          signature: proposal.signature,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'PROPOSAL',
-        });
-      });
-
-      it('should throw it not all individual signatures, after being split, are from owners or delegates', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from({ length: 4 }, () => {
-          const privateKey = generatePrivateKey();
-          return privateKeyToAccount(privateKey);
-        });
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers,
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length < 2
-        ) {
-          throw new Error('Transaction must have at least 2 confirmations');
-        }
-        const sender =
-          transaction.confirmations[transaction.confirmations.length - 1].owner;
-        safe.owners.pop();
-        const signature = concat(
-          transaction.confirmations.map(({ signature }) => signature!),
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', sender)
-          .with('signature', signature)
-          .build();
-        mockDelegatesRepository.getDelegates.mockResolvedValue(
-          pageBuilder<Delegate>().with('results', []).build(),
-        );
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Invalid signature',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Recovered address does not match signer',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          signerAddress: proposal.sender,
-          signature: proposal.signature,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'PROPOSAL',
-        });
-      });
-
-      it('should not throw if the signature is not from an owner or a delegate', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const confirmation = faker.helpers.arrayElement(
-          transaction.confirmations,
-        );
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', confirmation.owner)
-          .with('signature', confirmation.signature)
-          .build();
-        safe.owners = [getAddress(faker.finance.ethereumAddress())];
-        mockDelegatesRepository.getDelegates.mockResolvedValue(
-          pageBuilder<Delegate>().with('results', []).build(),
-        );
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Invalid signature',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Recovered address does not match signer',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          signerAddress: proposal.sender,
-          signature: proposal.signature,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'PROPOSAL',
-        });
-      });
-
-      it('should block addresses in the blocklist', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        signers.push(privateKeyToAccount(generatePrivateKey()));
-        // Last signer is blocked
-        const blockedAddress = getAddress(signers[signers.length - 1].address);
-        initTarget({
-          ethSign: true,
-          blocklist: [
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(faker.finance.ethereumAddress()),
-            blockedAddress,
-            getAddress(faker.finance.ethereumAddress()),
-          ],
-        });
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .buildWithConfirmations({
-            chainId,
-            signers,
-            safe,
-          });
-        if (
-          !transaction.confirmations ||
-          transaction.confirmations.length === 0
-        ) {
-          throw new Error('Transaction must have at least 1 confirmation');
-        }
-        const proposal = proposeTransactionDtoBuilder()
-          .with('to', transaction.to)
-          .with('value', transaction.value)
-          .with('data', transaction.data)
-          .with('nonce', transaction.nonce.toString())
-          .with('operation', transaction.operation)
-          .with('safeTxGas', transaction.safeTxGas!.toString())
-          .with('baseGas', transaction.baseGas!.toString())
-          .with('gasPrice', transaction.gasPrice!)
-          .with('gasToken', transaction.gasToken!)
-          .with('refundReceiver', transaction.refundReceiver)
-          .with('safeTxHash', transaction.safeTxHash)
-          .with('sender', blockedAddress)
-          // Use the last signer's signature
-          .with(
-            'signature',
-            transaction.confirmations[transaction.confirmations.length - 1]
-              .signature,
-          )
-          .build();
-
-        await expect(
-          target.verifyProposal({ chainId, safe, proposal }),
-        ).rejects.toThrow(
-          new HttpExceptionNoLog(
-            'Unauthorized address',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Unauthorized address',
-          chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          blockedAddress: blockedAddress,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'PROPOSAL',
-        });
-      });
-    });
-
-    it('should block eth_sign', async () => {
-      initTarget({ ethSign: false, blocklist: [] });
-
+    it('should allow a transaction with concatenated signatures', async () => {
       const chainId = faker.string.numeric();
       const signers = Array.from(
-        { length: faker.number.int({ min: 1, max: 5 }) },
+        { length: faker.number.int({ min: 2, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 2,
+            max: signers.length,
+          }),
+          safe,
+        });
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with(
+          'signature',
+          concat(
+            transaction.confirmations!.map(
+              (confirmation) => confirmation.signature!,
+            ),
+          ),
+        )
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).resolves.not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should allow a transaction from a delegate', async () => {
+      const chainId = faker.string.numeric();
+      const [delegate, ...signers] = Array.from(
+        { length: faker.number.int({ min: 2, max: 5 }) },
         () => {
           const privateKey = generatePrivateKey();
           return privateKeyToAccount(privateKey);
@@ -1649,17 +782,12 @@ describe('TransactionVerifierHelper', () => {
             max: signers.length,
           }),
           safe,
-          signatureType: SignatureType.EthSign,
         });
-      if (
-        !transaction.confirmations ||
-        transaction.confirmations.length === 0
-      ) {
-        throw new Error('Transaction must have at least 1 confirmation');
-      }
-      const confirmation = faker.helpers.arrayElement(
-        transaction.confirmations,
-      );
+      const signature = await getSignature({
+        signer: delegate,
+        hash: transaction.safeTxHash,
+        signatureType: faker.helpers.enumValue(SignatureType),
+      });
       const proposal = proposeTransactionDtoBuilder()
         .with('to', transaction.to)
         .with('value', transaction.value)
@@ -1672,26 +800,613 @@ describe('TransactionVerifierHelper', () => {
         .with('gasToken', transaction.gasToken!)
         .with('refundReceiver', transaction.refundReceiver)
         .with('safeTxHash', transaction.safeTxHash)
-        .with('sender', confirmation.owner)
-        .with('signature', confirmation.signature)
+        .with('sender', delegate.address)
+        .with('signature', signature)
+        .build();
+      mockDelegatesRepository.getDelegates.mockResolvedValue(
+        pageBuilder<Delegate>()
+          .with('results', [
+            delegateBuilder().with('delegate', delegate.address).build(),
+          ])
+          .build(),
+      );
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw if the nonce is below that of the Safe', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce - 1)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new HttpExceptionNoLog('Invalid nonce', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    // TODO: Add once https://github.com/safe-global/safe-client-gateway/pull/2427 is merged
+    it.todo('should allow trusted delegate calls');
+
+    it.todo('should throw for delegate calls by default');
+
+    it.todo(
+      'should throw for untrusted delegate calls if only trusted delegate calls are enabled',
+    );
+
+    it.todo(
+      'should throw for delegate calls when the contract cannot be found and only trusted delegate calls are enabled',
+    );
+
+    it('should throw and log if the safeTxHash could not be calculated', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      // @ts-expect-error - data is hex
+      transaction.data = faker.number.int();
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
         .build();
 
       await expect(
         target.verifyProposal({ chainId, safe, proposal }),
       ).rejects.toThrow(
-        new HttpExceptionNoLog(
-          'eth_sign is disabled',
-          HttpStatus.UNPROCESSABLE_ENTITY,
-        ),
+        new HttpExceptionNoLog('Could not calculate safeTxHash', 422),
       );
 
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Could not calculate safeTxHash',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'PROPOSAL',
+      });
+    });
+
+    it('should throw and log if the safeTxHash does not match', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      transaction.data = faker.string.hexadecimal({
+        length: 64,
+      }) as `0x${string}`;
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new HttpExceptionNoLog('Invalid safeTxHash', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'safeTxHash does not match',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'PROPOSAL',
+      });
+    });
+
+    it('should throw if the signature length is invalid', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with(
+          'signature',
+          (transaction.confirmations![0].signature +
+            'deadbeef') as `0x${string}`,
+        )
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new Error('Invalid signature length'));
+
       expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it.each(Object.values(SignatureType))(
+      'should throw if a %s signature is invalid',
+      async (signatureType) => {
+        const chainId = faker.string.numeric();
+        const signers = Array.from(
+          { length: faker.number.int({ min: 1, max: 5 }) },
+          () => {
+            const privateKey = generatePrivateKey();
+            return privateKeyToAccount(privateKey);
+          },
+        );
+        const safe = safeBuilder()
+          .with(
+            'owners',
+            signers.map((s) => s.address),
+          )
+          .build();
+        const transaction = await multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('nonce', safe.nonce)
+          .with('operation', Operation.CALL)
+          .buildWithConfirmations({
+            chainId,
+            signers: faker.helpers.arrayElements(signers, {
+              min: 1,
+              max: signers.length,
+            }),
+            safe,
+            signatureType,
+          });
+        const v = transaction.confirmations![0].signature?.slice(-2);
+        const proposal = proposeTransactionDtoBuilder()
+          .with('to', transaction.to)
+          .with('value', transaction.value)
+          .with('data', transaction.data)
+          .with('nonce', transaction.nonce.toString())
+          .with('operation', transaction.operation)
+          .with('safeTxGas', transaction.safeTxGas!.toString())
+          .with('baseGas', transaction.baseGas!.toString())
+          .with('gasPrice', transaction.gasPrice!)
+          .with('gasToken', transaction.gasToken!)
+          .with('refundReceiver', transaction.refundReceiver)
+          .with('safeTxHash', transaction.safeTxHash)
+          .with('sender', transaction.confirmations![0].owner)
+          .with(
+            'signature',
+            `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
+          )
+          .build();
+
+        await expect(
+          target.verifyProposal({ chainId, safe, proposal }),
+        ).rejects.toThrow(new Error('Could not recover address'));
+
+        expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should throw and log if a signer is blocked', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 2, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          blockchain: {
+            ...defaultConfiguration.blockchain,
+            blocklist: [signers[0].address],
+          },
+        };
+      };
+      initTarget(testConfiguration);
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers,
+          safe,
+        });
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new HttpExceptionNoLog('Unauthorized address', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Unauthorized address',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        blockedAddress: signers[0].address,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'PROPOSAL',
+      });
+    });
+
+    it('should throw if eth_sign is disabled', async () => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          features: {
+            ...defaultConfiguration.features,
+            ethSign: false,
+          },
+        };
+      };
+      initTarget(testConfiguration);
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+          signatureType: SignatureType.EthSign,
+        });
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new HttpExceptionNoLog('eth_sign is disabled', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw and log if the signer is not the sender', async () => {
+      const chainId = faker.string.numeric();
+      const [sender, ...signers] = Array.from(
+        { length: faker.number.int({ min: 2, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+          signatureType: SignatureType.EthSign,
+        });
+      const signature = await getSignature({
+        signer: sender,
+        hash: transaction.safeTxHash,
+        signatureType: faker.helpers.enumValue(SignatureType),
+      });
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', getAddress(faker.finance.ethereumAddress()))
+        .with('signature', signature)
+        .build();
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new HttpExceptionNoLog('Invalid signature', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Recovered address does not match signer',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        signerAddress: proposal.sender,
+        signature: proposal.signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'PROPOSAL',
+      });
+    });
+
+    it('should throw and log if the signers are not all owners or delegates', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.CALL)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      safe.owners = [getAddress(faker.finance.ethereumAddress())];
+      const proposal = proposeTransactionDtoBuilder()
+        .with('to', transaction.to)
+        .with('value', transaction.value)
+        .with('data', transaction.data)
+        .with('nonce', transaction.nonce.toString())
+        .with('operation', transaction.operation)
+        .with('safeTxGas', transaction.safeTxGas!.toString())
+        .with('baseGas', transaction.baseGas!.toString())
+        .with('gasPrice', transaction.gasPrice!)
+        .with('gasToken', transaction.gasToken!)
+        .with('refundReceiver', transaction.refundReceiver)
+        .with('safeTxHash', transaction.safeTxHash)
+        .with('sender', transaction.confirmations![0].owner)
+        .with('signature', transaction.confirmations![0].signature)
+        .build();
+      mockDelegatesRepository.getDelegates.mockResolvedValue(
+        pageBuilder<Delegate>().with('results', []).build(),
+      );
+
+      await expect(
+        target.verifyProposal({ chainId, safe, proposal }),
+      ).rejects.toThrow(new HttpExceptionNoLog('Invalid signature', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Recovered address does not match signer',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        signerAddress: proposal.sender,
+        signature: proposal.signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'PROPOSAL',
+      });
     });
   });
 
   describe('verifyConfirmation', () => {
-    describe('safeTxHash verification', () => {
-      it('should validate a valid safeTxHash', async () => {
+    it.each(Object.values(SignatureType))(
+      'should allow a transaction with %s signature',
+      async (signatureType) => {
         const chainId = faker.string.numeric();
         const signers = Array.from(
           { length: faker.number.int({ min: 1, max: 5 }) },
@@ -1708,8 +1423,8 @@ describe('TransactionVerifierHelper', () => {
           .build();
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
-          .with('nonce', safe.nonce)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -1717,6 +1432,7 @@ describe('TransactionVerifierHelper', () => {
               max: signers.length,
             }),
             safe,
+            signatureType,
           });
 
         expect(() => {
@@ -1724,456 +1440,347 @@ describe('TransactionVerifierHelper', () => {
             chainId,
             safe,
             transaction,
-            signature: transaction.confirmations![0].signature!,
+            signature: faker.helpers.arrayElement(
+              transaction.confirmations!.map((confirmation) => {
+                return confirmation.signature!;
+              }),
+            ),
           });
         }).not.toThrow();
-      });
 
-      it('should throw for historical transactions', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', true)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
+        expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+      },
+    );
 
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Invalid nonce',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-      });
-
-      it('should throw if the nonce is below that of the Safe', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce - 1)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Invalid nonce',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-      });
-
-      it('should throw if safeTxHash could not be calculated', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        // @ts-expect-error - data is hex
-        transaction.data = faker.number.int();
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Could not calculate safeTxHash',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Could not calculate safeTxHash',
+    it('should throw for executed transactions', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', true)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
           chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          transaction: {
-            to: transaction.to,
-            value: transaction.value,
-            data: transaction.data,
-            operation: transaction.operation,
-            safeTxGas: transaction.safeTxGas,
-            baseGas: transaction.baseGas,
-            gasPrice: transaction.gasPrice,
-            gasToken: transaction.gasToken,
-            refundReceiver: transaction.refundReceiver,
-            nonce: transaction.nonce,
-          },
-          type: 'TRANSACTION_VALIDITY',
-          source: 'CONFIRMATION',
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
         });
-      });
 
-      it('should throw if safeTxHash is invalid', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-        transaction.data = faker.string.hexadecimal({
-          length: 64,
-        }) as `0x${string}`;
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Invalid safeTxHash',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenCalledWith({
-          message: 'safeTxHash does not match',
+      expect(() => {
+        return target.verifyConfirmation({
           chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          transaction: {
-            to: transaction.to,
-            value: transaction.value,
-            data: transaction.data,
-            operation: transaction.operation,
-            safeTxGas: transaction.safeTxGas,
-            baseGas: transaction.baseGas,
-            gasPrice: transaction.gasPrice,
-            gasToken: transaction.gasToken,
-            refundReceiver: transaction.refundReceiver,
-            nonce: transaction.nonce,
-          },
-          type: 'TRANSACTION_VALIDITY',
-          source: 'CONFIRMATION',
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
         });
+      }).toThrow(new HttpExceptionNoLog('Invalid nonce', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw if the nonce is below that of the Safe', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce - 1)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).toThrow(new HttpExceptionNoLog('Invalid nonce', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    // Note: we do not need to cover all test cases here as it internally calls verifyApiTransaction, tested above
+    it('should throw if the API transaction is invalid', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      // Confirmation duplication is only checked in verifyApiTransaction
+      transaction.confirmations?.push(transaction.confirmations[0]);
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).toThrow(
+        new HttpExceptionNoLog('Duplicate owners in confirmations', 502),
+      );
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Duplicate owners in confirmations',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        confirmations: transaction.confirmations,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
       });
     });
 
-    describe('signature verification', () => {
-      it('should validate a signature', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).not.toThrow();
-      });
-
-      it('should throw for historical transactions', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', true)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Invalid nonce',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-      });
-
-      it('should throw if the nonce is below that of the Safe', async () => {
-        const chainId = faker.string.numeric();
-        const signers = Array.from(
-          { length: faker.number.int({ min: 1, max: 5 }) },
-          () => {
-            const privateKey = generatePrivateKey();
-            return privateKeyToAccount(privateKey);
-          },
-        );
-        const safe = safeBuilder()
-          .with(
-            'owners',
-            signers.map((s) => s.address),
-          )
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce - 1)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: faker.helpers.arrayElements(signers, {
-              min: 1,
-              max: signers.length,
-            }),
-            safe,
-          });
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Invalid nonce',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-      });
-
-      it.each(Object.values(SignatureType))(
-        'should throw if an an address cannot be recovered from an %s signature',
-        async (signatureType) => {
-          const chainId = faker.string.numeric();
-          const signers = Array.from(
-            { length: faker.number.int({ min: 1, max: 5 }) },
-            () => {
-              const privateKey = generatePrivateKey();
-              return privateKeyToAccount(privateKey);
-            },
-          );
-          const safe = safeBuilder()
-            .with(
-              'owners',
-              signers.map((s) => s.address),
-            )
-            .build();
-          const transaction = await multisigTransactionBuilder()
-            .with('safe', safe.address)
-            .with('nonce', safe.nonce)
-            .with('isExecuted', false)
-            .buildWithConfirmations({
-              chainId,
-              signers: faker.helpers.arrayElements(signers, {
-                min: 1,
-                max: signers.length,
-              }),
-              safe,
-              signatureType,
-            });
-          const v = transaction.confirmations![0].signature!.slice(-2);
-          transaction.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
-
-          expect(() => {
-            return target.verifyConfirmation({
-              chainId,
-              safe,
-              transaction,
-              signature: transaction.confirmations![0].signature!,
-            });
-          }).toThrow(
-            new HttpExceptionNoLog(
-              'Could not recover address',
-              HttpStatus.UNPROCESSABLE_ENTITY,
-            ),
-          );
+    it('should throw and log if the safeTxHash could not be calculated', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
         },
       );
-
-      it('should throw if the signature is not from an owner', async () => {
-        const chainId = faker.string.numeric();
-        const privateKey = generatePrivateKey();
-        const signer = privateKeyToAccount(privateKey);
-        const safe = safeBuilder().with('owners', [signer.address]).build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: [signer],
-            safe,
-          });
-        safe.owners = [getAddress(faker.finance.ethereumAddress())];
-
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Invalid signature',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
-
-        expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
-        expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-          message: 'Recovered address does not match signer',
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
           chainId,
-          safeAddress: safe.address,
-          safeVersion: safe.version,
-          safeTxHash: transaction.safeTxHash,
-          signerAddress: signer.address,
-          signature: transaction.confirmations![0].signature!,
-          type: 'TRANSACTION_VALIDITY',
-          source: 'CONFIRMATION',
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
         });
+      // @ts-expect-error - data is hex
+      transaction.data = faker.number.int();
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).toThrow(new HttpExceptionNoLog('Could not calculate safeTxHash', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Could not calculate safeTxHash',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
       });
+    });
 
-      it('should block eth_sign', async () => {
-        initTarget({ ethSign: false, blocklist: [] });
+    it('should throw and log if the safeTxHash does not match', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+      transaction.data = faker.string.hexadecimal({
+        length: 64,
+      }) as `0x${string}`;
 
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).toThrow(new HttpExceptionNoLog('Invalid safeTxHash', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'safeTxHash does not match',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        transaction: {
+          to: transaction.to,
+          value: transaction.value,
+          data: transaction.data,
+          operation: transaction.operation,
+          safeTxGas: transaction.safeTxGas,
+          baseGas: transaction.baseGas,
+          gasPrice: transaction.gasPrice,
+          gasToken: transaction.gasToken,
+          refundReceiver: transaction.refundReceiver,
+          nonce: transaction.nonce,
+        },
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should throw if the signature length is invalid', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return (confirmation.signature! + 'deadbeef') as `0x${string}`;
+            }),
+          ),
+        });
+      }).toThrow(new Error('Invalid signature length'));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it.each(Object.values(SignatureType))(
+      'should throw if a %s signature is invalid',
+      async (signatureType) => {
         const chainId = faker.string.numeric();
         const signers = Array.from(
           { length: faker.number.int({ min: 1, max: 5 }) },
@@ -2190,8 +1797,8 @@ describe('TransactionVerifierHelper', () => {
           .build();
         const transaction = await multisigTransactionBuilder()
           .with('safe', safe.address)
-          .with('nonce', safe.nonce)
           .with('isExecuted', false)
+          .with('nonce', safe.nonce)
           .buildWithConfirmations({
             chainId,
             signers: faker.helpers.arrayElements(signers, {
@@ -2199,68 +1806,227 @@ describe('TransactionVerifierHelper', () => {
               max: signers.length,
             }),
             safe,
-            signatureType: SignatureType.EthSign,
+            signatureType,
           });
+        const v = transaction.confirmations![0].signature?.slice(-2);
 
         expect(() => {
           return target.verifyConfirmation({
             chainId,
             safe,
             transaction,
-            signature: transaction.confirmations![0].signature!,
+            signature: `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
           });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'eth_sign is disabled',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          ),
-        );
+        }).toThrow(new Error('Could not recover address'));
 
         expect(mockLoggingRepository.error).not.toHaveBeenCalled();
-      });
+      },
+    );
 
-      it('should block addresses in the blocklist', async () => {
-        const chainId = faker.string.numeric();
-        const blockedPrivateKey = generatePrivateKey();
-        const blockedSigner = privateKeyToAccount(blockedPrivateKey);
-        const legitPrivateKey = generatePrivateKey();
-        const legitSigner = privateKeyToAccount(legitPrivateKey);
-        initTarget({
-          ethSign: true,
-          blocklist: [
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(faker.finance.ethereumAddress()),
-            getAddress(blockedSigner.address),
-          ],
+    it('should throw and log if a signer is blocked', async () => {
+      const [blockedSigner, ...otherSigners] = Array.from(
+        { length: faker.number.int({ min: 2, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          blockchain: {
+            ...defaultConfiguration.blockchain,
+            blocklist: [blockedSigner.address],
+          },
+        };
+      };
+      initTarget(testConfiguration);
+      const chainId = faker.string.numeric();
+      const safe = safeBuilder()
+        .with('owners', [
+          blockedSigner.address,
+          ...otherSigners.map((signer) => signer.address),
+        ])
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: [blockedSigner, ...otherSigners],
+          safe,
         });
-        const safe = safeBuilder()
-          .with('owners', [blockedSigner.address, legitSigner.address])
+      // We need to remove the blocked signer from the signers array
+      // so as to not be verified as an API signature
+      const blockedConfirmation = transaction.confirmations![0];
+      transaction.confirmations?.shift();
 
-          .build();
-        const transaction = await multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('nonce', safe.nonce)
-          .with('isExecuted', false)
-          .buildWithConfirmations({
-            chainId,
-            signers: [blockedSigner, legitSigner],
-            safe,
-          });
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: blockedConfirmation.signature!,
+        });
+      }).toThrow(new HttpExceptionNoLog('Unauthorized address', 422));
 
-        expect(() => {
-          return target.verifyConfirmation({
-            chainId,
-            safe,
-            transaction,
-            signature: transaction.confirmations![0].signature!,
-          });
-        }).toThrow(
-          new HttpExceptionNoLog(
-            'Unauthorized address',
-            HttpStatus.BAD_GATEWAY,
-          ),
-        );
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Unauthorized address',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        blockedAddress: blockedSigner.address,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'CONFIRMATION',
       });
+    });
+
+    it('should throw if eth_sign is disabled', async () => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): ReturnType<typeof configuration> => {
+        return {
+          ...defaultConfiguration,
+          features: {
+            ...defaultConfiguration.features,
+            ethSign: false,
+          },
+        };
+      };
+      initTarget(testConfiguration);
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+          signatureType: SignatureType.EthSign,
+        });
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).toThrow(new HttpExceptionNoLog('eth_sign is disabled', 422));
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw and log if the signer is not an owner', async () => {
+      const chainId = faker.string.numeric();
+      const privateKey = generatePrivateKey();
+      const signer = privateKeyToAccount(privateKey);
+      const safe = safeBuilder().with('owners', [signer.address]).build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .buildWithConfirmations({
+          chainId,
+          signers: [signer],
+          safe,
+        });
+      safe.owners = [getAddress(faker.finance.ethereumAddress())];
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).toThrow(new HttpExceptionNoLog('Invalid signature', 422));
+
+      expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
+        message: 'Recovered address does not match signer',
+        chainId,
+        safeAddress: safe.address,
+        safeVersion: safe.version,
+        safeTxHash: transaction.safeTxHash,
+        signerAddress: transaction.confirmations![0].owner,
+        signature: transaction.confirmations![0].signature,
+        type: 'TRANSACTION_VALIDITY',
+        source: 'API',
+      });
+    });
+
+    it('should not block delegate calls', async () => {
+      const chainId = faker.string.numeric();
+      const signers = Array.from(
+        { length: faker.number.int({ min: 1, max: 5 }) },
+        () => {
+          const privateKey = generatePrivateKey();
+          return privateKeyToAccount(privateKey);
+        },
+      );
+      const safe = safeBuilder()
+        .with(
+          'owners',
+          signers.map((s) => s.address),
+        )
+        .build();
+      const transaction = await multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('isExecuted', false)
+        .with('nonce', safe.nonce)
+        .with('operation', Operation.DELEGATE)
+        .buildWithConfirmations({
+          chainId,
+          signers: faker.helpers.arrayElements(signers, {
+            min: 1,
+            max: signers.length,
+          }),
+          safe,
+        });
+
+      expect(() => {
+        return target.verifyConfirmation({
+          chainId,
+          safe,
+          transaction,
+          signature: faker.helpers.arrayElement(
+            transaction.confirmations!.map((confirmation) => {
+              return confirmation.signature!;
+            }),
+          ),
+        });
+      }).not.toThrow();
+
+      expect(mockLoggingRepository.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -483,7 +483,7 @@ describe('TransactionVerifierHelper', () => {
             signatureType,
           });
         const v = transaction.confirmations![0].signature?.slice(-2);
-        transaction.confirmations![0].signature = `0x--------------------------------------------------------------------------------------------------------------------------------${v}`;
+        transaction.confirmations![0].signature = `0x${'-'.repeat(128)}${v}`;
 
         expect(() => {
           return target.verifyApiTransaction({ chainId, safe, transaction });
@@ -1126,10 +1126,7 @@ describe('TransactionVerifierHelper', () => {
           .with('refundReceiver', transaction.refundReceiver)
           .with('safeTxHash', transaction.safeTxHash)
           .with('sender', transaction.confirmations![0].owner)
-          .with(
-            'signature',
-            `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
-          )
+          .with('signature', `0x${'-'.repeat(128)}${v}`)
           .build();
 
         await expect(
@@ -1815,7 +1812,7 @@ describe('TransactionVerifierHelper', () => {
             chainId,
             safe,
             transaction,
-            signature: `0x--------------------------------------------------------------------------------------------------------------------------------${v}`,
+            signature: `0x${'-'.repeat(128)}${v}`,
           });
         }).toThrow(new Error('Could not recover address'));
 

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -15,6 +15,7 @@ import { LogType } from '@/domain/common/entities/log-type.entity';
 import { SafeSignature } from '@/domain/common/entities/safe-signature';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 import { LogSource } from '@/domain/common/entities/log-source.entity';
+import { isAddressEqual } from 'viem';
 
 enum ErrorMessage {
   MalformedHash = 'Could not calculate safeTxHash',
@@ -278,7 +279,9 @@ export class TransactionVerifierHelper {
         signature: confirmation.signature,
       });
 
-      const isBlocked = this.blocklist.includes(signature.owner);
+      const isBlocked = this.blocklist.some((blockedAddress) => {
+        return isAddressEqual(blockedAddress, signature.owner);
+      });
       if (isBlocked) {
         this.logBlockedAddress({
           ...args,
@@ -289,10 +292,13 @@ export class TransactionVerifierHelper {
         throw new HttpExceptionNoLog(ErrorMessage.BlockedAddress, args.code);
       }
 
+      const isOwner = args.safe.owners.some((owner) => {
+        return isAddressEqual(owner, signature.owner);
+      });
       if (
-        signature.owner !== confirmation.owner ||
         // We can be certain of no ownership changes as we only verify the queue
-        !args.safe.owners.includes(signature.owner)
+        !isOwner ||
+        !isAddressEqual(signature.owner, confirmation.owner)
       ) {
         this.logInvalidSignature({
           ...args,
@@ -325,7 +331,10 @@ export class TransactionVerifierHelper {
         signature: `0x${args.proposal.signature.slice(i, i + 130)}`,
       });
 
-      if (this.blocklist.includes(signature.owner)) {
+      const isBlocked = this.blocklist.some((blockedAddress) => {
+        return isAddressEqual(blockedAddress, signature.owner);
+      });
+      if (isBlocked) {
         this.logBlockedAddress({
           ...args,
           safeTxHash: args.proposal.safeTxHash,
@@ -346,7 +355,7 @@ export class TransactionVerifierHelper {
     }
 
     const isSender = signatures.some((signature) => {
-      return signature.owner === args.proposal.sender;
+      return isAddressEqual(signature.owner, args.proposal.sender);
     });
     if (!isSender) {
       this.logInvalidSignature({
@@ -360,7 +369,9 @@ export class TransactionVerifierHelper {
     }
 
     const areOwners = signatures.every((signature) => {
-      return args.safe.owners.includes(signature.owner);
+      return args.safe.owners.some((owner) => {
+        return isAddressEqual(owner, signature.owner);
+      });
     });
     if (areOwners) {
       return;
@@ -371,7 +382,7 @@ export class TransactionVerifierHelper {
       safeAddress: args.safe.address,
     });
     const isDelegate = delegates.results.some(({ delegate }) => {
-      return delegate === args.proposal.sender;
+      return isAddressEqual(delegate, args.proposal.sender);
     });
     if (isDelegate) {
       return;
@@ -399,7 +410,10 @@ export class TransactionVerifierHelper {
       hash: args.transaction.safeTxHash,
     });
 
-    if (this.blocklist.includes(signature.owner)) {
+    const isBlocked = this.blocklist.some((blockedAddress) => {
+      return isAddressEqual(blockedAddress, signature.owner);
+    });
+    if (isBlocked) {
       this.logBlockedAddress({
         ...args,
         safeTxHash: args.transaction.safeTxHash,
@@ -416,7 +430,10 @@ export class TransactionVerifierHelper {
       throw new HttpExceptionNoLog(ErrorMessage.EthSignDisabled, args.code);
     }
 
-    if (!args.safe.owners.includes(signature.owner)) {
+    const isOwner = args.safe.owners.some((owner) => {
+      return isAddressEqual(owner, signature.owner);
+    });
+    if (!isOwner) {
       this.logInvalidSignature({
         ...args,
         safeTxHash: args.transaction.safeTxHash,

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -119,6 +119,9 @@ export class TransactionVerifierHelper {
     ) {
       throw new HttpExceptionNoLog(ErrorMessage.InvalidNonce, code);
     }
+
+    this.verifyApiTransaction(args);
+
     if (this.isProposalHashVerificationEnabled) {
       this.verifyConfirmSafeTxHash({ ...args, code });
     }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -18,7 +18,6 @@ import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transac
 import type { DelegatesV2Repository } from '@/domain/delegate/v2/delegates.v2.repository';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import type { ILoggingService } from '@/logging/logging.interface';
-import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -208,33 +207,5 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
       detailedExecutionInfo: multisigExecutionDetails,
       safeAppInfo,
     });
-  });
-
-  it('should not block eth_sign', async () => {
-    initTarget({ ethSign: false, blocklist: [] });
-
-    const chainId = faker.string.numeric();
-    const privateKey = generatePrivateKey();
-    const signer = privateKeyToAccount(privateKey);
-    const safe = safeBuilder().with('owners', [signer.address]).build();
-    const transaction = await multisigTransactionBuilder()
-      .with('safe', safe.address)
-      .with('isExecuted', false)
-      .with('nonce', safe.nonce)
-      .buildWithConfirmations({
-        chainId,
-        safe,
-        signers: [signer],
-        signatureType: SignatureType.EthSign,
-      });
-
-    await expect(
-      mapper.mapDetails(chainId, transaction, safe),
-    ).resolves.toEqual(
-      expect.objectContaining({
-        safeAddress: safe.address,
-        txId: `multisig_${safe.address}_${transaction.safeTxHash}`,
-      }),
-    );
   });
 });

--- a/src/validation/entities/schemas/__tests__/signature.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/signature.schema.spec.ts
@@ -1,0 +1,59 @@
+import { faker } from '@faker-js/faker';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
+
+describe('SignatureSchema', () => {
+  it('should validate a signature', () => {
+    const signature = faker.string.hexadecimal({
+      length: 130,
+    }) as `0x${string}`;
+
+    const result = SignatureSchema.safeParse(signature);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a concatenated signature', () => {
+    const signature = faker.string.hexadecimal({
+      length: 130 * faker.number.int({ min: 2, max: 5 }),
+    }) as `0x${string}`;
+
+    const result = SignatureSchema.safeParse(signature);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not validate a non-hex signature', () => {
+    const signature = faker.string.alphanumeric() as `0x${string}`;
+
+    const result = SignatureSchema.safeParse(signature);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: [],
+      },
+      {
+        code: 'custom',
+        message: 'Invalid signature',
+        path: [],
+      },
+    ]);
+  });
+
+  it('should not validate a incorrect length signature', () => {
+    const signature = faker.string.hexadecimal({
+      length: 129,
+    }) as `0x${string}`;
+
+    const result = SignatureSchema.safeParse(signature);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid signature',
+        path: [],
+      },
+    ]);
+  });
+});

--- a/src/validation/entities/schemas/signature.schema.ts
+++ b/src/validation/entities/schemas/signature.schema.ts
@@ -1,0 +1,10 @@
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+
+function isSignature(value: `0x${string}`): boolean {
+  // We accept proposals of singular or concatenated signatures
+  return (value.length - 2) % 130 === 0;
+}
+
+export const SignatureSchema = HexSchema.refine(isSignature, {
+  message: 'Invalid signature',
+});


### PR DESCRIPTION
## Summary

This adds extensive test coverage to refinement of proposal/confirmation and API transactions/messages. It also includes small fixes that we found due to adding test coverage.

## Changes

- Increase test coverage of `TransactionVerifier` and `MessageVerifier`
- Propagate similar test coverage to respective controller tests for transactions/messages