### PR TITLE
fix: allow empty strings for domain names

### DIFF
--- a/src/domain/messages/entities/__tests__/typed-data.entity.spec.ts
+++ b/src/domain/messages/entities/__tests__/typed-data.entity.spec.ts
@@ -65,6 +65,14 @@ describe('TypedDataSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should accept an empty string as a domain name', () => {
+      const domain = typedDataDomainBuilder().with('name', '').build();
+
+      const result = _TypedDataDomainSchema.safeParse(domain);
+
+      expect(result.success).toBe(true);
+    });
+
     it.each([
       ['string', faker.string.numeric()],
       ['number', faker.number.int()],

--- a/src/domain/messages/entities/typed-data.entity.ts
+++ b/src/domain/messages/entities/typed-data.entity.ts
@@ -7,7 +7,7 @@ import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 export const _TypedDataDomainSchema = z.object({
-  name: TypedDataDomainSchema.shape.name,
+  name: TypedDataDomainSchema.shape.name.or(z.literal('')),
   version: TypedDataDomainSchema.shape.version,
   // Overwrite chainId, salt and address for strictness/checksumming
   chainId: z.coerce.number().optional(),


### PR DESCRIPTION
## Summary

Resolves #2531

The Transaction Service allows `''` domain `name` values. Our current domain validation expects explicit values, however. This means that validation does not succeed, blocking Safes that have messages with such values.

This allows empty strings to be set as the `domain`. We initially considered making it optional, but the hash would then differ if not present.

## Changes

- Allow empty strings for domain `name`s
- Add appropriate test coverage