### PR TITLE
refactor: create ERC-4262 decoder

### DIFF
--- a/src/routes/transactions/__tests__/encoders/erc4262-encoder.builder.ts
+++ b/src/routes/transactions/__tests__/encoders/erc4262-encoder.builder.ts
@@ -1,0 +1,62 @@
+import { faker } from '@faker-js/faker';
+import { encodeFunctionData, erc4626Abi, getAddress } from 'viem';
+import { Builder } from '@/__tests__/builder';
+import type { IEncoder } from '@/__tests__/encoder-builder';
+
+// deposit
+
+type Erc4262DepositArgs = {
+  assets: bigint;
+  receiver: `0x${string}`;
+};
+
+class Erc4262DepositEncoder<T extends Erc4262DepositArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): `0x${string}` {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: erc4626Abi,
+      functionName: 'deposit',
+      args: [args.assets, args.receiver],
+    });
+  }
+}
+
+export function erc4262DepositEncoder(): Erc4262DepositEncoder<Erc4262DepositArgs> {
+  return new Erc4262DepositEncoder()
+    .with('assets', faker.number.bigInt())
+    .with('receiver', getAddress(faker.finance.ethereumAddress()));
+}
+
+// withdraw
+
+type Erc4262WithdrawArgs = {
+  assets: bigint;
+  receiver: `0x${string}`;
+  owner: `0x${string}`;
+};
+
+class Erc4262WithdrawEncoder<T extends Erc4262WithdrawArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): `0x${string}` {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: erc4626Abi,
+      functionName: 'withdraw',
+      args: [args.assets, args.receiver, args.owner],
+    });
+  }
+}
+
+export function erc4262WithdrawEncoder(): Erc4262WithdrawEncoder<Erc4262WithdrawArgs> {
+  return new Erc4262WithdrawEncoder()
+    .with('assets', faker.number.bigInt())
+    .with('receiver', getAddress(faker.finance.ethereumAddress()))
+    .with('owner', getAddress(faker.finance.ethereumAddress()));
+}

--- a/src/routes/transactions/decoders/erc4262-decoder.helper.spec.ts
+++ b/src/routes/transactions/decoders/erc4262-decoder.helper.spec.ts
@@ -1,0 +1,42 @@
+import { faker } from '@faker-js/faker';
+import { Erc4262Decoder } from '@/routes/transactions/decoders/erc4262-decoder.helper';
+import {
+  erc4262DepositEncoder,
+  erc4262WithdrawEncoder,
+} from '@/routes/transactions/__tests__/encoders/erc4262-encoder.builder';
+
+describe('ERC4262Decoder', () => {
+  let target: Erc4262Decoder;
+
+  beforeEach(() => {
+    target = new Erc4262Decoder();
+  });
+
+  it('decodes a deposit function call correctly', () => {
+    const deposit = erc4262DepositEncoder();
+    const args = deposit.build();
+    const data = deposit.encode();
+
+    expect(target.decodeFunctionData({ data })).toEqual({
+      functionName: 'deposit',
+      args: [args.assets, args.receiver],
+    });
+  });
+
+  it('decodes a withdraw function call correctly', () => {
+    const withdraw = erc4262WithdrawEncoder();
+    const args = withdraw.build();
+    const data = withdraw.encode();
+
+    expect(target.decodeFunctionData({ data })).toEqual({
+      functionName: 'withdraw',
+      args: [args.assets, args.receiver, args.owner],
+    });
+  });
+
+  it('throws if the function call cannot be decoded', () => {
+    const data = faker.string.hexadecimal({ length: 138 }) as `0x${string}`;
+
+    expect(() => target.decodeFunctionData({ data })).toThrow();
+  });
+});

--- a/src/routes/transactions/decoders/erc4262-decoder.helper.ts
+++ b/src/routes/transactions/decoders/erc4262-decoder.helper.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { erc4626Abi } from 'viem';
+import { AbiDecoder } from '@/domain/contracts/decoders/abi-decoder.helper';
+
+@Injectable()
+export class Erc4262Decoder extends AbiDecoder<typeof erc4626Abi> {
+  constructor() {
+    super(erc4626Abi);
+  }
+}

--- a/src/routes/transactions/helpers/kiln-vault.helper.spec.ts
+++ b/src/routes/transactions/helpers/kiln-vault.helper.spec.ts
@@ -1,0 +1,189 @@
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
+import { KilnVaultHelper } from '@/routes/transactions/helpers/kiln-vault.helper';
+import { TransactionFinder } from '@/routes/transactions/helpers/transaction-finder.helper';
+import type { ILoggingService } from '@/logging/logging.interface';
+import {
+  erc4262DepositEncoder,
+  erc4262WithdrawEncoder,
+} from '@/routes/transactions/__tests__/encoders/erc4262-encoder.builder';
+import {
+  multiSendEncoder,
+  multiSendTransactionsEncoder,
+} from '@/domain/contracts/__tests__/encoders/multi-send-encoder.builder';
+import { shuffle } from 'lodash';
+
+const mockLoggingService = {
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+describe('KilnVaultHelper', () => {
+  let target: KilnVaultHelper;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    const multiSendDecoder = new MultiSendDecoder(mockLoggingService);
+    const transactionFinder = new TransactionFinder(multiSendDecoder);
+    target = new KilnVaultHelper(transactionFinder);
+  });
+
+  describe('getVaultDepositTransaction', () => {
+    it('should decode a vault deposit transaction', () => {
+      const deposit = erc4262DepositEncoder();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const value = faker.string.numeric();
+      const args = deposit.build();
+      const data = deposit.encode();
+
+      const transaction = target.getVaultDepositTransaction({
+        to,
+        data,
+        value,
+      });
+
+      expect(transaction).toEqual({
+        to,
+        data,
+        value,
+        assets: Number(args.assets),
+      });
+    });
+
+    it('should decode a batched vault deposit transaction', () => {
+      const deposit = erc4262DepositEncoder();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const value = faker.string.numeric();
+      const args = deposit.build();
+      const data = deposit.encode();
+      const transactions = [
+        ...faker.helpers.multiple(
+          () => {
+            return {
+              operation: faker.number.int({ min: 0, max: 1 }),
+              to: getAddress(faker.finance.ethereumAddress()),
+              value: faker.number.bigInt(),
+              data: faker.string.hexadecimal() as `0x${string}`,
+            };
+          },
+          { count: { min: 1, max: 5 } },
+        ),
+        {
+          operation: faker.number.int({ min: 0, max: 1 }),
+          to,
+          value: BigInt(value),
+          data,
+        },
+      ];
+      const multiSend = multiSendEncoder().with(
+        'transactions',
+        multiSendTransactionsEncoder(shuffle(transactions)),
+      );
+
+      const transaction = target.getVaultDepositTransaction({
+        to,
+        data: multiSend.encode(),
+        value,
+      });
+
+      expect(transaction).toEqual({
+        to,
+        data,
+        value,
+        assets: Number(args.assets),
+      });
+    });
+
+    it('should return null if there is no data', () => {
+      const to = getAddress(faker.finance.ethereumAddress());
+      const value = faker.string.numeric();
+
+      const transaction = target.getVaultDepositTransaction({
+        to,
+        data: null,
+        value,
+      });
+
+      expect(transaction).toBeNull();
+    });
+
+    it('should return null if there is no value', () => {
+      const to = getAddress(faker.finance.ethereumAddress());
+      const data = erc4262DepositEncoder().encode();
+
+      const transaction = target.getVaultDepositTransaction({
+        to,
+        data,
+        value: null,
+      });
+
+      expect(transaction).toBeNull();
+    });
+
+    it('should return null if no deposit transaction is found', () => {
+      const transactions = faker.helpers.multiple(
+        () => {
+          return {
+            operation: faker.number.int({ min: 0, max: 1 }),
+            to: getAddress(faker.finance.ethereumAddress()),
+            value: faker.number.bigInt(),
+            data: faker.string.hexadecimal() as `0x${string}`,
+          };
+        },
+        { count: { min: 1, max: 5 } },
+      );
+      const multiSend = multiSendEncoder().with(
+        'transactions',
+        multiSendTransactionsEncoder(shuffle(transactions)),
+      );
+
+      const transaction = target.getVaultDepositTransaction({
+        to: getAddress(faker.finance.ethereumAddress()),
+        data: multiSend.encode(),
+        value: faker.string.numeric(),
+      });
+
+      expect(transaction).toBeNull();
+    });
+
+    it('should return null if the transaction is not a deposit', () => {
+      const withdraw = erc4262WithdrawEncoder();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const value = faker.string.numeric();
+      const data = withdraw.encode();
+      const transactions = [
+        ...faker.helpers.multiple(
+          () => {
+            return {
+              operation: faker.number.int({ min: 0, max: 1 }),
+              to: getAddress(faker.finance.ethereumAddress()),
+              value: faker.number.bigInt(),
+              data: faker.string.hexadecimal() as `0x${string}`,
+            };
+          },
+          { count: { min: 1, max: 5 } },
+        ),
+        {
+          operation: faker.number.int({ min: 0, max: 1 }),
+          to,
+          value: BigInt(value),
+          data,
+        },
+      ];
+      const multiSend = multiSendEncoder().with(
+        'transactions',
+        multiSendTransactionsEncoder(shuffle(transactions)),
+      );
+
+      const transaction = target.getVaultDepositTransaction({
+        to,
+        data: multiSend.encode(),
+        value,
+      });
+
+      expect(transaction).toBeNull();
+    });
+  });
+});

--- a/src/routes/transactions/helpers/kiln-vault.helper.spec.ts
+++ b/src/routes/transactions/helpers/kiln-vault.helper.spec.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker';
+import { shuffle } from 'lodash';
 import { getAddress } from 'viem';
 
 import { MultiSendDecoder } from '@/domain/contracts/decoders/multi-send-decoder.helper';
 import { KilnVaultHelper } from '@/routes/transactions/helpers/kiln-vault.helper';
 import { TransactionFinder } from '@/routes/transactions/helpers/transaction-finder.helper';
-import type { ILoggingService } from '@/logging/logging.interface';
 import {
   erc4262DepositEncoder,
   erc4262WithdrawEncoder,
@@ -13,7 +13,8 @@ import {
   multiSendEncoder,
   multiSendTransactionsEncoder,
 } from '@/domain/contracts/__tests__/encoders/multi-send-encoder.builder';
-import { shuffle } from 'lodash';
+import { execTransactionEncoder } from '@/domain/contracts/__tests__/encoders/safe-encoder.builder';
+import type { ILoggingService } from '@/logging/logging.interface';
 
 const mockLoggingService = {
   warn: jest.fn(),
@@ -65,7 +66,7 @@ describe('KilnVaultHelper', () => {
               operation: faker.number.int({ min: 0, max: 1 }),
               to: getAddress(faker.finance.ethereumAddress()),
               value: faker.number.bigInt(),
-              data: faker.string.hexadecimal() as `0x${string}`,
+              data: execTransactionEncoder().encode(),
             };
           },
           { count: { min: 1, max: 5 } },
@@ -79,7 +80,7 @@ describe('KilnVaultHelper', () => {
       ];
       const multiSend = multiSendEncoder().with(
         'transactions',
-        multiSendTransactionsEncoder(shuffle(transactions)),
+        multiSendTransactionsEncoder(transactions),
       );
 
       const transaction = target.getVaultDepositTransaction({
@@ -129,7 +130,7 @@ describe('KilnVaultHelper', () => {
             operation: faker.number.int({ min: 0, max: 1 }),
             to: getAddress(faker.finance.ethereumAddress()),
             value: faker.number.bigInt(),
-            data: faker.string.hexadecimal() as `0x${string}`,
+            data: execTransactionEncoder().encode(),
           };
         },
         { count: { min: 1, max: 5 } },
@@ -160,7 +161,7 @@ describe('KilnVaultHelper', () => {
               operation: faker.number.int({ min: 0, max: 1 }),
               to: getAddress(faker.finance.ethereumAddress()),
               value: faker.number.bigInt(),
-              data: faker.string.hexadecimal() as `0x${string}`,
+              data: execTransactionEncoder().encode(),
             };
           },
           { count: { min: 1, max: 5 } },

--- a/src/routes/transactions/helpers/kiln-vault.helper.ts
+++ b/src/routes/transactions/helpers/kiln-vault.helper.ts
@@ -1,73 +1,113 @@
+import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
+import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
+import { Erc4262Decoder } from '@/routes/transactions/decoders/erc4262-decoder.helper';
 import {
   TransactionFinder,
   TransactionFinderModule,
 } from '@/routes/transactions/helpers/transaction-finder.helper';
 import { Injectable, Module } from '@nestjs/common';
 import {
-  decodeFunctionData,
+  ContractFunctionName,
+  DecodeFunctionDataReturnType,
+  erc4626Abi,
   getAbiItem,
-  parseAbi,
   toFunctionSelector,
 } from 'viem';
 
-export const KilnVaultAbi = parseAbi([
-  'function deposit(uint256 assets, address receiver)',
-]);
-
 @Injectable()
-export class KilnVaultHelper {
-  private static readonly VAULT_DEPOSIT_SIGNATURE = getAbiItem({
-    abi: KilnVaultAbi,
-    name: 'deposit',
-  });
+export class KilnVaultHelper extends Erc4262Decoder {
+  constructor(private readonly transactionFinder: TransactionFinder) {
+    super();
+  }
 
-  constructor(private readonly transactionFinder: TransactionFinder) {}
-
-  public getVaultDepositTransaction(args: {
-    to?: `0x${string}`;
-    data: `0x${string}`;
-    value: string;
-  }): {
+  public getVaultDepositTransaction(
+    args: Pick<
+      MultisigTransaction | ModuleTransaction,
+      'to' | 'data' | 'value'
+    >,
+  ): {
     to?: `0x${string}`;
     data: `0x${string}`;
     assets: number;
   } | null {
-    const transaction = this.findVaultDepositTransaction(args);
-    if (!transaction) {
+    const decoded = this.getDecodedTransaction({
+      functionName: 'deposit',
+      transaction: args,
+    });
+
+    if (!decoded) {
       return null;
     }
 
-    const decoded = decodeFunctionData({
-      abi: KilnVaultAbi,
-      data: transaction.data,
-    });
-
     return {
-      to: transaction.to,
-      data: transaction.data,
+      ...decoded.transaction,
       assets: Number(decoded.args[0]),
     };
   }
 
-  private findVaultDepositTransaction(args: {
-    to?: `0x${string}`;
-    data: `0x${string}`;
-    value: string;
-  }): { to?: `0x${string}`; data: `0x${string}`; value: string } | null {
-    const selector = toFunctionSelector(
-      KilnVaultHelper.VAULT_DEPOSIT_SIGNATURE,
-    );
-    return this.transactionFinder.findTransaction(
+  // TODO: Move to generic helper as it replaces a majority of ABI methods
+  private getDecodedTransaction<
+    TAbi extends typeof erc4626Abi,
+    TFunctionName extends ContractFunctionName<TAbi>,
+  >(args: {
+    functionName: TFunctionName;
+    transaction: Pick<
+      MultisigTransaction | ModuleTransaction,
+      'to' | 'data' | 'value'
+    >;
+  }): {
+    transaction: {
+      to?: `0x${string}`;
+      data: `0x${string}`;
+      value: string;
+    };
+    args: DecodeFunctionDataReturnType<TAbi, TFunctionName>['args'];
+  } | null {
+    if (!args.transaction.data || !args.transaction.value) {
+      return null;
+    }
+
+    // ContractFunctionName does not match AbiItemName - handle (impossible) array case
+    const name = Array.isArray(args.functionName)
+      ? args.functionName[0]
+      : args.functionName;
+    const item = getAbiItem({
+      abi: erc4626Abi,
+      name,
+    });
+
+    const selector = toFunctionSelector(item);
+    const transaction = this.transactionFinder.findTransaction(
       (transaction) => transaction.data.startsWith(selector),
-      args,
+      {
+        to: args.transaction.to,
+        data: args.transaction.data,
+        value: args.transaction.value,
+      },
     );
+
+    if (!transaction) {
+      return null;
+    }
+
+    const decoded = this.decodeFunctionData({
+      data: transaction.data,
+    });
+    if (decoded.functionName !== args.functionName) {
+      return null;
+    }
+
+    return {
+      transaction,
+      args: decoded.args,
+    };
   }
 }
 
 @Module({
   imports: [TransactionFinderModule],
-  providers: [KilnVaultHelper, KilnDecoder],
+  providers: [Erc4262Decoder, KilnVaultHelper, KilnDecoder],
   exports: [KilnVaultHelper, KilnDecoder],
 })
 export class KilnVaultHelperModule {}

--- a/src/routes/transactions/helpers/kiln-vault.helper.ts
+++ b/src/routes/transactions/helpers/kiln-vault.helper.ts
@@ -68,15 +68,17 @@ export class KilnVaultHelper extends Erc4262Decoder {
       return null;
     }
 
-    // ContractFunctionName does not match AbiItemName - handle (impossible) array case
+    // On a type level, functionName can be a union {@link ContractFunctionName},
+    // whereas the value is always a string. For type-safety, we extract the first
+    // value of the union to use as the name instead of casting
     const name = Array.isArray(args.functionName)
       ? args.functionName[0]
       : args.functionName;
+
     const item = getAbiItem({
       abi: erc4626Abi,
       name,
     });
-
     const selector = toFunctionSelector(item);
     const transaction = this.transactionFinder.findTransaction(
       (transaction) => transaction.data.startsWith(selector),


### PR DESCRIPTION
## Summary

Kiln vaults are built on the ERC-4262 standard - the ABI of which is distributed with viem. This refactors the `KilnVaultHelper` to extend a new `Erc4262Decoder`.

The viem-distributed has been added to a new helper, from which we extend and call the decoder of within the vault helper. There is also a new generic `getDecodedTransaction` method that can be called for any method on the defined ABI. It can be later used for decoding `deposit` transactions.

## Changes

- Create `Erc4262Decoder`
- Refactor `KilnVaultHelper` to use the `Erc4262Decoder`