### PR TITLE
feat: add and use typed data validation/entity

### DIFF
--- a/src/domain/common/utils/__tests__/safe.spec.ts
+++ b/src/domain/common/utils/__tests__/safe.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { getAddress, type TypedDataDomain } from 'viem';
+import { getAddress } from 'viem';
 import { Builder } from '@/__tests__/builder';
 import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
 import { Operation } from '@/domain/safe/entities/operation.entity';
@@ -11,6 +11,7 @@ import {
   getSafeMessageMessageHash,
   getSafeTxHash,
 } from '@/domain/common/utils/safe';
+import { typedDataBuilder } from '@/routes/messages/entities/__tests__/typed-data.builder';
 import type { BaseMultisigTransaction } from '@/domain/common/utils/safe';
 import type { IBuilder } from '@/__tests__/builder';
 
@@ -33,43 +34,6 @@ const TYPES_WITH_BASEGAS_VERSIONS = [
   '1.4.0',
   '1.4.1',
 ];
-
-// Note: the following is not strictly typed
-function buildTypedData(): IBuilder<{
-  domain: TypedDataDomain;
-  primaryType: string;
-  types: Record<string, Array<{ name: string; type: string }>>;
-  message: Record<string, unknown>;
-}> {
-  const domain = {
-    chainId: faker.number.int(),
-    verifyingContract: getAddress(faker.finance.ethereumAddress()),
-  };
-
-  const primaryType = faker.lorem.word();
-
-  const types = {
-    [primaryType]: [
-      { name: 'field1', type: 'uint256' },
-      { name: 'field2', type: 'address' },
-    ],
-  };
-  const message = {
-    field1: BigInt(faker.number.int()),
-    field2: getAddress(faker.finance.ethereumAddress()),
-  };
-
-  return new Builder<{
-    domain: TypedDataDomain;
-    primaryType: string;
-    types: Record<string, Array<{ name: string; type: string }>>;
-    message: Record<string, unknown>;
-  }>()
-    .with('domain', domain)
-    .with('primaryType', primaryType)
-    .with('types', types)
-    .with('message', message);
-}
 
 function safeTxHashMultisigTransactionBuilder(): IBuilder<BaseMultisigTransaction> {
   return new Builder<BaseMultisigTransaction>()
@@ -126,7 +90,7 @@ describe('Safe', () => {
       it('should handle typedData', () => {
         const chainId = faker.string.numeric();
         const safe = safeBuilder().build();
-        const message = buildTypedData().build();
+        const message = typedDataBuilder().build();
 
         expect(() =>
           getSafeMessageMessageHash({
@@ -144,7 +108,7 @@ describe('Safe', () => {
           const safe = safeBuilder().with('version', version).build();
           const message = faker.helpers.arrayElement([
             faker.lorem.sentence(),
-            buildTypedData().build(),
+            typedDataBuilder().build(),
           ]);
 
           expect(() =>
@@ -160,7 +124,7 @@ describe('Safe', () => {
           const safe = safeBuilder().with('version', version).build();
           const message = faker.helpers.arrayElement([
             faker.lorem.sentence(),
-            buildTypedData().build(),
+            typedDataBuilder().build(),
           ]);
 
           expect(() =>
@@ -261,7 +225,7 @@ describe('Safe', () => {
         it('should generate a valid 1.0.0 messageHash', () => {
           const chainId = '';
           const safe = safeBuilder().with('version', '1.0.0').build();
-          const message = {};
+          const message = '';
 
           const result = getSafeMessageMessageHash({
             chainId,
@@ -275,7 +239,7 @@ describe('Safe', () => {
         it('should generate a valid 1.1.0 messageHash', () => {
           const chainId = '';
           const safe = safeBuilder().with('version', '1.1.1').build();
-          const message = {};
+          const message = '';
 
           const result = getSafeMessageMessageHash({
             chainId,
@@ -289,7 +253,7 @@ describe('Safe', () => {
         it('should generate a valid 1.2.0 messageHash', () => {
           const chainId = '';
           const safe = safeBuilder().with('version', '1.2.0').build();
-          const message = {};
+          const message = '';
 
           const result = getSafeMessageMessageHash({
             chainId,
@@ -303,7 +267,7 @@ describe('Safe', () => {
         it('should generate a valid 1.3.0 messageHash', () => {
           const chainId = '';
           const safe = safeBuilder().with('version', '1.3.0').build();
-          const message = {};
+          const message = '';
 
           const result = getSafeMessageMessageHash({
             chainId,
@@ -317,7 +281,7 @@ describe('Safe', () => {
         it('should generate a valid 1.4.0 messageHash', () => {
           const chainId = '';
           const safe = safeBuilder().with('version', '1.4.0').build();
-          const message = {};
+          const message = '';
 
           const result = getSafeMessageMessageHash({
             chainId,
@@ -331,7 +295,7 @@ describe('Safe', () => {
         it('should generate a valid 1.4.1 messageHash', () => {
           const chainId = '';
           const safe = safeBuilder().with('version', '1.4.1').build();
-          const message = {};
+          const message = '';
 
           const result = getSafeMessageMessageHash({
             chainId,

--- a/src/domain/common/utils/safe.ts
+++ b/src/domain/common/utils/safe.ts
@@ -1,13 +1,9 @@
 import semverSatisfies from 'semver/functions/satisfies';
-import {
-  hashMessage,
-  hashTypedData,
-  zeroAddress,
-  type TypedDataDefinition,
-} from 'viem';
+import { hashMessage, hashTypedData, zeroAddress } from 'viem';
 import { MessageSchema } from '@/domain/messages/entities/message.entity';
 import type { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import type { Safe } from '@/domain/safe/entities/safe.entity';
+import type { TypedData } from '@/domain/messages/entities/typed-data.entity';
 
 const CHAIN_ID_DOMAIN_HASH_VERSION = '>=1.3.0';
 const TRANSACTION_PRIMARY_TYPE = 'SafeTx';
@@ -17,15 +13,13 @@ const MESSAGE_PRIMARY_TYPE = 'SafeMessage';
 export function getSafeMessageMessageHash(args: {
   chainId: string;
   safe: Safe;
-  message: string | Record<string, unknown>;
+  message: string | TypedData;
 }): `0x${string}` {
   if (!args.safe.version) {
     throw new Error('Safe version is required');
   }
   try {
-    const message = MessageSchema.shape.message.parse(args.message) as
-      | string
-      | TypedDataDefinition;
+    const message = MessageSchema.shape.message.parse(args.message);
 
     return hashTypedData({
       domain: _getSafeDomain({

--- a/src/domain/messages/entities/__tests__/message.entity.spec.ts
+++ b/src/domain/messages/entities/__tests__/message.entity.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
-import { fakeJson } from '@/__tests__/faker';
+import { typedDataBuilder } from '@/routes/messages/entities/__tests__/typed-data.builder';
 import { messageBuilder } from '@/domain/messages/entities/__tests__/message.builder';
 import { MessageSchema } from '@/domain/messages/entities/message.entity';
 import type { Message } from '@/domain/messages/entities/message.entity';
@@ -85,12 +85,10 @@ describe('MessageSchema', () => {
 
   it.each([
     ['string', faker.string.alphanumeric()],
-    ['record', JSON.parse(fakeJson())],
+    ['typed data', typedDataBuilder().build()],
   ])('should accept a %s message', (_, message) => {
     const result = MessageSchema.safeParse(
-      messageBuilder()
-        .with('message', message as Message['message'])
-        .build(),
+      messageBuilder().with('message', message).build(),
     );
 
     expect(result.success && result.data.message).toStrictEqual(message);

--- a/src/domain/messages/entities/message.entity.spec.ts
+++ b/src/domain/messages/entities/message.entity.spec.ts
@@ -1,4 +1,4 @@
-import { fakeJson } from '@/__tests__/faker';
+import { typedDataBuilder } from '@/routes/messages/entities/__tests__/typed-data.builder';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { messageBuilder } from '@/domain/messages/entities/__tests__/message.builder';
 import {
@@ -73,7 +73,7 @@ describe('Message entity schemas', () => {
 
     it.each([
       ['string', faker.lorem.sentence()],
-      ['object', JSON.parse(fakeJson())],
+      ['typed data', typedDataBuilder().build()],
     ])('should allow a %s message', (_, message) => {
       const result = MessageSchema.safeParse({
         ...messageBuilder().build(),

--- a/src/domain/messages/entities/message.entity.ts
+++ b/src/domain/messages/entities/message.entity.ts
@@ -1,5 +1,6 @@
 import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { MessageConfirmationSchema } from '@/domain/messages/entities/message-confirmation.entity';
+import { TypedDataSchema } from '@/domain/messages/entities/typed-data.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { z } from 'zod';
@@ -11,7 +12,7 @@ export const MessageSchema = z.object({
   modified: z.coerce.date(),
   safe: AddressSchema,
   messageHash: HexSchema,
-  message: z.union([z.string(), z.record(z.unknown())]),
+  message: z.union([z.string(), TypedDataSchema]),
   proposedBy: AddressSchema,
   safeAppId: z.number().nullish().default(null),
   confirmations: z.array(MessageConfirmationSchema),

--- a/src/domain/messages/entities/typed-data.entity.ts
+++ b/src/domain/messages/entities/typed-data.entity.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import {
+  TypedDataDomain as TypedDataDomainSchema,
+  TypedDataParameter as TypedDataParameterSchema,
+} from 'abitype/zod';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+
+// Overwrite chainId and salt for strictness
+const _TypedDataDomainSchema = TypedDataDomainSchema.merge(
+  z.object({ chainId: z.number().optional(), salt: HexSchema.optional() }),
+);
+
+export const TypedDataSchema = z.object({
+  domain: _TypedDataDomainSchema,
+  primaryType: z.string(),
+  types: z.record(z.array(TypedDataParameterSchema)),
+  message: z.record(z.unknown()),
+});
+
+export type TypedData = z.infer<typeof TypedDataSchema>;

--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -8,9 +8,8 @@ import { getSafeMessageMessageHash } from '@/domain/common/utils/safe';
 import { Message } from '@/domain/messages/entities/message.entity';
 import { Safe } from '@/domain/safe/entities/safe.entity';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
-import { CreateMessageDto } from '@/routes/messages/entities/create-message.dto.entity';
 import { HttpStatus, Inject, Injectable } from '@nestjs/common';
-import { isAddressEqual, TypedDataDefinition } from 'viem';
+import { isAddressEqual } from 'viem';
 
 enum ErrorMessage {
   MalformedHash = 'Could not calculate messageHash',
@@ -100,7 +99,7 @@ export class MessageVerifierHelper {
     chainId: string;
     safe: Safe;
     expectedHash: `0x${string}`;
-    message: string | Record<string, unknown>;
+    message: Message['message'];
     source: LogSource;
   }): void {
     const calculatedHash = this.calculateMessageHash(args);
@@ -125,10 +124,7 @@ export class MessageVerifierHelper {
   }): `0x${string}` {
     let calculatedHash: `0x${string}`;
     try {
-      calculatedHash = getSafeMessageMessageHash({
-        ...args,
-        message: args.message as string | TypedDataDefinition,
-      });
+      calculatedHash = getSafeMessageMessageHash(args);
     } catch {
       this.logMalformedMessageHash(args);
       throw new HttpExceptionNoLog(
@@ -193,7 +189,7 @@ export class MessageVerifierHelper {
   private logMalformedMessageHash(args: {
     chainId: string;
     safe: Safe;
-    message: CreateMessageDto['message'];
+    message: Message['message'];
     source: LogSource;
   }): void {
     this.loggingService.error({
@@ -211,7 +207,7 @@ export class MessageVerifierHelper {
     chainId: string;
     safe: Safe;
     messageHash: `0x${string}`;
-    message: CreateMessageDto['message'];
+    message: Message['message'];
     source: LogSource;
   }): void {
     this.loggingService.error({

--- a/src/domain/messages/messages.repository.interface.ts
+++ b/src/domain/messages/messages.repository.interface.ts
@@ -5,6 +5,7 @@ import { MessagesRepository } from '@/domain/messages/messages.repository';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
 import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
 import { MessageVerifierHelper } from '@/domain/messages/helpers/message-verifier.helper';
+import { TypedData } from '@/domain/messages/entities/typed-data.entity';
 
 export const IMessagesRepository = Symbol('IMessagesRepository');
 
@@ -24,7 +25,7 @@ export interface IMessagesRepository {
   createMessage(args: {
     chainId: string;
     safeAddress: `0x${string}`;
-    message: string | Record<string, unknown>;
+    message: string | TypedData;
     safeAppId: number;
     signature: `0x${string}`;
     origin: string | null;

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -9,6 +9,7 @@ import {
 } from '@/domain/messages/entities/message.entity';
 import { MessageVerifierHelper } from '@/domain/messages/helpers/message-verifier.helper';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
+import { TypedData } from '@/domain/messages/entities/typed-data.entity';
 
 @Injectable()
 export class MessagesRepository implements IMessagesRepository {
@@ -52,7 +53,7 @@ export class MessagesRepository implements IMessagesRepository {
   async createMessage(args: {
     chainId: string;
     safeAddress: `0x${string}`;
-    message: string | Record<string, unknown>;
+    message: string | TypedData;
     safeAppId: number | null;
     signature: `0x${string}`;
     origin: string | null;

--- a/src/routes/messages/entities/__tests__/typed-data.builder.ts
+++ b/src/routes/messages/entities/__tests__/typed-data.builder.ts
@@ -1,0 +1,36 @@
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { Builder } from '@/__tests__/builder';
+import type { IBuilder } from '@/__tests__/builder';
+import type { TypedData } from '@/domain/messages/entities/typed-data.entity';
+
+// Note: the following is not strictly typed
+export function typedDataBuilder(): IBuilder<TypedData> {
+  const primaryType = faker.lorem.word();
+
+  const field1 = faker.lorem.word();
+  const field2 = faker.lorem.word();
+
+  return new Builder<TypedData>()
+    .with('domain', {
+      chainId: faker.number.int(),
+      verifyingContract: getAddress(faker.finance.ethereumAddress()),
+    })
+    .with('primaryType', primaryType)
+    .with('types', {
+      [primaryType]: [
+        {
+          name: field1,
+          type: 'uint256',
+        },
+        {
+          name: field2,
+          type: 'address',
+        },
+      ],
+    })
+    .with('message', {
+      [field1]: BigInt(faker.number.int()),
+      [field2]: getAddress(faker.finance.ethereumAddress()),
+    });
+}

--- a/src/routes/messages/entities/__tests__/typed-data.entity.spec.ts
+++ b/src/routes/messages/entities/__tests__/typed-data.entity.spec.ts
@@ -1,0 +1,75 @@
+import { TypedDataSchema } from '@/domain/messages/entities/typed-data.entity';
+
+// TODO: Increase test coverage
+describe('TypedDataSchema', () => {
+  it('should validate typed data', () => {
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          {
+            name: 'name',
+            type: 'string',
+          },
+          {
+            name: 'version',
+            type: 'string',
+          },
+          {
+            name: 'chainId',
+            type: 'uint256',
+          },
+          {
+            name: 'verifyingContract',
+            type: 'address',
+          },
+        ],
+        Person: [
+          {
+            name: 'name',
+            type: 'string',
+          },
+          {
+            name: 'wallet',
+            type: 'address',
+          },
+        ],
+        Mail: [
+          {
+            name: 'from',
+            type: 'Person',
+          },
+          {
+            name: 'to',
+            type: 'Person',
+          },
+          {
+            name: 'contents',
+            type: 'string',
+          },
+        ],
+      },
+      primaryType: 'Mail',
+      domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+      },
+      message: {
+        from: {
+          name: 'Cow',
+          wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        },
+        to: {
+          name: 'Bob',
+          wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        },
+        contents: 'Hello, Bob!',
+      },
+    };
+
+    const result = TypedDataSchema.safeParse(typedData);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/routes/messages/entities/create-message.dto.entity.ts
+++ b/src/routes/messages/entities/create-message.dto.entity.ts
@@ -1,12 +1,21 @@
 import { CreateMessageDtoSchema } from '@/routes/messages/entities/schemas/create-message.dto.schema';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TypedData } from '@/routes/messages/entities/typed-data.entity';
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import { z } from 'zod';
 
+@ApiExtraModels(TypedData)
 export class CreateMessageDto
   implements z.infer<typeof CreateMessageDtoSchema>
 {
-  @ApiProperty()
-  message!: string | Record<string, unknown>;
+  @ApiProperty({
+    oneOf: [{ type: 'string' }, { $ref: getSchemaPath(TypedData) }],
+  })
+  message!: string | TypedData;
   @ApiPropertyOptional({ type: Number, nullable: true, deprecated: true })
   safeAppId!: number | null;
   @ApiProperty()

--- a/src/routes/messages/entities/message.entity.ts
+++ b/src/routes/messages/entities/message.entity.ts
@@ -1,12 +1,19 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { MessageConfirmation } from '@/routes/messages/entities/message-confirmation.entity';
+import { TypedData } from '@/routes/messages/entities/typed-data.entity';
 
 export enum MessageStatus {
   NeedsConfirmation = 'NEEDS_CONFIRMATION',
   Confirmed = 'CONFIRMED',
 }
 
+@ApiExtraModels(TypedData)
 export class Message {
   @ApiProperty()
   messageHash: `0x${string}`;
@@ -16,8 +23,10 @@ export class Message {
   logoUri: string | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   name: string | null;
-  @ApiProperty()
-  message: string | Record<string, unknown>;
+  @ApiProperty({
+    oneOf: [{ type: 'string' }, { $ref: getSchemaPath(TypedData) }],
+  })
+  message: string | TypedData;
   @ApiProperty()
   creationTimestamp: number;
   @ApiProperty()
@@ -40,7 +49,7 @@ export class Message {
     status: MessageStatus,
     logoUri: string | null,
     name: string | null,
-    message: string | Record<string, unknown>,
+    message: string | TypedData,
     creationTimestamp: number,
     modifiedTimestamp: number,
     confirmationsSubmitted: number,

--- a/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
+++ b/src/routes/messages/entities/schemas/__tests__/create-message.dto.schema.spec.ts
@@ -1,4 +1,4 @@
-import { fakeJson } from '@/__tests__/faker';
+import { typedDataBuilder } from '@/routes/messages/entities/__tests__/typed-data.builder';
 import { createMessageDtoBuilder } from '@/routes/messages/entities/__tests__/create-message.dto.builder';
 import { CreateMessageDtoSchema } from '@/routes/messages/entities/schemas/create-message.dto.schema';
 import { faker } from '@faker-js/faker';
@@ -6,8 +6,8 @@ import { ZodError } from 'zod';
 
 describe('CreateMessageDtoSchema', () => {
   describe('message', () => {
-    it('should validate a valid record message', () => {
-      const message = JSON.parse(fakeJson()) as Record<string, unknown>;
+    it('should validate a valid typed data message', () => {
+      const message = typedDataBuilder().build();
       const createMessageDto = createMessageDtoBuilder()
         .with('message', message)
         .build();
@@ -34,43 +34,33 @@ describe('CreateMessageDtoSchema', () => {
 
       const result = CreateMessageDtoSchema.safeParse(createMessageDto);
 
-      expect(!result.success && result.error).toStrictEqual(
-        new ZodError([
-          {
-            code: 'invalid_union',
-            unionErrors: [
-              // @ts-expect-error - inferred type doesn't allow optional properties
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_union',
+          message: 'Invalid input',
+          path: ['message'],
+          unionErrors: [
+            new ZodError([
               {
-                issues: [
-                  {
-                    code: 'invalid_type',
-                    expected: 'object',
-                    received: 'undefined',
-                    path: ['message'],
-                    message: 'Required',
-                  },
-                ],
-                name: 'ZodError',
+                code: 'invalid_type',
+                expected: 'string',
+                received: 'undefined',
+                path: ['message'],
+                message: 'Required',
               },
-              // @ts-expect-error - inferred type doesn't allow optional properties
+            ]),
+            new ZodError([
               {
-                issues: [
-                  {
-                    code: 'invalid_type',
-                    expected: 'string',
-                    received: 'undefined',
-                    path: ['message'],
-                    message: 'Required',
-                  },
-                ],
-                name: 'ZodError',
+                code: 'invalid_type',
+                expected: 'object',
+                received: 'undefined',
+                path: ['message'],
+                message: 'Required',
               },
-            ],
-            path: ['message'],
-            message: 'Invalid input',
-          },
-        ]),
-      );
+            ]),
+          ],
+        },
+      ]);
     });
   });
 

--- a/src/routes/messages/entities/schemas/create-message.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/create-message.dto.schema.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
 import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
+import { MessageSchema } from '@/domain/messages/entities/message.entity';
 
 export const CreateMessageDtoSchema = z.object({
-  message: z.union([z.record(z.unknown()), z.string()]),
+  message: MessageSchema.shape.message,
   safeAppId: z.number().int().gte(0).nullish().default(null),
   signature: SignatureSchema,
   origin: z.string().nullish().default(null),

--- a/src/routes/messages/entities/typed-data.entity.ts
+++ b/src/routes/messages/entities/typed-data.entity.ts
@@ -1,0 +1,61 @@
+import { TypedData as DomainTypedData } from '@/domain/messages/entities/typed-data.entity';
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+  getSchemaPath,
+} from '@nestjs/swagger';
+
+class TypedDataDomain {
+  @ApiPropertyOptional({ type: Number })
+  chainId?: number;
+
+  @ApiPropertyOptional({
+    type: String,
+  })
+  name?: string;
+
+  @ApiPropertyOptional({ type: String })
+  salt?: `0x${string}`;
+
+  @ApiPropertyOptional({
+    type: String,
+  })
+  verifyingContract?: `0x${string}`;
+
+  @ApiPropertyOptional({
+    type: String,
+  })
+  version?: string;
+}
+
+class TypedDataParameter {
+  @ApiProperty({ type: String })
+  name!: string;
+
+  @ApiProperty({ type: String })
+  type!: string;
+}
+
+@ApiExtraModels(TypedDataParameter)
+export class TypedData implements DomainTypedData {
+  @ApiProperty({ type: TypedDataDomain })
+  domain!: TypedDataDomain;
+
+  @ApiProperty({ type: String })
+  primaryType!: string;
+
+  @ApiProperty({
+    type: Object,
+    additionalProperties: {
+      items: { $ref: getSchemaPath(TypedDataParameter) },
+      type: 'array',
+    },
+  })
+  types!: Record<string, Array<TypedDataParameter>>;
+
+  @ApiProperty({
+    type: Object,
+  })
+  message!: Record<string, unknown>;
+}

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -858,10 +858,10 @@ describe('Messages controller', () => {
         .expect({
           statusCode: 422,
           code: 'invalid_type',
-          expected: 'object',
+          expected: 'string',
           received: 'number',
           path: ['message'],
-          message: 'Expected object, received number',
+          message: 'Expected string, received number',
         });
     });
 


### PR DESCRIPTION
## Summary

We define typed data of messages as a standard record. This is vague and [unclear for clients generating types](https://github.com/safe-global/safe-client-gateway/pull/2468).

This adds a new `TypedDataSchema`, from which a domain entity is inferred. It is built from the (already installed) [`abitype/zod` schemas](https://abitype.dev/api/zod). Using this, we can safely validate incoming data and thus create a Swagger entity from it correctly.

## Changes

- Add `TypedDataSchema` and infer domain entity from it
- Validate creation/retrieval of messages with it
- Propagate types throughout project in messages
- Add/update test coverage accordingly