### PR TITLE
fix: preserve numerical string decimals

### DIFF
--- a/src/domain/common/utils/utils.ts
+++ b/src/domain/common/utils/utils.ts
@@ -2,13 +2,14 @@
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
 const MAX_MAXIMUM_FRACTION_DIGITS = 100;
 
-export function getNumberString(value: number): string {
+const formatter = new Intl.NumberFormat('en-US', {
   // Prevent scientific notation
-  const formatter = new Intl.NumberFormat('en-US', {
-    notation: 'standard',
-    useGrouping: false,
-    maximumFractionDigits: MAX_MAXIMUM_FRACTION_DIGITS,
-  });
+  notation: 'standard',
+  useGrouping: false,
+  maximumFractionDigits: MAX_MAXIMUM_FRACTION_DIGITS,
+});
+
+export function getNumberString(value: number): string {
   return formatter.format(value);
 }
 

--- a/src/domain/common/utils/utils.ts
+++ b/src/domain/common/utils/utils.ts
@@ -1,9 +1,15 @@
+// We use the maximum value in order to preserve all decimals
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
+const MAX_MAXIMUM_FRACTION_DIGITS = 100;
+
 export function getNumberString(value: number): string {
   // Prevent scientific notation
-  return value.toLocaleString('en-US', {
+  const formatter = new Intl.NumberFormat('en-US', {
     notation: 'standard',
     useGrouping: false,
+    maximumFractionDigits: MAX_MAXIMUM_FRACTION_DIGITS,
   });
+  return formatter.format(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

When converting to numerical strings, we use the local formatting (`en-US`). This reduces the number of decimals places that can be returned, notably for fiat balances returned by prices providers.

This pivots from using `toLocaleString` to `Intl.NumberFormat` with the maximum fraction digits possible. Therefore, balances are now returned with greater accuracy.

## Changes

- Use `Intl.NumberFormat`.