### PR TITLE
fix: verify proposals with fresh transaction data

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -811,7 +811,7 @@ export class TransactionApi implements ITransactionApi {
     safeTransactionHash: string,
   ): Promise<Raw<MultisigTransaction>> {
     try {
-      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}`;
+      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
       const { data } = await this.networkService.get<Raw<MultisigTransaction>>({
         url,
       });


### PR DESCRIPTION
## Summary
This PR changes the way a transaction is fetched before checking the addition of new confirmations (via the `propose` endpoint). Instead of getting the transaction first and clearing the cache when it does not exist, it uses always fresh data (from the Safe Transaction Service), so no need for clearing the cache.

## Changes
- Fetches the transaction data by calling `transactionService.getMultisigTransactionWithNoCache` instead of the cached endpoint.
