### PR TITLE
fix: Log Firebase auth and send error message

### DIFF
--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -20,8 +20,8 @@ import {
   FirebaseOauth2Token,
   FirebaseOauth2TokenSchema,
 } from '@/datasources/push-notifications-api/entities/firebase-oauth2-token.entity';
-import { get } from 'lodash';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import { getFirstAvailable } from '@/domain/common/utils/array';
 
 @Injectable()
 export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
@@ -35,7 +35,10 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
   private static readonly DefaultIosNotificationBody =
     'New Activity with your Safe';
 
-  private static readonly ERROR_ARRAY_PATH = 'data.error_description';
+  private static readonly ERROR_ARRAY_PATH = [
+    'data.error_description',
+    'data.error.message',
+  ];
 
   private readonly baseUrl: string;
   private readonly project: string;
@@ -199,7 +202,7 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
 
   private mapError(error: unknown): unknown {
     if (error instanceof NetworkResponseError) {
-      const errorMessage = get(
+      const errorMessage = getFirstAvailable(
         error,
         FirebaseCloudMessagingApiService.ERROR_ARRAY_PATH,
       );

--- a/src/domain/common/utils/__tests__/array.spec.ts
+++ b/src/domain/common/utils/__tests__/array.spec.ts
@@ -1,0 +1,53 @@
+import { getFirstAvailable } from '../array';
+
+describe('getFirstAvailable()', () => {
+  it('Should return the first available value from the given paths', () => {
+    const sourceObject = { a: 1, b: 2, c: 3 };
+    const paths = ['b', 'c', 'a'];
+
+    const result = getFirstAvailable(sourceObject, paths);
+
+    expect(result).toBe(sourceObject.b);
+  });
+
+  it('Should return undefined if none of the paths exist in the source object', () => {
+    const sourceObject = { a: 1, b: 2 };
+    const paths = ['c', 'd'];
+
+    const result = getFirstAvailable(sourceObject, paths);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('Should return undefined if the paths array is empty', () => {
+    const sourceObject = { a: 1, b: 2 };
+    const paths: Array<string> = [];
+
+    const result = getFirstAvailable(sourceObject, paths);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('Should handle nested paths correctly', () => {
+    const sourceObject = { a: { b: { c: 42 } } };
+    const paths = ['a.b.c', 'a.b', 'a'];
+
+    const result = getFirstAvailable(sourceObject, paths);
+
+    expect(result).toBe(sourceObject.a.b.c);
+  });
+
+  it('Should return undefined if the source object is empty', () => {
+    const sourceObject = {};
+    const paths = ['a', 'b'];
+    const result = getFirstAvailable(sourceObject, paths);
+    expect(result).toBeUndefined();
+  });
+
+  it('Should return the first non-undefined value even if it is falsy', () => {
+    const sourceObject = { a: undefined, b: 0, c: false };
+    const paths = ['a', 'b', 'c'];
+    const result = getFirstAvailable(sourceObject, paths);
+    expect(result).toBe(0);
+  });
+});

--- a/src/domain/common/utils/array.ts
+++ b/src/domain/common/utils/array.ts
@@ -1,0 +1,16 @@
+import type { GetFieldType } from 'lodash';
+import get from 'lodash/get';
+
+export function getFirstAvailable<TObject, TPath extends string>(
+  sourceObject: TObject,
+  paths: Array<string>,
+): GetFieldType<TObject, TPath> | undefined {
+  for (const path of paths) {
+    const value = get(sourceObject, path);
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
In a previous [PR](https://github.com/safe-global/safe-client-gateway/pull/2536), we added the ability to directly log error messages from the Firebase `Auth` endpoint. However, the error structure for `sendMessage` differs from that of the `Auth` endpoint. In this PR, we update the logging to handle and log both error structures.

## Changes
- Logs the Firebase `sendMessage` endpoint errors.
- Added a helper to get the first available key in an array.