### PR TITLE
fix: Retain `chainId` parameter for Swagger documentation in unregisterDevice method

### DIFF
--- a/src/routes/notifications/v1/notifications.controller.ts
+++ b/src/routes/notifications/v1/notifications.controller.ts
@@ -192,6 +192,7 @@ export class NotificationsController {
 
   @Delete('chains/:chainId/notifications/devices/:uuid')
   async unregisterDevice(
+    @Param('chainId') _: string, // We need to keep this parameter for the swagger documentation
     @Param('uuid', new ValidationPipe(UuidSchema)) uuid: UUID,
   ): Promise<void> {
     await this.notificationServiceV2.deleteDevice(uuid);


### PR DESCRIPTION
## Summary
This PR adds the `chainId` parameter to the `unregisterDevice` method of notification v1 controller for accurate Swagger documentation. Without the parameter the frontend app will get an error generating types for the `CGW`.

## Changes
- Included `chainId` as a parameter in the `unregisterDevice` method for Notification v1.
