### PR TITLE
fix: add tests for `TypedDataSchema`

### DIFF
--- a/src/domain/messages/entities/__tests__/typed-data.entity.spec.ts
+++ b/src/domain/messages/entities/__tests__/typed-data.entity.spec.ts
@@ -1,0 +1,159 @@
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import {
+  _TypedDataDomainSchema,
+  TypedDataSchema,
+  type TypedData,
+} from '@/domain/messages/entities/typed-data.entity';
+import {
+  typedDataBuilder,
+  typedDataDomainBuilder,
+} from '@/routes/messages/entities/__tests__/typed-data.builder';
+
+describe('TypedDataSchema', () => {
+  it('should validate TypedData', () => {
+    const typedData = typedDataBuilder().build();
+
+    const result = TypedDataSchema.safeParse(typedData);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("shouldn't validate invalid TypedData", () => {
+    const typedData = { invalid: 'typedData' };
+
+    const result = TypedDataSchema.safeParse(typedData);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'object',
+        message: 'Required',
+        path: ['domain'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['primaryType'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'object',
+        message: 'Required',
+        path: ['types'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'object',
+        message: 'Required',
+        path: ['message'],
+        received: 'undefined',
+      },
+    ]);
+  });
+
+  describe('domain', () => {
+    it('should validate a TypedDataDomain domain', () => {
+      const domain = typedDataDomainBuilder().build();
+
+      const result = _TypedDataDomainSchema.safeParse(domain);
+
+      expect(result.success).toBe(true);
+    });
+
+    it.each([
+      ['string', faker.string.numeric()],
+      ['number', faker.number.int()],
+    ])('should accept a %s chainId, coercing it to a number', (_, chainId) => {
+      const domain = typedDataDomainBuilder()
+        .with('chainId', chainId as unknown as number)
+        .build();
+
+      const result = _TypedDataDomainSchema.safeParse(domain);
+
+      expect(result.success && result.data.chainId).toBe(Number(chainId));
+    });
+
+    it('should require a hex salt', () => {
+      const domain = typedDataDomainBuilder()
+        .with('salt', faker.string.alpha() as `0x${string}`)
+        .build();
+
+      const result = _TypedDataDomainSchema.safeParse(domain);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'custom',
+          message: 'Invalid "0x" notated hex string',
+          path: ['salt'],
+        },
+      ]);
+    });
+
+    it('should checksum the verifyingContract', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase() as `0x${string}`;
+      const domain = typedDataDomainBuilder()
+        .with('verifyingContract', nonChecksummedAddress)
+        .build();
+
+      const result = _TypedDataDomainSchema.safeParse(domain);
+
+      expect(result.success && result.data.verifyingContract).toBe(
+        getAddress(nonChecksummedAddress),
+      );
+    });
+
+    it.each(Object.keys(typedDataDomainBuilder().build()))(
+      'should allow an optional %s',
+      (key) => {
+        const domain = typedDataDomainBuilder().build();
+        // @ts-expect-error - Object.keys is not type safe
+        delete domain[key];
+
+        const result = _TypedDataDomainSchema.safeParse(domain);
+
+        expect(result.success).toBe(true);
+      },
+    );
+  });
+
+  describe('types', () => {
+    it('should validate TypedDataParameters', () => {
+      const types = faker.helpers
+        .multiple(() => faker.lorem.word())
+        .reduce<TypedData['types']>((acc, cur) => {
+          acc[cur] = faker.helpers.multiple(() => ({
+            name: faker.lorem.word(),
+            type: faker.lorem.word(),
+          }));
+          return acc;
+        }, {});
+
+      const result = TypedDataSchema.shape.types.safeParse(types);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("shouldn't validate invalid TypedDataParamters", () => {
+      const types = { invalid: 'types' };
+
+      const result = TypedDataSchema.shape.types.safeParse(types);
+
+      expect(!result.success && result.error.issues).toStrictEqual([
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          message: 'Expected array, received string',
+          path: ['invalid'],
+          received: 'string',
+        },
+      ]);
+    });
+  });
+});

--- a/src/domain/messages/entities/typed-data.entity.ts
+++ b/src/domain/messages/entities/typed-data.entity.ts
@@ -4,14 +4,16 @@ import {
   TypedDataParameter as TypedDataParameterSchema,
 } from 'abitype/zod';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
-// Overwrite chainId and salt for strictness
-const _TypedDataDomainSchema = TypedDataDomainSchema.merge(
-  z.object({
-    chainId: z.coerce.number().optional(),
-    salt: HexSchema.optional(),
-  }),
-);
+export const _TypedDataDomainSchema = z.object({
+  name: TypedDataDomainSchema.shape.name,
+  version: TypedDataDomainSchema.shape.version,
+  // Overwrite chainId, salt and address for strictness/checksumming
+  chainId: z.coerce.number().optional(),
+  salt: HexSchema.optional(),
+  verifyingContract: AddressSchema.optional(),
+});
 
 export const TypedDataSchema = z.object({
   domain: _TypedDataDomainSchema,

--- a/src/routes/messages/entities/__tests__/typed-data.builder.ts
+++ b/src/routes/messages/entities/__tests__/typed-data.builder.ts
@@ -34,3 +34,12 @@ export function typedDataBuilder(): IBuilder<TypedData> {
       [field2]: getAddress(faker.finance.ethereumAddress()),
     });
 }
+
+export function typedDataDomainBuilder(): IBuilder<TypedData['domain']> {
+  return new Builder<TypedData['domain']>()
+    .with('chainId', faker.number.int())
+    .with('name', faker.lorem.word())
+    .with('salt', faker.string.hexadecimal({ length: 64 }) as `0x${string}`)
+    .with('verifyingContract', getAddress(faker.finance.ethereumAddress()))
+    .with('version', faker.system.semver());
+}


### PR DESCRIPTION
## Summary

Our `TypedData` entity, inferred from the `TypedDataSchema` has no test covered. Without it, we discovered [a bug](https://github.com/safe-global/safe-client-gateway/pull/2490). This adds the appropriate test coverage to ensure it works as expected.

## Changes

- Simplify `_TypedDataDomainSchema` structure
- Add `typedDataDomainBuilder` for mocking
- Add test coverage of `TypedDataSchema`