### PR TITLE
fix: coerce `chainId` of typed data

### DIFF
--- a/src/domain/messages/entities/typed-data.entity.ts
+++ b/src/domain/messages/entities/typed-data.entity.ts
@@ -7,7 +7,10 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 
 // Overwrite chainId and salt for strictness
 const _TypedDataDomainSchema = TypedDataDomainSchema.merge(
-  z.object({ chainId: z.number().optional(), salt: HexSchema.optional() }),
+  z.object({
+    chainId: z.coerce.number().optional(),
+    salt: HexSchema.optional(),
+  }),
 );
 
 export const TypedDataSchema = z.object({


### PR DESCRIPTION
## Summary

The `chainId` of typed data domains should be a `number`. However, it can be returned as a `string`. This coerces all incoming values to a `number`.

## Changes

- Expect any value for the `chainId` of typed data domains, coercing it to a `number`