### PR TITLE
fix: do not cache missing transactions on proposals

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -629,7 +629,13 @@ export class SafeRepository implements ISafeRepository {
       this.getMultiSigTransaction({
         chainId: args.chainId,
         safeTransactionHash: args.proposeTransactionDto.safeTxHash,
-      }).catch(() => null),
+      }).catch(async () => {
+        await this.clearMultisigTransaction({
+          chainId: args.chainId,
+          safeTransactionHash: args.proposeTransactionDto.safeTxHash,
+        });
+        return null;
+      }),
     ]);
 
     await this.transactionVerifier.verifyProposal({

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -630,6 +630,7 @@ export class SafeRepository implements ISafeRepository {
         chainId: args.chainId,
         safeTransactionHash: args.proposeTransactionDto.safeTxHash,
       }).catch(async () => {
+        // If the transaction is not found, clear it from cache to avoid caching its absence.
         await this.clearMultisigTransaction({
           chainId: args.chainId,
           safeTransactionHash: args.proposeTransactionDto.safeTxHash,


### PR DESCRIPTION
## Summary
A regression bug was introduced in [this PR](https://github.com/safe-global/safe-client-gateway/pull/2460/files), as the cache gets populated with a 404 before the transaction gets proposed/created. So after the transaction proposal, and before receiving the appropriate event hook, the proposal flow tries to get the newly created transaction but it gets the cached value, returning a 404.

## Changes
- Clears the cache when a transaction cannot be found while checking its signatures when proposing.
