### PR TITLE
fix: map transfers without token info if fetching fails

### DIFF
--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
@@ -89,6 +89,41 @@ describe('Transfer Info mapper (Unit)', () => {
     );
   });
 
+  it('should build an ERC20 TransferTransactionInfo without token info if fetching it fails', async () => {
+    const chainId = faker.string.numeric();
+    const transfer = erc20TransferBuilder().build();
+    const safe = safeBuilder().build();
+    const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    tokenRepository.getToken.mockRejectedValue(
+      new Error('Failed to fetch token'),
+    );
+
+    const actual = await mapper.mapTransferInfo(chainId, transfer, safe);
+
+    expect(actual).toBeInstanceOf(TransferTransactionInfo);
+    if (!(actual instanceof TransferTransactionInfo)) {
+      throw new Error('Not a TransferTransactionInfo instance');
+    }
+    expect(actual.transferInfo).toBeInstanceOf(Erc20Transfer);
+    expect(actual).toEqual(
+      expect.objectContaining({
+        sender: addressInfo,
+        recipient: addressInfo,
+        direction: TransferDirection.Unknown,
+        transferInfo: expect.objectContaining({
+          type: 'ERC20',
+          tokenAddress: transfer.tokenAddress,
+          value: transfer.value,
+          tokenName: null,
+          tokenSymbol: null,
+          logoUri: null,
+          decimals: null,
+        }),
+      }),
+    );
+  });
+
   it('should build an ERC721 TransferTransactionInfo', async () => {
     const chainId = faker.string.numeric();
     const transfer = erc721TransferBuilder().build();
@@ -119,6 +154,40 @@ describe('Transfer Info mapper (Unit)', () => {
           tokenName: token.name,
           tokenSymbol: token.symbol,
           logoUri: token.logoUri,
+        }),
+      }),
+    );
+  });
+
+  it('should build an ERC721 TransferTransactionInfo without token info if fetching it fails', async () => {
+    const chainId = faker.string.numeric();
+    const transfer = erc721TransferBuilder().build();
+    const safe = safeBuilder().build();
+    const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    tokenRepository.getToken.mockRejectedValue(
+      new Error('Failed to fetch token'),
+    );
+
+    const actual = await mapper.mapTransferInfo(chainId, transfer, safe);
+
+    expect(actual).toBeInstanceOf(TransferTransactionInfo);
+    if (!(actual instanceof TransferTransactionInfo)) {
+      throw new Error('Not a TransferTransactionInfo instance');
+    }
+    expect(actual.transferInfo).toBeInstanceOf(Erc721Transfer);
+    expect(actual).toEqual(
+      expect.objectContaining({
+        sender: addressInfo,
+        recipient: addressInfo,
+        direction: TransferDirection.Unknown,
+        transferInfo: expect.objectContaining({
+          type: 'ERC721',
+          tokenAddress: transfer.tokenAddress,
+          tokenId: transfer.tokenId,
+          tokenName: null,
+          tokenSymbol: null,
+          logoUri: null,
         }),
       }),
     );

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -106,33 +106,27 @@ export class TransferInfoMapper {
       const token = await this.getToken(chainId, tokenAddress).catch(
         () => null,
       );
-      if (token?.type !== 'ERC20') {
-        throw Error('Token is not ERC-20');
-      }
       return new Erc20Transfer(
         tokenAddress,
         value,
-        token.name,
-        token.symbol,
-        token.logoUri,
-        token.decimals,
-        token.trusted,
+        token?.name,
+        token?.symbol,
+        token?.logoUri,
+        token?.decimals,
+        token?.trusted,
       );
     } else if (domainTransfer.type === 'ERC721_TRANSFER') {
       const { tokenAddress, tokenId } = domainTransfer;
       const token = await this.getToken(chainId, tokenAddress).catch(
         () => null,
       );
-      if (token?.type !== 'ERC721') {
-        throw Error('Token is not ERC-721');
-      }
       return new Erc721Transfer(
         tokenAddress,
         tokenId,
-        token.name,
-        token.symbol,
-        token.logoUri,
-        token.trusted,
+        token?.name,
+        token?.symbol,
+        token?.logoUri,
+        token?.trusted,
       );
     } else if (domainTransfer.type === 'ETHER_TRANSFER') {
       return new NativeCoinTransfer(domainTransfer.value);


### PR DESCRIPTION
## Summary

https://github.com/safe-global/safe-client-gateway/pull/2309 introduced a regression whereby tokens that could not be fetched, [threw the mapper](https://github.com/safe-global/safe-client-gateway/pull/2309/files#diff-e71537626c00f304d6f5a6e18f9d4fe64a39cc739a29deeeb36b8bd7df2693e4R109-R128).

As fetching may fail, and we can be sure that the `type` from the Transaction Service (`ERC20_TRANSFER`/`ERC721_TRANSFER`), this removes the unnecessary check, reverting the mapping to have "empty" token data.

## Changes

- Don't throw error if token cannot be fetched
- Add appropriate test coverage