### PR TITLE
refactor: improve error handling in notification services

### DIFF
--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -1,7 +1,6 @@
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
-import type { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import type { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { firebaseNotificationBuilder } from '@/datasources/push-notifications-api/__tests__/firebase-notification.builder';
@@ -17,10 +16,6 @@ const mockNetworkService = jest.mocked({
 const mockJwtService = jest.mocked({
   sign: jest.fn(),
 } as jest.MockedObjectDeep<IJwtService>);
-
-const mockHttpErrorFactory = jest.mocked({
-  from: jest.fn(),
-} as jest.MockedObjectDeep<HttpErrorFactory>);
 
 describe('FirebaseCloudMessagingApiService', () => {
   let target: FirebaseCloudMessagingApiService;
@@ -63,7 +58,6 @@ describe('FirebaseCloudMessagingApiService', () => {
       fakeConfigurationService,
       fakeCacheService,
       mockJwtService,
-      mockHttpErrorFactory,
     );
   });
 

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -2,6 +2,7 @@ import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import type { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { firebaseNotificationBuilder } from '@/datasources/push-notifications-api/__tests__/firebase-notification.builder';
 import { FirebaseCloudMessagingApiService } from '@/datasources/push-notifications-api/firebase-cloud-messaging-api.service';
@@ -165,5 +166,48 @@ describe('FirebaseCloudMessagingApiService', () => {
         },
       },
     });
+  });
+
+  it('Should throw an error if the network request fails', async () => {
+    const oauth2AssertionJwt = faker.string.alphanumeric();
+    const oauth2Token = faker.string.alphanumeric();
+    const oauth2TokenExpiresIn = faker.number.int();
+    await fakeCacheService.hSet(
+      new CacheDir('firebase_oauth2_token', ''),
+      oauth2Token,
+      oauth2TokenExpiresIn,
+    );
+    const fcmToken = faker.string.alphanumeric();
+    const notification = firebaseNotificationBuilder().build();
+    const errorMessage = 'A Firebase error occurred';
+    mockJwtService.sign.mockReturnValue(oauth2AssertionJwt);
+    mockNetworkService.post.mockRejectedValueOnce(
+      new NetworkResponseError(
+        new URL(
+          `${pushNotificationsBaseUri}/${pushNotificationsProject}/messages:send`,
+        ),
+        {
+          status: 500,
+        } as Response,
+        { error_description: errorMessage },
+      ),
+    );
+
+    await expect(
+      target.enqueueNotification(fcmToken, notification),
+    ).rejects.toThrow(errorMessage);
+  });
+
+  it('Should throw an error if JWT generation fails', async () => {
+    const fcmToken = faker.string.alphanumeric();
+    const notification = firebaseNotificationBuilder().build();
+    const errorMessage = 'JWT error';
+    mockJwtService.sign.mockImplementationOnce(() => {
+      throw new Error(errorMessage);
+    });
+
+    await expect(
+      target.enqueueNotification(fcmToken, notification),
+    ).rejects.toThrow(errorMessage);
   });
 });


### PR DESCRIPTION
## Summary
This PR refactors the handling of Firebase error messages to enable proper logging. Firebase errors are now mapped explicitly, as the actual error details are found in data.error_description rather than the standard message property.

## Changes
- Maps `Firebase` error message