### PR TITLE
refactor: simplify `SwapOrderHelper['getToken']`

### DIFF
--- a/src/routes/transactions/helpers/swap-order.helper.ts
+++ b/src/routes/transactions/helpers/swap-order.helper.ts
@@ -110,8 +110,6 @@ export class SwapOrderHelper {
   }
 
   /**
-   * TODO: Investigate if needed after token-specific entities. This was required for decimals.
-   *
    * Retrieves a token object based on the provided Ethereum chain ID and token address.
    * If the specified address is the placeholder for the native currency of the chain,
    * it fetches the chain's native currency details from the {@link IChainsRepository}.
@@ -128,7 +126,7 @@ export class SwapOrderHelper {
   public async getToken(args: {
     chainId: string;
     address: `0x${string}`;
-  }): Promise<Token & { decimals: NonNullable<Token['decimals']> }> {
+  }): Promise<Token> {
     // We perform lower case comparison because the provided address (3rd party service)
     // might not be checksummed.
     if (
@@ -148,16 +146,10 @@ export class SwapOrderHelper {
         trusted: true,
       };
     } else {
-      const token = await this.tokenRepository.getToken({
+      return await this.tokenRepository.getToken({
         chainId: args.chainId,
         address: args.address,
       });
-
-      if (token.decimals === null) {
-        throw new Error('Invalid token decimals');
-      }
-
-      return { ...token, decimals: token.decimals };
     }
   }
 }


### PR DESCRIPTION
## Summary

With the [addition of token-specific entities](https://github.com/safe-global/safe-client-gateway/pull/2309) we no longer need to assert the `decimals` of a token for swap-specific tokens. This removes the relative redundant code.

## Changes

- Remove redundant code and TODO comment