### PR TITLE
fix: add filter `value` parsing feature flag

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -181,6 +181,7 @@ export default (): ReturnType<typeof configuration> => ({
     ethSign: true,
     trustedDelegateCall: false,
     trustedForDelegateCallContractsList: false,
+    filterValueParsing: false,
   },
   httpClient: { requestTimeout: faker.number.int() },
   locking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -274,6 +274,8 @@ export default () => ({
     trustedForDelegateCallContractsList:
       process.env.FF_TRUSTED_FOR_DELEGATE_CALL_CONTRACTS_LIST?.toLowerCase() ===
       'true',
+    filterValueParsing:
+      process.env.FF_FILTER_VALUE_PARSING?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -55,8 +55,19 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
   beforeEach(async () => {
     jest.resetAllMocks();
 
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): ReturnType<typeof configuration> => {
+      return {
+        ...defaultConfiguration,
+        features: {
+          ...defaultConfiguration.features,
+          filterValueParsing: true,
+        },
+      };
+    };
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule.register(configuration)],
+      imports: [AppModule.register(testConfiguration)],
     })
       .overrideModule(PostgresDatabaseModule)
       .useModule(TestPostgresDatabaseModule)


### PR DESCRIPTION
## Summary

Due to a [client-side dependency](https://github.com/safe-global/safe-wallet-monorepo/pull/5460), [filter `value` parsing](https://github.com/safe-global/safe-client-gateway/pull/2485) should be aligned with the former being release. As such, this puts the logic behind a new feature flag, set by the `FF_FILTER_VALUE_PARSING` env. var.

## Changes

- Add new feature flag env. var./configuration
- Hide feature behind feature flag