### PR TITLE
fix: ensure API signatures are even in length

### DIFF
--- a/src/domain/messages/entities/__tests__/message-confirmation.builder.ts
+++ b/src/domain/messages/entities/__tests__/message-confirmation.builder.ts
@@ -12,7 +12,7 @@ export function messageConfirmationBuilder(): IBuilder<MessageConfirmation> {
     .with('owner', getAddress(faker.finance.ethereumAddress()))
     .with(
       'signature',
-      faker.string.hexadecimal({ length: 32 }) as `0x${string}`,
+      faker.string.hexadecimal({ length: 130 }) as `0x${string}`,
     )
     .with('signatureType', faker.helpers.objectValue(SignatureType));
 }

--- a/src/domain/messages/entities/message-confirmation.entity.spec.ts
+++ b/src/domain/messages/entities/message-confirmation.entity.spec.ts
@@ -60,7 +60,7 @@ describe('MessageConfirmationSchema', () => {
         },
         {
           code: 'custom',
-          message: 'Invalid signature',
+          message: 'Invalid hex bytes',
           path: ['signature'],
         },
       ]),

--- a/src/domain/messages/entities/message-confirmation.entity.spec.ts
+++ b/src/domain/messages/entities/message-confirmation.entity.spec.ts
@@ -58,6 +58,11 @@ describe('MessageConfirmationSchema', () => {
           message: 'Invalid "0x" notated hex string',
           path: ['signature'],
         },
+        {
+          code: 'custom',
+          message: 'Invalid signature',
+          path: ['signature'],
+        },
       ]),
     );
   });

--- a/src/domain/messages/entities/message-confirmation.entity.ts
+++ b/src/domain/messages/entities/message-confirmation.entity.ts
@@ -1,6 +1,6 @@
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { SignatureLikeSchema } from '@/validation/entities/schemas/signature.schema';
 import { z } from 'zod';
 
 export type MessageConfirmation = z.infer<typeof MessageConfirmationSchema>;
@@ -9,6 +9,6 @@ export const MessageConfirmationSchema = z.object({
   created: z.coerce.date(),
   modified: z.coerce.date(),
   owner: AddressSchema,
-  signature: HexSchema,
+  signature: SignatureLikeSchema,
   signatureType: z.nativeEnum(SignatureType),
 });

--- a/src/domain/messages/entities/message-confirmation.entity.ts
+++ b/src/domain/messages/entities/message-confirmation.entity.ts
@@ -1,6 +1,6 @@
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { SignatureLikeSchema } from '@/validation/entities/schemas/signature.schema';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
 import { z } from 'zod';
 
 export type MessageConfirmation = z.infer<typeof MessageConfirmationSchema>;
@@ -9,6 +9,7 @@ export const MessageConfirmationSchema = z.object({
   created: z.coerce.date(),
   modified: z.coerce.date(),
   owner: AddressSchema,
-  signature: SignatureLikeSchema,
+  // We don't validate signature length as they are on the Transaction Service
+  signature: HexBytesSchema,
   signatureType: z.nativeEnum(SignatureType),
 });

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -7,7 +7,7 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
-import { SignatureLikeSchema } from '@/validation/entities/schemas/signature.schema';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
 
 export type Confirmation = z.infer<typeof ConfirmationSchema>;
 
@@ -18,7 +18,8 @@ export const ConfirmationSchema = z.object({
   submissionDate: z.coerce.date(),
   transactionHash: HexSchema.nullish().default(null),
   signatureType: z.nativeEnum(SignatureType),
-  signature: SignatureLikeSchema.nullish().default(null),
+  // We don't validate signature length as they are on the Transaction Service
+  signature: HexBytesSchema.nullish().default(null),
 });
 
 export const MultisigTransactionSchema = z.object({

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -7,7 +7,7 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
-import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
+import { SignatureLikeSchema } from '@/validation/entities/schemas/signature.schema';
 
 export type Confirmation = z.infer<typeof ConfirmationSchema>;
 
@@ -18,7 +18,7 @@ export const ConfirmationSchema = z.object({
   submissionDate: z.coerce.date(),
   transactionHash: HexSchema.nullish().default(null),
   signatureType: z.nativeEnum(SignatureType),
-  signature: SignatureSchema.nullish().default(null),
+  signature: SignatureLikeSchema.nullish().default(null),
 });
 
 export const MultisigTransactionSchema = z.object({

--- a/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
@@ -165,6 +165,11 @@ describe('CreateMessageDtoSchema', () => {
           },
           {
             code: 'custom',
+            message: 'Invalid hex bytes',
+            path: ['signature'],
+          },
+          {
+            code: 'custom',
             message: 'Invalid signature',
             path: ['signature'],
           },

--- a/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/update-message.dto.schema.spec.ts
@@ -33,6 +33,11 @@ describe('UpdateMessageSignatureDtoSchema', () => {
         },
         {
           code: 'custom',
+          message: 'Invalid hex bytes',
+          path: ['signature'],
+        },
+        {
+          code: 'custom',
           message: 'Invalid signature',
           path: ['signature'],
         },
@@ -54,6 +59,11 @@ describe('UpdateMessageSignatureDtoSchema', () => {
 
     expect(!result.success && result.error).toStrictEqual(
       new ZodError([
+        {
+          code: 'custom',
+          message: 'Invalid hex bytes',
+          path: ['signature'],
+        },
         {
           code: 'custom',
           message: 'Invalid signature',

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -1330,7 +1330,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
           signers,
           safe,
         });
-      multisigTransaction.confirmations![0].signature = `0xdeadbeef`;
+      multisigTransaction.confirmations![0].signature = `0xdeadbee`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${multisigTransaction.safeTxHash}/`;

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -986,7 +986,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           });
       };
       const nonce1 = await getTransaction(1);
-      nonce1.confirmations![0].signature = '0xdeadbeef';
+      nonce1.confirmations![0].signature = '0xdeadbee';
       const nonce2 = await getTransaction(2);
       const transactions: Array<MultisigTransaction> = [
         multisigToJson(nonce1) as MultisigTransaction,

--- a/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
+++ b/src/routes/transactions/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
@@ -150,6 +150,11 @@ describe('ProposeTransactionDtoSchema', () => {
         },
         {
           code: 'custom',
+          message: 'Invalid hex bytes',
+          path: ['signature'],
+        },
+        {
+          code: 'custom',
           message: 'Invalid signature',
           path: ['signature'],
         },

--- a/src/validation/entities/schemas/__tests__/hexbytes.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/hexbytes.schema.spec.ts
@@ -1,0 +1,26 @@
+import { faker } from '@faker-js/faker';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
+
+describe('HexBytesSchema', () => {
+  it('should return true if the value is a valid hex bytes', () => {
+    const value = faker.string.hexadecimal({ length: 4 });
+
+    const result = HexBytesSchema.safeParse(value);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should return false if the value is not a valid hex bytes', () => {
+    const value = faker.string.hexadecimal({ length: 3 });
+
+    const result = HexBytesSchema.safeParse(value);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid hex bytes',
+        path: [],
+      },
+    ]);
+  });
+});

--- a/src/validation/entities/schemas/__tests__/signature.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/signature.schema.spec.ts
@@ -1,8 +1,5 @@
 import { faker } from '@faker-js/faker';
-import {
-  SignatureLikeSchema,
-  SignatureSchema,
-} from '@/validation/entities/schemas/signature.schema';
+import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
 
 describe('SignatureSchema', () => {
   it('should validate a signature', () => {
@@ -38,6 +35,11 @@ describe('SignatureSchema', () => {
       },
       {
         code: 'custom',
+        message: 'Invalid hex bytes',
+        path: [],
+      },
+      {
+        code: 'custom',
         message: 'Invalid signature',
         path: [],
       },
@@ -54,52 +56,9 @@ describe('SignatureSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
-        message: 'Invalid signature',
+        message: 'Invalid hex bytes',
         path: [],
       },
-    ]);
-  });
-});
-
-describe('SignatureLikeSchema', () => {
-  it('should validate a signature', () => {
-    const signature = faker.string.hexadecimal({
-      // Somewhat "standard" length for dynamic signature
-      length: 130 + 64,
-    }) as `0x${string}`;
-
-    const result = SignatureLikeSchema.safeParse(signature);
-
-    expect(result.success).toBe(true);
-  });
-
-  it('should not validate a non-hex signature', () => {
-    const signature = faker.string.alphanumeric() as `0x${string}`;
-
-    const result = SignatureLikeSchema.safeParse(signature);
-
-    expect(!result.success && result.error.issues).toStrictEqual([
-      {
-        code: 'custom',
-        message: 'Invalid "0x" notated hex string',
-        path: [],
-      },
-      {
-        code: 'custom',
-        message: 'Invalid signature',
-        path: [],
-      },
-    ]);
-  });
-
-  it('should not validate a incorrect length signature', () => {
-    const signature = faker.string.hexadecimal({
-      length: 129,
-    }) as `0x${string}`;
-
-    const result = SignatureLikeSchema.safeParse(signature);
-
-    expect(!result.success && result.error.issues).toStrictEqual([
       {
         code: 'custom',
         message: 'Invalid signature',

--- a/src/validation/entities/schemas/__tests__/signature.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/signature.schema.spec.ts
@@ -1,5 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
+import {
+  SignatureLikeSchema,
+  SignatureSchema,
+} from '@/validation/entities/schemas/signature.schema';
 
 describe('SignatureSchema', () => {
   it('should validate a signature', () => {
@@ -47,6 +50,54 @@ describe('SignatureSchema', () => {
     }) as `0x${string}`;
 
     const result = SignatureSchema.safeParse(signature);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid signature',
+        path: [],
+      },
+    ]);
+  });
+});
+
+describe('SignatureLikeSchema', () => {
+  it('should validate a signature', () => {
+    const signature = faker.string.hexadecimal({
+      // Somewhat "standard" length for dynamic signature
+      length: 130 + 64,
+    }) as `0x${string}`;
+
+    const result = SignatureLikeSchema.safeParse(signature);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not validate a non-hex signature', () => {
+    const signature = faker.string.alphanumeric() as `0x${string}`;
+
+    const result = SignatureLikeSchema.safeParse(signature);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid "0x" notated hex string',
+        path: [],
+      },
+      {
+        code: 'custom',
+        message: 'Invalid signature',
+        path: [],
+      },
+    ]);
+  });
+
+  it('should not validate a incorrect length signature', () => {
+    const signature = faker.string.hexadecimal({
+      length: 129,
+    }) as `0x${string}`;
+
+    const result = SignatureLikeSchema.safeParse(signature);
 
     expect(!result.success && result.error.issues).toStrictEqual([
       {

--- a/src/validation/entities/schemas/hexbytes.schema.ts
+++ b/src/validation/entities/schemas/hexbytes.schema.ts
@@ -1,0 +1,9 @@
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+
+function isHexBytes(value: `0x${string}`): boolean {
+  return value.length % 2 === 0;
+}
+
+export const HexBytesSchema = HexSchema.refine(isHexBytes, {
+  message: 'Invalid hex bytes',
+});

--- a/src/validation/entities/schemas/signature.schema.ts
+++ b/src/validation/entities/schemas/signature.schema.ts
@@ -1,4 +1,4 @@
-import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
 
 // This does not take dynamic parts into account but we can safely
 // apply it to proposed signatures as we do not support contract
@@ -8,17 +8,6 @@ function isSignature(value: `0x${string}`): boolean {
   return (value.length - 2) % 130 === 0;
 }
 
-export const SignatureSchema = HexSchema.refine(isSignature, {
-  message: 'Invalid signature',
-});
-
-// As indexed signatures may be contract signatures, we need to assume
-// that signatures from our API may have a dynamic part meaning that
-// we can only check that the length is "byte-aligned"
-function isSignatureLike(value: `0x${string}`): boolean {
-  return value.length % 2 === 0;
-}
-
-export const SignatureLikeSchema = HexSchema.refine(isSignatureLike, {
+export const SignatureSchema = HexBytesSchema.refine(isSignature, {
   message: 'Invalid signature',
 });

--- a/src/validation/entities/schemas/signature.schema.ts
+++ b/src/validation/entities/schemas/signature.schema.ts
@@ -1,10 +1,24 @@
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 
+// This does not take dynamic parts into account but we can safely
+// apply it to proposed signatures as we do not support contract
+// signatures in the inferface
 function isSignature(value: `0x${string}`): boolean {
   // We accept proposals of singular or concatenated signatures
   return (value.length - 2) % 130 === 0;
 }
 
 export const SignatureSchema = HexSchema.refine(isSignature, {
+  message: 'Invalid signature',
+});
+
+// As indexed signatures may be contract signatures, we need to assume
+// that signatures from our API may have a dynamic part meaning that
+// we can only check that the length is "byte-aligned"
+function isSignatureLike(value: `0x${string}`): boolean {
+  return value.length % 2 === 0;
+}
+
+export const SignatureLikeSchema = HexSchema.refine(isSignatureLike, {
   message: 'Invalid signature',
 });

--- a/src/validation/entities/schemas/signature.schema.ts
+++ b/src/validation/entities/schemas/signature.schema.ts
@@ -2,7 +2,7 @@ import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
 
 // This does not take dynamic parts into account but we can safely
 // apply it to proposed signatures as we do not support contract
-// signatures in the inferface
+// signatures in the interface
 function isSignature(value: `0x${string}`): boolean {
   // We accept proposals of singular or concatenated signatures
   return (value.length - 2) % 130 === 0;


### PR DESCRIPTION
## Summary

We currently validate that transaction signatures from our API are hex and a denomination fo 130 and that message signatures are hex.

Whilst we can be sure that incoming signatures from clients are a denomination of 130 (because the interface does not currently support proposal of contract signatures), we cannot be sure that the Transaction Service hasn't indexed contract signatures with dynamic parts.

This creates a new `HexBytesSchema` which ensures a string is hex and even in length, aka "byte-aligned", applying it to the validation of transaction/message signatures from our API.

## Changes

- Add and use `HexBytesSchema`
- Add/update tests accordingly