### PR TITLE
refactor: rename string message property on JSON logs

### DIFF
--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -34,21 +34,21 @@ async function redisClientFactory(
     loggingService.error({
       type: LogType.CacheError,
       source: 'CacheModule',
-      message: err.code ?? err.message,
+      event: err.code ?? err.message,
     }),
   );
   client.on('reconnecting', () =>
     loggingService.warn({
       type: LogType.CacheEvent,
       source: 'CacheModule',
-      message: 'Reconnecting to Redis',
+      event: 'Reconnecting to Redis',
     }),
   );
   client.on('end', () =>
     loggingService.warn({
       type: LogType.CacheEvent,
       source: 'CacheModule',
-      message: 'Redis connection closed',
+      event: 'Redis connection closed',
     }),
   );
   await client.connect();

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -62,7 +62,7 @@ export class RedisCacheService
       this.loggingService.error({
         type: LogType.CacheError,
         source: 'RedisCacheService',
-        message: `Error setting/expiring ${key}:${cacheDir.field}`,
+        event: `Error setting/expiring ${key}:${cacheDir.field}`,
       });
       await this.client.unlink(key);
       throw error;
@@ -134,7 +134,7 @@ export class RedisCacheService
     this.loggingService.warn({
       type: LogType.CacheEvent,
       source: 'RedisCacheService',
-      message: 'Closing Redis connection',
+      event: 'Closing Redis connection',
     });
     const forceQuitTimeout = setTimeout(() => {
       this.forceQuit.bind(this);
@@ -150,7 +150,7 @@ export class RedisCacheService
     this.loggingService.warn({
       type: LogType.CacheEvent,
       source: 'RedisCacheService',
-      message: 'Forcing Redis connection close',
+      event: 'Forcing Redis connection close',
     });
     await this.client.disconnect();
   }

--- a/src/domain/messages/helpers/message-verifier.helper.spec.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.spec.ts
@@ -295,7 +295,7 @@ describe('MessageVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -331,7 +331,7 @@ describe('MessageVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -661,7 +661,7 @@ describe('MessageVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -699,7 +699,7 @@ describe('MessageVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,

--- a/src/domain/messages/helpers/message-verifier.helper.ts
+++ b/src/domain/messages/helpers/message-verifier.helper.ts
@@ -231,7 +231,7 @@ export class MessageVerifierHelper {
     source: LogSource;
   }): void {
     this.loggingService.error({
-      message: 'Unauthorized address',
+      event: 'Unauthorized address',
       chainId: args.chainId,
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,
@@ -252,7 +252,7 @@ export class MessageVerifierHelper {
     source: LogSource;
   }): void {
     this.loggingService.error({
-      message: 'Recovered address does not match signer',
+      event: 'Recovered address does not match signer',
       chainId: args.chainId,
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -1102,7 +1102,7 @@ describe('Messages controller', () => {
           });
 
         expect(loggingService.error).toHaveBeenCalledWith({
-          message: 'Unauthorized address',
+          event: 'Unauthorized address',
           chainId: chain.chainId,
           safeAddress: safe.address,
           safeVersion: safe.version,
@@ -1211,7 +1211,7 @@ describe('Messages controller', () => {
           });
 
         expect(loggingService.error).toHaveBeenCalledWith({
-          message: 'Recovered address does not match signer',
+          event: 'Recovered address does not match signer',
           chainId: chain.chainId,
           safeAddress: safe.address,
           safeVersion: safe.version,
@@ -1643,7 +1643,7 @@ describe('Messages controller', () => {
           });
 
         expect(loggingService.error).toHaveBeenCalledWith({
-          message: 'Unauthorized address',
+          event: 'Unauthorized address',
           chainId: chain.chainId,
           safeAddress: safe.address,
           safeVersion: safe.version,
@@ -1768,7 +1768,7 @@ describe('Messages controller', () => {
           });
 
         expect(loggingService.error).toHaveBeenCalledWith({
-          message: 'Recovered address does not match signer',
+          event: 'Recovered address does not match signer',
           chainId: chain.chainId,
           safeAddress: safe.address,
           safeVersion: safe.version,

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -425,7 +425,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -584,7 +584,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -702,7 +702,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -1167,7 +1167,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1366,7 +1366,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1424,7 +1424,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -781,7 +781,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId: chainResponse.chainId,
         safeAddress: safeResponse.address,
         safeVersion: safeResponse.version,
@@ -1069,7 +1069,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId: chainResponse.chainId,
         safeAddress: safeResponse.address,
         safeVersion: safeResponse.version,
@@ -1159,7 +1159,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId: chainResponse.chainId,
         safeAddress: safeResponse.address,
         safeVersion: safeResponse.version,
@@ -1248,7 +1248,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId: chainResponse.chainId,
         safeAddress: safeResponse.address,
         safeVersion: safeResponse.version,

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -1089,7 +1089,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1293,7 +1293,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1595,7 +1595,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1689,7 +1689,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         });
 
       expect(loggingService.error).toHaveBeenCalledWith({
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId: chain.chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,

--- a/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.spec.ts
@@ -278,7 +278,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -455,7 +455,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -490,7 +490,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1179,7 +1179,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1367,7 +1367,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1597,7 +1597,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1662,7 +1662,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -1924,7 +1924,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'safeTxHash does not match',
+        event: 'safeTxHash does not match',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -2086,7 +2086,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Unauthorized address',
+        event: 'Unauthorized address',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,
@@ -2184,7 +2184,7 @@ describe('TransactionVerifierHelper', () => {
 
       expect(mockLoggingRepository.error).toHaveBeenCalledTimes(1);
       expect(mockLoggingRepository.error).toHaveBeenNthCalledWith(1, {
-        message: 'Recovered address does not match signer',
+        event: 'Recovered address does not match signer',
         chainId,
         safeAddress: safe.address,
         safeVersion: safe.version,

--- a/src/routes/transactions/helpers/transaction-verifier.helper.ts
+++ b/src/routes/transactions/helpers/transaction-verifier.helper.ts
@@ -492,7 +492,7 @@ export class TransactionVerifierHelper {
     source: LogSource;
   }): void {
     this.loggingService.error({
-      message: 'safeTxHash does not match',
+      event: 'safeTxHash does not match',
       chainId: args.chainId,
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,
@@ -511,7 +511,7 @@ export class TransactionVerifierHelper {
     source: LogSource;
   }): void {
     this.loggingService.error({
-      message: 'Unauthorized address',
+      event: 'Unauthorized address',
       chainId: args.chainId,
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,
@@ -531,7 +531,7 @@ export class TransactionVerifierHelper {
     source: LogSource;
   }): void {
     this.loggingService.error({
-      message: 'Recovered address does not match signer',
+      event: 'Recovered address does not match signer',
       chainId: args.chainId,
       safeAddress: args.safe.address,
       safeVersion: args.safe.version,


### PR DESCRIPTION
## Summary
This PR renames all plain string `message` properties on logs to avoid parsing errors in log ingestion pipelines.

## Changes
- Renames `message` to `event` on string typed log properties.