### PR TITLE
fix: prefetch deduplicated AddressInfos for MultisigTransactions

### DIFF
--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.spec.ts
@@ -1,0 +1,117 @@
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import {
+  dataDecodedBuilder,
+  dataDecodedParameterBuilder,
+} from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
+import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
+import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
+import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
+import type { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
+import type { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
+import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
+import type { SafeAppInfoMapper } from '@/routes/transactions/mappers/common/safe-app-info.mapper';
+import type { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
+import type { MultisigTransactionExecutionInfoMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper';
+import type { MultisigTransactionStatusMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper';
+import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper';
+
+describe('MultisigTransactionMapper', () => {
+  let mapper: MultisigTransactionMapper;
+
+  const addressInfoHelper = jest.mocked({
+    getCollection: jest.fn(),
+  } as jest.MockedObjectDeep<AddressInfoHelper>);
+
+  beforeEach(() => {
+    mapper = new MultisigTransactionMapper(
+      jest.mocked({} as jest.Mocked<MultisigTransactionStatusMapper>),
+      jest.mocked({} as jest.Mocked<MultisigTransactionInfoMapper>),
+      jest.mocked({} as jest.Mocked<MultisigTransactionExecutionInfoMapper>),
+      jest.mocked({} as jest.Mocked<SafeAppInfoMapper>),
+      jest.mocked({} as jest.Mocked<TransactionVerifierHelper>),
+      addressInfoHelper,
+      new DataDecodedParamHelper(),
+    );
+  });
+
+  describe('prefetchAddressInfos', () => {
+    it('should call addressInfoHelper.getCollection with the correct parameters', async () => {
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const tokens = [tokenBuilder().build(), tokenBuilder().build()];
+      const contracts = [contractBuilder().build(), contractBuilder().build()];
+      const transactions = [
+        multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('to', tokens[0].address)
+          .with(
+            'dataDecoded',
+            dataDecodedBuilder()
+              .with('method', 'transferFrom')
+              .with('parameters', [
+                dataDecodedParameterBuilder()
+                  .with('name', 'from')
+                  .with('value', contracts[0].address)
+                  .build(),
+                dataDecodedParameterBuilder()
+                  .with('name', 'to')
+                  .with('value', contracts[1].address)
+                  .build(),
+              ])
+              .build(),
+          )
+          .build(),
+        multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('to', tokens[1].address)
+          .with(
+            'dataDecoded',
+            dataDecodedBuilder()
+              .with('method', 'transfer')
+              .with('parameters', [
+                dataDecodedParameterBuilder()
+                  .with('name', 'to')
+                  .with('value', tokens[0].address)
+                  .build(),
+              ])
+              .build(),
+          )
+          .build(),
+        multisigTransactionBuilder()
+          .with('safe', safe.address)
+          .with('to', tokens[1].address)
+          .with(
+            'dataDecoded',
+            dataDecodedBuilder()
+              .with('method', 'transfer')
+              .with('parameters', [
+                dataDecodedParameterBuilder()
+                  .with('name', 'to')
+                  .with('value', tokens[0].address)
+                  .build(),
+              ])
+              .build(),
+          )
+          .build(),
+      ];
+      await mapper.prefetchAddressInfos({
+        chainId: chain.chainId,
+        transactions,
+      });
+
+      // Check that the addressInfoHelper.getCollection was called with deduplicated addresses
+      expect(addressInfoHelper.getCollection).toHaveBeenCalledWith(
+        chain.chainId,
+        expect.arrayContaining([
+          safe.address,
+          tokens[0].address,
+          tokens[1].address,
+          contracts[0].address,
+          contracts[1].address,
+        ]),
+        ['TOKEN', 'CONTRACT'],
+      );
+    });
+  });
+});

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -11,6 +11,9 @@ import { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/com
 import { MultisigTransactionExecutionInfoMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper';
 import { MultisigTransactionStatusMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper';
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
+import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
+import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
+import { getAddress, isAddress } from 'viem';
 
 @Injectable()
 export class MultisigTransactionMapper {
@@ -20,6 +23,8 @@ export class MultisigTransactionMapper {
     private readonly executionInfoMapper: MultisigTransactionExecutionInfoMapper,
     private readonly safeAppInfoMapper: SafeAppInfoMapper,
     private readonly transactionVerifier: TransactionVerifierHelper,
+    private readonly addressInfoHelper: AddressInfoHelper,
+    private readonly dataDecodedParamHelper: DataDecodedParamHelper,
   ) {}
 
   async mapTransaction(
@@ -56,6 +61,43 @@ export class MultisigTransactionMapper {
       executionInfo,
       safeAppInfo,
       transaction.transactionHash,
+    );
+  }
+
+  /**
+   * Prefetches the AddressInfo for the given transactions.
+   * This method collects all unique addresses from the transactions and fetches their AddressInfo,
+   * to prevent multiple parallel requests for the same addresses.
+   */
+  public async prefetchAddressInfos(args: {
+    chainId: string;
+    transactions: Array<MultisigTransaction>;
+  }): Promise<void> {
+    const addresses: Set<`0x${string}`> = new Set();
+    for (const transaction of args.transactions) {
+      addresses.add(transaction.safe);
+      addresses.add(transaction.to);
+      if (transaction.dataDecoded) {
+        const toAddress = this.dataDecodedParamHelper.getFromParam(
+          transaction.dataDecoded,
+          transaction.safe,
+        );
+        if (isAddress(toAddress)) {
+          addresses.add(getAddress(toAddress));
+        }
+        const fromAddress = this.dataDecodedParamHelper.getToParam(
+          transaction.dataDecoded,
+          transaction.safe,
+        );
+        if (isAddress(fromAddress)) {
+          addresses.add(getAddress(fromAddress));
+        }
+      }
+    }
+    await this.addressInfoHelper.getCollection(
+      args.chainId,
+      Array.from(addresses),
+      ['TOKEN', 'CONTRACT'],
     );
   }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -78,19 +78,19 @@ export class MultisigTransactionMapper {
       addresses.add(transaction.safe);
       addresses.add(transaction.to);
       if (transaction.dataDecoded) {
-        const toAddress = this.dataDecodedParamHelper.getFromParam(
-          transaction.dataDecoded,
-          transaction.safe,
-        );
-        if (isAddress(toAddress)) {
-          addresses.add(getAddress(toAddress));
-        }
-        const fromAddress = this.dataDecodedParamHelper.getToParam(
+        const fromAddress = this.dataDecodedParamHelper.getFromParam(
           transaction.dataDecoded,
           transaction.safe,
         );
         if (isAddress(fromAddress)) {
           addresses.add(getAddress(fromAddress));
+        }
+        const toAddress = this.dataDecodedParamHelper.getToParam(
+          transaction.dataDecoded,
+          transaction.safe,
+        );
+        if (isAddress(toAddress)) {
+          addresses.add(getAddress(toAddress));
         }
       }
     }

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -79,7 +79,7 @@ export class QueuedItemsMapper {
     transactionGroup: TransactionGroup,
   ): Promise<Array<TransactionQueuedItem>> {
     // Prefetch tokens and contracts to avoid multiple parallel requests for the same address
-    await this.prefetchAddressInfos({
+    await this.mapper.prefetchAddressInfos({
       chainId: chainId,
       transactions: transactionGroup.transactions,
     });
@@ -100,17 +100,6 @@ export class QueuedItemsMapper {
         );
       }),
     );
-  }
-
-  private async prefetchAddressInfos(args: {
-    chainId: string;
-    transactions: Array<MultisigTransaction>;
-  }): Promise<void> {
-    const addresses = Array.from(new Set(args.transactions.map((tx) => tx.to)));
-    await this.addressInfoHelper.getCollection(args.chainId, addresses, [
-      'TOKEN',
-      'CONTRACT',
-    ]);
   }
 
   private getConflictType(

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -207,6 +207,10 @@ export class TransactionsService {
       chainId: args.chainId,
       address: args.safeAddress,
     });
+    await this.multisigTransactionMapper.prefetchAddressInfos({
+      chainId: args.chainId,
+      transactions: domainTransactions.results,
+    });
     const results = await Promise.all(
       domainTransactions.results.map(
         async (domainTransaction) =>


### PR DESCRIPTION
## Summary
Closes #2528

This PR extends the token/contract metadata prefetch procedure to the `GET /v1/chains/:chainId/safes/:safeAddress/multisig-transactions` endpoint of the CGW API.

Rationale: before this PR, and due to the async nature of the CGW, tokens and contracts metadata were requested on demand. That means each transaction was being mapped in parallel, so each token or contract metadata was being requested N times, even if the token/contract was present on several transactions. 

This PR implements a `prefetchAddressInfos` function that de-duplicates the set of token/contracts addresses beforehand and requests/stores their metadata in the cache. So, when the actual mapping happens, the mappers already have that data available in the cache.

This PR also centralises the implementation of this `prefetchAddressInfos` function. (see the previous implementation on https://github.com/safe-global/safe-client-gateway/pull/2503)

## Changes
- Add `MultisigTransactionMapper.prefetchAddressInfos` function.
- Calls the new function from `TransactionsHistoryMapper`, `QueuedItemsMapper`, and `TransactionsService`.