### PR TITLE
fix: improve twap definition

### DIFF
--- a/src/routes/transactions/entities/swaps/twap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/twap-order-info.entity.ts
@@ -25,38 +25,42 @@ export enum StartTimeValue {
   AtEpoch = 'AT_EPOCH',
 }
 
-export type DurationOfPart =
-  | { durationType: DurationType.Auto }
-  | { durationType: DurationType.LimitDuration; duration: string };
-
-export type StartTime =
-  | { startType: StartTimeValue.AtMiningTime }
-  | { startType: StartTimeValue.AtEpoch; epoch: number };
+type DurationOfPart = DurationAuto | DurationLimit;
 
 export class DurationAuto {
   @ApiProperty({ enum: [DurationType.Auto] })
-  durationType!: DurationType.Auto;
+  durationType = DurationType.Auto;
 }
 
 export class DurationLimit {
   @ApiProperty({ enum: [DurationType.LimitDuration] })
-  durationType!: DurationType.LimitDuration;
+  durationType = DurationType.LimitDuration;
 
   @ApiProperty()
-  duration!: string;
+  duration: string;
+
+  constructor(duration: string) {
+    this.duration = duration;
+  }
 }
+
+type StartTime = StartTimeAtMining | StartTimeAtEpoch;
 
 export class StartTimeAtMining {
   @ApiProperty({ enum: [StartTimeValue.AtMiningTime] })
-  startType!: StartTimeValue.AtMiningTime;
+  startType = StartTimeValue.AtMiningTime;
 }
 
 export class StartTimeAtEpoch {
   @ApiProperty({ enum: [StartTimeValue.AtEpoch] })
-  startType!: StartTimeValue.AtEpoch;
+  startType = StartTimeValue.AtEpoch;
 
   @ApiProperty()
-  epoch!: number;
+  epoch: number;
+
+  constructor(epoch: number) {
+    this.epoch = epoch;
+  }
 }
 
 export type TwapOrderInfo = {

--- a/src/routes/transactions/entities/swaps/twap-order-info.entity.ts
+++ b/src/routes/transactions/entities/swaps/twap-order-info.entity.ts
@@ -12,6 +12,7 @@ import {
   ApiExtraModels,
   ApiProperty,
   ApiPropertyOptional,
+  getSchemaPath,
 } from '@nestjs/swagger';
 
 export enum DurationType {
@@ -31,6 +32,32 @@ export type DurationOfPart =
 export type StartTime =
   | { startType: StartTimeValue.AtMiningTime }
   | { startType: StartTimeValue.AtEpoch; epoch: number };
+
+export class DurationAuto {
+  @ApiProperty({ enum: [DurationType.Auto] })
+  durationType!: DurationType.Auto;
+}
+
+export class DurationLimit {
+  @ApiProperty({ enum: [DurationType.LimitDuration] })
+  durationType!: DurationType.LimitDuration;
+
+  @ApiProperty()
+  duration!: string;
+}
+
+export class StartTimeAtMining {
+  @ApiProperty({ enum: [StartTimeValue.AtMiningTime] })
+  startType!: StartTimeValue.AtMiningTime;
+}
+
+export class StartTimeAtEpoch {
+  @ApiProperty({ enum: [StartTimeValue.AtEpoch] })
+  startType!: StartTimeValue.AtEpoch;
+
+  @ApiProperty()
+  epoch!: number;
+}
 
 export type TwapOrderInfo = {
   status: OrderStatus;
@@ -58,7 +85,13 @@ export type TwapOrderInfo = {
   startTime: StartTime;
 };
 
-@ApiExtraModels(TokenInfo)
+@ApiExtraModels(
+  TokenInfo,
+  DurationAuto,
+  DurationLimit,
+  StartTimeAtMining,
+  StartTimeAtEpoch,
+)
 export class TwapOrderTransactionInfo
   extends TransactionInfo
   implements TwapOrderInfo
@@ -175,11 +208,19 @@ export class TwapOrderTransactionInfo
 
   @ApiProperty({
     description: 'Whether the TWAP is valid for the entire interval or not',
+    oneOf: [
+      { $ref: getSchemaPath(DurationAuto) },
+      { $ref: getSchemaPath(DurationLimit) },
+    ],
   })
   durationOfPart: DurationOfPart;
 
   @ApiProperty({
     description: 'The start time of the TWAP',
+    oneOf: [
+      { $ref: getSchemaPath(StartTimeAtMining) },
+      { $ref: getSchemaPath(StartTimeAtEpoch) },
+    ],
   })
   startTime: StartTime;
 

--- a/src/routes/transactions/helpers/twap-order.helper.ts
+++ b/src/routes/transactions/helpers/twap-order.helper.ts
@@ -13,10 +13,10 @@ import {
   SellTokenBalance,
 } from '@/domain/swaps/entities/order.entity';
 import {
-  DurationType,
-  StartTimeValue,
-  DurationOfPart,
-  StartTime,
+  DurationAuto,
+  DurationLimit,
+  StartTimeAtEpoch,
+  StartTimeAtMining,
   TwapOrderInfo,
 } from '@/routes/transactions/entities/swaps/twap-order-info.entity';
 import { GPv2OrderParameters } from '@/domain/swaps/contracts/decoders/gp-v2-decoder.helper';
@@ -99,13 +99,13 @@ export class TwapOrderHelper {
     const buyAmount = minPartLimit * numberOfParts;
 
     const isSpanZero = Number(span) === 0;
-    const durationOfPart: DurationOfPart = isSpanZero
-      ? { durationType: DurationType.Auto }
-      : { durationType: DurationType.LimitDuration, duration: span.toString() };
+    const durationOfPart = isSpanZero
+      ? new DurationAuto()
+      : new DurationLimit(span.toString());
 
-    const startTime: StartTime = isSpanZero
-      ? { startType: StartTimeValue.AtMiningTime }
-      : { startType: StartTimeValue.AtEpoch, epoch: Number(startEpoch) };
+    const startTime = isSpanZero
+      ? new StartTimeAtMining()
+      : new StartTimeAtEpoch(Number(startEpoch));
 
     return {
       kind: OrderKind.Sell,


### PR DESCRIPTION
## Summary
durationOfPart and startTime were exported as a generic object, but in reality they do have a concrete form. I've updated the swagger definition and we now have a more type safe swagger definition.

## Changes
