### PR TITLE
fix: error handling in notification services

### DIFF
--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -21,6 +21,7 @@ import {
   FirebaseOauth2Token,
   FirebaseOauth2TokenSchema,
 } from '@/datasources/push-notifications-api/entities/firebase-oauth2-token.entity';
+import { asError } from '@/logging/utils';
 
 @Injectable()
 export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
@@ -128,12 +129,12 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
       });
     } catch (error) {
       /**
-       * TODO: Error handling based on `error.details[i].reason`, e.g.
-       * - expired OAuth2 token
-       * - stale FCM token
-       * - don't expose the error to clients, logging on domain level
+       * @todo Handle error properly
+       * We should consider NotificationRespository when handling errors because the logic is parially handled there.
        */
-      throw this.httpErrorFactory.from(error);
+      const errorMessage = asError(error).message;
+
+      throw new Error(errorMessage);
     }
   }
 

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -77,8 +77,9 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
           // No need to log as datasource does
           .catch(() => null);
       } else {
-        this.loggingService.info(`Failed to enqueue notification: ${e}`);
-        throw new UnprocessableEntityException();
+        throw new UnprocessableEntityException(
+          `Failed to enqueue notification, ${e}`,
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
Enhance error handling in notification services to provide clearer error messages.
Currently, the Firebase error is not logged properly because there is no `message` property in the error thrown so for that reason `HttpErrorFactory` logs a generic error message. This PR logs the error message from the Firebase directly.

## Changes
- Logs the error message of Firebase endpoint call