### PR TITLE
fix: distinguish the name of an Organization from its creator

### DIFF
--- a/src/domain/organizations/organizations.repository.integration.spec.ts
+++ b/src/domain/organizations/organizations.repository.integration.spec.ts
@@ -204,7 +204,7 @@ describe('OrganizationsRepository', () => {
         id: expect.any(Number),
         role: 'ADMIN',
         status: 'ACTIVE',
-        name,
+        name: expect.any(String),
         invitedBy: null,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
@@ -217,6 +217,58 @@ describe('OrganizationsRepository', () => {
         organization: {
           id: expect.any(Number),
           name,
+          status: orgStatus,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it('should set the name of the organization', async () => {
+      const userStatus = faker.helpers.arrayElement(UserStatusKeys);
+      const organizationName = faker.word.noun();
+      const orgStatus = faker.helpers.arrayElement(OrgStatusKeys);
+      const user = await dbUserRepo.insert({
+        status: userStatus,
+      });
+      const userId = user.identifiers[0].id as User['id'];
+
+      const org = await orgRepo.create({
+        userId,
+        name: organizationName,
+        status: orgStatus,
+      });
+
+      expect(org).toEqual({
+        id: expect.any(Number),
+        name: organizationName,
+      });
+
+      const dbUserOrg = await dbUserOrgRepo.findOneOrFail({
+        where: { user: { id: userId } },
+        relations: {
+          user: true,
+          organization: true,
+        },
+      });
+
+      expect(dbUserOrg).toEqual({
+        id: expect.any(Number),
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        name: `${organizationName} creator`,
+        invitedBy: null,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        user: {
+          id: userId,
+          status: userStatus,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+        organization: {
+          id: expect.any(Number),
+          name: organizationName,
           status: orgStatus,
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),

--- a/src/domain/organizations/organizations.repository.ts
+++ b/src/domain/organizations/organizations.repository.ts
@@ -41,7 +41,7 @@ export class OrganizationsRepository implements IOrganizationsRepository {
 
     // @todo Move to UserOrganizationsRepository
     const userOrganization = new UserOrganization();
-    userOrganization.name = args.name;
+    userOrganization.name = `${organization.name} creator`;
     userOrganization.role = getEnumKey(
       UserOrganizationRole,
       UserOrganizationRole.ADMIN,

--- a/src/routes/organizations/organizations.controller.ts
+++ b/src/routes/organizations/organizations.controller.ts
@@ -52,7 +52,7 @@ export class OrganizationsController {
 
   @Post()
   @ApiOkResponse({
-    description: 'Organizations created',
+    description: 'Organization created',
     type: CreateOrganizationResponse,
   })
   @ApiNotFoundResponse({ description: 'User not found.' })
@@ -72,7 +72,7 @@ export class OrganizationsController {
 
   @Post('/create-with-user')
   @ApiOkResponse({
-    description: 'Organizations created',
+    description: 'Organization created',
     type: CreateOrganizationResponse,
   })
   @ApiForbiddenResponse({ description: 'Forbidden resource' })

--- a/src/routes/organizations/user-organizations.controller.spec.ts
+++ b/src/routes/organizations/user-organizations.controller.spec.ts
@@ -1108,7 +1108,7 @@ describe('UserOrganizationsController', () => {
                 id: expect.any(Number),
                 role: 'ADMIN',
                 status: 'ACTIVE',
-                name: orgName,
+                name: `${orgName} creator`,
                 invitedBy: null, // org creator's `invitedBy` field value is null
                 createdAt: expect.any(String),
                 updatedAt: expect.any(String),


### PR DESCRIPTION
## Summary
Previously to this PR, the organization name was reused as the name of the user who created the organization (its first admin). This PR changes the default name to `${organizationName} creator` instead, in order to distinguish the organization name fro the user name.

## Changes
- Sets the default name to `${organizationName} creator` for the user who creates the organization.