### PR TITLE
feat: map batched `TokenInfo` into `tokenInfoIndex`

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -214,6 +214,9 @@ export default (): ReturnType<typeof configuration> => ({
     history: {
       maxNestedTransfers: faker.number.int({ min: 1, max: 5 }),
     },
+    transactionData: {
+      maxTokenInfoIndexSize: faker.number.int({ min: 1, max: 5 }),
+    },
     safe: {
       maxOverviews: faker.number.int({ min: 1, max: 5 }),
     },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -323,6 +323,9 @@ export default () => ({
         process.env.MAX_NESTED_TRANSFERS ?? `${100}`,
       ),
     },
+    transactionData: {
+      maxTokenInfoIndexSize: parseInt(process.env.MAX_TOKEN_INFO ?? `${100}`),
+    },
     safe: {
       maxOverviews: parseInt(process.env.MAX_SAFE_OVERVIEWS ?? `${10}`),
     },

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -295,6 +295,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             dataDecoded: moduleTransaction.dataDecoded,
             operation: Operation.CALL,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
             trustedDelegateCallTarget: null,
           },
           detailedExecutionInfo: {
@@ -577,6 +578,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             operation: tx.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
           detailedExecutionInfo: {
             type: 'MULTISIG',
@@ -758,6 +760,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             operation: tx.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
           detailedExecutionInfo: {
             type: 'MULTISIG',
@@ -937,6 +940,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             operation: tx.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
           detailedExecutionInfo: {
             submittedAt: tx.submissionDate.getTime(),

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
@@ -225,6 +225,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             operation: previewTransactionDto.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
         });
     });
@@ -371,6 +372,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             operation: previewTransactionDto.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
         });
     });
@@ -801,6 +803,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             operation: previewTransactionDto.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
         });
     });
@@ -945,6 +948,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             operation: previewTransactionDto.operation,
             trustedDelegateCallTarget: null,
             addressInfoIndex: null,
+            tokenInfoIndex: null,
           },
         });
     });

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -227,6 +227,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               operation: previewTransactionDto.operation,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,
+              tokenInfoIndex: null,
             },
           });
       });
@@ -383,6 +384,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               operation: previewTransactionDto.operation,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,
+              tokenInfoIndex: null,
             },
           });
       });
@@ -985,6 +987,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               operation: previewTransactionDto.operation,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,
+              tokenInfoIndex: null,
             },
           });
       });
@@ -1136,6 +1139,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               operation: previewTransactionDto.operation,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,
+              tokenInfoIndex: null,
             },
           });
       });
@@ -1732,6 +1736,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               operation: previewTransactionDto.operation,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,
+              tokenInfoIndex: null,
             },
           });
       });
@@ -1882,6 +1887,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               operation: previewTransactionDto.operation,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,
+              tokenInfoIndex: null,
             },
           });
       });

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -164,6 +164,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           operation: previewTransactionDto.operation,
           trustedDelegateCallTarget: null,
           addressInfoIndex: null,
+          tokenInfoIndex: null,
         },
       });
   });
@@ -233,6 +234,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           operation: previewTransactionDto.operation,
           trustedDelegateCallTarget: null,
           addressInfoIndex: null,
+          tokenInfoIndex: null,
         },
       });
   });
@@ -298,6 +300,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           operation: previewTransactionDto.operation,
           trustedDelegateCallTarget: null,
           addressInfoIndex: null,
+          tokenInfoIndex: null,
         },
       });
   });
@@ -378,6 +381,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           operation: previewTransactionDto.operation,
           trustedDelegateCallTarget: true,
           addressInfoIndex: null,
+          tokenInfoIndex: null,
         },
       });
   });

--- a/src/routes/transactions/entities/transaction-data.entity.ts
+++ b/src/routes/transactions/entities/transaction-data.entity.ts
@@ -6,8 +6,13 @@ import {
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
+import {
+  Erc20Token,
+  Erc721Token,
+  NativeToken,
+} from '@/routes/balances/entities/token.entity';
 
-@ApiExtraModels(AddressInfo, DataDecoded)
+@ApiExtraModels(AddressInfo, DataDecoded, Erc20Token, Erc721Token, NativeToken)
 export class TransactionData {
   @ApiPropertyOptional({ type: String, nullable: true })
   hexData: string | null;
@@ -23,6 +28,11 @@ export class TransactionData {
   trustedDelegateCallTarget: boolean | null;
   @ApiPropertyOptional({ type: Object, nullable: true })
   addressInfoIndex: Record<string, AddressInfo> | null;
+  @ApiPropertyOptional({ type: Object, nullable: true })
+  tokenInfoIndex: Record<
+    `0x${string}`,
+    Erc20Token | Erc721Token | NativeToken
+  > | null;
 
   constructor(
     hexData: string | null,
@@ -32,6 +42,10 @@ export class TransactionData {
     operation: Operation,
     trustedDelegateCallTarget: boolean | null,
     addressInfoIndex: Record<string, AddressInfo> | null,
+    tokenInfoIndex: Record<
+      `0x${string}`,
+      Erc20Token | Erc721Token | NativeToken
+    > | null,
   ) {
     this.hexData = hexData;
     this.dataDecoded = dataDecoded;
@@ -40,5 +54,6 @@ export class TransactionData {
     this.operation = operation;
     this.trustedDelegateCallTarget = trustedDelegateCallTarget;
     this.addressInfoIndex = addressInfoIndex;
+    this.tokenInfoIndex = tokenInfoIndex;
   }
 }

--- a/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
+++ b/src/routes/transactions/mappers/common/data-decoded-param.helper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
+import { BaseDataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 
 @Injectable()
@@ -8,7 +8,7 @@ export class DataDecodedParamHelper {
   private readonly TRANSFER_FROM_METHOD = 'transferFrom';
   private readonly SAFE_TRANSFER_FROM_METHOD = 'safeTransferFrom';
 
-  getFromParam(dataDecoded: DataDecoded | null, fallback: string): string {
+  getFromParam(dataDecoded: BaseDataDecoded | null, fallback: string): string {
     if (!dataDecoded || !dataDecoded.parameters) return fallback;
 
     switch (dataDecoded.method) {
@@ -23,7 +23,7 @@ export class DataDecodedParamHelper {
     }
   }
 
-  getToParam(dataDecoded: DataDecoded | null, fallback: string): string {
+  getToParam(dataDecoded: BaseDataDecoded | null, fallback: string): string {
     if (!dataDecoded || !dataDecoded.parameters) return fallback;
 
     switch (dataDecoded.method) {
@@ -41,7 +41,7 @@ export class DataDecodedParamHelper {
     }
   }
 
-  getValueParam(dataDecoded: DataDecoded | null, fallback: string): string {
+  getValueParam(dataDecoded: BaseDataDecoded | null, fallback: string): string {
     if (!dataDecoded || !dataDecoded.parameters) return fallback;
 
     switch (dataDecoded.method) {
@@ -60,14 +60,14 @@ export class DataDecodedParamHelper {
   }
 
   getValueAtPosition(
-    dataDecoded: DataDecoded | null,
+    dataDecoded: BaseDataDecoded | null,
     position: number,
   ): unknown {
     if (!dataDecoded || !dataDecoded.parameters?.length) return null;
     return dataDecoded.parameters[position]?.value ?? null;
   }
 
-  hasNestedDelegate(dataDecoded: DataDecoded): boolean {
+  hasNestedDelegate(dataDecoded: BaseDataDecoded): boolean {
     if (!dataDecoded.parameters) return false;
     return dataDecoded.parameters.some(
       (param) =>

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
@@ -1,8 +1,10 @@
 import { faker } from '@faker-js/faker';
 import type { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import {
+  baseDataDecodedBuilder,
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
+  multisendBuilder,
 } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import type { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
@@ -12,6 +14,16 @@ import { MULTI_SEND_METHOD_NAME } from '@/routes/transactions/constants';
 import type { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { TransactionDataMapper } from '@/routes/transactions/mappers/common/transaction-data.mapper';
 import { getAddress } from 'viem';
+import type { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
+import type { IChainsRepository } from '@/domain/chains/chains.repository.interface';
+import type { TokenRepository } from '@/domain/tokens/token.repository';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import {
+  erc20TransferEncoder,
+  erc20TransferFromEncoder,
+} from '@/domain/relay/contracts/__tests__/encoders/erc20-encoder.builder';
+import { erc20TokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 
 const addressInfoHelper = jest.mocked({
   get: jest.fn(),
@@ -25,15 +37,44 @@ const dataDecodedParamHelper = jest.mocked({
   hasNestedDelegate: jest.fn(),
 } as jest.MockedObjectDeep<DataDecodedParamHelper>);
 
+const transactionInfoMapper = jest.mocked({
+  isValidTokenTransfer: jest.fn(),
+} as jest.MockedObjectDeep<MultisigTransactionInfoMapper>);
+
+const chainsRepository = jest.mocked({
+  getChain: jest.fn(),
+} as jest.MockedObjectDeep<IChainsRepository>);
+
+const tokenRepository = jest.mocked({
+  getToken: jest.fn(),
+} as jest.MockedObjectDeep<TokenRepository>);
+
+const configurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
 describe('Transaction Data Mapper (Unit)', () => {
   let mapper: TransactionDataMapper;
+  const maxTokenInfoIndexSize = 2;
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    configurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'mappings.transactionData.maxTokenInfoIndexSize') {
+        return maxTokenInfoIndexSize;
+      }
+      throw new Error(`Unknown config key: ${key}`);
+    });
+
     mapper = new TransactionDataMapper(
       addressInfoHelper,
       contractsRepository,
       dataDecodedParamHelper,
+      transactionInfoMapper,
+      chainsRepository,
+      tokenRepository,
+      configurationService,
     );
   });
 
@@ -400,6 +441,687 @@ describe('Transaction Data Mapper (Unit)', () => {
         },
       });
       expect(addressInfoHelper.get).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('Build TokenInfo index', () => {
+    it('should return an empty TokenInfo index if there are no dataDecoded parameters', async () => {
+      const chainId = faker.number.int({ min: 1 }).toString();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('parameters', null)
+        .build();
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({});
+    });
+
+    it('should return an empty TokenInfo index if the method is not multiSend', async () => {
+      const chainId = faker.number.int({ min: 1 }).toString();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', faker.word.noun())
+        .build();
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({});
+    });
+
+    it('should return an empty TokenInfo index if the multiSend parameter name is not transactions', async () => {
+      const chainId = faker.number.int({ min: 1 }).toString();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', faker.word.noun())
+            .with('type', 'bytes')
+            .with('valueDecoded', [multisendBuilder().build()])
+            .build(),
+        ])
+        .build();
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({});
+    });
+
+    it('should return an empty TokenInfo index if the multiSend parameter type is not bytes', async () => {
+      const chainId = faker.number.int({ min: 1 }).toString();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', faker.word.noun())
+            .with('valueDecoded', [multisendBuilder().build()])
+            .build(),
+        ])
+        .build();
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({});
+    });
+
+    it('should build a deduped TokenInfo index for a multiSend transaction with multiple native transfers', async () => {
+      const chain = chainBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', 'bytes')
+            .with(
+              'valueDecoded',
+              faker.helpers.multiple(
+                () =>
+                  multisendBuilder()
+                    // Native transfer
+                    .with('value', faker.number.int({ min: 1 }).toString())
+                    .build(),
+                {
+                  count: {
+                    // Should be deduped
+                    min: 2,
+                    max: 5,
+                  },
+                },
+              ),
+            )
+            .build(),
+        ])
+        .build();
+      chainsRepository.getChain.mockResolvedValue(chain);
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId: chain.chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({
+        [NULL_ADDRESS]: {
+          address: NULL_ADDRESS,
+          decimals: chain.nativeCurrency.decimals,
+          logoUri: chain.nativeCurrency.logoUri,
+          name: chain.nativeCurrency.name,
+          symbol: chain.nativeCurrency.symbol,
+          trusted: true,
+          type: 'NATIVE_TOKEN',
+        },
+      });
+    });
+
+    it('should build a deduped TokenInfo index for a multiSend transaction with multiple token transfers', async () => {
+      const chain = chainBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const erc20Token = erc20TokenBuilder().build();
+      const firstRecipient = getAddress(faker.finance.ethereumAddress());
+      const firstValue = faker.number.int({ min: 1 }).toString();
+      const secondRecipient = getAddress(faker.finance.ethereumAddress());
+      const secondValue = faker.number.int({ min: 1 }).toString();
+      const thirdRecipient = getAddress(faker.finance.ethereumAddress());
+      const thirdValue = faker.number.int({ min: 1 }).toString();
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', 'bytes')
+            .with('valueDecoded', [
+              multisendBuilder()
+                .with('value', '0')
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', firstRecipient)
+                    .with('value', BigInt(firstValue))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', firstRecipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', firstValue)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+              multisendBuilder()
+                .with('value', '0')
+                // Same address, should be deduped
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', secondRecipient)
+                    .with('value', BigInt(secondValue))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', secondRecipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', secondValue)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+              multisendBuilder()
+                .with('value', '0')
+                // Same address, should be deduped
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferFromEncoder()
+                    .with('sender', safeAddress)
+                    .with('recipient', thirdRecipient)
+                    .with('amount', BigInt(thirdValue))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'sender')
+                        .with('type', 'address')
+                        .with('value', safeAddress)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'recipient')
+                        .with('type', 'address')
+                        .with('value', thirdRecipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'amount')
+                        .with('type', 'uint256')
+                        .with('value', thirdValue)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+            ])
+            .build(),
+        ])
+        .build();
+      chainsRepository.getChain.mockResolvedValue(chain);
+      transactionInfoMapper.isValidTokenTransfer.mockReturnValue(true);
+      tokenRepository.getToken.mockImplementation(({ address }) => {
+        if (address === erc20Token.address) {
+          return Promise.resolve(erc20Token);
+        }
+        throw new Error('Token not found');
+      });
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId: chain.chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({
+        [erc20Token.address]: {
+          address: erc20Token.address,
+          decimals: erc20Token.decimals,
+          logoUri: erc20Token.logoUri,
+          name: erc20Token.name,
+          symbol: erc20Token.symbol,
+          trusted: erc20Token.trusted,
+          type: 'ERC20',
+        },
+      });
+    });
+
+    it('should build a deduped TokenInfo index for a multiSend transaction with multiple native/token transfers', async () => {
+      const chain = chainBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const erc20Token = erc20TokenBuilder().build();
+      const firstErc20Recipient = getAddress(faker.finance.ethereumAddress());
+      const firstErc20Value = faker.number.int({ min: 1 }).toString();
+      const secondErc20Recipient = getAddress(faker.finance.ethereumAddress());
+      const secondErc20Value = faker.number.int({ min: 1 }).toString();
+      const thirdErc20Recipient = getAddress(faker.finance.ethereumAddress());
+      const thirdErc20Value = faker.number.int({ min: 1 }).toString();
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', 'bytes')
+            .with('valueDecoded', [
+              ...faker.helpers.multiple(
+                () =>
+                  multisendBuilder()
+                    // Native transfer
+                    .with('value', faker.number.int({ min: 1 }).toString())
+                    .build(),
+                {
+                  count: {
+                    // Should be deduped
+                    min: 2,
+                    max: 5,
+                  },
+                },
+              ),
+              multisendBuilder()
+                .with('value', '0')
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', firstErc20Recipient)
+                    .with('value', BigInt(firstErc20Value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', firstErc20Recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', firstErc20Value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+              multisendBuilder()
+                .with('value', '0')
+                // Same address, should be deduped
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', secondErc20Recipient)
+                    .with('value', BigInt(secondErc20Value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', secondErc20Recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', secondErc20Value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+              multisendBuilder()
+                .with('value', '0')
+                // Same address, should be deduped
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferFromEncoder()
+                    .with('sender', safeAddress)
+                    .with('recipient', thirdErc20Recipient)
+                    .with('amount', BigInt(thirdErc20Value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'sender')
+                        .with('type', 'address')
+                        .with('value', safeAddress)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'recipient')
+                        .with('type', 'address')
+                        .with('value', thirdErc20Recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'amount')
+                        .with('type', 'uint256')
+                        .with('value', thirdErc20Value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+            ])
+            .build(),
+        ])
+        .build();
+      chainsRepository.getChain.mockResolvedValue(chain);
+      transactionInfoMapper.isValidTokenTransfer.mockReturnValue(true);
+      tokenRepository.getToken.mockImplementation(({ address }) => {
+        if (address === erc20Token.address) {
+          return Promise.resolve(erc20Token);
+        }
+        throw new Error('Token not found');
+      });
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId: chain.chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({
+        [NULL_ADDRESS]: {
+          address: NULL_ADDRESS,
+          decimals: chain.nativeCurrency.decimals,
+          logoUri: chain.nativeCurrency.logoUri,
+          name: chain.nativeCurrency.name,
+          symbol: chain.nativeCurrency.symbol,
+          trusted: true,
+          type: 'NATIVE_TOKEN',
+        },
+        [erc20Token.address]: {
+          address: erc20Token.address,
+          decimals: erc20Token.decimals,
+          logoUri: erc20Token.logoUri,
+          name: erc20Token.name,
+          symbol: erc20Token.symbol,
+          trusted: erc20Token.trusted,
+          type: 'ERC20',
+        },
+      });
+    });
+
+    it('should limit the size of the TokenInfo index', async () => {
+      const chain = chainBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const firstErc20Token = erc20TokenBuilder().build();
+      const firstErc20Recipient = getAddress(faker.finance.ethereumAddress());
+      const firstErc20Value = faker.number.int({ min: 1 }).toString();
+      const secondErc20Token = erc20TokenBuilder().build();
+      const secondErc20Recipient = getAddress(faker.finance.ethereumAddress());
+      const secondErc20Value = faker.number.int({ min: 1 }).toString();
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', 'bytes')
+            .with('valueDecoded', [
+              multisendBuilder()
+                // Native transfer
+                .with('value', faker.number.int({ min: 1 }).toString())
+                .build(),
+              multisendBuilder()
+                .with('value', '0')
+                .with('to', firstErc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', firstErc20Recipient)
+                    .with('value', BigInt(firstErc20Value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', firstErc20Recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', firstErc20Value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+              multisendBuilder()
+                .with('value', '0')
+                .with('to', secondErc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', secondErc20Recipient)
+                    .with('value', BigInt(secondErc20Value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', secondErc20Recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', secondErc20Value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+            ])
+            .build(),
+        ])
+        .build();
+      chainsRepository.getChain.mockResolvedValue(chain);
+      transactionInfoMapper.isValidTokenTransfer.mockReturnValue(true);
+      tokenRepository.getToken.mockImplementation(({ address }) => {
+        if (address === firstErc20Token.address) {
+          return Promise.resolve(firstErc20Token);
+        }
+        if (address === secondErc20Token.address) {
+          return Promise.resolve(secondErc20Token);
+        }
+        throw new Error('Token not found');
+      });
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId: chain.chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      // secondErc20Token goes beyond limit
+      expect(actual).toStrictEqual({
+        [NULL_ADDRESS]: {
+          address: NULL_ADDRESS,
+          decimals: chain.nativeCurrency.decimals,
+          logoUri: chain.nativeCurrency.logoUri,
+          name: chain.nativeCurrency.name,
+          symbol: chain.nativeCurrency.symbol,
+          trusted: true,
+          type: 'NATIVE_TOKEN',
+        },
+        [firstErc20Token.address]: {
+          address: firstErc20Token.address,
+          decimals: firstErc20Token.decimals,
+          logoUri: firstErc20Token.logoUri,
+          name: firstErc20Token.name,
+          symbol: firstErc20Token.symbol,
+          trusted: firstErc20Token.trusted,
+          type: 'ERC20',
+        },
+      });
+    });
+
+    it('should not include token transfers of invalid token transfers', async () => {
+      const chain = chainBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const erc20Token = erc20TokenBuilder().build();
+      const recipient = getAddress(faker.finance.ethereumAddress());
+      const value = faker.number.int({ min: 1 }).toString();
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', 'bytes')
+            .with('valueDecoded', [
+              multisendBuilder()
+                .with('value', '0')
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', recipient)
+                    .with('value', BigInt(value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+            ])
+            .build(),
+        ])
+        .build();
+      chainsRepository.getChain.mockResolvedValue(chain);
+      transactionInfoMapper.isValidTokenTransfer.mockReturnValue(false);
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId: chain.chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({});
+    });
+
+    it('should not include tokens that cannot be found', async () => {
+      const chain = chainBuilder().build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const erc20Token = erc20TokenBuilder().build();
+      const recipient = getAddress(faker.finance.ethereumAddress());
+      const value = faker.number.int({ min: 1 }).toString();
+      const dataDecoded = baseDataDecodedBuilder()
+        .with('method', 'multiSend')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'transactions')
+            .with('type', 'bytes')
+            .with('valueDecoded', [
+              multisendBuilder()
+                .with('value', '0')
+                .with('to', erc20Token.address)
+                .with(
+                  'data',
+                  erc20TransferEncoder()
+                    .with('to', recipient)
+                    .with('value', BigInt(value))
+                    .encode(),
+                )
+                .with(
+                  'dataDecoded',
+                  baseDataDecodedBuilder()
+                    .with('method', 'transfer')
+                    .with('parameters', [
+                      dataDecodedParameterBuilder()
+                        .with('name', 'to')
+                        .with('type', 'address')
+                        .with('value', recipient)
+                        .build(),
+                      dataDecodedParameterBuilder()
+                        .with('name', 'value')
+                        .with('type', 'uint256')
+                        .with('value', value)
+                        .build(),
+                    ])
+                    .build(),
+                )
+                .build(),
+            ])
+            .build(),
+        ])
+        .build();
+      chainsRepository.getChain.mockResolvedValue(chain);
+      transactionInfoMapper.isValidTokenTransfer.mockReturnValue(true);
+      tokenRepository.getToken.mockRejectedValue(new Error('Token not found'));
+
+      const actual = await mapper.buildTokenInfoIndex({
+        chainId: chain.chainId,
+        safeAddress,
+        dataDecoded,
+      });
+
+      expect(actual).toStrictEqual({});
     });
   });
 });

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -226,7 +226,7 @@ export class TransactionDataMapper {
       this.maxTokenInfoIndexSize,
     );
     return (
-      await Promise.all(
+      await Promise.allSettled(
         tokenAddresses.map(async (tokenAddress) => {
           const isNativeCoin = tokenAddress === NULL_ADDRESS;
           if (isNativeCoin) {
@@ -243,16 +243,16 @@ export class TransactionDataMapper {
               trusted: true,
             };
           } else {
-            return await this.tokenRepository
-              .getToken({
-                chainId: args.chainId,
-                address: tokenAddress,
-              })
-              .catch(() => null);
+            return await this.tokenRepository.getToken({
+              chainId: args.chainId,
+              address: tokenAddress,
+            });
           }
         }),
       )
-    ).filter((token) => token !== null);
+    )
+      .filter((result) => result.status === 'fulfilled')
+      .map((result) => result.value);
   }
 
   /**

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -58,7 +58,7 @@ export class TransactionDataMapper {
     dataDecoded: DataDecoded | null,
     safeAddress: `0x${string}`,
   ): Promise<TransactionData> {
-    const [toAddress, isTrustedDelegateCall, addressInfoIndex, tokenInfoIndex] =
+    const [toAddress, isTrustedDelegateCall, addressInfoIndex] =
       await Promise.all([
         this.addressInfoHelper.getOrDefault(chainId, previewTransactionDto.to, [
           'CONTRACT',
@@ -70,12 +70,14 @@ export class TransactionDataMapper {
           dataDecoded,
         ),
         this.buildAddressInfoIndex(chainId, dataDecoded),
-        this.buildTokenInfoIndex({
-          chainId,
-          safeAddress,
-          dataDecoded,
-        }),
       ]);
+
+    // We call this after as addressInfoIndex may warm the cache of some tokens
+    const tokenInfoIndex = await this.buildTokenInfoIndex({
+      chainId,
+      safeAddress,
+      dataDecoded,
+    });
 
     return new TransactionData(
       previewTransactionDto.data,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
@@ -30,6 +30,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
   const transactionDataMapper = jest.mocked({
     isTrustedDelegateCall: jest.fn(),
     buildAddressInfoIndex: jest.fn(),
+    buildTokenInfoIndex: jest.fn(),
   } as jest.MockedObjectDeep<TransactionDataMapper>);
 
   beforeEach(() => {
@@ -76,6 +77,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
         operation: transaction.operation,
         trustedDelegateCallTarget,
         addressInfoIndex: null,
+        tokenInfoIndex: null,
       }),
       txHash: transaction.transactionHash,
       detailedExecutionInfo: new ModuleExecutionDetails(addressInfo),

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
@@ -52,23 +52,32 @@ export class ModuleTransactionDetailsMapper {
     chainId: string,
     transaction: ModuleTransaction,
   ): Promise<TransactionData> {
-    const [addressInfoIndex, trustedDelegateCallTarget, toAddress] =
-      await Promise.all([
-        this.transactionDataMapper.buildAddressInfoIndex(
-          chainId,
-          transaction.dataDecoded,
-        ),
-        this.transactionDataMapper.isTrustedDelegateCall(
-          chainId,
-          transaction.operation,
-          transaction.to,
-          transaction.dataDecoded,
-        ),
-        this.addressInfoHelper.getOrDefault(chainId, transaction.to, [
-          'TOKEN',
-          'CONTRACT',
-        ]),
-      ]);
+    const [
+      addressInfoIndex,
+      trustedDelegateCallTarget,
+      toAddress,
+      tokenInfoIndex,
+    ] = await Promise.all([
+      this.transactionDataMapper.buildAddressInfoIndex(
+        chainId,
+        transaction.dataDecoded,
+      ),
+      this.transactionDataMapper.isTrustedDelegateCall(
+        chainId,
+        transaction.operation,
+        transaction.to,
+        transaction.dataDecoded,
+      ),
+      this.addressInfoHelper.getOrDefault(chainId, transaction.to, [
+        'TOKEN',
+        'CONTRACT',
+      ]),
+      this.transactionDataMapper.buildTokenInfoIndex({
+        chainId,
+        safeAddress: transaction.safe,
+        dataDecoded: transaction.dataDecoded,
+      }),
+    ]);
 
     return {
       to: toAddress,
@@ -78,6 +87,7 @@ export class ModuleTransactionDetailsMapper {
       operation: transaction.operation,
       addressInfoIndex: isEmpty(addressInfoIndex) ? null : addressInfoIndex,
       trustedDelegateCallTarget,
+      tokenInfoIndex: isEmpty(tokenInfoIndex) ? null : tokenInfoIndex,
     };
   }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -36,6 +36,7 @@ const transactionInfoMapper = jest.mocked({
 const transactionDataMapper = jest.mocked({
   isTrustedDelegateCall: jest.fn(),
   buildAddressInfoIndex: jest.fn(),
+  buildTokenInfoIndex: jest.fn(),
 } as jest.MockedObjectDeep<TransactionDataMapper>);
 
 const safeAppInfoMapper = jest.mocked({
@@ -152,6 +153,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
         operation: transaction.operation,
         trustedDelegateCallTarget: true,
         addressInfoIndex: null,
+        tokenInfoIndex: null,
       }),
       txHash: transaction.transactionHash,
       detailedExecutionInfo: multisigExecutionDetails,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -52,6 +52,7 @@ export class MultisigTransactionDetailsMapper {
       txInfo,
       detailedExecutionInfo,
       recipientAddressInfo,
+      tokenInfoIndex,
     ] = await Promise.all([
       this.transactionDataMapper.isTrustedDelegateCall(
         chainId,
@@ -71,6 +72,11 @@ export class MultisigTransactionDetailsMapper {
         safe,
       ),
       this._getRecipientAddressInfo(chainId, transaction.to),
+      this.transactionDataMapper.buildTokenInfoIndex({
+        chainId,
+        safeAddress: transaction.safe,
+        dataDecoded: transaction.dataDecoded,
+      }),
     ]);
 
     return {
@@ -87,6 +93,7 @@ export class MultisigTransactionDetailsMapper {
         transaction.operation,
         isTrustedDelegateCall,
         isEmpty(addressInfoIndex) ? null : addressInfoIndex,
+        isEmpty(tokenInfoIndex) ? null : tokenInfoIndex,
       ),
       txHash: transaction.transactionHash,
       detailedExecutionInfo,

--- a/src/routes/transactions/mappers/transaction-preview.mapper.ts
+++ b/src/routes/transactions/mappers/transaction-preview.mapper.ts
@@ -56,6 +56,7 @@ export class TransactionPreviewMapper {
       chainId,
       previewTransactionDto,
       dataDecoded,
+      safe.address,
     );
     return Promise.resolve(new TransactionPreview(txInfo, txData));
   }


### PR DESCRIPTION
## Summary

Resolves #2352

Batched transfers are mapped client-side from the `dataDecoded`. As there is no associated `TokenInfo` for each transfer, it is not possible to parse the `value`, display the `name`, etc.

This adds a new `TransactionData['tokenInfoIndex']` property (similar to `addressInfoIndex`) which is populated with the `TokenInfo` of transferred assets.

The `dataDecoded` of a transfer is traversed, parsing the relevant token addresses interacted with and subsequently fetched for mapping into the aforementioned.

Note: this is preliminarily limited to 100 tokens but can be set dynamically according to a new `MAX_TOKEN_INFO` env. var.

## Changes

- Add `mapping.transactionData.maxTokenInfoIndexSize` configuration.
- Add new `TransactionData['tokenInfoIndex']` property.
- Tweak types for parsing ERC-20 `dataDecoded`.
- Add new method to map batched `TokenInfo`.
- Add/update tests accordingly.