### PR TITLE
fix: Swagger definitions for `GET` `/v1/organizations/:organizationId/safes`

### DIFF
--- a/src/routes/organizations/entities/get-organization-safe.dto.entity.ts
+++ b/src/routes/organizations/entities/get-organization-safe.dto.entity.ts
@@ -1,14 +1,20 @@
 import type { OrganizationSafe } from '@/datasources/organizations/entities/organization-safes.entity.db';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class GetOrganizationSafes {
-  [chainId: OrganizationSafe['chainId']]: Array<OrganizationSafe['address']>;
-}
-
 export class GetOrganizationSafeResponse {
   @ApiProperty({
-    type: GetOrganizationSafes,
-    isArray: true,
+    type: 'object',
+    additionalProperties: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    example: {
+      '{chainId}': ['0x...'],
+    },
   })
-  public readonly safes!: GetOrganizationSafes;
+  public readonly safes!: {
+    [chainId: OrganizationSafe['chainId']]: Array<OrganizationSafe['address']>;
+  };
 }

--- a/src/routes/organizations/organization-safes.service.ts
+++ b/src/routes/organizations/organization-safes.service.ts
@@ -5,10 +5,7 @@ import { IOrganizationsRepository } from '@/domain/organizations/organizations.r
 import { IUsersRepository } from '@/domain/users/users.repository.interface';
 import { CreateOrganizationSafeDto } from '@/routes/organizations/entities/create-organization-safe.dto.entity';
 import { DeleteOrganizationSafeDto } from '@/routes/organizations/entities/delete-organization-safe.dto.entity';
-import {
-  GetOrganizationSafeResponse,
-  GetOrganizationSafes,
-} from '@/routes/organizations/entities/get-organization-safe.dto.entity';
+import { GetOrganizationSafeResponse } from '@/routes/organizations/entities/get-organization-safe.dto.entity';
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { groupBy, mapValues } from 'lodash';
 import { IOrganizationSafesRepository } from '@/domain/organizations/organizations-safe.repository.interface';
@@ -130,7 +127,7 @@ export class OrganizationSafesService {
    */
   private transformOrganizationSafesResponse(
     organizationSafes: Array<Pick<OrganizationSafe, 'chainId' | 'address'>>,
-  ): GetOrganizationSafes {
+  ): GetOrganizationSafeResponse['safes'] {
     const grouped = groupBy(organizationSafes, 'chainId');
 
     return mapValues(grouped, (items) => items.map((item) => item.address));


### PR DESCRIPTION
## Summary

The response type for `GET` `/v1/organizations/:organizationId/safes` is incorrect. Due to the dynamic `chainId` properties, this requires complex decorator usage, rather than classes. This removes the entities, preferring decorators instead.

## Changes

- Replace `GetOrganizationSafes` with decorator
- Import the equivalent of `GetOrganizationSafes` from `GetOrganizationSafeResponse['safes']`