### PR TITLE
feat: allow Safes to be added to multiple organizations

### DIFF
--- a/migrations/1742295485154-alter-organizations-safe-unique-index.ts
+++ b/migrations/1742295485154-alter-organizations-safe-unique-index.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterOrganizationsSafeUniqueIndex1742295485154
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX UQ_OS_chainId_address; CREATE UNIQUE INDEX UQ_OS_chainId_address_organization ON organization_safes (chain_id, address, organization_id);`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX UQ_OS_chainId_address_organization; CREATE UNIQUE INDEX UQ_OS_chainId_address ON organization_safes (chain_id, address);`,
+    );
+  }
+}

--- a/src/datasources/organizations/entities/organization-safes.entity.db.ts
+++ b/src/datasources/organizations/entities/organization-safes.entity.db.ts
@@ -12,7 +12,11 @@ import {
 } from 'typeorm';
 
 @Entity('organization_safes')
-@Unique('UQ_OS_chainId_address', ['chainId', 'address'])
+@Unique('UQ_OS_chainId_address_organization', [
+  'chainId',
+  'address',
+  'organization',
+])
 export class OrganizationSafe implements DomainOrganizationSafe {
   @PrimaryGeneratedColumn({
     primaryKeyConstraintName: 'PK_OS_id',

--- a/src/domain/organizations/organizations-safe.repository.spec.ts
+++ b/src/domain/organizations/organizations-safe.repository.spec.ts
@@ -412,7 +412,7 @@ describe('OrganizationSafesRepository', () => {
         ]),
       ).rejects.toThrow(
         new UniqueConstraintError(
-          `An OrganizationSafe with the same chainId and address already exists: Key (chain_id, address)=(${chainId}, ${address}) already exists.`,
+          `An OrganizationSafe with the same chainId and address already exists: Key (chain_id, address, organization_id)=(${chainId}, ${address}, ${orgId}) already exists.`,
         ),
       );
     });


### PR DESCRIPTION
## Summary
This PR allows multiple organizations to add the same Safe to their collection.

## Changes
- Changes the `OrganizationSafe` entity unique index.
- Adjusts tests accordingly and adds a new one verifying multiple organizations can add the same Safe.
