### PR TITLE
fix: standardise Docker casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # BUILD CONTAINER
 #
-FROM node:22.14.0 as base
+FROM node:22.14.0 AS base
 ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
@@ -18,7 +18,7 @@ RUN yarn install --immutable \
 #
 # PRODUCTION CONTAINER
 #
-FROM node:22.14.0-alpine as production
+FROM node:22.14.0-alpine AS production
 USER node
 
 ARG VERSION


### PR DESCRIPTION
## Summary

We use a mixture of casing in our `Dockerfile` and there are warnings when using Docker. This standarises casing.

## Changes

- Capitalise `as` in `Dockerfile`