### PR TITLE
feat: return 24h balance change

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -1,10 +1,10 @@
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { CoingeckoApi } from '@/datasources/balances-api/coingecko-api.service';
-import { faker } from '@faker-js/faker';
+import { fa, faker } from '@faker-js/faker';
 import type { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import {
-  AssetPricesSchema,
+  getAssetPricesSchema,
   type AssetPrice,
 } from '@/datasources/balances-api/entities/asset-price.entity';
 import type { ICacheService } from '@/datasources/cache/cache.service.interface';
@@ -196,8 +196,12 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const change = faker.number.float({ min: -1, max: 1 });
     const coingeckoPrice: AssetPrice = {
-      [tokenAddress]: { [lowerCaseFiatCode]: price },
+      [tokenAddress]: {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
@@ -216,7 +220,12 @@ describe('CoingeckoAPI', () => {
       '',
     );
     expect(assetPrice).toEqual([
-      { [tokenAddress]: { [lowerCaseFiatCode]: price } },
+      {
+        [tokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
@@ -227,6 +236,7 @@ describe('CoingeckoAPI', () => {
         params: {
           contract_addresses: tokenAddress,
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -235,7 +245,12 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.hSet).toHaveBeenCalledTimes(1);
     expect(mockCacheService.hSet).toHaveBeenCalledWith(
       expectedCacheDir,
-      JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
+      JSON.stringify({
+        [tokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      }),
       pricesTtlSeconds,
     );
     expect(mockInMemoryCache.get).toHaveBeenCalledTimes(1);
@@ -245,7 +260,12 @@ describe('CoingeckoAPI', () => {
     expect(mockInMemoryCache.set).toHaveBeenCalledTimes(1);
     expect(mockInMemoryCache.set).toHaveBeenCalledWith(
       `${chain.pricesProvider.chainName}_token_price_${tokenAddress}_${lowerCaseFiatCode}:`,
-      JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
+      JSON.stringify({
+        [tokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      }),
       pricesTtlSeconds * 1_000, // milliseconds
     );
   });
@@ -256,8 +276,12 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const change = faker.number.float({ min: -1, max: 1 });
     const coingeckoPrice: AssetPrice = {
-      [tokenAddress]: { [lowerCaseFiatCode]: price },
+      [tokenAddress]: {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
     };
     mockInMemoryCache.get.mockResolvedValue(JSON.stringify(coingeckoPrice));
 
@@ -268,7 +292,12 @@ describe('CoingeckoAPI', () => {
     });
 
     expect(assetPrice).toEqual([
-      { [tokenAddress]: { [lowerCaseFiatCode]: price } },
+      {
+        [tokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      },
     ]);
     expect(mockNetworkService.get).not.toHaveBeenCalled();
     expect(mockCacheService.hGet).not.toHaveBeenCalled();
@@ -285,8 +314,12 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const change = faker.number.float({ min: -1, max: 1 });
     const coingeckoPrice: AssetPrice = {
-      [tokenAddress]: { [lowerCaseFiatCode]: price },
+      [tokenAddress]: {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
@@ -313,7 +346,12 @@ describe('CoingeckoAPI', () => {
       '',
     );
     expect(assetPrice).toEqual([
-      { [tokenAddress]: { [lowerCaseFiatCode]: price } },
+      {
+        [tokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
@@ -321,6 +359,7 @@ describe('CoingeckoAPI', () => {
         params: {
           contract_addresses: tokenAddress,
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -329,7 +368,12 @@ describe('CoingeckoAPI', () => {
     expect(mockCacheService.hSet).toHaveBeenCalledTimes(1);
     expect(mockCacheService.hSet).toHaveBeenCalledWith(
       expectedCacheDir,
-      JSON.stringify({ [tokenAddress]: { [lowerCaseFiatCode]: price } }),
+      JSON.stringify({
+        [tokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      }),
       pricesTtlSeconds,
     );
   });
@@ -340,14 +384,26 @@ describe('CoingeckoAPI', () => {
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const firstTokenAddress = faker.finance.ethereumAddress();
     const firstPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const firstChange = faker.number.float({ min: -1, max: 1 });
     const secondTokenAddress = faker.finance.ethereumAddress();
     const secondPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const secondChange = faker.number.float({ min: -1, max: 1 });
     const thirdTokenAddress = faker.finance.ethereumAddress();
     const thirdPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const thirdChange = faker.number.float({ min: -1, max: 1 });
     const coingeckoPrice: AssetPrice = {
-      [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
-      [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
-      [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
+      [firstTokenAddress]: {
+        [lowerCaseFiatCode]: firstPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+      },
+      [secondTokenAddress]: {
+        [lowerCaseFiatCode]: secondPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+      },
+      [thirdTokenAddress]: {
+        [lowerCaseFiatCode]: thirdPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+      },
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
@@ -366,9 +422,24 @@ describe('CoingeckoAPI', () => {
     });
 
     expect(assetPrice).toEqual([
-      { [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice } },
-      { [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice } },
-      { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
+      {
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: firstPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+        },
+      },
+      {
+        [secondTokenAddress]: {
+          [lowerCaseFiatCode]: secondPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+        },
+      },
+      {
+        [thirdTokenAddress]: {
+          [lowerCaseFiatCode]: thirdPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+        },
+      },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
@@ -383,6 +454,7 @@ describe('CoingeckoAPI', () => {
             thirdTokenAddress,
           ].join(','),
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -412,7 +484,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: firstPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -422,7 +497,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
+        [secondTokenAddress]: {
+          [lowerCaseFiatCode]: secondPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -432,7 +510,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
+        [thirdTokenAddress]: {
+          [lowerCaseFiatCode]: thirdPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -444,15 +525,21 @@ describe('CoingeckoAPI', () => {
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const firstTokenAddress = faker.finance.ethereumAddress();
     const firstPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const firstChange = faker.number.float({ min: -1, max: 1 });
     const secondTokenAddress = faker.finance.ethereumAddress();
     const secondPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const secondChange = faker.number.float({ min: -1, max: 1 });
     const thirdTokenAddress = faker.finance.ethereumAddress();
     const thirdPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const thirdChange = faker.number.float({ min: -1, max: 1 });
 
     // One token price from network, one from cache, and one from memory
     mockNetworkService.get.mockResolvedValue({
       data: rawify({
-        [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: firstPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+        },
       }),
       status: 200,
     });
@@ -463,7 +550,10 @@ describe('CoingeckoAPI', () => {
       ) {
         return Promise.resolve(
           JSON.stringify({
-            [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
+            [secondTokenAddress]: {
+              [lowerCaseFiatCode]: secondPrice,
+              [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+            },
           }),
         );
       }
@@ -476,7 +566,10 @@ describe('CoingeckoAPI', () => {
       ) {
         return Promise.resolve(
           JSON.stringify({
-            [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
+            [thirdTokenAddress]: {
+              [lowerCaseFiatCode]: thirdPrice,
+              [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+            },
           }),
         );
       }
@@ -495,9 +588,24 @@ describe('CoingeckoAPI', () => {
 
     expect(assetPrice).toEqual(
       expect.arrayContaining([
-        { [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice } },
-        { [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice } },
-        { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
+        {
+          [firstTokenAddress]: {
+            [lowerCaseFiatCode]: firstPrice,
+            [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+          },
+        },
+        {
+          [secondTokenAddress]: {
+            [lowerCaseFiatCode]: secondPrice,
+            [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+          },
+        },
+        {
+          [thirdTokenAddress]: {
+            [lowerCaseFiatCode]: thirdPrice,
+            [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+          },
+        },
       ]),
     );
 
@@ -511,6 +619,7 @@ describe('CoingeckoAPI', () => {
         params: {
           contract_addresses: firstTokenAddress,
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -530,14 +639,20 @@ describe('CoingeckoAPI', () => {
     expect(mockInMemoryCache.set).toHaveBeenCalledWith(
       `${chain.pricesProvider.chainName}_token_price_${firstTokenAddress}_${lowerCaseFiatCode}:`,
       JSON.stringify({
-        [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: firstPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+        },
       }),
       pricesTtlSeconds * 1_000, // milliseconds
     );
     expect(mockInMemoryCache.set).toHaveBeenCalledWith(
       `${chain.pricesProvider.chainName}_token_price_${secondTokenAddress}_${lowerCaseFiatCode}:`,
       JSON.stringify({
-        [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
+        [secondTokenAddress]: {
+          [lowerCaseFiatCode]: secondPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+        },
       }),
       pricesTtlSeconds * 1_000, // milliseconds
     );
@@ -563,7 +678,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: firstPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -576,10 +694,18 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const change = faker.number.float({ min: -1, max: 1 });
     const anotherPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const anotherChange = faker.number.float({ min: -1, max: 1 });
     const coingeckoPrice: AssetPrice = {
-      [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price },
-      [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice },
+      [highRefreshRateTokenAddress]: {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
+      [anotherTokenAddress]: {
+        [lowerCaseFiatCode]: anotherPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: anotherChange,
+      },
     };
     mockCacheService.hGet.mockResolvedValue(undefined);
     mockNetworkService.get.mockResolvedValue({
@@ -610,8 +736,18 @@ describe('CoingeckoAPI', () => {
     });
 
     expect(assetPrice).toEqual([
-      { [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price } },
-      { [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice } },
+      {
+        [highRefreshRateTokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
+      },
+      {
+        [anotherTokenAddress]: {
+          [lowerCaseFiatCode]: anotherPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: anotherChange,
+        },
+      },
     ]);
     expect(mockNetworkService.get).toHaveBeenCalledWith({
       url: `${coingeckoBaseUri}/simple/token_price/${chain.pricesProvider.chainName}`,
@@ -625,6 +761,7 @@ describe('CoingeckoAPI', () => {
             anotherTokenAddress,
           ].join(','),
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -643,7 +780,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [highRefreshRateTokenAddress]: { [lowerCaseFiatCode]: price },
+        [highRefreshRateTokenAddress]: {
+          [lowerCaseFiatCode]: price,
+          [`${lowerCaseFiatCode}_24h_change`]: change,
+        },
       }),
       highRefreshRateTokensTtlSeconds,
     );
@@ -660,7 +800,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [anotherTokenAddress]: { [lowerCaseFiatCode]: anotherPrice },
+        [anotherTokenAddress]: {
+          [lowerCaseFiatCode]: anotherPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: anotherChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -672,18 +815,30 @@ describe('CoingeckoAPI', () => {
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const firstTokenAddress = faker.finance.ethereumAddress();
     const firstPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const firstChange = faker.number.float({ min: -1, max: 1 });
     const secondTokenAddress = faker.finance.ethereumAddress();
     const secondPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const secondChange = faker.number.float({ min: -1, max: 1 });
     const thirdTokenAddress = faker.finance.ethereumAddress();
     const thirdPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const thirdChange = faker.number.float({ min: -1, max: 1 });
     const coingeckoPrice: AssetPrice = {
-      [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
-      [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
+      [firstTokenAddress]: {
+        [lowerCaseFiatCode]: firstPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+      },
+      [thirdTokenAddress]: {
+        [lowerCaseFiatCode]: thirdPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+      },
     };
     mockCacheService.hGet.mockResolvedValueOnce(undefined);
     mockCacheService.hGet.mockResolvedValueOnce(
       JSON.stringify({
-        [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
+        [secondTokenAddress]: {
+          [lowerCaseFiatCode]: secondPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+        },
       }),
     );
     mockCacheService.hGet.mockResolvedValueOnce(undefined);
@@ -702,14 +857,29 @@ describe('CoingeckoAPI', () => {
         ],
         fiatCode,
       })
-      .then(AssetPricesSchema.parse);
+      .then(getAssetPricesSchema(lowerCaseFiatCode).parse);
 
     expect(sortBy(assetPrices, (i) => Object.keys(i)[0])).toEqual(
       sortBy(
         [
-          { [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice } },
-          { [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice } },
-          { [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice } },
+          {
+            [firstTokenAddress]: {
+              [lowerCaseFiatCode]: firstPrice,
+              [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+            },
+          },
+          {
+            [secondTokenAddress]: {
+              [lowerCaseFiatCode]: secondPrice,
+              [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+            },
+          },
+          {
+            [thirdTokenAddress]: {
+              [lowerCaseFiatCode]: thirdPrice,
+              [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+            },
+          },
         ],
         (i) => Object.keys(i)[0],
       ),
@@ -723,6 +893,7 @@ describe('CoingeckoAPI', () => {
         params: {
           contract_addresses: [firstTokenAddress, thirdTokenAddress].join(','),
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -753,7 +924,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: firstPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -764,7 +938,10 @@ describe('CoingeckoAPI', () => {
         '',
       ),
       JSON.stringify({
-        [thirdTokenAddress]: { [lowerCaseFiatCode]: thirdPrice },
+        [thirdTokenAddress]: {
+          [lowerCaseFiatCode]: thirdPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: thirdChange,
+        },
       }),
       pricesTtlSeconds,
     );
@@ -776,18 +953,31 @@ describe('CoingeckoAPI', () => {
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const firstTokenAddress = faker.finance.ethereumAddress();
     const firstPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const firstChange = faker.number.float({ min: -1, max: 1 });
     const secondTokenAddress = faker.finance.ethereumAddress();
     const secondPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const secondChange = faker.number.float({ min: -1, max: 1 });
     const thirdTokenAddress = faker.finance.ethereumAddress();
     const coingeckoPrice: AssetPrice = {
-      [firstTokenAddress]: { [lowerCaseFiatCode]: firstPrice },
+      [firstTokenAddress]: {
+        [lowerCaseFiatCode]: firstPrice,
+        [`${lowerCaseFiatCode}_24h_change`]: firstChange,
+      },
     };
     mockCacheService.hGet.mockResolvedValueOnce(
-      JSON.stringify({ [firstTokenAddress]: { [lowerCaseFiatCode]: null } }),
+      JSON.stringify({
+        [firstTokenAddress]: {
+          [lowerCaseFiatCode]: null,
+          [`${lowerCaseFiatCode}_24h_change`]: null,
+        },
+      }),
     );
     mockCacheService.hGet.mockResolvedValueOnce(
       JSON.stringify({
-        [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice },
+        [secondTokenAddress]: {
+          [lowerCaseFiatCode]: secondPrice,
+          [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+        },
       }),
     );
     mockCacheService.hGet.mockResolvedValueOnce(undefined);
@@ -806,14 +996,29 @@ describe('CoingeckoAPI', () => {
         ],
         fiatCode,
       })
-      .then(AssetPricesSchema.parse);
+      .then(getAssetPricesSchema(lowerCaseFiatCode).parse);
 
     expect(sortBy(assetPrices, (i) => Object.keys(i)[0])).toEqual(
       sortBy(
         [
-          { [firstTokenAddress]: { [lowerCaseFiatCode]: null } },
-          { [secondTokenAddress]: { [lowerCaseFiatCode]: secondPrice } },
-          { [thirdTokenAddress]: { [lowerCaseFiatCode]: null } },
+          {
+            [firstTokenAddress]: {
+              [lowerCaseFiatCode]: null,
+              [`${lowerCaseFiatCode}_24h_change`]: null,
+            },
+          },
+          {
+            [secondTokenAddress]: {
+              [lowerCaseFiatCode]: secondPrice,
+              [`${lowerCaseFiatCode}_24h_change`]: secondChange,
+            },
+          },
+          {
+            [thirdTokenAddress]: {
+              [lowerCaseFiatCode]: null,
+              [`${lowerCaseFiatCode}_24h_change`]: null,
+            },
+          },
         ],
         (i) => Object.keys(i)[0],
       ),
@@ -827,6 +1032,7 @@ describe('CoingeckoAPI', () => {
         params: {
           contract_addresses: thirdTokenAddress,
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
     });
@@ -851,7 +1057,12 @@ describe('CoingeckoAPI', () => {
     );
     expect(mockCacheService.hSet).toHaveBeenCalledTimes(1);
     expect(mockCacheService.hSet.mock.calls[0][1]).toEqual(
-      JSON.stringify({ [thirdTokenAddress]: { [lowerCaseFiatCode]: null } }),
+      JSON.stringify({
+        [thirdTokenAddress]: {
+          [lowerCaseFiatCode]: null,
+          [`${lowerCaseFiatCode}_24h_change`]: null,
+        },
+      }),
     );
     expect(mockCacheService.hSet.mock.calls[0][2]).toBeGreaterThanOrEqual(
       fakeConfigurationService.get(
@@ -870,8 +1081,12 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const change = faker.number.float({ min: -1, max: 1 });
     const expectedAssetPrice: AssetPrice = {
-      [`${chain.pricesProvider.nativeCoin}`]: { [lowerCaseFiatCode]: price },
+      [`${chain.pricesProvider.nativeCoin}`]: {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
     };
     const cacheDir = new CacheDir(
       `${chain.pricesProvider.nativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
@@ -891,6 +1106,7 @@ describe('CoingeckoAPI', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
@@ -898,7 +1114,10 @@ describe('CoingeckoAPI', () => {
     });
     expect(mockInMemoryCache.set).toHaveBeenCalledWith(
       `${cacheDir.key}:`,
-      price,
+      {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
       nativeCoinPricesTtlSeconds * 1_000, // milliseconds
     );
   });
@@ -908,8 +1127,12 @@ describe('CoingeckoAPI', () => {
     const fiatCode = faker.finance.currencyCode();
     const lowerCaseFiatCode = fiatCode.toLowerCase();
     const price = faker.number.float({ min: 0.01, multipleOf: 0.01 });
+    const change = faker.number.float({ min: -1, max: 1 });
     const expectedAssetPrice: AssetPrice = {
-      [`${chain.pricesProvider.nativeCoin}`]: { [lowerCaseFiatCode]: price },
+      [`${chain.pricesProvider.nativeCoin}`]: {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
     };
     const cacheDir = new CacheDir(
       `${chain.pricesProvider.nativeCoin}_native_coin_price_${lowerCaseFiatCode}`,
@@ -935,6 +1158,7 @@ describe('CoingeckoAPI', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: lowerCaseFiatCode,
+          include_24hr_change: true,
         },
       },
       notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
@@ -942,7 +1166,10 @@ describe('CoingeckoAPI', () => {
     });
     expect(mockInMemoryCache.set).toHaveBeenCalledWith(
       `${cacheDir.key}:`,
-      price,
+      {
+        [lowerCaseFiatCode]: price,
+        [`${lowerCaseFiatCode}_24h_change`]: change,
+      },
       nativeCoinPricesTtlSeconds * 1_000, // milliseconds
     );
   });

--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -1,7 +1,7 @@
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { CoingeckoApi } from '@/datasources/balances-api/coingecko-api.service';
-import { fa, faker } from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
 import type { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import {
   getAssetPricesSchema,

--- a/src/datasources/balances-api/entities/__tests__/asset-price.schema.spec.ts
+++ b/src/datasources/balances-api/entities/__tests__/asset-price.schema.spec.ts
@@ -1,29 +1,35 @@
-import { AssetPriceSchema } from '@/datasources/balances-api/entities/asset-price.entity';
+import { getAssetPriceSchema } from '@/datasources/balances-api/entities/asset-price.entity';
 import { faker } from '@faker-js/faker';
 
-describe('AssetPriceSchema', () => {
+describe('getAssetPriceSchema', () => {
   it('should allow an object with string keys and a mixture of number and null values', () => {
+    const currencyCode = faker.finance.currencyCode();
     const assetPrice = {
       [faker.finance.ethereumAddress()]: {
-        [faker.finance.currencyCode()]: faker.helpers.arrayElement([
+        [currencyCode]: faker.helpers.arrayElement([
+          faker.number.float(),
+          null,
+        ]),
+        [`${currencyCode}_24h_change`]: faker.helpers.arrayElement([
           faker.number.float(),
           null,
         ]),
       },
     };
 
-    const result = AssetPriceSchema.safeParse(assetPrice);
+    const result = getAssetPriceSchema(currencyCode).safeParse(assetPrice);
 
     expect(result.success).toBe(true);
   });
 
   it('should not validate an object with non-object values', () => {
+    const currencyCode = faker.finance.currencyCode();
     const address = faker.finance.ethereumAddress();
     const assetPrice = {
       [address]: faker.number.int(),
     };
 
-    const result = AssetPriceSchema.safeParse(assetPrice);
+    const result = getAssetPriceSchema(currencyCode).safeParse(assetPrice);
 
     expect(!result.success && result.error.issues).toStrictEqual([
       {
@@ -42,10 +48,11 @@ describe('AssetPriceSchema', () => {
     const assetPrice = {
       [address]: {
         [currency]: faker.string.alphanumeric(),
+        [`${currency}_24h_change`]: faker.string.alphanumeric(),
       },
     };
 
-    const result = AssetPriceSchema.safeParse(assetPrice);
+    const result = getAssetPriceSchema(currency).safeParse(assetPrice);
 
     expect(!result.success && result.error.issues).toStrictEqual([
       {
@@ -53,6 +60,13 @@ describe('AssetPriceSchema', () => {
         expected: 'number',
         message: 'Expected number, received string',
         path: [address, currency],
+        received: 'string',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Expected number, received string',
+        path: [address, `${currency}_24h_change`],
         received: 'string',
       },
     ]);

--- a/src/datasources/balances-api/entities/asset-price.entity.ts
+++ b/src/datasources/balances-api/entities/asset-price.entity.ts
@@ -1,7 +1,23 @@
 import { z } from 'zod';
 
-export type AssetPrice = z.infer<typeof AssetPriceSchema>;
+export type AssetPrice = z.infer<ReturnType<typeof getAssetPriceSchema>>;
 
-export const AssetPriceSchema = z.record(z.record(z.number().nullable()));
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getAssetPriceSchema<const T extends string>(
+  lowerCaseFiatCode: T,
+) {
+  return z.record(
+    z.object({
+      [lowerCaseFiatCode]: z.number().nullish().default(null),
+      [`${lowerCaseFiatCode}_24h_change`]: z.number().nullish().default(null),
+    }),
+  );
+}
 
-export const AssetPricesSchema = z.array(AssetPriceSchema);
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getAssetPricesSchema<const T extends string>(
+  lowerCaseFiatCode: T,
+) {
+  const AssetPriceSchema = getAssetPriceSchema(lowerCaseFiatCode);
+  return z.array(AssetPriceSchema);
+}

--- a/src/datasources/balances-api/prices-api.interface.ts
+++ b/src/datasources/balances-api/prices-api.interface.ts
@@ -8,7 +8,7 @@ export interface IPricesApi {
   getNativeCoinPrice(args: {
     chain: Chain;
     fiatCode: string;
-  }): Promise<number | null>;
+  }): Promise<AssetPrice[string] | null>;
 
   getTokenPrices(args: {
     chain: Chain;

--- a/src/datasources/balances-api/zerion-balances-api.service.ts
+++ b/src/datasources/balances-api/zerion-balances-api.service.ts
@@ -233,7 +233,7 @@ export class ZerionBalancesApi implements IBalancesApi {
   ): Raw<Array<Balance>> {
     const balances = zerionBalances
       .filter((zb) => zb.attributes.flags.displayable)
-      .map((zb) => {
+      .map((zb): Balance => {
         const implementation = zb.attributes.fungible_info.implementations.find(
           (implementation) => implementation.chain_id === chainName,
         );
@@ -250,6 +250,7 @@ export class ZerionBalancesApi implements IBalancesApi {
             ? this._mapNativeBalance(zb.attributes)
             : this._mapErc20Balance(zb.attributes, implementation.address)),
           fiatBalance,
+          fiatBalance24hChange: null,
           fiatConversion,
         };
       });

--- a/src/domain/balances/entities/__tests__/balance.builder.ts
+++ b/src/domain/balances/entities/__tests__/balance.builder.ts
@@ -6,15 +6,11 @@ import type { Balance } from '@/domain/balances/entities/balance.entity';
 import { getAddress } from 'viem';
 
 export function balanceBuilder(): IBuilder<Balance> {
-  return (
-    new Builder<Balance>()
-      .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
-      .with('token', balanceTokenBuilder().build())
-      .with('balance', faker.string.numeric())
-      .with('fiatBalance', null)
-      .with('fiatConversion', null)
-      // TODO: Separate entity into base and extended to avoid doing this
-      // Transaction Service does not return this field and it will default to null
-      .with('fiatBalance24hChange', null)
-  );
+  return new Builder<Balance>()
+    .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('token', balanceTokenBuilder().build())
+    .with('balance', faker.string.numeric())
+    .with('fiatBalance', null)
+    .with('fiatConversion', null)
+    .with('fiatBalance24hChange', null);
 }

--- a/src/domain/balances/entities/__tests__/balance.builder.ts
+++ b/src/domain/balances/entities/__tests__/balance.builder.ts
@@ -6,10 +6,15 @@ import type { Balance } from '@/domain/balances/entities/balance.entity';
 import { getAddress } from 'viem';
 
 export function balanceBuilder(): IBuilder<Balance> {
-  return new Builder<Balance>()
-    .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
-    .with('token', balanceTokenBuilder().build())
-    .with('balance', faker.string.numeric())
-    .with('fiatBalance', null)
-    .with('fiatConversion', null);
+  return (
+    new Builder<Balance>()
+      .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
+      .with('token', balanceTokenBuilder().build())
+      .with('balance', faker.string.numeric())
+      .with('fiatBalance', null)
+      .with('fiatConversion', null)
+      // TODO: Separate entity into base and extended to avoid doing this
+      // Transaction Service does not return this field and it will default to null
+      .with('fiatBalance24hChange', null)
+  );
 }

--- a/src/domain/balances/entities/balance.entity.ts
+++ b/src/domain/balances/entities/balance.entity.ts
@@ -23,6 +23,11 @@ export const Erc20BalanceSchema = z.object({
 
 const FiatSchema = z.object({
   fiatBalance: z.string().nullish().default(null),
+  fiatBalance24hChange: z.coerce
+    .string()
+    .nullable()
+    // Transaction Service does not return this field
+    .catch(() => null),
   fiatConversion: z.string().nullish().default(null),
 });
 

--- a/src/domain/balances/entities/balance.entity.ts
+++ b/src/domain/balances/entities/balance.entity.ts
@@ -23,11 +23,7 @@ export const Erc20BalanceSchema = z.object({
 
 const FiatSchema = z.object({
   fiatBalance: z.string().nullish().default(null),
-  fiatBalance24hChange: z.coerce
-    .string()
-    .nullable()
-    // Transaction Service does not return this field
-    .catch(() => null),
+  fiatBalance24hChange: z.coerce.string().nullish().default(null),
   fiatConversion: z.string().nullish().default(null),
 });
 

--- a/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
+++ b/src/routes/balances/__tests__/controllers/zerion-balances.controller.spec.ts
@@ -224,6 +224,7 @@ describe('Balances Controller (Unit)', () => {
                   },
                   balance: '25000000000000000',
                   fiatBalance: '100.001',
+                  fiatBalance24hChange: null,
                   fiatConversion: '5.05',
                 },
                 {
@@ -241,6 +242,7 @@ describe('Balances Controller (Unit)', () => {
                   },
                   balance: '12000000000000000',
                   fiatBalance: '20.002',
+                  fiatBalance24hChange: null,
                   fiatConversion: '10.1',
                 },
               ],
@@ -375,6 +377,7 @@ describe('Balances Controller (Unit)', () => {
                   },
                   balance: '25000000000000000',
                   fiatBalance: '100000000000000000',
+                  fiatBalance24hChange: null,
                   fiatConversion: '5.05',
                 },
                 {
@@ -392,6 +395,7 @@ describe('Balances Controller (Unit)', () => {
                   },
                   balance: '12000000000000000',
                   fiatBalance: '20000000000000000',
+                  fiatBalance24hChange: null,
                   fiatConversion: '10.1',
                 },
               ],

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -118,11 +118,18 @@ describe('Balances Controller (Unit)', () => {
       const nativeCoinPriceProviderResponse = {
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
+          [`${currency.toLowerCase()}_24h_change`]: 1.6942,
         },
       };
       const tokenPriceProviderResponse = {
-        [tokenAddress]: { [currency.toLowerCase()]: 12.5 },
-        [secondTokenAddress]: { [currency.toLowerCase()]: 10 },
+        [tokenAddress]: {
+          [currency.toLowerCase()]: 12.5,
+          [`${currency.toLowerCase()}_24h_change`]: null,
+        },
+        [secondTokenAddress]: {
+          [currency.toLowerCase()]: 10,
+          [`${currency.toLowerCase()}_24h_change`]: 1.42069,
+        },
       };
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
@@ -174,6 +181,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '3000000000000000000',
               fiatBalance: '4610.25',
+              fiatBalance24hChange: '1.6942',
               fiatConversion: '1536.75',
             },
             {
@@ -189,6 +197,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '4000000000000000000',
               fiatBalance: '500',
+              fiatBalance24hChange: null,
               fiatConversion: '12.5',
             },
             {
@@ -204,6 +213,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '3000000000000000000',
               fiatBalance: '300',
+              fiatBalance24hChange: '1.42069',
               fiatConversion: '10',
             },
           ],
@@ -235,6 +245,7 @@ describe('Balances Controller (Unit)', () => {
             tokenAddress.toLowerCase(),
             secondTokenAddress.toLowerCase(),
           ].join(','),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[4][0].url).toBe(
@@ -245,6 +256,7 @@ describe('Balances Controller (Unit)', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
+          include_24hr_change: true,
         },
       });
     });
@@ -264,7 +276,10 @@ describe('Balances Controller (Unit)', () => {
       const trusted = true;
       const currency = faker.finance.currencyCode();
       const tokenPriceProviderResponse = {
-        [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
+        [tokenAddress]: {
+          [currency.toLowerCase()]: 2.5,
+          [`${currency.toLowerCase()}_24h_change`]: 1.6942,
+        },
       };
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
@@ -319,6 +334,7 @@ describe('Balances Controller (Unit)', () => {
       const nativeCoinPriceProviderResponse = {
         [chain.pricesProvider.nativeCoin!]: {
           [currency.toLowerCase()]: 1536.75,
+          [`${currency.toLowerCase()}_24h_change`]: 1.6942,
         },
       };
       networkService.get.mockImplementation(({ url }) => {
@@ -366,6 +382,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '3000000000000000000',
               fiatBalance: '4610.25',
+              fiatBalance24hChange: '1.6942',
               fiatConversion: '1536.75',
             },
           ],
@@ -429,6 +446,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '3000000000000000000',
               fiatBalance: '0',
+              fiatBalance24hChange: null,
               fiatConversion: '0',
             },
           ],
@@ -499,6 +517,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '3000000000000000000',
               fiatBalance: '0',
+              fiatBalance24hChange: null,
               fiatConversion: '0',
             },
             {
@@ -514,6 +533,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '3000000000000000000',
               fiatBalance: '0',
+              fiatBalance24hChange: null,
               fiatConversion: '0',
             },
           ],
@@ -533,7 +553,10 @@ describe('Balances Controller (Unit)', () => {
       ];
       const currency = faker.finance.currencyCode();
       const tokenPriceProviderResponse = {
-        [tokenAddress]: { [currency.toLowerCase()]: 2.5 },
+        [tokenAddress]: {
+          [currency.toLowerCase()]: 2.5,
+          [`${currency.toLowerCase()}_24h_change`]: 1.6942,
+        },
       };
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
@@ -580,6 +603,7 @@ describe('Balances Controller (Unit)', () => {
               },
               balance: '40000000000000000000000000000000000',
               fiatBalance: '1000000000000000000',
+              fiatBalance24hChange: '1.6942',
               fiatConversion: '2.5',
             },
           ],
@@ -687,6 +711,7 @@ describe('Balances Controller (Unit)', () => {
                 },
                 balance: '40000000000000000000000000000000000',
                 fiatBalance: '0',
+                fiatBalance24hChange: null,
                 fiatConversion: '0',
               },
             ],
@@ -754,6 +779,7 @@ describe('Balances Controller (Unit)', () => {
                 },
                 balance: '40000000000000000000000000000000000',
                 fiatBalance: '0',
+                fiatBalance24hChange: null,
                 fiatConversion: '0',
               },
             ],

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -79,6 +79,7 @@ export class BalancesService {
       },
       balance: balance.balance,
       fiatBalance: balance.fiatBalance ?? '0',
+      fiatBalance24hChange: balance.fiatBalance24hChange,
       fiatConversion: balance.fiatConversion ?? '0',
     };
   }

--- a/src/routes/balances/entities/balance.entity.ts
+++ b/src/routes/balances/entities/balance.entity.ts
@@ -1,4 +1,9 @@
-import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import {
   NativeToken,
   Erc20Token,
@@ -21,4 +26,6 @@ export class Balance {
     ],
   })
   tokenInfo!: NativeToken | Erc20Token | Erc721Token;
+  @ApiPropertyOptional({ nullable: true })
+  fiatBalance24hChange!: string | null;
 }

--- a/src/routes/safes/safes.controller.overview.spec.ts
+++ b/src/routes/safes/safes.controller.overview.spec.ts
@@ -245,6 +245,7 @@ describe('Safes Controller Overview (Unit)', () => {
             tokenAddress.toLowerCase(),
             secondTokenAddress.toLowerCase(),
           ].join(','),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[5][0].url).toBe(
@@ -255,6 +256,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[6][0].url).toBe(
@@ -413,6 +415,7 @@ describe('Safes Controller Overview (Unit)', () => {
             tokenAddress.toLowerCase(),
             secondTokenAddress.toLowerCase(),
           ].join(','),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[5][0].url).toBe(
@@ -423,6 +426,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[6][0].url).toBe(
@@ -1008,6 +1012,7 @@ describe('Safes Controller Overview (Unit)', () => {
             tokenAddress.toLowerCase(),
             secondTokenAddress.toLowerCase(),
           ].join(','),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[5][0].url).toBe(
@@ -1018,6 +1023,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[6][0].url).toBe(
@@ -1159,6 +1165,7 @@ describe('Safes Controller Overview (Unit)', () => {
             tokenAddress.toLowerCase(),
             secondTokenAddress.toLowerCase(),
           ].join(','),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[5][0].url).toBe(
@@ -1169,6 +1176,7 @@ describe('Safes Controller Overview (Unit)', () => {
         params: {
           ids: chain.pricesProvider.nativeCoin,
           vs_currencies: currency.toLowerCase(),
+          include_24hr_change: true,
         },
       });
       expect(networkService.get.mock.calls[6][0].url).toBe(


### PR DESCRIPTION
## Summary

Our prices provider returns a 24h balance change but we are not exposing it. This adds the relevant logic to include it in balance requests under a new `fiatBalance24hChange` field.

## Changes

- Convert `AssetPriceSchema` to be dynamic, based on a provided currency code
- Map and return `{currency}_24h_change` from CoinGecko, with a default of `null` with Zerion/Transaction Service
- Map change onto balances
- Update test coverage accordingly