### PR TITLE
fix: relay swagger type response was missing

### DIFF
--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Post, Param, Get, UseFilters, Body } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { RelayDto } from '@/routes/relay/entities/relay.dto.entity';
 import { RelayService } from '@/routes/relay/relay.service';
 import { RelayLimitReachedExceptionFilter } from '@/domain/relay/exception-filters/relay-limit-reached.exception-filter';
@@ -11,8 +11,8 @@ import { UnofficialMultiSendExceptionFilter } from '@/domain/relay/exception-fil
 import { UnofficialProxyFactoryExceptionFilter } from '@/domain/relay/exception-filters/unofficial-proxy-factory.exception-filter';
 import { RelayDtoSchema } from '@/routes/relay/entities/schemas/relay.dto.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import type { Relay } from '@/routes/relay/entities/relay.entity';
-import type { RelaysRemaining } from '@/routes/relay/entities/relays-remaining.entity';
+import { Relay } from '@/routes/relay/entities/relay.entity';
+import { RelaysRemaining } from '@/routes/relay/entities/relays-remaining.entity';
 
 @ApiTags('relay')
 @Controller({
@@ -31,6 +31,7 @@ export class RelayController {
     UnofficialMultiSendExceptionFilter,
     UnofficialProxyFactoryExceptionFilter,
   )
+  @ApiOkResponse({ type: Relay })
   async relay(
     @Param('chainId') chainId: string,
     @Body(new ValidationPipe(RelayDtoSchema))
@@ -39,6 +40,7 @@ export class RelayController {
     return this.relayService.relay({ chainId, relayDto });
   }
 
+  @ApiOkResponse({ type: RelaysRemaining })
   @Get(':safeAddress')
   async getRelaysRemaining(
     @Param('chainId') chainId: string,


### PR DESCRIPTION
## Summary
The relay swagger definition was missing the `@ApiOkResponse` tag and as such the response types were unknown.

## Changes
