### PR TITLE
fix: adjust OrganizationSafeRepository tests

### DIFF
--- a/src/domain/organizations/organizations-safe.repository.spec.ts
+++ b/src/domain/organizations/organizations-safe.repository.spec.ts
@@ -290,6 +290,7 @@ describe('OrganizationSafesRepository', () => {
         user: { id: userId },
         role: 'ADMIN',
         status: 'ACTIVE',
+        name: faker.word.noun(),
         organization: { id: orgId },
       });
 
@@ -345,6 +346,7 @@ describe('OrganizationSafesRepository', () => {
         user: { id: userId },
         role: 'ADMIN',
         status: 'ACTIVE',
+        name: faker.word.noun(),
         organization: { id: orgId },
       });
 


### PR DESCRIPTION
Related to https://github.com/safe-global/safe-client-gateway/pull/2375

## Changes
- Adds the missing `name` field to `OrganizationSafesRepository` tests.
