### PR TITLE
feat: map vault deposit transactions

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -292,6 +292,7 @@ export default (): ReturnType<typeof configuration> => ({
       baseUri: faker.internet.url({ appendSlash: false }),
       apiKey: faker.string.hexadecimal({ length: 32 }),
     },
+    isBaseProductionActive: faker.datatype.boolean(),
   },
   swaps: {
     api: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -431,6 +431,9 @@ export default () => ({
       baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
       apiKey: process.env.STAKING_API_KEY,
     },
+    // TODO: activate this to point Base vault deployments to Kiln mainnet API.
+    isBaseProductionActive:
+      process.env.STAKING_BASE_PRODUCTION_ACTIVE?.toLowerCase() === 'true',
   },
   swaps: {
     api: {

--- a/src/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder.ts
@@ -1,12 +1,21 @@
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
-import type { DefiVaultStats } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
+import type {
+  DefiVaultStats,
+  DefiVaultStatsAdditionalReward,
+} from '@/datasources/staking-api/entities/defi-vault-stats.entity';
 import {
   DefiVaultStatsChains,
   DefiVaultStatsProtocols,
 } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
+
+export function defiVaultAdditionalRewardBuilder(): IBuilder<DefiVaultStatsAdditionalReward> {
+  return new Builder<DefiVaultStatsAdditionalReward>()
+    .with('asset', getAddress(faker.finance.ethereumAddress()))
+    .with('nrr', faker.number.float());
+}
 
 export function defiVaultStatsBuilder(): IBuilder<DefiVaultStats> {
   return new Builder<DefiVaultStats>()
@@ -25,5 +34,11 @@ export function defiVaultStatsBuilder(): IBuilder<DefiVaultStats> {
     .with('chain', faker.helpers.arrayElement(DefiVaultStatsChains))
     .with('chain_id', faker.number.int())
     .with('asset_decimals', faker.number.int())
-    .with('updated_at_block', faker.number.int());
+    .with('updated_at_block', faker.number.int())
+    .with(
+      'additional_rewards',
+      faker.helpers.multiple(() => defiVaultAdditionalRewardBuilder().build(), {
+        count: faker.number.int({ min: 0, max: 5 }),
+      }),
+    );
 }

--- a/src/datasources/staking-api/entities/__tests__/deployment.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/deployment.entity.builder.ts
@@ -21,5 +21,6 @@ export function deploymentBuilder(): IBuilder<Deployment> {
     .with('chain_id', faker.number.int())
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('status', faker.helpers.arrayElement(DeploymentStatuses))
-    .with('product_fee', faker.string.numeric());
+    .with('product_fee', faker.string.numeric())
+    .with('external_links', { deposit_url: faker.internet.url() });
 }

--- a/src/datasources/staking-api/entities/defi-vault-stats.entity.ts
+++ b/src/datasources/staking-api/entities/defi-vault-stats.entity.ts
@@ -14,7 +14,17 @@ export const DefiVaultStatsChains = [
   'bsc',
   'matic',
   'op',
+  'base',
 ] as const;
+
+export const DefiVaultStatsAdditionalRewardSchema = z.object({
+  asset: AddressSchema,
+  nrr: z.number(),
+});
+
+export type DefiVaultStatsAdditionalReward = z.infer<
+  typeof DefiVaultStatsAdditionalRewardSchema
+>;
 
 export const DefiVaultStatsSchema = z.object({
   asset: AddressSchema,
@@ -33,6 +43,10 @@ export const DefiVaultStatsSchema = z.object({
   chain_id: z.number(),
   asset_decimals: z.number(),
   updated_at_block: z.number(),
+  additional_rewards: z
+    .array(DefiVaultStatsAdditionalRewardSchema)
+    .nullish()
+    .default(null),
 });
 
 export const DefiVaultsStateSchema = z.array(DefiVaultStatsSchema);

--- a/src/datasources/staking-api/entities/deployment.entity.ts
+++ b/src/datasources/staking-api/entities/deployment.entity.ts
@@ -4,7 +4,14 @@ import { z } from 'zod';
 
 export const DeploymentProductTypes = ['defi', 'pooling', 'dedicated'] as const;
 
-export const DeploymentChains = ['eth', 'arb', 'bsc', 'matic', 'op'] as const;
+export const DeploymentChains = [
+  'eth',
+  'arb',
+  'bsc',
+  'matic',
+  'op',
+  'base',
+] as const;
 
 export const DeploymentStatuses = [
   'active',
@@ -12,6 +19,10 @@ export const DeploymentStatuses = [
   'pending',
   'disabled',
 ] as const;
+
+export const DeploymentExternalLinksSchema = z.object({
+  deposit_url: z.string().url().nullish().default(null),
+});
 
 export const DeploymentSchema = z.object({
   id: z.string().uuid(),
@@ -25,6 +36,7 @@ export const DeploymentSchema = z.object({
   address: AddressSchema,
   status: z.enum([...DeploymentStatuses, 'unknown']).catch('unknown'),
   product_fee: NumericStringSchema.nullish().default(null),
+  external_links: DeploymentExternalLinksSchema.nullish().default(null),
 });
 
 export const DeploymentsSchema = z.array(DeploymentSchema);

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -26,6 +26,7 @@ export class KilnApi implements IStakingApi {
     bsc: '56',
     matic: '137',
     op: '10',
+    base: '8453',
   };
 
   private readonly stakingExpirationTimeInSeconds: number;

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -2281,4 +2281,28 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
       });
     });
   });
+
+  describe('Lending Vaults', () => {
+    describe('deposit', () => {
+      it.todo('should preview a transaction');
+      it.todo(
+        'should return a "standard" transaction preview if the deployment is unavailable',
+      );
+      it.todo(
+        'should return a "standard" transaction preview if the deployment product type is not defi',
+      );
+      it.todo(
+        'should return a "standard" transaction preview if the deployment is not active',
+      );
+      it.todo(
+        'should return a "standard" transaction preview if the deployment is on a different chain',
+      );
+      it.todo(
+        'should return a "standard" transaction preview if the vault stats are not available',
+      );
+      it.todo(
+        'should return a "standard" transaction preview if the underlying token is unknown',
+      );
+    });
+  });
 });

--- a/src/routes/transactions/entities/base-transaction.entity.ts
+++ b/src/routes/transactions/entities/base-transaction.entity.ts
@@ -10,6 +10,7 @@ import { TwapOrderTransactionInfo } from '@/routes/transactions/entities/swaps/t
 import { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
 import { TransferTransactionInfo } from '@/routes/transactions/entities/transfer-transaction-info.entity';
 import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer-transaction-info.entity';
+import { VaultDepositTransactionInfo } from '@/routes/transactions/entities/vaults/vault-deposit-info.entity';
 
 @ApiExtraModels(
   TransactionInfo,
@@ -23,6 +24,7 @@ import { SwapTransferTransactionInfo } from '@/routes/transactions/swap-transfer
   NativeStakingDepositTransactionInfo,
   NativeStakingValidatorsExitTransactionInfo,
   NativeStakingWithdrawTransactionInfo,
+  VaultDepositTransactionInfo,
 )
 export class BaseTransaction {
   @ApiProperty({
@@ -37,6 +39,7 @@ export class BaseTransaction {
       { $ref: getSchemaPath(NativeStakingDepositTransactionInfo) },
       { $ref: getSchemaPath(NativeStakingValidatorsExitTransactionInfo) },
       { $ref: getSchemaPath(NativeStakingWithdrawTransactionInfo) },
+      { $ref: getSchemaPath(VaultDepositTransactionInfo) },
     ],
   })
   txInfo: TransactionInfo;

--- a/src/routes/transactions/entities/transaction-info.entity.ts
+++ b/src/routes/transactions/entities/transaction-info.entity.ts
@@ -3,14 +3,15 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 export enum TransactionInfoType {
   Creation = 'Creation',
   Custom = 'Custom',
-  SettingsChange = 'SettingsChange',
-  Transfer = 'Transfer',
-  SwapOrder = 'SwapOrder',
-  SwapTransfer = 'SwapTransfer',
-  TwapOrder = 'TwapOrder',
   NativeStakingDeposit = 'NativeStakingDeposit',
   NativeStakingValidatorsExit = 'NativeStakingValidatorsExit',
   NativeStakingWithdraw = 'NativeStakingWithdraw',
+  SettingsChange = 'SettingsChange',
+  SwapOrder = 'SwapOrder',
+  SwapTransfer = 'SwapTransfer',
+  Transfer = 'Transfer',
+  TwapOrder = 'TwapOrder',
+  VaultDeposit = 'VaultDeposit',
 }
 
 export class TransactionInfo {

--- a/src/routes/transactions/entities/vaults/vault-deposit-info.entity.ts
+++ b/src/routes/transactions/entities/vaults/vault-deposit-info.entity.ts
@@ -1,0 +1,93 @@
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
+import {
+  TransactionInfo,
+  TransactionInfoType,
+} from '@/routes/transactions/entities/transaction-info.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class VaultDepositAdditionalRewards {
+  @ApiProperty()
+  tokenInfo: TokenInfo;
+
+  @ApiProperty()
+  returnRate: number;
+
+  constructor(args: { tokenInfo: TokenInfo; returnRate: number }) {
+    this.tokenInfo = args.tokenInfo;
+    this.returnRate = args.returnRate;
+  }
+}
+export class VaultDepositTransactionInfo extends TransactionInfo {
+  @ApiProperty({ enum: [TransactionInfoType.VaultDeposit] })
+  override type = TransactionInfoType.VaultDeposit;
+
+  @ApiProperty()
+  chainId: string;
+
+  @ApiProperty()
+  expectedMonthlyReward: number;
+
+  @ApiProperty()
+  expectedAnnualReward: number;
+
+  @ApiProperty()
+  tokenInfo: TokenInfo;
+
+  @ApiProperty()
+  value: number;
+
+  @ApiProperty()
+  returnRate: number;
+
+  @ApiProperty()
+  vaultAddress: `0x${string}`;
+
+  @ApiProperty()
+  vaultName: string;
+
+  @ApiProperty()
+  vaultDisplayName: string;
+
+  @ApiProperty()
+  vaultDescription: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  vaultDashboardURL: string | null;
+
+  @ApiProperty()
+  vaultTVL: number;
+
+  @ApiPropertyOptional({ type: VaultDepositAdditionalRewards, isArray: true })
+  additionalRewards: Array<VaultDepositAdditionalRewards> | null;
+
+  constructor(args: {
+    chainId: string;
+    expectedAnnualReward: number;
+    expectedMonthlyReward: number;
+    returnRate: number;
+    tokenInfo: TokenInfo;
+    value: number;
+    vaultAddress: `0x${string}`;
+    vaultDashboardURL: string | null;
+    vaultDescription: string;
+    vaultDisplayName: string;
+    vaultName: string;
+    vaultTVL: number;
+    additionalRewards: Array<VaultDepositAdditionalRewards> | null;
+  }) {
+    super(TransactionInfoType.VaultDeposit, null);
+    this.chainId = args.chainId;
+    this.expectedAnnualReward = args.expectedAnnualReward;
+    this.expectedMonthlyReward = args.expectedMonthlyReward;
+    this.returnRate = args.returnRate;
+    this.tokenInfo = args.tokenInfo;
+    this.value = args.value;
+    this.vaultAddress = args.vaultAddress;
+    this.vaultDashboardURL = args.vaultDashboardURL;
+    this.vaultDescription = args.vaultDescription;
+    this.vaultDisplayName = args.vaultDisplayName;
+    this.vaultName = args.vaultName;
+    this.vaultTVL = args.vaultTVL;
+    this.additionalRewards = args.additionalRewards;
+  }
+}

--- a/src/routes/transactions/helpers/kiln-vault.helper.ts
+++ b/src/routes/transactions/helpers/kiln-vault.helper.ts
@@ -1,0 +1,73 @@
+import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
+import {
+  TransactionFinder,
+  TransactionFinderModule,
+} from '@/routes/transactions/helpers/transaction-finder.helper';
+import { Injectable, Module } from '@nestjs/common';
+import {
+  decodeFunctionData,
+  getAbiItem,
+  parseAbi,
+  toFunctionSelector,
+} from 'viem';
+
+export const KilnVaultAbi = parseAbi([
+  'function deposit(uint256 assets, address receiver)',
+]);
+
+@Injectable()
+export class KilnVaultHelper {
+  private static readonly VAULT_DEPOSIT_SIGNATURE = getAbiItem({
+    abi: KilnVaultAbi,
+    name: 'deposit',
+  });
+
+  constructor(private readonly transactionFinder: TransactionFinder) {}
+
+  public getVaultDepositTransaction(args: {
+    to?: `0x${string}`;
+    data: `0x${string}`;
+    value: string;
+  }): {
+    to?: `0x${string}`;
+    data: `0x${string}`;
+    assets: number;
+  } | null {
+    const transaction = this.findVaultDepositTransaction(args);
+    if (!transaction) {
+      return null;
+    }
+
+    const decoded = decodeFunctionData({
+      abi: KilnVaultAbi,
+      data: transaction.data,
+    });
+
+    return {
+      to: transaction.to,
+      data: transaction.data,
+      assets: Number(decoded.args[0]),
+    };
+  }
+
+  private findVaultDepositTransaction(args: {
+    to?: `0x${string}`;
+    data: `0x${string}`;
+    value: string;
+  }): { to?: `0x${string}`; data: `0x${string}`; value: string } | null {
+    const selector = toFunctionSelector(
+      KilnVaultHelper.VAULT_DEPOSIT_SIGNATURE,
+    );
+    return this.transactionFinder.findTransaction(
+      (transaction) => transaction.data.startsWith(selector),
+      args,
+    );
+  }
+}
+
+@Module({
+  imports: [TransactionFinderModule],
+  providers: [KilnVaultHelper, KilnDecoder],
+  exports: [KilnVaultHelper, KilnDecoder],
+})
+export class KilnVaultHelperModule {}

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
@@ -1,0 +1,175 @@
+import {
+  defiVaultAdditionalRewardBuilder,
+  defiVaultStatsBuilder,
+} from '@/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder';
+import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import type { StakingRepository } from '@/domain/staking/staking.repository';
+import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import type { ITokenRepository } from '@/domain/tokens/token.repository.interface';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
+import { TransactionInfoType } from '@/routes/transactions/entities/transaction-info.entity';
+import { VaultTransactionMapper } from '@/routes/transactions/mappers/common/vault-transaction.mapper';
+import { faker } from '@faker-js/faker/.';
+import { NotFoundException } from '@nestjs/common';
+import { getAddress } from 'viem';
+
+const mockStakingRepository = jest.mocked({
+  getDeployment: jest.fn(),
+  getDefiVaultStats: jest.fn(),
+} as jest.MockedObjectDeep<StakingRepository>);
+
+const mockTokenRepository = {
+  getToken: jest.fn(),
+} as jest.MockedObjectDeep<ITokenRepository>;
+
+describe('VaultTransactionMapper', () => {
+  let target: VaultTransactionMapper;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    target = new VaultTransactionMapper(
+      mockStakingRepository,
+      mockTokenRepository,
+    );
+  });
+
+  describe('mapDepositInfo', () => {
+    it('should map deposit info correctly', async () => {
+      const chain = chainBuilder().build();
+      const vaultAddress = getAddress(faker.finance.ethereumAddress());
+      const deployment = deploymentBuilder()
+        .with('product_type', 'defi')
+        .with('product_fee', '0.1')
+        .with('status', 'active')
+        .with('chain_id', Number(chain.chainId))
+        .build();
+      const token = tokenBuilder()
+        .with('type', 'ERC20')
+        .with('decimals', 2)
+        .build();
+      const additionalTokens = faker.helpers.multiple(() =>
+        tokenBuilder().with('type', 'ERC20').with('decimals', 3).build(),
+      );
+      const defiVaultStats = defiVaultStatsBuilder()
+        .with('asset', token.address)
+        .with('tvl', '2000000')
+        .with('nrr', 10)
+        .with(
+          'additional_rewards',
+          additionalTokens.map((additionalToken, index) =>
+            defiVaultAdditionalRewardBuilder()
+              .with('asset', additionalToken.address)
+              .with('nrr', index + 1)
+              .build(),
+          ),
+        )
+        .build();
+      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockStakingRepository.getDefiVaultStats.mockResolvedValue(defiVaultStats);
+      mockTokenRepository.getToken.mockImplementation((args) => {
+        const additionalToken = additionalTokens.find(
+          (token) => token.address === args.address,
+        );
+        if (args.address === token.address) {
+          return Promise.resolve(token);
+        }
+        if (additionalToken) {
+          return Promise.resolve(additionalToken);
+        }
+        throw new Error('Token not found');
+      });
+
+      const actual = await target.mapDepositInfo({
+        chainId: chain.chainId,
+        to: vaultAddress,
+        assets: 1_000_000,
+        data: '0x',
+      });
+
+      expect(actual).toEqual({
+        type: TransactionInfoType.VaultDeposit,
+        chainId: chain.chainId,
+        expectedAnnualReward: 900, // 10 * 0.9 / 100 * 1_000_000 / 10 ** 2,
+        expectedMonthlyReward: 75, // 900 / 12,
+        humanDescription: null,
+        value: 10_000, // 1_000_000 / 10 ** 2
+        tokenInfo: new TokenInfo({ ...token, trusted: true }),
+        returnRate: 9, // 10 * 0.9
+        vaultAddress,
+        vaultName: defiVaultStats.vault,
+        vaultDisplayName: deployment.display_name,
+        vaultDescription: deployment.description,
+        vaultDashboardURL: deployment.external_links?.deposit_url ?? null,
+        vaultTVL: 2_000_000,
+        additionalRewards: additionalTokens.map((additionalToken, index) => ({
+          tokenInfo: new TokenInfo({ ...additionalToken, trusted: true }),
+          returnRate: index + 1,
+        })),
+      });
+    });
+
+    it('should fail if the deployment product type is not DeFi', async () => {
+      const chain = chainBuilder().build();
+      const vaultAddress = getAddress(faker.finance.ethereumAddress());
+      const deployment = deploymentBuilder()
+        .with('product_type', 'pooling')
+        .with('product_fee', '0.1')
+        .with('status', 'active')
+        .with('chain_id', Number(chain.chainId))
+        .build();
+      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+
+      await expect(
+        target.mapDepositInfo({
+          chainId: chain.chainId,
+          to: vaultAddress,
+          assets: faker.number.int(),
+          data: '0x',
+        }),
+      ).rejects.toThrow(new NotFoundException('DeFi deployment not found'));
+    });
+    it('should fail if the deployment is not active', async () => {
+      const chain = chainBuilder().build();
+      const vaultAddress = getAddress(faker.finance.ethereumAddress());
+      const deployment = deploymentBuilder()
+        .with('product_type', 'defi')
+        .with('product_fee', '0.1')
+        .with('status', 'disabled')
+        .with('chain_id', Number(chain.chainId))
+        .build();
+      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+
+      await expect(
+        target.mapDepositInfo({
+          chainId: chain.chainId,
+          to: vaultAddress,
+          assets: faker.number.int(),
+          data: '0x',
+        }),
+      ).rejects.toThrow(new NotFoundException('DeFi deployment not found'));
+    });
+
+    it('should fail if the deployment chainId is different', async () => {
+      const chain = chainBuilder().build();
+      const vaultAddress = getAddress(faker.finance.ethereumAddress());
+      const deployment = deploymentBuilder()
+        .with('product_type', 'defi')
+        .with('product_fee', '0.1')
+        .with('status', 'active')
+        .with('chain_id', faker.number.int())
+        .build();
+      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+
+      await expect(
+        target.mapDepositInfo({
+          chainId: chain.chainId,
+          to: vaultAddress,
+          assets: faker.number.int(),
+          data: '0x',
+        }),
+      ).rejects.toThrow(new NotFoundException('DeFi deployment not found'));
+    });
+  });
+});

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.ts
@@ -1,0 +1,105 @@
+import { DefiVaultStatsAdditionalReward } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
+import { Deployment } from '@/datasources/staking-api/entities/deployment.entity';
+import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
+import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
+import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
+import {
+  VaultDepositAdditionalRewards,
+  VaultDepositTransactionInfo,
+} from '@/routes/transactions/entities/vaults/vault-deposit-info.entity';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class VaultTransactionMapper {
+  constructor(
+    @Inject(IStakingRepository)
+    private readonly stakingRepository: IStakingRepository,
+    @Inject(ITokenRepository)
+    private readonly tokenRepository: ITokenRepository,
+  ) {}
+
+  public async mapDepositInfo(args: {
+    chainId: string;
+    to: `0x${string}`;
+    assets: number;
+    data: `0x${string}`;
+  }): Promise<VaultDepositTransactionInfo> {
+    const deployment = await this.stakingRepository.getDeployment({
+      chainId: args.chainId,
+      address: args.to,
+    });
+    this.validateDeployment({ chainId: args.chainId, deployment });
+    const defiVaultStats = await this.stakingRepository.getDefiVaultStats({
+      chainId: args.chainId,
+      vault: args.to,
+    });
+    const token = await this.tokenRepository.getToken({
+      chainId: args.chainId,
+      address: defiVaultStats.asset,
+    });
+    const additionalRewards = await this.mapAdditionalRewards({
+      chainId: args.chainId,
+      additionalRewards: defiVaultStats.additional_rewards,
+    });
+    const value = (args.assets ?? 0) / 10 ** token.decimals;
+    const fee = deployment.product_fee ? Number(deployment.product_fee) : 0;
+    const nrr = defiVaultStats.nrr * (1 - fee);
+    const expectedAnnualReward = (nrr / 100) * value;
+    const expectedMonthlyReward = expectedAnnualReward / 12;
+    return new VaultDepositTransactionInfo({
+      chainId: args.chainId,
+      expectedMonthlyReward,
+      expectedAnnualReward,
+      value,
+      tokenInfo: new TokenInfo({ ...token, trusted: true }),
+      returnRate: nrr,
+      vaultAddress: args.to,
+      vaultName: defiVaultStats.vault,
+      vaultDisplayName: deployment.display_name,
+      vaultDescription: deployment.description,
+      vaultDashboardURL: deployment.external_links?.deposit_url ?? null,
+      vaultTVL: Number(defiVaultStats.tvl),
+      additionalRewards,
+    });
+  }
+
+  private async mapAdditionalRewards(args: {
+    chainId: string;
+    additionalRewards: Array<DefiVaultStatsAdditionalReward> | null;
+  }): Promise<Array<VaultDepositAdditionalRewards>> {
+    if (!args.additionalRewards) {
+      return Promise.resolve([]);
+    }
+    const rewards = [];
+    for (const reward of args.additionalRewards) {
+      const token = await this.tokenRepository
+        .getToken({
+          chainId: args.chainId,
+          address: reward.asset,
+        })
+        .catch(() => null);
+      if (token && reward.nrr) {
+        rewards.push(
+          new VaultDepositAdditionalRewards({
+            tokenInfo: new TokenInfo({ ...token, trusted: true }),
+            returnRate: reward.nrr,
+          }),
+        );
+      }
+    }
+    return rewards;
+  }
+
+  private validateDeployment(args: {
+    chainId: string;
+    deployment: Deployment;
+  }): void {
+    if (
+      args.deployment.product_type !== 'defi' ||
+      args.deployment.status !== 'active' ||
+      args.deployment.chain_id.toString() !== args.chainId
+    ) {
+      throw new NotFoundException('DeFi deployment not found');
+    }
+  }
+}

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -50,6 +50,8 @@ import { TransactionsService } from '@/routes/transactions/transactions.service'
 import { Module } from '@nestjs/common';
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
 import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.repository.interface';
+import { KilnVaultHelperModule } from '@/routes/transactions/helpers/kiln-vault.helper';
+import { VaultTransactionMapper } from '@/routes/transactions/mappers/common/vault-transaction.mapper';
 
 @Module({
   controllers: [TransactionsController],
@@ -59,19 +61,20 @@ import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.r
     ContractsRepositoryModule,
     DataDecoderRepositoryModule,
     DelegatesV2RepositoryModule,
-    HumanDescriptionRepositoryModule,
-    SafeRepositoryModule,
-    SafeAppsRepositoryModule,
     GPv2DecoderModule,
+    HumanDescriptionRepositoryModule,
     KilnNativeStakingHelperModule,
+    KilnVaultHelperModule,
+    SafeAppsRepositoryModule,
+    SafeRepositoryModule,
     StakingRepositoryModule,
     SwapAppsHelperModule,
-    SwapOrderMapperModule,
     SwapOrderHelperModule,
+    SwapOrderMapperModule,
     SwapsRepositoryModule,
     TokenRepositoryModule,
-    TwapOrderMapperModule,
     TwapOrderHelperModule,
+    TwapOrderMapperModule,
   ],
   providers: [
     CreationTransactionMapper,
@@ -80,7 +83,7 @@ import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.r
     Erc20TransferMapper,
     Erc721TransferMapper,
     GPv2OrderHelper,
-    TransferMapper,
+    HumanDescriptionMapper,
     ModuleTransactionDetailsMapper,
     ModuleTransactionMapper,
     ModuleTransactionStatusMapper,
@@ -89,8 +92,8 @@ import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.r
     MultisigTransactionExecutionInfoMapper,
     MultisigTransactionInfoMapper,
     MultisigTransactionMapper,
-    MultisigTransactionStatusMapper,
     MultisigTransactionNoteMapper,
+    MultisigTransactionStatusMapper,
     NativeCoinTransferMapper,
     NativeStakingMapper,
     QueuedItemsMapper,
@@ -101,11 +104,12 @@ import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.r
     TransactionPreviewMapper,
     TransactionsHistoryMapper,
     TransactionsService,
-    TransferDetailsMapper,
-    TransferInfoMapper,
-    TransferImitationMapper,
     TransactionVerifierHelper,
-    HumanDescriptionMapper,
+    TransferDetailsMapper,
+    TransferImitationMapper,
+    TransferInfoMapper,
+    TransferMapper,
+    VaultTransactionMapper,
   ],
 })
 export class TransactionsModule {}


### PR DESCRIPTION
## Summary
This PR implements mappings for ERC-4626 deposit transactions.

## Changes
- Adds a `VaultDepositTransactionInfo` and its mappings in the routes layer.
- Extends `DefiVaultStats` and its schema entity with additional properties.
- Adds a new `KilnVaultHelper` to decode ERC-4626 deposits.
- Adds related test cases.
