### PR TITLE
fix: normalize foreign key column names

### DIFF
--- a/migrations/1741792345987-unify-foreign-keys-column-names.ts
+++ b/migrations/1741792345987-unify-foreign-keys-column-names.ts
@@ -1,0 +1,25 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UnifyForeignKeysColumnNames1741792345987
+  implements MigrationInterface
+{
+  name = 'UnifyForeignKeysColumnNames1741792345987';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_organizations" RENAME COLUMN "userId" TO "user_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_organizations" RENAME COLUMN "organizationId" TO "organization_id"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_organizations" RENAME COLUMN "user_id" TO "userId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_organizations" RENAME COLUMN "organization_id" TO "organizationId"`,
+    );
+  }
+}

--- a/src/datasources/users/entities/user-organizations.entity.db.ts
+++ b/src/datasources/users/entities/user-organizations.entity.db.ts
@@ -32,6 +32,7 @@ export class UserOrganization implements DomainUserOrganization {
     nullable: false,
   })
   @JoinColumn({
+    name: 'user_id',
     foreignKeyConstraintName: 'FK_UO_user_id',
   })
   user!: User;
@@ -45,6 +46,7 @@ export class UserOrganization implements DomainUserOrganization {
     },
   )
   @JoinColumn({
+    name: 'organization_id',
     foreignKeyConstraintName: 'FK_UO_organization_id',
   })
   organization!: Organization;


### PR DESCRIPTION
## Changes
- Renames foreign keys to `user_id` and `operation_id` in the `user_organizations` table, sticking to naming conventions.
