### PR TITLE
fix: delete member from one organization

### DIFF
--- a/src/domain/users/user-organizations.repository.ts
+++ b/src/domain/users/user-organizations.repository.ts
@@ -314,6 +314,7 @@ export class UsersOrganizationsRepository
       await this.postgresDatabaseService.getRepository(DbUserOrganization);
     const deleteResult = await userOrganizationRepository.delete({
       user: { id: args.userId },
+      organization: { id: args.orgId },
     });
 
     if (deleteResult.affected === 0) {


### PR DESCRIPTION
## Summary
This PR fixes the problem with organization's members removal. Prior to this PR, the removal from an organization triggered a removal from all organizations, as the `organization_id` filter was missing in the deletion query.

## Changes
- Adds `organization_id` to the member's removal query.
- Adds an additional test checking a deletion is not triggered for all the organizations.
