### PR TITLE
fix: check the member is active when listing members/safes

### DIFF
--- a/src/domain/users/user-organizations.repository.ts
+++ b/src/domain/users/user-organizations.repository.ts
@@ -244,11 +244,15 @@ export class UsersOrganizationsRepository
     const userOrganizationRepository =
       await this.postgresDatabaseService.getRepository(DbUserOrganization);
     const userOrganization = await userOrganizationRepository.findOne({
-      where: { user: { id: user.id }, organization: { id: args.orgId } },
+      where: {
+        user: { id: user.id },
+        organization: { id: args.orgId },
+        status: 'ACTIVE',
+      },
     });
     if (!userOrganization) {
       throw new UnauthorizedException(
-        'The user is not a member of the organization.',
+        'The user is not an active member of the organization.',
       );
     }
     const org = await this.organizationsRepository.findOneOrFail({

--- a/src/routes/organizations/organization-safes.service.ts
+++ b/src/routes/organizations/organization-safes.service.ts
@@ -123,6 +123,7 @@ export class OrganizationSafesService {
     const userOrganization = await this.userOrganizationsRepository.findOne({
       user: { id: userId },
       organization: { id: organizationId },
+      status: 'ACTIVE',
     });
 
     if (!userOrganization) {


### PR DESCRIPTION
## Changes
- Adds a filter, requiring the member user to be `ACTIVE` when listing organization Safes/members.
- Adds the associated test cases.