### PR TITLE
fix: parse `value` parameter for incoming/multisig transaction

### DIFF
--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -183,6 +183,12 @@ export class TransactionsService {
     const domainTransactions =
       await this.safeRepository.getMultisigTransactions({
         ...args,
+        ...(args.value && {
+          value: await this.parseTokenValue({
+            ...args,
+            value: args.value,
+          }),
+        }),
         limit: args.paginationData.limit,
         offset: args.paginationData.offset,
       });
@@ -377,21 +383,6 @@ export class TransactionsService {
     };
   }
 
-  private async parseTokenValue(args: {
-    chainId: string;
-    value: string;
-    tokenAddress?: `0x${string}`;
-  }): Promise<string | undefined> {
-    if (!args.tokenAddress) {
-      return parseEther(args.value).toString();
-    }
-    const token = await this.tokenRepository.getToken({
-      chainId: args.chainId,
-      address: args.tokenAddress,
-    });
-    return parseUnits(args.value, token.decimals).toString();
-  }
-
   async previewTransaction(args: {
     chainId: string;
     safeAddress: `0x${string}`;
@@ -582,6 +573,21 @@ export class TransactionsService {
         paginationData.offset - 1,
       );
     }
+  }
+
+  private async parseTokenValue(args: {
+    chainId: string;
+    value: string;
+    tokenAddress?: `0x${string}`;
+  }): Promise<string> {
+    if (!args.tokenAddress) {
+      return parseEther(args.value).toString();
+    }
+    const token = await this.tokenRepository.getToken({
+      chainId: args.chainId,
+      address: args.tokenAddress,
+    });
+    return parseUnits(args.value, token.decimals).toString();
   }
 
   private getNextPageFirstNonce(

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -36,13 +36,20 @@ import { TransactionPreviewMapper } from '@/routes/transactions/mappers/transact
 import { TransactionsHistoryMapper } from '@/routes/transactions/mappers/transactions-history.mapper';
 import { TransferDetailsMapper } from '@/routes/transactions/mappers/transfers/transfer-details.mapper';
 import { TransferMapper } from '@/routes/transactions/mappers/transfers/transfer.mapper';
-import { getAddress, isAddress, isAddressEqual } from 'viem';
+import {
+  getAddress,
+  isAddress,
+  isAddressEqual,
+  parseEther,
+  parseUnits,
+} from 'viem';
 import { LoggingService, ILoggingService } from '@/logging/logging.interface';
 import { MultisigTransactionNoteMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper';
 import { LogType } from '@/domain/common/entities/log-type.entity';
 import { TXSMultisigTransaction } from '@/routes/transactions/entities/txs-multisig-transaction.entity';
 import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-multisig-transaction-page.entity';
 import { TXSCreationTransaction } from '@/routes/transactions/entities/txs-creation-transaction.entity';
+import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
 
 @Injectable()
 export class TransactionsService {
@@ -59,6 +66,8 @@ export class TransactionsService {
     private readonly multisigTransactionNoteMapper: MultisigTransactionNoteMapper,
     private readonly transferDetailsMapper: TransferDetailsMapper,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    @Inject(ITokenRepository)
+    private readonly tokenRepository: ITokenRepository,
   ) {}
 
   async getById(args: {
@@ -332,6 +341,12 @@ export class TransactionsService {
   }): Promise<Partial<Page<IncomingTransfer>>> {
     const transfers = await this.safeRepository.getIncomingTransfers({
       ...args,
+      ...(args.value && {
+        value: await this.parseTokenValue({
+          ...args,
+          value: args.value,
+        }),
+      }),
       limit: args.paginationData?.limit,
       offset: args.paginationData?.offset,
     });
@@ -360,6 +375,21 @@ export class TransactionsService {
       previous: previousURL?.toString() ?? null,
       results,
     };
+  }
+
+  private async parseTokenValue(args: {
+    chainId: string;
+    value: string;
+    tokenAddress?: `0x${string}`;
+  }): Promise<string | undefined> {
+    if (!args.tokenAddress) {
+      return parseEther(args.value).toString();
+    }
+    const token = await this.tokenRepository.getToken({
+      chainId: args.chainId,
+      address: args.tokenAddress,
+    });
+    return parseUnits(args.value, token.decimals).toString();
   }
 
   async previewTransaction(args: {


### PR DESCRIPTION
## Summary

When requesting incoming/multisig transactions, a pre-parsed value is required. This instead parses the incoming/multisig `value` to allow for floats to be used as queries.

## Changes

- If a `value` is present, parse it according to the relevant decimals
- Add appropriate test coverage