### PR TITLE
fix: check the admin is active when updating/deleting Safes and organizations

### DIFF
--- a/src/routes/organizations/organization-safes.service.ts
+++ b/src/routes/organizations/organization-safes.service.ts
@@ -98,6 +98,7 @@ export class OrganizationSafesService {
         id: organizationId,
         userOrganizations: {
           role: 'ADMIN',
+          status: 'ACTIVE',
           user: {
             id: userId,
           },

--- a/src/routes/organizations/organizations.service.ts
+++ b/src/routes/organizations/organizations.service.ts
@@ -189,6 +189,7 @@ export class OrganizationsService {
         id: organizationId,
         userOrganizations: {
           role: getEnumKey(UserOrganizationRole, UserOrganizationRole.ADMIN),
+          status: 'ACTIVE',
           user: {
             id: userId,
           },


### PR DESCRIPTION
## Changes
- Adds a `status: ACTIVE` filter to the `assertOrganizationAdmin` function.
- Adds related tests.
