### PR TITLE
fix: add `permissions` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 env:
   DOCKER_IMAGE_REGISTRY: safeglobal
   DOCKER_IMAGE_NAME: safe-client-gateway-nest


### PR DESCRIPTION
## Summary

The CI has no `permissions` set, inheriting those from the org. This explicitly sets them on the CI to be as strict as possible instead.

## Changes

- Add `contents: read` permissions