### PR TITLE
fix: settings-change entity wrong SettingsInfo type

### DIFF
--- a/src/routes/transactions/entities/settings-change-transaction.entity.ts
+++ b/src/routes/transactions/entities/settings-change-transaction.entity.ts
@@ -1,17 +1,53 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
 import { SettingsChange } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 import {
   TransactionInfo,
   TransactionInfoType,
 } from '@/routes/transactions/entities/transaction-info.entity';
+import { AddOwner } from '@/routes/transactions/entities/settings-changes/add-owner.entity';
+import { ChangeMasterCopy } from '@/routes/transactions/entities/settings-changes/change-master-copy.entity';
+import { ChangeThreshold } from '@/routes/transactions/entities/settings-changes/change-threshold.entity';
+import { DeleteGuard } from '@/routes/transactions/entities/settings-changes/delete-guard';
+import { DisableModule } from '@/routes/transactions/entities/settings-changes/disable-module.entity';
+import { EnableModule } from '@/routes/transactions/entities/settings-changes/enable-module.entity';
+import { RemoveOwner } from '@/routes/transactions/entities/settings-changes/remove-owner.entity';
+import { SetFallbackHandler } from '@/routes/transactions/entities/settings-changes/set-fallback-handler.entity';
+import { SetGuard } from '@/routes/transactions/entities/settings-changes/set-guard.entity';
+import { SwapOwner } from '@/routes/transactions/entities/settings-changes/swap-owner.entity';
 
+@ApiExtraModels(
+  AddOwner,
+  ChangeMasterCopy,
+  ChangeThreshold,
+  DeleteGuard,
+  DisableModule,
+  EnableModule,
+  RemoveOwner,
+  SetFallbackHandler,
+  SetGuard,
+  SettingsChange,
+  SwapOwner,
+)
 export class SettingsChangeTransaction extends TransactionInfo {
   @ApiProperty({ enum: [TransactionInfoType.SettingsChange] })
   override type = TransactionInfoType.SettingsChange;
   @ApiProperty()
   dataDecoded: DataDecoded;
-  @ApiPropertyOptional({ type: SettingsChange, nullable: true })
+  @ApiProperty({
+    oneOf: [
+      { $ref: getSchemaPath(AddOwner) },
+      { $ref: getSchemaPath(ChangeMasterCopy) },
+      { $ref: getSchemaPath(ChangeThreshold) },
+      { $ref: getSchemaPath(DeleteGuard) },
+      { $ref: getSchemaPath(DisableModule) },
+      { $ref: getSchemaPath(EnableModule) },
+      { $ref: getSchemaPath(RemoveOwner) },
+      { $ref: getSchemaPath(SetFallbackHandler) },
+      { $ref: getSchemaPath(SetGuard) },
+      { $ref: getSchemaPath(SwapOwner) },
+    ],
+  })
   settingsInfo: SettingsChange | null;
 
   constructor(

--- a/src/routes/transactions/entities/settings-changes/add-owner.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/add-owner.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class AddOwner extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.AddOwner] })
+  readonly type!: SettingsChangeType.AddOwner;
+
   @ApiProperty()
   owner: AddressInfo;
   @ApiProperty()

--- a/src/routes/transactions/entities/settings-changes/change-master-copy.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/change-master-copy.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class ChangeMasterCopy extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.ChangeMasterCopy] })
+  override type!: SettingsChangeType.ChangeMasterCopy;
+
   @ApiProperty()
   implementation: AddressInfo;
 

--- a/src/routes/transactions/entities/settings-changes/change-threshold.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/change-threshold.entity.ts
@@ -5,6 +5,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class ChangeThreshold extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.ChangeThreshold] })
+  override type!: SettingsChangeType.ChangeThreshold;
+
   @ApiProperty()
   threshold: number;
 

--- a/src/routes/transactions/entities/settings-changes/delete-guard.ts
+++ b/src/routes/transactions/entities/settings-changes/delete-guard.ts
@@ -2,8 +2,12 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class DeleteGuard extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.DeleteGuard] })
+  override type!: SettingsChangeType.DeleteGuard;
+
   constructor() {
     super(SettingsChangeType.DeleteGuard);
   }

--- a/src/routes/transactions/entities/settings-changes/disable-module.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/disable-module.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class DisableModule extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.DisableModule] })
+  override type!: SettingsChangeType.DisableModule;
+
   @ApiProperty()
   module: AddressInfo;
 

--- a/src/routes/transactions/entities/settings-changes/enable-module.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/enable-module.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class EnableModule extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.EnableModule] })
+  override type!: SettingsChangeType.EnableModule;
+
   @ApiProperty()
   module: AddressInfo;
 

--- a/src/routes/transactions/entities/settings-changes/remove-owner.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/remove-owner.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class RemoveOwner extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.RemoveOwner] })
+  override type!: SettingsChangeType.RemoveOwner;
+
   @ApiProperty()
   owner: AddressInfo;
   @ApiProperty()

--- a/src/routes/transactions/entities/settings-changes/set-fallback-handler.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/set-fallback-handler.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class SetFallbackHandler extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.SetFallbackHandler] })
+  override type!: SettingsChangeType.SetFallbackHandler;
+
   @ApiProperty()
   handler: AddressInfo;
 

--- a/src/routes/transactions/entities/settings-changes/set-guard.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/set-guard.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class SetGuard extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.SetGuard] })
+  override type!: SettingsChangeType.SetGuard;
+
   @ApiProperty()
   guard: AddressInfo;
 

--- a/src/routes/transactions/entities/settings-changes/swap-owner.entity.ts
+++ b/src/routes/transactions/entities/settings-changes/swap-owner.entity.ts
@@ -6,6 +6,9 @@ import {
 } from '@/routes/transactions/entities/settings-changes/settings-change.entity';
 
 export class SwapOwner extends SettingsChange {
+  @ApiProperty({ enum: [SettingsChangeType.SwapOwner] })
+  override type!: SettingsChangeType.SwapOwner;
+
   @ApiProperty()
   oldOwner: AddressInfo;
   @ApiProperty()


### PR DESCRIPTION
## Summary
The possible settingsInfo types were wrong in the generated swagger and susequently in the generated RKT code.

## Changes
