### PR TITLE
fix: Swagger defintions for `POST` `/v1/users/wallet/add`

### DIFF
--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -23,7 +23,7 @@ import { UserWithWallets } from '@/routes/users/entities/user-with-wallets.entit
 import { CreatedUserWithWallet } from '@/routes/users/entities/created-user-with-wallet.entity';
 import { WalletAddedToUser } from '@/routes/users/entities/wallet-added-to-user.entity';
 import { SiweDtoSchema } from '@/routes/auth/entities/siwe.dto.entity';
-import type { SiweDto } from '@/routes/auth/entities/siwe.dto.entity';
+import { SiweDto } from '@/routes/auth/entities/siwe.dto.entity';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 
 @ApiTags('users')


### PR DESCRIPTION
## Summary

The parameters of the `/v1/users/wallet/add` endpoint were not being shown on Swagger. This removes the `type` from the relative import, resolving the issue.

## Changes

- Don't import `SiweDto` as a `type`