### PR TITLE
feat: limit the number of Safes per Space

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -270,6 +270,10 @@ export default (): ReturnType<typeof configuration> => ({
   safeWebApp: {
     baseUri: faker.internet.url({ appendSlash: false }),
   },
+  spaces: {
+    maxSafesPerSpace: faker.number.int({ min: 5, max: 10 }),
+    maxInvites: faker.number.int({ min: 5, max: 10 }),
+  },
   staking: {
     testnet: {
       baseUri: faker.internet.url({ appendSlash: false }),
@@ -304,8 +308,5 @@ export default (): ReturnType<typeof configuration> => ({
         baseDir: 'assets/targeted-messaging',
       },
     },
-  },
-  users: {
-    maxInvites: faker.number.int({ min: 5, max: 10 }),
   },
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -398,6 +398,12 @@ export default () => ({
   safeWebApp: {
     baseUri: process.env.SAFE_WEB_APP_BASE_URI || 'https://app.safe.global',
   },
+  spaces: {
+    maxSafesPerSpace: parseInt(
+      process.env.SPACES_MAX_SAFES_PER_SPACE ?? `${10}`,
+    ),
+    maxInvites: parseInt(process.env.SPACES_MAX_INVITES ?? `${50}`),
+  },
   staking: {
     testnet: {
       baseUri:
@@ -458,8 +464,5 @@ export default () => ({
           'assets/targeted-messaging',
       },
     },
-  },
-  users: {
-    maxInvites: 50,
   },
 });

--- a/src/domain/spaces/space-safes.repository.spec.ts
+++ b/src/domain/spaces/space-safes.repository.spec.ts
@@ -17,7 +17,7 @@ import type { Repository } from 'typeorm';
 import type { ConfigService } from '@nestjs/config';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
 
 const mockLoggingService = {
@@ -32,7 +32,6 @@ const SpaceStatusKeys = getStringEnumKeys(SpaceStatus);
 describe('SpaceSafesRepository', () => {
   let postgresDatabaseService: PostgresDatabaseService;
   let spaceSafesRepo: SpaceSafesRepository;
-
   let dbWalletRepo: Repository<Wallet>;
   let dbUserRepo: Repository<User>;
   let dbSpaceRepository: Repository<Space>;
@@ -54,6 +53,8 @@ describe('SpaceSafesRepository', () => {
     migrationsTableName: testConfiguration.db.orm.migrationsTableName,
     entities: [Member, Space, SpaceSafe, User, Wallet],
   });
+
+  const maxSafesPerSpace = 5;
 
   beforeAll(async () => {
     // Create database
@@ -90,6 +91,9 @@ describe('SpaceSafesRepository', () => {
         if (key === 'db.migrator.retryAfterMs') {
           return testConfiguration.db.migrator.retryAfterMs;
         }
+        if (key === 'spaces.maxSafesPerSpace') {
+          return maxSafesPerSpace;
+        }
       }),
     } as jest.MockedObjectDeep<ConfigService>;
     const migrator = new DatabaseMigrator(
@@ -99,7 +103,10 @@ describe('SpaceSafesRepository', () => {
     );
     await migrator.migrate();
 
-    spaceSafesRepo = new SpaceSafesRepository(postgresDatabaseService);
+    spaceSafesRepo = new SpaceSafesRepository(
+      postgresDatabaseService,
+      mockConfigService,
+    );
 
     dbWalletRepo = dataSource.getRepository(Wallet);
     dbUserRepo = dataSource.getRepository(User);
@@ -320,7 +327,7 @@ describe('SpaceSafesRepository', () => {
           chainId: faker.string.numeric(),
           address: getAddress(faker.finance.ethereumAddress()),
         }),
-        { count: { min: 2, max: 5 } },
+        { count: { min: 2, max: maxSafesPerSpace } },
       );
       const user = await dbUserRepo.insert({
         status: 'ACTIVE',
@@ -356,6 +363,64 @@ describe('SpaceSafesRepository', () => {
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
         })),
+      );
+    });
+
+    it('should fail if the number of SpaceSafes surpasses the limit', async () => {
+      const user = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      const userId = user.identifiers[0].id as User['id'];
+      await dbWalletRepo.insert({
+        user: { id: userId },
+        address: getAddress(faker.finance.ethereumAddress()),
+      });
+      const space = await dbSpaceRepository.insert({
+        status: faker.helpers.arrayElement(getStringEnumKeys(SpaceStatus)),
+        name: faker.word.noun(),
+      });
+      const spaceId = space.identifiers[0].id as Space['id'];
+      await dbMembersRepository.insert({
+        user: { id: userId },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        name: faker.word.noun(),
+        space: { id: spaceId },
+      });
+
+      // Create (maxSafesPerSpace - 1) Safes
+      await spaceSafesRepo.create({
+        spaceId: spaceId,
+        payload: faker.helpers.multiple(
+          () => ({
+            chainId: faker.string.numeric(),
+            address: getAddress(faker.finance.ethereumAddress()),
+          }),
+          { count: maxSafesPerSpace - 1 },
+        ),
+      });
+
+      // Create 2 Safes more to surpass the limit
+      await expect(
+        spaceSafesRepo.create({
+          spaceId: spaceId,
+          payload: faker.helpers.multiple(
+            () => ({
+              chainId: faker.string.numeric(),
+              address: getAddress(faker.finance.ethereumAddress()),
+            }),
+            { count: 2 },
+          ),
+        }),
+      ).rejects.toThrow(
+        new BadRequestException(
+          `Safes limit (${maxSafesPerSpace}) reached for Space ${spaceId}. Existing safes: ${maxSafesPerSpace - 1}. Safes to add: 2`,
+        ),
+      );
+
+      // The Space should still have (maxSafesPerSpace - 1) Safes
+      await expect(spaceSafesRepo.findBySpaceId(spaceId)).resolves.toHaveLength(
+        maxSafesPerSpace - 1,
       );
     });
 

--- a/src/domain/spaces/space-safes.repository.ts
+++ b/src/domain/spaces/space-safes.repository.ts
@@ -1,10 +1,11 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
 import { SpaceSafe } from '@/datasources/spaces/entities/space-safes.entity.db';
 import { Space } from '@/datasources/spaces/entities/space.entity.db';
 import type { ISpaceSafesRepository } from '@/domain/spaces/space-safes.repository.interface';
-import { Inject, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
 import {
   FindOptionsRelations,
   FindOptionsSelect,
@@ -12,10 +13,18 @@ import {
 } from 'typeorm';
 
 export class SpaceSafesRepository implements ISpaceSafesRepository {
+  private readonly maxSafesPerSpace: number;
+
   public constructor(
     @Inject(PostgresDatabaseService)
     private readonly postgresDatabaseService: PostgresDatabaseService,
-  ) {}
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.maxSafesPerSpace = this.configurationService.getOrThrow<number>(
+      'spaces.maxSafesPerSpace',
+    );
+  }
 
   public async create(args: {
     spaceId: Space['id'];
@@ -28,12 +37,17 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
       await this.postgresDatabaseService.getRepository(SpaceSafe);
 
     const safesToInsert = args.payload.map((safe) => ({
-      space: {
-        id: args.spaceId,
-      },
+      space: { id: args.spaceId },
       chainId: safe.chainId,
       address: safe.address,
     }));
+
+    const existingSafes = await this.findBySpaceId(args.spaceId);
+    if (existingSafes.length + safesToInsert.length > this.maxSafesPerSpace) {
+      throw new BadRequestException(
+        `Safes limit (${this.maxSafesPerSpace}) reached for Space ${args.spaceId}. Existing safes: ${existingSafes.length}. Safes to add: ${args.payload.length}`,
+      );
+    }
 
     try {
       await spaceSafeRepository.insert(safesToInsert);
@@ -55,11 +69,7 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
 
     return await spaceSafeRepository.find({
       select: { chainId: true, address: true },
-      where: {
-        space: {
-          id: spaceId,
-        },
-      },
+      where: { space: { id: spaceId } },
     });
   }
 
@@ -99,9 +109,7 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
     const findSpaceSafesWhereClause: Array<FindOptionsWhere<SpaceSafe>> =
       args.payload.map((safe) => {
         return {
-          space: {
-            id: args.spaceId,
-          },
+          space: { id: args.spaceId },
           chainId: safe.chainId,
           address: safe.address,
         };

--- a/src/routes/spaces/members.controller.spec.ts
+++ b/src/routes/spaces/members.controller.spec.ts
@@ -82,7 +82,7 @@ describe('MembersController', () => {
     const configService = moduleFixture.get<IConfigurationService>(
       IConfigurationService,
     );
-    maxInvites = configService.getOrThrow('users.maxInvites');
+    maxInvites = configService.getOrThrow('spaces.maxInvites');
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();

--- a/src/routes/spaces/members.service.ts
+++ b/src/routes/spaces/members.service.ts
@@ -12,6 +12,7 @@ import { AcceptInviteDto } from '@/routes/spaces/entities/accept-invite.dto.enti
 
 export class MembersService {
   private readonly maxInvites: number;
+
   public constructor(
     @Inject(IMembersRepository)
     private readonly membersRepository: IMembersRepository,
@@ -19,7 +20,7 @@ export class MembersService {
     private readonly configurationService: IConfigurationService,
   ) {
     this.maxInvites =
-      this.configurationService.getOrThrow<number>('users.maxInvites');
+      this.configurationService.getOrThrow<number>('spaces.maxInvites');
   }
 
   public async inviteUser(args: {


### PR DESCRIPTION
## Summary
This PR limits the number of Safes that can be added to the same Space. If the sum of the already present Safes in the Space and the requested Safes to add surpasses this limit, then no Safes are added to the Space, and an error is thrown.

## Changes
- Adds a `maxSafesPerSpace` limit to `SpaceSafesRepository`.
- Adds related test cases.