### PR TITLE
fix: swagger typed-data message type

### DIFF
--- a/src/routes/messages/entities/typed-data.entity.ts
+++ b/src/routes/messages/entities/typed-data.entity.ts
@@ -55,7 +55,8 @@ export class TypedData implements DomainTypedData {
   types!: Record<string, Array<TypedDataParameter>>;
 
   @ApiProperty({
-    type: Object,
+    type: 'object',
+    additionalProperties: true,
   })
   message!: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
Not sure if this change is 100% correct. The old type in the safe-gateway-typescript-sdk is set set to 

message: Record<string, unknown>

What we are able to generate from swagger right now is
message: object

With my modifications we end up with:
  message: {
    [key: string]: any
  }

Which is a bit more compatible with the old type. If you have better ideas, let me know.

## Changes
