### PR TITLE
feat: rate limit address book upsertion

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -281,8 +281,14 @@ export default (): ReturnType<typeof configuration> => ({
     maxSpaceCreationsPerUser: faker.number.int({ min: 100, max: 200 }),
     maxInvites: faker.number.int({ min: 5, max: 10 }),
     rateLimit: {
-      max: faker.number.int({ min: 100, max: 200 }),
-      windowSeconds: faker.number.int({ min: 100, max: 200 }),
+      creation: {
+        max: faker.number.int({ min: 100, max: 200 }),
+        windowSeconds: faker.number.int({ min: 100, max: 200 }),
+      },
+      addressBookUpsertion: {
+        max: faker.number.int({ min: 100, max: 200 }),
+        windowSeconds: faker.number.int({ min: 100, max: 200 }),
+      },
     },
   },
   staking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -416,10 +416,20 @@ export default () => ({
     ),
     maxInvites: parseInt(process.env.SPACES_MAX_INVITES ?? `${50}`),
     rateLimit: {
-      max: parseInt(process.env.SPACES_RATE_LIMIT_MAX ?? `${10}`),
-      windowSeconds: parseInt(
-        process.env.SPACES_RATE_LIMIT_WINDOW_SECONDS ?? `${600}`,
-      ),
+      creation: {
+        max: parseInt(process.env.SPACES_RATE_LIMIT_MAX ?? `${10}`),
+        windowSeconds: parseInt(
+          process.env.SPACES_RATE_LIMIT_WINDOW_SECONDS ?? `${600}`,
+        ),
+      },
+      addressBookUpsertion: {
+        max: parseInt(
+          process.env.SPACES_ADDRESS_BOOK_RATE_LIMIT_MAX ?? `${500}`,
+        ),
+        windowSeconds: parseInt(
+          process.env.SPACES_ADDRESS_BOOK_RATE_LIMIT_WINDOW_SECONDS ?? `${600}`,
+        ),
+      },
     },
   },
   staking: {

--- a/src/routes/spaces/address-books.controller.ts
+++ b/src/routes/spaces/address-books.controller.ts
@@ -15,6 +15,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -64,6 +65,7 @@ export class AddressBooksController {
   @ApiNotFoundResponse({ description: 'User, member or space not found' })
   @ApiUnauthorizedResponse({ description: 'Signer address not provided' })
   @ApiForbiddenResponse({ description: 'Signer not authorized.' })
+  @ApiBadRequestResponse({ description: 'Address book items limit exceeded.' })
   @Put('/:spaceId/address-book')
   @UseGuards(SpacesAddressBookRateLimitGuard)
   @UseGuards(AuthGuard)

--- a/src/routes/spaces/address-books.controller.ts
+++ b/src/routes/spaces/address-books.controller.ts
@@ -28,6 +28,7 @@ import {
   UpsertAddressBookItemsSchema,
 } from '@/routes/spaces/entities/upsert-address-book-items.dto.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { SpacesAddressBookRateLimitGuard } from '@/routes/spaces/guards/spaces-address-book-rate-limit.guard';
 
 @ApiTags('spaces')
 @Controller({ path: 'spaces', version: '1' })
@@ -64,6 +65,7 @@ export class AddressBooksController {
   @ApiUnauthorizedResponse({ description: 'Signer address not provided' })
   @ApiForbiddenResponse({ description: 'Signer not authorized.' })
   @Put('/:spaceId/address-book')
+  @UseGuards(SpacesAddressBookRateLimitGuard)
   @UseGuards(AuthGuard)
   public async upsertAddressBookItems(
     @Auth() authPayload: AuthPayload,

--- a/src/routes/spaces/guards/spaces-address-book-rate-limit.guard.ts
+++ b/src/routes/spaces/guards/spaces-address-book-rate-limit.guard.ts
@@ -8,7 +8,7 @@ import { RateLimitGuard } from '@/routes/common/guards/rate-limit.guard';
 import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class SpacesRateLimitGuard extends RateLimitGuard {
+export class SpacesAddressBookRateLimitGuard extends RateLimitGuard {
   constructor(
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
@@ -16,9 +16,11 @@ export class SpacesRateLimitGuard extends RateLimitGuard {
     @Inject(LoggingService) loggingService: ILoggingService,
   ) {
     const rateLimits = {
-      max: configurationService.getOrThrow<number>('spaces.rateLimit.max'),
+      max: configurationService.getOrThrow<number>(
+        'spaces.rateLimit.addressBookUpsertion.max',
+      ),
       windowSeconds: configurationService.getOrThrow<number>(
-        'spaces.rateLimit.windowSeconds',
+        'spaces.rateLimit.addressBookUpsertion.windowSeconds',
       ),
     };
     super(cacheService, loggingService, rateLimits);

--- a/src/routes/spaces/guards/spaces-creation-rate-limit.guard.ts
+++ b/src/routes/spaces/guards/spaces-creation-rate-limit.guard.ts
@@ -1,0 +1,28 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { RateLimitGuard } from '@/routes/common/guards/rate-limit.guard';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SpacesCreationRateLimitGuard extends RateLimitGuard {
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(CacheService) cacheService: ICacheService,
+    @Inject(LoggingService) loggingService: ILoggingService,
+  ) {
+    const rateLimits = {
+      max: configurationService.getOrThrow<number>(
+        'spaces.rateLimit.creation.max',
+      ),
+      windowSeconds: configurationService.getOrThrow<number>(
+        'spaces.rateLimit.creation.windowSeconds',
+      ),
+    };
+    super(cacheService, loggingService, rateLimits);
+  }
+}

--- a/src/routes/spaces/spaces.controller.spec.ts
+++ b/src/routes/spaces/spaces.controller.spec.ts
@@ -56,7 +56,13 @@ describe('SpacesController', () => {
         maxSpaceCreationsPerUser:
           args?.maxSpaceCreationsPerUser ??
           defaultConfiguration.spaces.maxSpaceCreationsPerUser,
-        rateLimit: args?.rateLimit ?? defaultConfiguration.spaces.rateLimit,
+        rateLimit: {
+          ...defaultConfiguration.spaces.rateLimit,
+          creation: {
+            ...(args?.rateLimit ??
+              defaultConfiguration.spaces.rateLimit.creation),
+          },
+        },
       },
       features: {
         ...defaultConfiguration.features,

--- a/src/routes/spaces/spaces.controller.ts
+++ b/src/routes/spaces/spaces.controller.ts
@@ -39,7 +39,7 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import { getEnumKey } from '@/domain/common/utils/enum';
 import { UserStatus } from '@/domain/users/entities/user.entity';
-import { SpacesRateLimitGuard } from '@/routes/spaces/guards/spaces-rate-limit.guard';
+import { SpacesCreationRateLimitGuard } from '@/routes/spaces/guards/spaces-creation-rate-limit.guard';
 
 @ApiTags('spaces')
 @UseGuards(AuthGuard)
@@ -48,7 +48,7 @@ export class SpacesController {
   public constructor(private readonly spacesService: SpacesService) {}
 
   @Post()
-  @UseGuards(SpacesRateLimitGuard)
+  @UseGuards(SpacesCreationRateLimitGuard)
   @ApiOkResponse({
     description: 'Space created',
     type: CreateSpaceResponse,
@@ -69,7 +69,7 @@ export class SpacesController {
   }
 
   @Post('/create-with-user')
-  @UseGuards(SpacesRateLimitGuard)
+  @UseGuards(SpacesCreationRateLimitGuard)
   @ApiOkResponse({
     description: 'Space created',
     type: CreateSpaceResponse,
@@ -123,7 +123,7 @@ export class SpacesController {
   }
 
   @Patch('/:id')
-  @UseGuards(SpacesRateLimitGuard)
+  @UseGuards(SpacesCreationRateLimitGuard)
   @ApiOkResponse({
     description: 'Space updated',
     type: UpdateSpaceResponse,


### PR DESCRIPTION
## Summary

This adds rate limiting to the upsertion of address book entries - 500 items every 10 minutes.

## Changes

- Rename/update existing Spaces creation Guard
- Add new `SpacesAddressBookRateLimitGuard`
- Add/update relevant configuration
- Add appropriate test coverage