### PR TITLE
feat: rate limit Spaces creation and update

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -278,6 +278,10 @@ export default (): ReturnType<typeof configuration> => ({
     maxSafesPerSpace: faker.number.int({ min: 5, max: 10 }),
     maxSpaceCreationsPerUser: faker.number.int({ min: 100, max: 200 }),
     maxInvites: faker.number.int({ min: 5, max: 10 }),
+    rateLimit: {
+      max: faker.number.int({ min: 1000, max: 2000 }),
+      windowSeconds: faker.number.int({ min: 1000, max: 2000 }),
+    },
   },
   staking: {
     testnet: {

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -279,8 +279,8 @@ export default (): ReturnType<typeof configuration> => ({
     maxSpaceCreationsPerUser: faker.number.int({ min: 100, max: 200 }),
     maxInvites: faker.number.int({ min: 5, max: 10 }),
     rateLimit: {
-      max: faker.number.int({ min: 1000, max: 2000 }),
-      windowSeconds: faker.number.int({ min: 1000, max: 2000 }),
+      max: faker.number.int({ min: 100, max: 200 }),
+      windowSeconds: faker.number.int({ min: 100, max: 200 }),
     },
   },
   staking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -413,6 +413,12 @@ export default () => ({
       process.env.MAX_SPACE_CREATIONS_PER_USER ?? `${3}`,
     ),
     maxInvites: parseInt(process.env.SPACES_MAX_INVITES ?? `${50}`),
+    rateLimit: {
+      max: parseInt(process.env.SPACES_RATE_LIMIT_MAX ?? `${10}`),
+      windowSeconds: parseInt(
+        process.env.SPACES_RATE_LIMIT_WINDOW_SECONDS ?? `${600}`,
+      ),
+    },
   },
   staking: {
     testnet: {

--- a/src/domain/common/entities/log-type.entity.ts
+++ b/src/domain/common/entities/log-type.entity.ts
@@ -4,10 +4,12 @@ export enum LogType {
   CacheHit = 'CACHE_HIT',
   CacheMiss = 'CACHE_MISS',
   ExternalRequest = 'EXTERNAL_REQUEST',
+  InvalidIp = 'INVALID_IP',
   MemoryHit = 'MEMORY_HIT',
   MemoryMiss = 'MEMORY_MISS',
   MessagePropose = 'MESSAGE_PROPOSE',
   MessageValidity = 'MESSAGE_VALIDITY',
+  RateLimit = 'RATE_LIMIT',
   TransactionPropose = 'TRANSACTION_PROPOSE',
   TransactionValidity = 'TRANSACTION_VALIDITY',
 }

--- a/src/routes/common/guards/rate-limit.guard.spec.ts
+++ b/src/routes/common/guards/rate-limit.guard.spec.ts
@@ -1,0 +1,115 @@
+import { RateLimitGuard } from './rate-limit.guard';
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { faker } from '@faker-js/faker/.';
+
+const mockCacheService = jest.mocked({
+  increment: jest.fn(),
+} as jest.MockedObjectDeep<ICacheService>);
+
+const mockLoggingService = {
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+describe('RateLimitGuard', () => {
+  it('should allow the request if under the rate limit', async () => {
+    const ip = faker.internet.ipv4();
+    const path = new URL(faker.internet.url()).pathname;
+    const windowSeconds = faker.number.int({ min: 10, max: 20 });
+    const mockExecutionContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          ip,
+          route: { path },
+          method: 'POST',
+        }),
+      }),
+    } as jest.MockedObjectDeep<ExecutionContext>;
+    mockCacheService.increment.mockResolvedValue(1); // under or equal to the limit
+    const guard = new RateLimitGuard(mockCacheService, mockLoggingService, {
+      max: faker.number.int({ min: 1, max: 10 }),
+      windowSeconds,
+    });
+
+    const result = await guard.canActivate(mockExecutionContext);
+
+    expect(result).toBe(true);
+    expect(mockCacheService.increment).toHaveBeenCalledWith(
+      `${path}:POST:${ip}_rate_limit`,
+      windowSeconds,
+    );
+  });
+
+  it('should block the request if over the rate limit', async () => {
+    const ip = faker.internet.ip();
+    const path = new URL(faker.internet.url()).pathname;
+    const windowSeconds = faker.number.int({ min: 10, max: 20 });
+    const maxRequests = faker.number.int({ min: 2, max: 10 });
+    const mockExecutionContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          ip,
+          route: { path },
+          method: 'PATCH',
+        }),
+      }),
+    } as jest.MockedObjectDeep<ExecutionContext>;
+    mockCacheService.increment.mockResolvedValue(maxRequests + 1); // over the limit
+    const guard = new RateLimitGuard(mockCacheService, mockLoggingService, {
+      max: maxRequests,
+      windowSeconds,
+    });
+
+    await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+      new HttpException('Rate limit reached', HttpStatus.TOO_MANY_REQUESTS),
+    );
+
+    expect(mockCacheService.increment).toHaveBeenCalledWith(
+      `${path}:PATCH:${ip}_rate_limit`,
+      windowSeconds,
+    );
+    expect(mockLoggingService.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'RATE_LIMIT',
+        method: 'PATCH',
+        route: path,
+        clientIp: ip,
+        maxRequests,
+        windowSeconds,
+        currentRequest: maxRequests + 1,
+      }),
+    );
+  });
+
+  it('should log a warning for invalid client IP', async () => {
+    const invalidIp = faker.string.sample(10);
+    const path = new URL(faker.internet.url()).pathname;
+    const mockExecutionContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          ip: invalidIp,
+          route: { path },
+          method: 'PATCH',
+        }),
+      }),
+    } as jest.MockedObjectDeep<ExecutionContext>;
+    mockCacheService.increment.mockResolvedValue(1);
+    const guard = new RateLimitGuard(mockCacheService, mockLoggingService, {
+      max: faker.number.int({ min: 1, max: 10 }),
+      windowSeconds: faker.number.int({ min: 1, max: 10 }),
+    });
+
+    await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+      new BadRequestException('Invalid client IP address'),
+    );
+
+    expect(mockLoggingService.warn).toHaveBeenCalledWith({
+      clientIp: invalidIp,
+      method: 'PATCH',
+      route: path,
+      type: 'INVALID_IP',
+    });
+  });
+});

--- a/src/routes/common/guards/rate-limit.guard.spec.ts
+++ b/src/routes/common/guards/rate-limit.guard.spec.ts
@@ -37,7 +37,7 @@ describe('RateLimitGuard', () => {
 
     expect(result).toBe(true);
     expect(mockCacheService.increment).toHaveBeenCalledWith(
-      `${path}:POST:${ip}_rate_limit`,
+      `${path}_POST_${ip}_rate_limit`,
       windowSeconds,
     );
   });
@@ -67,7 +67,7 @@ describe('RateLimitGuard', () => {
     );
 
     expect(mockCacheService.increment).toHaveBeenCalledWith(
-      `${path}:PATCH:${ip}_rate_limit`,
+      `${path}_PATCH_${ip}_rate_limit`,
       windowSeconds,
     );
     expect(mockLoggingService.warn).toHaveBeenCalledWith(

--- a/src/routes/common/guards/rate-limit.guard.ts
+++ b/src/routes/common/guards/rate-limit.guard.ts
@@ -1,0 +1,72 @@
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import { LogType } from '@/domain/common/entities/log-type.entity';
+import type { ILoggingService } from '@/logging/logging.interface';
+import type { CanActivate, ExecutionContext } from '@nestjs/common';
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import type { Request } from 'express';
+import { z } from 'zod';
+
+/**
+ * RateLimitGuard is a guard that limits the number of requests
+ * a client can make to a specific route within a given time window.
+ * It uses a cache service to track the number of requests made by each client.
+ * If the limit is exceeded, it throws an HttpException with a 429 status code.
+ */
+export class RateLimitGuard implements CanActivate {
+  constructor(
+    private readonly cacheService: ICacheService,
+    private readonly loggingService: ILoggingService,
+    private rateLimit: { max: number; windowSeconds: number },
+  ) {
+    this.rateLimit = rateLimit;
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: Request = context.switchToHttp().getRequest();
+    const { success: isValidIp } = z.string().ip().safeParse(req.ip);
+    if (!isValidIp) {
+      this.logInvalidIp(req);
+      throw new BadRequestException('Invalid client IP address');
+    }
+    const currentRequest = await this.cacheService.increment(
+      CacheRouter.getRateLimitCacheKey(
+        `${req.route.path}:${req.method}:${req.ip}`,
+      ),
+      this.rateLimit.windowSeconds,
+    );
+    if (currentRequest > this.rateLimit.max) {
+      this.logRateLimitHit({ req, currentRequest });
+      throw new HttpException(
+        'Rate limit reached',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return true;
+  }
+
+  private logInvalidIp(req: Request): void {
+    this.loggingService.warn({
+      type: LogType.InvalidIp,
+      method: req.method,
+      route: req.route.path,
+      clientIp: req.ip,
+    });
+  }
+
+  private logRateLimitHit(args: {
+    req: Request;
+    currentRequest: number;
+  }): void {
+    this.loggingService.warn({
+      type: LogType.RateLimit,
+      method: args.req.method,
+      route: args.req.route.path,
+      clientIp: args.req.ip,
+      maxRequests: this.rateLimit.max,
+      windowSeconds: this.rateLimit.windowSeconds,
+      currentRequest: args.currentRequest,
+    });
+  }
+}

--- a/src/routes/common/guards/rate-limit.guard.ts
+++ b/src/routes/common/guards/rate-limit.guard.ts
@@ -31,7 +31,7 @@ export class RateLimitGuard implements CanActivate {
     }
     const currentRequest = await this.cacheService.increment(
       CacheRouter.getRateLimitCacheKey(
-        `${req.route.path}:${req.method}:${req.ip}`,
+        `${req.route.path}_${req.method}_${req.ip}`,
       ),
       this.rateLimit.windowSeconds,
     );

--- a/src/routes/common/guards/rate-limit.guard.ts
+++ b/src/routes/common/guards/rate-limit.guard.ts
@@ -42,7 +42,6 @@ export class RateLimitGuard implements CanActivate {
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }
-
     return true;
   }
 

--- a/src/routes/spaces/guards/spaces-rate-limit.guard.ts
+++ b/src/routes/spaces/guards/spaces-rate-limit.guard.ts
@@ -1,0 +1,25 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { RateLimitGuard } from '@/routes/common/guards/rate-limit.guard';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SpacesRateLimitGuard extends RateLimitGuard {
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(CacheService) cacheService: ICacheService,
+    @Inject(LoggingService) loggingService: ILoggingService,
+  ) {
+    super(cacheService, loggingService, {
+      max: configurationService.getOrThrow<number>('spaces.rateLimit.max'),
+      windowSeconds: configurationService.getOrThrow<number>(
+        'spaces.rateLimit.windowSeconds',
+      ),
+    });
+  }
+}

--- a/src/routes/spaces/guards/spaces-rate-limit.guard.ts
+++ b/src/routes/spaces/guards/spaces-rate-limit.guard.ts
@@ -15,11 +15,12 @@ export class SpacesRateLimitGuard extends RateLimitGuard {
     @Inject(CacheService) cacheService: ICacheService,
     @Inject(LoggingService) loggingService: ILoggingService,
   ) {
-    super(cacheService, loggingService, {
+    const rateLimits = {
       max: configurationService.getOrThrow<number>('spaces.rateLimit.max'),
       windowSeconds: configurationService.getOrThrow<number>(
         'spaces.rateLimit.windowSeconds',
       ),
-    });
+    };
+    super(cacheService, loggingService, rateLimits);
   }
 }

--- a/src/routes/spaces/spaces.controller.spec.ts
+++ b/src/routes/spaces/spaces.controller.spec.ts
@@ -152,6 +152,7 @@ describe('SpacesController', () => {
         .send({ name: nameBuilder() })
         .expect(201);
 
+      // Second request, but rateLimit.max = 1
       await request(app.getHttpServer())
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])

--- a/src/routes/spaces/spaces.controller.ts
+++ b/src/routes/spaces/spaces.controller.ts
@@ -39,6 +39,7 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import { getEnumKey } from '@/domain/common/utils/enum';
 import { UserStatus } from '@/domain/users/entities/user.entity';
+import { SpacesRateLimitGuard } from '@/routes/spaces/guards/spaces-rate-limit.guard';
 
 @ApiTags('spaces')
 @UseGuards(AuthGuard)
@@ -47,6 +48,7 @@ export class SpacesController {
   public constructor(private readonly spacesService: SpacesService) {}
 
   @Post()
+  @UseGuards(SpacesRateLimitGuard)
   @ApiOkResponse({
     description: 'Space created',
     type: CreateSpaceResponse,
@@ -67,6 +69,7 @@ export class SpacesController {
   }
 
   @Post('/create-with-user')
+  @UseGuards(SpacesRateLimitGuard)
   @ApiOkResponse({
     description: 'Space created',
     type: CreateSpaceResponse,
@@ -120,6 +123,7 @@ export class SpacesController {
   }
 
   @Patch('/:id')
+  @UseGuards(SpacesRateLimitGuard)
   @ApiOkResponse({
     description: 'Space updated',
     type: UpdateSpaceResponse,


### PR DESCRIPTION
## Summary
This PR adds a rate-limiter to Spaces-related `POST/PATCH` HTTP routes. It adds a generic `RateLimitGuard` Guard, so it can be extended by configured subclasses like `SpacesRateLimitGuard`.

## Changes
- Adds `RateLimitGuard`, a guard to implement per-route/method/IP requests rate limits.
- Adds `SpaceRateLimitGuard`, a Spaces-specific guard that extends `RateLimitGuard` by adding configuration.
- Adds the related test suites and modifies existing ones.
