### PR TITLE
feat: iterate on trusted contracts list

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -103,7 +103,7 @@ export default (): ReturnType<typeof configuration> => ({
   },
   contracts: {
     trustedForDelegateCall: {
-      maxSequentialPages: faker.number.int(),
+      maxSequentialPages: faker.number.int({ min: 1, max: 5 }),
     },
   },
   db: {

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -101,6 +101,11 @@ export default (): ReturnType<typeof configuration> => ({
       apiKey: faker.string.hexadecimal({ length: 32 }),
     },
   },
+  contracts: {
+    trustedForDelegateCall: {
+      maxSequentialPages: faker.number.int(),
+    },
+  },
   db: {
     migrator: {
       executeMigrations: true,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -151,6 +151,13 @@ export default () => ({
       apiKey: process.env.INFURA_API_KEY,
     },
   },
+  contracts: {
+    trustedForDelegateCall: {
+      maxSequentialPages: parseInt(
+        process.env.TRUSTED_CONTRACTS_MAX_SEQUENTIAL_PAGES ?? `${3}`,
+      ),
+    },
+  },
   db: {
     migrator: {
       // Determines if database migrations should be executed. By default, it will execute

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -535,7 +535,7 @@ describe('TransactionApi', () => {
       const cacheDir = new CacheDir(`${chainId}_trusted_contracts`, '');
       mockDataSource.get.mockResolvedValueOnce(rawify(contractPage));
 
-      const actual = await service.getTrustedForDelegateCallContracts();
+      const actual = await service.getTrustedForDelegateCallContracts({});
 
       expect(actual).toBe(contractPage);
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
@@ -547,6 +547,41 @@ describe('TransactionApi', () => {
         networkRequest: {
           params: {
             trusted_for_delegate_call: true,
+          },
+        },
+      });
+    });
+
+    it('should relay pagination', async () => {
+      const contractPage = pageBuilder()
+        .with('results', [
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+          contractBuilder().with('trustedForDelegateCall', true).build(),
+        ])
+        .build();
+      const getTrustedForDelegateCallContractsUrl = `${baseUrl}/api/v1/contracts/`;
+      const cacheDir = new CacheDir(`${chainId}_trusted_contracts`, '');
+      mockDataSource.get.mockResolvedValueOnce(rawify(contractPage));
+      const limit = faker.number.int();
+      const offset = faker.number.int();
+
+      const actual = await service.getTrustedForDelegateCallContracts({
+        limit,
+        offset,
+      });
+
+      expect(actual).toBe(contractPage);
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir,
+        url: getTrustedForDelegateCallContractsUrl,
+        notFoundExpireTimeSeconds: notFoundExpireTimeSeconds,
+        expireTimeSeconds: defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            trusted_for_delegate_call: true,
+            limit,
+            offset,
           },
         },
       });
@@ -574,7 +609,7 @@ describe('TransactionApi', () => {
       );
 
       await expect(
-        service.getTrustedForDelegateCallContracts(),
+        service.getTrustedForDelegateCallContracts({}),
       ).rejects.toThrow(expected);
 
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -272,7 +272,10 @@ export class TransactionApi implements ITransactionApi {
 
   // Important: there is no hook which invalidates this endpoint,
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
-  async getTrustedForDelegateCallContracts(): Promise<Raw<Page<Contract>>> {
+  async getTrustedForDelegateCallContracts(args: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<Contract>>> {
     try {
       const cacheDir = CacheRouter.getTrustedForDelegateCallContractsCacheDir(
         this.chainId,
@@ -286,6 +289,8 @@ export class TransactionApi implements ITransactionApi {
         networkRequest: {
           params: {
             trusted_for_delegate_call: true,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
       });

--- a/src/domain/common/constants.ts
+++ b/src/domain/common/constants.ts
@@ -4,3 +4,9 @@
  * Ref: https://www.postgresql.org/docs/16/datatype-numeric.html
  */
 export const DB_MAX_SAFE_INTEGER = Math.pow(2, 31) - 1;
+
+/**
+ * The default pagination limit on the Safe Transaction Service.
+ * Ref: https://github.com/safe-global/safe-transaction-service/blob/491be54c7f9a15bed352469d0764ce06cb012561/safe_transaction_service/contracts/pagination.py#L5
+ */
+export const SAFE_TRANSACTION_SERVICE_MAX_LIMIT = 200;

--- a/src/domain/contracts/contracts.repository.spec.ts
+++ b/src/domain/contracts/contracts.repository.spec.ts
@@ -1,0 +1,268 @@
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { SAFE_TRANSACTION_SERVICE_MAX_LIMIT as LIMIT } from '@/domain/common/constants';
+import { ContractsRepository } from '@/domain/contracts/contracts.repository';
+import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import {
+  limitAndOffsetUrlFactory,
+  pageBuilder,
+} from '@/domain/entities/__tests__/page.builder';
+import type { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
+import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { rawify } from '@/validation/entities/raw.entity';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+const mockLoggingService = {
+  error: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+const mockTransactionApiManager = {
+  getApi: jest.fn(),
+} as jest.MockedObjectDeep<ITransactionApiManager>;
+const mockTransactionApi = {
+  getContract: jest.fn(),
+  getTrustedForDelegateCallContracts: jest.fn(),
+} as jest.MockedObjectDeep<ITransactionApi>;
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+describe('ContractsRepository', () => {
+  let target: ContractsRepository;
+  const maxSequentialPages = 3;
+
+  function initTarget(args: { trustedList: boolean }): void {
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'contracts.trustedForDelegateCall.maxSequentialPages')
+        return maxSequentialPages;
+      if (key === 'features.trustedForDelegateCallContractsList')
+        return args.trustedList;
+    });
+
+    target = new ContractsRepository(
+      mockTransactionApiManager,
+      mockConfigurationService,
+      mockLoggingService,
+    );
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    initTarget({ trustedList: false });
+  });
+
+  describe('trustedForDelegateCallContractsList disabled', () => {
+    it('should return false if the contract is not trusted for delegate call', async () => {
+      const chain = chainBuilder().build();
+      const contract = contractBuilder()
+        .with('trustedForDelegateCall', false)
+        .build();
+      mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+      mockTransactionApi.getContract.mockResolvedValue(rawify(contract));
+
+      const actual = await target.isTrustedForDelegateCall({
+        chainId: chain.chainId,
+        contractAddress: contract.address,
+      });
+
+      expect(actual).toBe(false);
+      expect(mockTransactionApi.getContract).toHaveBeenCalledTimes(1);
+      expect(mockTransactionApi.getContract).toHaveBeenCalledWith(
+        contract.address,
+      );
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return true if the contract is trusted for delegate call', async () => {
+      const chain = chainBuilder().build();
+      const contract = contractBuilder()
+        .with('trustedForDelegateCall', true)
+        .build();
+      mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+      mockTransactionApi.getContract.mockResolvedValue(rawify(contract));
+
+      const actual = await target.isTrustedForDelegateCall({
+        chainId: chain.chainId,
+        contractAddress: contract.address,
+      });
+
+      expect(actual).toBe(true);
+      expect(mockTransactionApi.getContract).toHaveBeenCalledTimes(1);
+      expect(mockTransactionApi.getContract).toHaveBeenCalledWith(
+        contract.address,
+      );
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trustedForDelegateCallContractsList enabled', () => {
+    it('should return false if the contract is not in the list of trusted for delegate call contracts', async () => {
+      initTarget({ trustedList: true });
+      const chain = chainBuilder().build();
+      const contracts = faker.helpers.multiple(
+        () => contractBuilder().with('trustedForDelegateCall', true).build(),
+        {
+          count: 10,
+        },
+      );
+      const contractPage = pageBuilder().with('results', contracts).build();
+      mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValue(
+        rawify(contractPage),
+      );
+
+      const actual = await target.isTrustedForDelegateCall({
+        chainId: chain.chainId,
+        contractAddress: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      expect(actual).toBe(false);
+    });
+
+    it('should return true if the contract is in the list of trusted for delegate call contracts', async () => {
+      initTarget({ trustedList: true });
+      const chain = chainBuilder().build();
+      const contracts = faker.helpers.multiple(
+        () => contractBuilder().with('trustedForDelegateCall', true).build(),
+        {
+          count: LIMIT,
+        },
+      );
+      const contractPage = pageBuilder().with('results', contracts).build();
+      mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValue(
+        rawify(contractPage),
+      );
+
+      const actual = await target.isTrustedForDelegateCall({
+        chainId: chain.chainId,
+        contractAddress: faker.helpers.arrayElement(contracts).address,
+      });
+
+      expect(actual).toBe(true);
+    });
+
+    it('should iterate over the complete list of trusted for delegate call contracts', async () => {
+      initTarget({ trustedList: true });
+      const chain = chainBuilder().build();
+      const contracts = faker.helpers.multiple(
+        () => contractBuilder().with('trustedForDelegateCall', true).build(),
+        {
+          count: LIMIT,
+        },
+      );
+      mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValueOnce(
+        rawify(
+          pageBuilder()
+            .with('results', contracts)
+            .with('next', limitAndOffsetUrlFactory(LIMIT, LIMIT))
+            .build(),
+        ),
+      );
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValueOnce(
+        rawify(
+          pageBuilder().with('results', contracts).with('next', null).build(),
+        ),
+      );
+
+      const actual = await target.isTrustedForDelegateCall({
+        chainId: chain.chainId,
+        contractAddress: faker.helpers.arrayElement(contracts).address,
+      });
+
+      expect(actual).toBe(true);
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenNthCalledWith(1, {
+        limit: LIMIT,
+        offset: 0,
+      });
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenNthCalledWith(2, {
+        limit: LIMIT,
+        offset: LIMIT,
+      });
+      expect(mockLoggingService.error).not.toHaveBeenCalled();
+    });
+
+    it('should iterate over the complete list of trusted for delegate call contracts until maxSequentialPages', async () => {
+      initTarget({ trustedList: true });
+      const chain = chainBuilder().build();
+      const contracts = faker.helpers.multiple(
+        () => contractBuilder().with('trustedForDelegateCall', true).build(),
+        {
+          count: LIMIT,
+        },
+      );
+
+      mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValueOnce(
+        rawify(
+          pageBuilder()
+            .with('results', contracts)
+            .with('next', limitAndOffsetUrlFactory(LIMIT, LIMIT))
+            .build(),
+        ),
+      );
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValueOnce(
+        rawify(
+          pageBuilder()
+            .with('results', contracts)
+            .with('next', limitAndOffsetUrlFactory(LIMIT, LIMIT * 2))
+            .build(),
+        ),
+      );
+      mockTransactionApi.getTrustedForDelegateCallContracts.mockResolvedValueOnce(
+        rawify(
+          pageBuilder()
+            .with('results', contracts)
+            .with('next', limitAndOffsetUrlFactory(LIMIT, LIMIT * 3))
+            .build(),
+        ),
+      );
+
+      const actual = await target.isTrustedForDelegateCall({
+        chainId: chain.chainId,
+        contractAddress: faker.helpers.arrayElement(contracts).address,
+      });
+
+      expect(actual).toBe(true);
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenCalledTimes(maxSequentialPages);
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenNthCalledWith(1, {
+        limit: LIMIT,
+        offset: 0,
+      });
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenNthCalledWith(2, {
+        limit: LIMIT,
+        offset: LIMIT,
+      });
+      expect(
+        mockTransactionApi.getTrustedForDelegateCallContracts,
+      ).toHaveBeenNthCalledWith(3, {
+        limit: LIMIT,
+        offset: LIMIT * 2,
+      });
+      expect(mockLoggingService.error).toHaveBeenCalledWith({
+        chainId: chain.chainId,
+        message: 'Max sequential pages reached',
+        next: expect.any(String),
+      });
+    });
+  });
+});

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -43,7 +43,10 @@ export interface ITransactionApi {
 
   getContract(contractAddress: `0x${string}`): Promise<Raw<Contract>>;
 
-  getTrustedForDelegateCallContracts(): Promise<Raw<Page<Contract>>>;
+  getTrustedForDelegateCallContracts(args: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<Contract>>>;
 
   getDelegates(args: {
     safeAddress?: `0x${string}`;

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -586,6 +586,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
             .build(),
           contractBuilder().with('trustedForDelegateCall', true).build(),
         ])
+        .with('next', null)
         .build();
       const proposeTransactionDto = proposeTransactionDtoBuilder()
         .with('to', transaction.to)
@@ -773,6 +774,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           contractBuilder().with('trustedForDelegateCall', true).build(),
           contractBuilder().with('trustedForDelegateCall', true).build(),
         ])
+        .with('next', null)
         .build();
       const proposeTransactionDto = proposeTransactionDtoBuilder()
         .with('to', transaction.to)


### PR DESCRIPTION
## Summary
Related to https://github.com/safe-global/safe-client-gateway/pull/2430

As the number of trusted for delegate call contracts can be more than the default page size, it might be necessary to request several pages of contract metadata from the Transaction Service to get the full list. 

## Changes
- Modifies `ContractsRepository.getTrustedForDelegateCallContracts` to iterate over the pages of trusted contracts received from the Transaction Service.
