### PR TITLE
feat: include source in message verification error logs

### DIFF
--- a/src/domain/messages/helpers/message-verifier.helper.spec.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.spec.ts
@@ -127,6 +127,7 @@ describe('MessageVerifierHelper', () => {
         safeVersion: safe.version,
         safeMessage: message.message,
         type: 'MESSAGE_VALIDITY',
+        source: 'PROPOSAL',
       });
     });
 
@@ -285,6 +286,7 @@ describe('MessageVerifierHelper', () => {
         signature: message.confirmations[0].signature,
         blockedAddress: signer.address,
         type: 'MESSAGE_VALIDITY',
+        source: 'PROPOSAL',
       });
     });
 
@@ -320,6 +322,7 @@ describe('MessageVerifierHelper', () => {
         signerAddress: signer.address,
         signature: message.confirmations[0].signature,
         type: 'MESSAGE_VALIDITY',
+        source: 'PROPOSAL',
       });
     });
   });
@@ -409,6 +412,7 @@ describe('MessageVerifierHelper', () => {
         safeVersion: safe.version,
         safeMessage: message.message,
         type: 'MESSAGE_VALIDITY',
+        source: 'CONFIRMATION',
       });
     });
 
@@ -460,6 +464,7 @@ describe('MessageVerifierHelper', () => {
         messageHash: message.messageHash,
         safeMessage: message.message,
         type: 'MESSAGE_VALIDITY',
+        source: 'CONFIRMATION',
       });
     });
 
@@ -621,6 +626,7 @@ describe('MessageVerifierHelper', () => {
         signature: message.confirmations[0].signature,
         blockedAddress: signer.address,
         type: 'MESSAGE_VALIDITY',
+        source: 'CONFIRMATION',
       });
     });
 
@@ -658,6 +664,7 @@ describe('MessageVerifierHelper', () => {
         signerAddress: signer.address,
         signature: message.confirmations[0].signature,
         type: 'MESSAGE_VALIDITY',
+        source: 'CONFIRMATION',
       });
     });
   });

--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -109,7 +109,6 @@ export class MessageVerifierHelper {
       this.logMismatchMessageHash({
         ...args,
         messageHash: args.expectedHash,
-        source: args.source,
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.HashMismatch,
@@ -159,7 +158,6 @@ export class MessageVerifierHelper {
       this.logBlockedAddress({
         ...args,
         blockedAddress: signature.owner,
-        source: args.source,
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.BlockedAddress,
@@ -184,7 +182,6 @@ export class MessageVerifierHelper {
       this.logInvalidSignature({
         ...args,
         signerAddress: signature.owner,
-        source: args.source,
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.InvalidSignature,

--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -1,4 +1,5 @@
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { LogSource } from '@/domain/common/entities/log-source.entity';
 import { LogType } from '@/domain/common/entities/log-type.entity';
 import { SafeSignature } from '@/domain/common/entities/safe-signature';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
@@ -53,13 +54,17 @@ export class MessageVerifierHelper {
     }
 
     // We can't verify the messageHash as we have no comparison hash
-    const calculatedHash = this.calculateMessageHash(args);
+    const calculatedHash = this.calculateMessageHash({
+      ...args,
+      source: LogSource.Proposal,
+    });
 
     this.verifySignature({
       safe: args.safe,
       chainId: args.chainId,
       messageHash: calculatedHash,
       signature: args.signature,
+      source: LogSource.Proposal,
     });
   }
 
@@ -79,6 +84,7 @@ export class MessageVerifierHelper {
       safe: args.safe,
       message: args.message,
       expectedHash: args.messageHash,
+      source: LogSource.Confirmation,
     });
 
     this.verifySignature({
@@ -86,6 +92,7 @@ export class MessageVerifierHelper {
       chainId: args.chainId,
       messageHash: args.messageHash,
       signature: args.signature,
+      source: LogSource.Confirmation,
     });
   }
 
@@ -94,6 +101,7 @@ export class MessageVerifierHelper {
     safe: Safe;
     expectedHash: `0x${string}`;
     message: string | Record<string, unknown>;
+    source: LogSource;
   }): void {
     const calculatedHash = this.calculateMessageHash(args);
 
@@ -101,6 +109,7 @@ export class MessageVerifierHelper {
       this.logMismatchMessageHash({
         ...args,
         messageHash: args.expectedHash,
+        source: args.source,
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.HashMismatch,
@@ -113,6 +122,7 @@ export class MessageVerifierHelper {
     chainId: string;
     safe: Safe;
     message: Message['message'];
+    source: LogSource;
   }): `0x${string}` {
     let calculatedHash: `0x${string}`;
     try {
@@ -135,6 +145,7 @@ export class MessageVerifierHelper {
     chainId: string;
     messageHash: `0x${string}`;
     signature: `0x${string}`;
+    source: LogSource;
   }): void {
     const signature = new SafeSignature({
       hash: args.messageHash,
@@ -156,6 +167,7 @@ export class MessageVerifierHelper {
       this.logBlockedAddress({
         ...args,
         blockedAddress: signature.owner,
+        source: args.source,
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.BlockedAddress,
@@ -168,6 +180,7 @@ export class MessageVerifierHelper {
       this.logInvalidSignature({
         ...args,
         signerAddress: signature.owner,
+        source: args.source,
       });
       throw new HttpExceptionNoLog(
         ErrorMessage.InvalidSignature,
@@ -180,6 +193,7 @@ export class MessageVerifierHelper {
     chainId: string;
     safe: Safe;
     message: CreateMessageDto['message'];
+    source: LogSource;
   }): void {
     this.loggingService.error({
       message: 'Could not calculate messageHash',
@@ -188,6 +202,7 @@ export class MessageVerifierHelper {
       safeVersion: args.safe.version,
       safeMessage: args.message,
       type: LogType.MessageValidity,
+      source: args.source,
     });
   }
 
@@ -196,6 +211,7 @@ export class MessageVerifierHelper {
     safe: Safe;
     messageHash: `0x${string}`;
     message: CreateMessageDto['message'];
+    source: LogSource;
   }): void {
     this.loggingService.error({
       message: 'messageHash does not match',
@@ -205,6 +221,7 @@ export class MessageVerifierHelper {
       messageHash: args.messageHash,
       safeMessage: args.message,
       type: LogType.MessageValidity,
+      source: args.source,
     });
   }
 
@@ -214,6 +231,7 @@ export class MessageVerifierHelper {
     messageHash: `0x${string}`;
     signature: `0x${string}`;
     blockedAddress: `0x${string}`;
+    source: LogSource;
   }): void {
     this.loggingService.error({
       message: 'Unauthorized address',
@@ -224,6 +242,7 @@ export class MessageVerifierHelper {
       signature: args.signature,
       blockedAddress: args.blockedAddress,
       type: LogType.MessageValidity,
+      source: args.source,
     });
   }
 
@@ -233,6 +252,7 @@ export class MessageVerifierHelper {
     messageHash: `0x${string}`;
     signerAddress: `0x${string}`;
     signature: `0x${string}`;
+    source: LogSource;
   }): void {
     this.loggingService.error({
       message: 'Recovered address does not match signer',
@@ -243,6 +263,7 @@ export class MessageVerifierHelper {
       signerAddress: args.signerAddress,
       signature: args.signature,
       type: LogType.MessageValidity,
+      source: args.source,
     });
   }
 }

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -965,6 +965,7 @@ describe('Messages controller', () => {
           safeVersion: safe.version,
           safeMessage: message.message,
           type: 'MESSAGE_VALIDITY',
+          source: 'PROPOSAL',
         });
       });
 
@@ -1110,6 +1111,7 @@ describe('Messages controller', () => {
           signature: message.confirmations[0].signature,
           blockedAddress: signer.address,
           type: 'MESSAGE_VALIDITY',
+          source: 'PROPOSAL',
         });
       });
 
@@ -1218,6 +1220,7 @@ describe('Messages controller', () => {
           signerAddress: signer.address,
           signature: message.confirmations[0].signature,
           type: 'MESSAGE_VALIDITY',
+          source: 'PROPOSAL',
         });
       });
     });
@@ -1422,6 +1425,7 @@ describe('Messages controller', () => {
           safeVersion: safe.version,
           safeMessage: message.message,
           type: 'MESSAGE_VALIDITY',
+          source: 'CONFIRMATION',
         });
       });
 
@@ -1484,6 +1488,7 @@ describe('Messages controller', () => {
           messageHash: message.messageHash,
           safeMessage: message.message,
           type: 'MESSAGE_VALIDITY',
+          source: 'CONFIRMATION',
         });
       });
 
@@ -1648,6 +1653,7 @@ describe('Messages controller', () => {
           signature: message.confirmations[0].signature,
           blockedAddress: signer.address,
           type: 'MESSAGE_VALIDITY',
+          source: 'CONFIRMATION',
         });
       });
 
@@ -1772,6 +1778,7 @@ describe('Messages controller', () => {
           signerAddress: signer.address,
           signature: message.confirmations[0].signature,
           type: 'MESSAGE_VALIDITY',
+          source: 'CONFIRMATION',
         });
       });
     });


### PR DESCRIPTION
## Summary
This PR adds a new field to the `MESSAGE_VALIDITY` type error logs, depending on the source of the error.

## Changes
- Adds a `source: LogSource` field to `MESSAGE_VALIDITY` logs.
