### PR TITLE
fix: improve swagger message type

### DIFF
--- a/src/routes/messages/entities/message-item.entity.ts
+++ b/src/routes/messages/entities/message-item.entity.ts
@@ -2,8 +2,8 @@ import { Message } from '@/routes/messages/entities/message.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class MessageItem extends Message {
-  @ApiProperty()
-  type: string;
+  @ApiProperty({ enum: ['MESSAGE'] })
+  type: 'MESSAGE';
 
   constructor(...args: ConstructorParameters<typeof Message>) {
     super(...args);

--- a/src/routes/messages/entities/message.entity.ts
+++ b/src/routes/messages/entities/message.entity.ts
@@ -37,7 +37,7 @@ export class Message {
   confirmationsRequired: number;
   @ApiProperty()
   proposedBy: AddressInfo;
-  @ApiProperty({ type: [MessageConfirmation] })
+  @ApiProperty({ type: MessageConfirmation, isArray: true })
   confirmations: Array<MessageConfirmation>;
   @ApiPropertyOptional({ type: String, nullable: true })
   preparedSignature: `0x${string}` | null;

--- a/src/routes/messages/entities/message.entity.ts
+++ b/src/routes/messages/entities/message.entity.ts
@@ -37,7 +37,7 @@ export class Message {
   confirmationsRequired: number;
   @ApiProperty()
   proposedBy: AddressInfo;
-  @ApiProperty()
+  @ApiProperty({ type: [MessageConfirmation] })
   confirmations: Array<MessageConfirmation>;
   @ApiPropertyOptional({ type: String, nullable: true })
   preparedSignature: `0x${string}` | null;


### PR DESCRIPTION
## Summary
MessageItem has only a type equal to "MESSAGE" and string is too broad.

Message.confirmation was ending up as sting[] as in reality it is a MessageConfirmation[] type.

## Changes
