### PR TITLE
build: pin Action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,62 @@ env:
   DOCKER_IMAGE_NAME: safe-client-gateway-nest
   DOCKER_BUILD_IMAGE_TAG: buildcache
 
+aliases:
+  actions:
+    checkout: &checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    setup-node: &setup-node
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      with:
+        node-version: '22.14.0' # jod
+        cache: 'yarn'
+
+    coveralls: &coveralls
+      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    docker-setup-qemu: &docker-setup-qemu
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      with:
+        platforms: arm64
+
+    docker-setup-buildx: &docker-setup-buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+    docker-login: &docker-login
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    docker-build-push: &docker-build-push
+      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+      with:
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: |
+          BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+          VERSION=${{ github.ref_name }}
+        # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
+        cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
+        cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.14.0' # jod
-          cache: 'yarn'
+      - *checkout
+      - *setup-node
       - run: yarn install --immutable
       - run: yarn run format-check
 
   es-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.14.0' # jod
-          cache: 'yarn'
+      - *checkout
+      - *setup-node
       - run: yarn install --immutable
       - run: yarn run lint-check
 
@@ -81,11 +117,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.11.0' # jod
-          cache: 'yarn'
+      - *checkout
+      - *setup-node
       - run: yarn install --immutable
       - run: yarn run build
       - run: yarn run ${{matrix.task}}
@@ -96,9 +129,8 @@ jobs:
           LOG_SILENT: true
       - name: Coveralls Parallel
         continue-on-error: true
-        uses: coverallsapp/github-action@v2.3.6
+        <<: *coveralls
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: run-${{ matrix.task }}
           parallel: true
 
@@ -107,9 +139,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2.3.6
+        <<: *coveralls
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
   docker-publish-staging:
@@ -117,66 +148,40 @@ jobs:
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - *checkout
       - run: |
           BUILD_NUMBER=${{ github.sha }}
           echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
-      - uses: docker/setup-qemu-action@v3.6.0
+      - *docker-setup-qemu
+      - *docker-setup-buildx
+      - *docker-login
+      - *docker-build-push
         with:
-          platforms: arm64
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
-            VERSION=${{ github.ref_name }}
           tags: ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:staging
-          # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
-          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
-          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   docker-publish-release:
     if: (github.event_name == 'release' && github.event.action == 'released')
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - *checkout
       - run: |
           BUILD_NUMBER=${{ github.sha }}
           echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
-      - uses: docker/setup-qemu-action@v3.6.0
+      - *docker-setup-qemu
+      - *docker-setup-buildx
+      - *docker-login
+      - *docker-build-push
         with:
-          platforms: arm64
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
-            VERSION=${{ github.ref_name }}
           tags: |
             ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.ref_name }}
             ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:latest
-          # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
-          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
-          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   autodeploy:
     runs-on: ubuntu-latest
     needs: [docker-publish-staging]
     steps:
-      - uses: actions/checkout@v4
+      - *checkout
       - name: Deploy Staging
         run: bash scripts/autodeploy.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - *docker-setup-qemu
       - *docker-setup-buildx
       - *docker-login
-      - *docker-build-push
+      - <<: *docker-build-push
         with:
           tags: ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:staging
 
@@ -171,7 +171,7 @@ jobs:
       - *docker-setup-qemu
       - *docker-setup-buildx
       - *docker-login
-      - *docker-build-push
+      - <<: *docker-build-push
         with:
           tags: |
             ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,62 +11,26 @@ env:
   DOCKER_IMAGE_NAME: safe-client-gateway-nest
   DOCKER_BUILD_IMAGE_TAG: buildcache
 
-aliases:
-  actions:
-    checkout: &checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    setup-node: &setup-node
-      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-      with:
-        node-version: '22.14.0' # jod
-        cache: 'yarn'
-
-    coveralls: &coveralls
-      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-
-    docker-setup-qemu: &docker-setup-qemu
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      with:
-        platforms: arm64
-
-    docker-setup-buildx: &docker-setup-buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
-    docker-login: &docker-login
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-      with:
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    docker-build-push: &docker-build-push
-      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-      with:
-        platforms: linux/amd64,linux/arm64
-        push: true
-        build-args: |
-          BUILD_NUMBER=${{ env.BUILD_NUMBER }}
-          VERSION=${{ github.ref_name }}
-        # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
-        cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
-        cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
-
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - *checkout
-      - *setup-node
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: '22.14.0' # jod
+          cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run format-check
 
   es-lint:
     runs-on: ubuntu-latest
     steps:
-      - *checkout
-      - *setup-node
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: '22.14.0' # jod
+          cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run lint-check
 
@@ -117,8 +81,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - *checkout
-      - *setup-node
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: '22.11.0' # jod
+          cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build
       - run: yarn run ${{matrix.task}}
@@ -129,8 +96,9 @@ jobs:
           LOG_SILENT: true
       - name: Coveralls Parallel
         continue-on-error: true
-        <<: *coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: run-${{ matrix.task }}
           parallel: true
 
@@ -139,8 +107,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        <<: *coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
   docker-publish-staging:
@@ -148,40 +117,66 @@ jobs:
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
     steps:
-      - *checkout
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           BUILD_NUMBER=${{ github.sha }}
           echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
-      - *docker-setup-qemu
-      - *docker-setup-buildx
-      - *docker-login
-      - <<: *docker-build-push
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+            VERSION=${{ github.ref_name }}
           tags: ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:staging
+          # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   docker-publish-release:
     if: (github.event_name == 'release' && github.event.action == 'released')
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
     steps:
-      - *checkout
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           BUILD_NUMBER=${{ github.sha }}
           echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
-      - *docker-setup-qemu
-      - *docker-setup-buildx
-      - *docker-login
-      - <<: *docker-build-push
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+            VERSION=${{ github.ref_name }}
           tags: |
             ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.ref_name }}
             ${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:latest
+          # Use Registry cache backend https://docs.docker.com/build/cache/backends/registry/
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }}
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   autodeploy:
     runs-on: ubuntu-latest
     needs: [docker-publish-staging]
     steps:
-      - *checkout
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Deploy Staging
         run: bash scripts/autodeploy.sh
         env:


### PR DESCRIPTION
## Summary

This pins GitHub Actions by hash instead of version.

## Changes

- Alias actions, pinning versions by hash