### PR TITLE
feat: `DELETE` `/spaces/:spaceId/address-book/:address`

### DIFF
--- a/src/domain/spaces/address-books/address-book-items.repository.interface.ts
+++ b/src/domain/spaces/address-books/address-book-items.repository.interface.ts
@@ -39,14 +39,14 @@ export interface IAddressBookItemsRepository {
   }): Promise<Array<AddressBookDbItem>>;
 
   /**
-   * Deletes an array of AddressBookItems by their IDs.
+   * Deletes an {@link AddressBookDbItem} by address.
    * @param {AuthPayload} args.authPayload - The authentication payload.
    * @param {number} args.spaceId - The ID of the Space.
-   * @param {Array<AddressBookDbItem>} args.addressBookItemIds - The IDs of the AddressBookItems to delete.
+   * @param {AddressBookDbItem['address']} args.address - The address of an AddressBookItem to delete.
    */
-  deleteMany(args: {
+  deleteByAddress(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    addressBookItemIds: Array<string>;
+    address: AddressBookDbItem['address'];
   }): Promise<void>;
 }

--- a/src/domain/spaces/address-books/address-book-items.repository.ts
+++ b/src/domain/spaces/address-books/address-book-items.repository.ts
@@ -84,13 +84,21 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
     return repository.findBy({ space: { id: space.id } });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public deleteMany(args: {
+  public async deleteByAddress(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    addressBookItemIds: Array<string>;
+    address: AddressBookDbItem['address'];
   }): Promise<void> {
-    throw new Error('Method not implemented.');
+    const space = await this.getSpaceAs({
+      ...args,
+      memberRoleIn: ['ADMIN'],
+    });
+    const repository = await this.db.getRepository(DbAddressBookItem);
+
+    await repository.delete({
+      address: args.address,
+      space: { id: space.id },
+    });
   }
 
   private async getSpaceAs(args: {

--- a/src/routes/spaces/address-books.controller.ts
+++ b/src/routes/spaces/address-books.controller.ts
@@ -6,6 +6,7 @@ import { SpaceAddressBookDto } from '@/routes/spaces/entities/space-address-book
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Inject,
   Param,
@@ -26,6 +27,7 @@ import {
   UpsertAddressBookItemsDto,
   UpsertAddressBookItemsSchema,
 } from '@/routes/spaces/entities/upsert-address-book-items.dto.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 @ApiTags('spaces')
 @Controller({ path: 'spaces', version: '1' })
@@ -71,5 +73,24 @@ export class AddressBooksController {
     addressBookItems: UpsertAddressBookItemsDto,
   ): Promise<SpaceAddressBookDto> {
     return this.service.upsertMany(authPayload, spaceId, addressBookItems);
+  }
+
+  @ApiOkResponse({
+    description: 'Address book item deleted',
+  })
+  @ApiNotFoundResponse({ description: 'User, member or Space not found' })
+  @ApiForbiddenResponse({
+    description: 'Signer address not present or not authorized',
+  })
+  @Delete('/:spaceId/address-book/:address')
+  @UseGuards(AuthGuard)
+  public async deleteByAddress(
+    @Auth() authPayload: AuthPayload,
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: number,
+    @Param('address', new ValidationPipe(AddressSchema))
+    address: `0x${string}`,
+  ): Promise<void> {
+    return this.service.deleteByAddress({ authPayload, spaceId, address });
   }
 }

--- a/src/routes/spaces/address-books.service.ts
+++ b/src/routes/spaces/address-books.service.ts
@@ -48,6 +48,14 @@ export class AddressBooksService {
     return this.mapAddressBookItems(spaceId, updatedItems);
   }
 
+  public async deleteByAddress(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+    address: AddressBookDbItem['address'];
+  }): Promise<void> {
+    await this.repository.deleteByAddress(args);
+  }
+
   private mapAddressBookItems(
     spaceId: Space['id'],
     items: Array<AddressBookDbItem>,


### PR DESCRIPTION
## Summary

This adds a new endpoint for deleting specified addresses from given Spaces: `DELETE` `/spaces/:spaceId/address-book/:address`.

The scaffolded `AddressBookItemsRepository['deleteMany']` has been renamed to `deleteByAddress` as deletion is only required for singular addresses, and it has been propagated to the appropriate controller.

## Changes

- Rename `AddressBookItemsRepository['deleteMany']` to `deleteByAddress`
- Implement `AddressBookItemsRepository['deleteByAddress']`
- Add `DELETE` `/spaces/:spaceId/address-book/:address` to `AddressBooksController`
- Add appropriate test coverage