### PR TITLE
fix: include name field in UserOrganization mappings

### DIFF
--- a/src/domain/organizations/organizations-safe.repository.spec.ts
+++ b/src/domain/organizations/organizations-safe.repository.spec.ts
@@ -290,6 +290,7 @@ describe('OrganizationSafesRepository', () => {
         user: { id: userId },
         role: 'ADMIN',
         status: 'ACTIVE',
+        name: faker.word.noun(),
         organization: { id: orgId },
       });
 
@@ -345,6 +346,7 @@ describe('OrganizationSafesRepository', () => {
         user: { id: userId },
         role: 'ADMIN',
         status: 'ACTIVE',
+        name: faker.word.noun(),
         organization: { id: orgId },
       });
 

--- a/src/routes/organizations/entities/user-organizations.dto.entity.ts
+++ b/src/routes/organizations/entities/user-organizations.dto.entity.ts
@@ -25,6 +25,9 @@ class UserOrganization {
   @ApiProperty({ enum: getStringEnumKeys(UserOrganizationStatus) })
   status!: keyof typeof UserOrganizationStatus;
 
+  @ApiProperty({ type: String })
+  name!: DomainUserOrganization['name'];
+
   @ApiPropertyOptional({ type: String, nullable: true })
   invitedBy!: DomainUserOrganization['invitedBy'];
 

--- a/src/routes/organizations/user-organizations.controller.spec.ts
+++ b/src/routes/organizations/user-organizations.controller.spec.ts
@@ -1108,6 +1108,7 @@ describe('UserOrganizationsController', () => {
                 id: expect.any(Number),
                 role: 'ADMIN',
                 status: 'ACTIVE',
+                name: orgName,
                 invitedBy: null, // org creator's `invitedBy` field value is null
                 createdAt: expect.any(String),
                 updatedAt: expect.any(String),
@@ -1120,6 +1121,7 @@ describe('UserOrganizationsController', () => {
                 id: expect.any(Number),
                 role: 'ADMIN',
                 status: 'INVITED',
+                name: user1Name,
                 invitedBy: authPayloadDto.signer_address,
                 createdAt: expect.any(String),
                 updatedAt: expect.any(String),
@@ -1132,6 +1134,7 @@ describe('UserOrganizationsController', () => {
                 id: expect.any(Number),
                 role: 'MEMBER',
                 status: 'INVITED',
+                name: user2Name,
                 invitedBy: authPayloadDto.signer_address,
                 createdAt: expect.any(String),
                 updatedAt: expect.any(String),

--- a/src/routes/organizations/user-organizations.service.ts
+++ b/src/routes/organizations/user-organizations.service.ts
@@ -74,6 +74,7 @@ export class UserOrganizationsService {
           id: userOrg.id,
           role: userOrg.role,
           status: userOrg.status,
+          name: userOrg.name,
           invitedBy: userOrg.invitedBy,
           createdAt: userOrg.createdAt,
           updatedAt: userOrg.updatedAt,


### PR DESCRIPTION
## Summary

## Changes
- Adds `name` to `src/routes/organizations/entities/user-organizations.dto.entity.ts`.
- Adjusts mappings and tests.
