### PR TITLE
refactor: simplify address recovery from contract signatures and approved hashes

### DIFF
--- a/src/domain/common/entities/safe-signature.spec.ts
+++ b/src/domain/common/entities/safe-signature.spec.ts
@@ -134,12 +134,12 @@ describe('SafeSignature', () => {
     );
 
     it('should memoize the owner', async () => {
-      const encodeApiParametersSpy = jest.spyOn(viem, 'encodeAbiParameters');
+      const getAddressSpy = jest.spyOn(viem, 'getAddress');
 
       const privateKey = generatePrivateKey();
       const signer = privateKeyToAccount(privateKey);
       const hash = faker.string.hexadecimal({ length: 66 }) as `0x${string}`;
-      // Recovered via encodeAbiParameters
+      // Recovered via getAddress
       const signatureType = faker.helpers.arrayElement([
         SignatureType.ApprovedHash,
         SignatureType.ContractSignature,
@@ -153,10 +153,10 @@ describe('SafeSignature', () => {
       const safeSignature = new SafeSignature({ signature, hash });
 
       expect(safeSignature.owner).toBe(signer.address);
-      expect(encodeApiParametersSpy).toHaveBeenCalledTimes(1);
+      expect(getAddressSpy).toHaveBeenCalledTimes(1);
 
       expect(safeSignature.owner).toBe(signer.address);
-      expect(encodeApiParametersSpy).toHaveBeenCalledTimes(1);
+      expect(getAddressSpy).toHaveBeenCalledTimes(1);
 
       const newPrivateKey = generatePrivateKey();
       const newSigner = privateKeyToAccount(newPrivateKey);
@@ -167,10 +167,10 @@ describe('SafeSignature', () => {
       });
 
       expect(safeSignature.owner).toBe(newSigner.address);
-      expect(encodeApiParametersSpy).toHaveBeenCalledTimes(2);
+      expect(getAddressSpy).toHaveBeenCalledTimes(2);
 
       expect(safeSignature.owner).toBe(newSigner.address);
-      expect(encodeApiParametersSpy).toHaveBeenCalledTimes(2);
+      expect(getAddressSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/domain/common/entities/safe-signature.ts
+++ b/src/domain/common/entities/safe-signature.ts
@@ -1,12 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { memoize } from 'lodash';
-import {
-  checksumAddress,
-  encodeAbiParameters,
-  hashMessage,
-  hexToBigInt,
-  parseAbiParameters,
-} from 'viem';
+import { getAddress, hashMessage } from 'viem';
 import { publicKeyToAddress } from 'viem/utils';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 
@@ -58,7 +52,7 @@ export class SafeSignature {
         switch (this.signatureType) {
           case SignatureType.ContractSignature:
           case SignatureType.ApprovedHash: {
-            return uint256ToAddress(this.r);
+            return getAddress(`0x${this.r.slice(-40)}`);
           }
           case SignatureType.EthSign: {
             // To differentiate signature types, eth_sign signatures have v value increased by 4
@@ -84,13 +78,6 @@ export class SafeSignature {
       return this.signature + this.hash;
     },
   );
-}
-
-function uint256ToAddress(value: `0x${string}`): `0x${string}` {
-  const encoded = encodeAbiParameters(parseAbiParameters('uint256'), [
-    hexToBigInt(value),
-  ]);
-  return checksumAddress(`0x${encoded.slice(-40)}`);
 }
 
 function recoverAddress(args: {


### PR DESCRIPTION
## Summary

We recover addresses from contract signatures/approved hashes by first encoding, the slicing and checksumming the `r` value. The signature, however, [already contains the address](https://docs.safe.global/advanced/smart-account-signatures#examples).

This simplifies the address recovery, by checksumming the last 40 characters of the `r` directly.

## Changes

- Call `getAddress` on the last 40 characters of the signature `r`