### PR TITLE
feat: warm token/contracts cache

### DIFF
--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -25,6 +25,10 @@ export class AddressInfoHelper {
    * The promise can be rejected if the address info cannot be retrieved for
    * any specified {@link source}
    *
+   * The function will try to get the address info from the provided sources
+   * in the order they are provided. If the address info cannot be retrieved
+   * from a source, the next source will be tried.
+   *
    * @param chainId - the chain id where the source exists
    * @param address - the address of the source to which we want to retrieve its metadata
    * @param sources - a collection of {@link Source} to which we want to retrieve its metadata

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -29,6 +29,7 @@ import {
 } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import type { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
+import { erc20TokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import {
   type ILoggingService,
@@ -189,13 +190,14 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       multisigToJson(nonce3) as MultisigTransaction,
       multisigToJson(nonce4) as MultisigTransaction,
     ];
-
+    const tokenResponse = erc20TokenBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -218,6 +220,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.resolve({ data: rawify(contractResponse), status: 200 });
+      }
+      if (url.startsWith(getTokenUrlPattern)) {
+        return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -349,12 +354,14 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       multisigToJson(nonce3) as MultisigTransaction,
       multisigToJson(nonce3) as MultisigTransaction,
     ];
+    const tokenResponse = erc20TokenBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -381,6 +388,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.resolve({ data: rawify(contractResponse), status: 200 });
+      }
+      if (url.startsWith(getTokenUrlPattern)) {
+        return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -502,12 +512,14 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       multisigToJson(nonce1) as MultisigTransaction,
       multisigToJson(nonce2) as MultisigTransaction,
     ];
+    const tokenResponse = erc20TokenBuilder().build();
     networkService.get.mockImplementation(({ url, networkRequest }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -535,6 +547,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.resolve({ data: rawify(contractResponse), status: 200 });
+      }
+      if (url.startsWith(getTokenUrlPattern)) {
+        return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -617,10 +632,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce1) as MultisigTransaction,
         multisigToJson(nonce2) as MultisigTransaction,
       ];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -641,6 +657,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         }
         if (url === getSafeUrl) {
           return Promise.resolve({ data: rawify(safeResponse), status: 200 });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -716,10 +735,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce1) as MultisigTransaction,
         multisigToJson(nonce2) as MultisigTransaction,
       ];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -743,6 +763,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             data: rawify(safeResponse),
             status: 200,
           });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -810,10 +833,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce1) as MultisigTransaction,
         multisigToJson(nonce2) as MultisigTransaction,
       ];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -837,6 +861,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             data: rawify(safeResponse),
             status: 200,
           });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -899,10 +926,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce1) as MultisigTransaction,
         multisigToJson(nonce2) as MultisigTransaction,
       ];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -926,6 +954,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             data: rawify(safeResponse),
             status: 200,
           });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -1172,10 +1203,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce1) as MultisigTransaction,
         multisigToJson(nonce2) as MultisigTransaction,
       ];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -1199,6 +1231,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             data: rawify(safeResponse),
             status: 200,
           });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -1258,10 +1293,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce1) as MultisigTransaction,
         multisigToJson(nonce2) as MultisigTransaction,
       ];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -1285,6 +1321,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             data: rawify(safeResponse),
             status: 200,
           });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -1343,10 +1382,11 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigToJson(nonce2) as MultisigTransaction,
       ];
       safeResponse.owners = [getAddress(faker.finance.ethereumAddress())];
-
+      const tokenResponse = erc20TokenBuilder().build();
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainResponse.chainId}`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
       networkService.get.mockImplementation(({ url }) => {
         if (url === getChainUrl) {
           return Promise.resolve({
@@ -1370,6 +1410,9 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             data: rawify(safeResponse),
             status: 200,
           });
+        }
+        if (url.startsWith(getTokenUrlPattern)) {
+          return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -79,7 +79,7 @@ export class QueuedItemsMapper {
     transactionGroup: TransactionGroup,
   ): Promise<Array<TransactionQueuedItem>> {
     // Prefetch tokens and contracts to avoid multiple parallel requests for the same address
-    await this.prefetchAddresses({
+    await this.prefetchAddressInfos({
       chainId: chainId,
       transactions: transactionGroup.transactions,
     });
@@ -102,7 +102,7 @@ export class QueuedItemsMapper {
     );
   }
 
-  private async prefetchAddresses(args: {
+  private async prefetchAddressInfos(args: {
     chainId: string;
     transactions: Array<MultisigTransaction>;
   }): Promise<void> {

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -60,7 +60,7 @@ export class TransactionsHistoryMapper {
     }
 
     // Prefetch tokens and contracts to avoid multiple parallel requests for the same address
-    await this.prefetchAddresses({
+    await this.prefetchAddressInfos({
       chainId,
       transactions: transactionsDomain,
     });
@@ -118,7 +118,7 @@ export class TransactionsHistoryMapper {
     );
   }
 
-  private async prefetchAddresses(args: {
+  private async prefetchAddressInfos(args: {
     chainId: string;
     transactions: Array<TransactionDomain>;
   }): Promise<void> {

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -21,6 +21,10 @@ import {
   calculateTimezoneOffset,
   convertToTimezone,
 } from '@/routes/transactions/helpers/timezone.helper';
+import { EthereumTransaction } from '@/domain/safe/entities/ethereum-transaction.entity';
+import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
+import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
+import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 
 @Injectable()
 export class TransactionsHistoryMapper {
@@ -34,6 +38,7 @@ export class TransactionsHistoryMapper {
     private readonly transferMapper: TransferMapper,
     private readonly transferImitationMapper: TransferImitationMapper,
     private readonly creationTransactionMapper: CreationTransactionMapper,
+    private readonly addressInfoHelper: AddressInfoHelper,
   ) {
     this.maxNestedTransfers = this.configurationService.getOrThrow(
       'mappings.history.maxNestedTransfers',
@@ -53,6 +58,12 @@ export class TransactionsHistoryMapper {
     if (transactionsDomain.length == 0) {
       return [];
     }
+
+    // Prefetch tokens and contracts to avoid multiple parallel requests for the same address
+    await this.prefetchAddresses({
+      chainId,
+      transactions: transactionsDomain,
+    });
 
     let previousTransaction: TransactionItem | undefined;
 
@@ -104,6 +115,47 @@ export class TransactionsHistoryMapper {
         return transactionList.concat(transactionsOnDay);
       },
       [],
+    );
+  }
+
+  private async prefetchAddresses(args: {
+    chainId: string;
+    transactions: Array<TransactionDomain>;
+  }): Promise<void> {
+    const transactions = args.transactions.filter(
+      isMultisigTransaction || isModuleTransaction,
+    );
+    const transfers = args.transactions.filter(isEthereumTransaction);
+    const addresses = Array.from(
+      new Set([
+        ...this.getAddressesFromTransactions(transactions),
+        ...this.getAddressesFromTransfers(transfers),
+      ]),
+    );
+    await this.addressInfoHelper.getCollection(args.chainId, addresses, [
+      'TOKEN',
+      'CONTRACT',
+    ]);
+  }
+
+  private getAddressesFromTransactions(
+    transactions: Array<MultisigTransaction | ModuleTransaction>,
+  ): Array<`0x${string}`> {
+    return transactions.map((tx) => tx.to);
+  }
+
+  private getAddressesFromTransfers(
+    transferTransactions: Array<EthereumTransaction>,
+  ): Array<`0x${string}`> {
+    return transferTransactions.flatMap((tx) =>
+      [
+        tx.from,
+        ...(tx.transfers?.flatMap((transfer) => [
+          transfer.to,
+          transfer.from,
+          'tokenAddress' in transfer ? transfer.tokenAddress : undefined,
+        ]) ?? []),
+      ].filter((address): address is `0x${string}` => !!address),
     );
   }
 


### PR DESCRIPTION
## Summary
This PR implements a pre-fetch step for tokens/contracts when getting the transactions queue/history.
The addresses from the transactions involved in the queue/history are extracted, de-duplicated, and fetched beforehand: this stores their values (or their absence), so subsequent mappers have this data available in the cache.

## Changes
- Adds a `prefetchAddressInfos` function to `QueuedItemsMapper` and `TransactionsHistoryMapper`.
- Adjusts the related tests.
