### PR TITLE
fix: remove `type` from malformed hash logs

### DIFF
--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -192,13 +192,13 @@ export class MessageVerifierHelper {
     message: Message['message'];
     source: LogSource;
   }): void {
+    // We do not include the type as it is not a validity error
     this.loggingService.error({
       message: 'Could not calculate messageHash',
       chainId: args.chainId,
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,
       safeMessage: args.message,
-      type: LogType.MessageValidity,
       source: args.source,
     });
   }

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -502,6 +502,7 @@ export class TransactionVerifierHelper {
     transaction: BaseMultisigTransaction;
     source: LogSource;
   }): void {
+    // We do not include the type as it is not a validity error
     this.loggingService.error({
       message: 'Could not calculate safeTxHash',
       chainId: args.chainId,
@@ -509,7 +510,6 @@ export class TransactionVerifierHelper {
       safeVersion: args.safe.version,
       safeTxHash: args.safeTxHash,
       transaction: getBaseMultisigTransaction(args.transaction),
-      type: LogType.TransactionValidity,
       source: args.source,
     });
   }


### PR DESCRIPTION
## Summary

If a hash cannot be calculated, we log them a validity errors. As this is no the case, this removes the categorisation of the logs.

## Changes

- Remove `type` from hash calculation errors.