### PR TITLE
fix: update members role within the organization only

### DIFF
--- a/src/domain/users/user-organizations.repository.ts
+++ b/src/domain/users/user-organizations.repository.ts
@@ -282,7 +282,7 @@ export class UsersOrganizationsRepository
     const userOrganizationRepository =
       await this.postgresDatabaseService.getRepository(DbUserOrganization);
     const updateResult = await userOrganizationRepository.update(
-      { user: { id: args.userId } },
+      { user: { id: args.userId }, organization: { id: args.orgId } },
       { role: args.role },
     );
 


### PR DESCRIPTION
## Summary
This PR fixes the problem with organization member's role updates. Prior to this PR, the role update within an organization triggered an update on all organizations, as the `organization_id` filter was missing in the update query.

## Changes
- Adds `organization_id` to the member's role update query.
- Adds an additional test checking a deletion is not triggered for all the organizations.
