### PR TITLE
feat: fall back to Decoder Service

### DIFF
--- a/src/domain/safe/entities/schemas/transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/transaction-type.schema.ts
@@ -10,4 +10,6 @@ const TransactionTypeSchema = z.discriminatedUnion('txType', [
   MultisigTransactionTypeSchema,
 ]);
 
+export type TransactionWithType = z.infer<typeof TransactionTypeSchema>;
+
 export const TransactionTypePageSchema = buildPageSchema(TransactionTypeSchema);

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -15,6 +15,7 @@ import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
 import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.repository.interface';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
+import { DataDecoderRepositoryModule } from '@/domain/data-decoder/v2/data-decoder.repository.module';
 
 export const ISafeRepository = Symbol('ISafeRepository');
 
@@ -224,6 +225,7 @@ export interface ISafeRepository {
     TransactionApiManagerModule,
     DelegatesV2RepositoryModule,
     ContractsRepositoryModule,
+    DataDecoderRepositoryModule,
   ],
   providers: [
     {


### PR DESCRIPTION
## Summary

Resolves #2533

The Transaction Service often returns a `dataDecoded` parameter that can be populated or `null`. This returns a "basic" decoding but doesn't, for example, follow proxy contracts. The new Decoder Service does, however.

This adds fallback logic to populate the `dataDecoded` if it is not and there is transaction `data`.

## Changes

- Add and wrap appropriate methods with `SafeRepository['withFallbackDataDecoded']`
- Add appropriate test coverage