### PR TITLE
chore: Move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@aws-sdk/client-s3": "3.779.0",
     "@fingerprintjs/fingerprintjs-pro-server-api": "6.2.0",
     "@nestjs/cache-manager": "3.0.1",
-    "@nestjs/cli": "11.0.5",
     "@nestjs/common": "11.0.16",
     "@nestjs/config": "4.0.0",
     "@nestjs/core": "11.0.16",
@@ -65,6 +64,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "9.3.0",
+    "@nestjs/cli": "11.0.5",
     "@nestjs/schematics": "11.0.2",
     "@nestjs/testing": "11.0.16",
     "@smithy/util-stream": "4.1.2",


### PR DESCRIPTION
## Summary
This PR shifts the `@nestjs/cli` package from dependencies to devDependencies. The package is a develop dependency and should not be included in the production build.

## Changes
- Moves `@nestjs/cli` to dev dependencies.