### PR TITLE
fix: log health check errors as errors instead of warnings

### DIFF
--- a/src/domain/health/health.repository.ts
+++ b/src/domain/health/health.repository.ts
@@ -71,7 +71,7 @@ export class HealthRepository implements IHealthRepository {
 
   private logHealthCheckError(error: unknown): void {
     if (error instanceof HealthCheckError) {
-      this.loggingService.warn(error.message);
+      this.loggingService.error(error.message);
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR changes the logging level for health check errors from warnings to errors to better reflect the severity of the issues.

## Changes
- Changed Health check error logs from `warning` to `error`.