### PR TITLE
fix: use dynamic TTL for in-memory price cache

### DIFF
--- a/src/datasources/balances-api/coingecko-api.service.spec.ts
+++ b/src/datasources/balances-api/coingecko-api.service.spec.ts
@@ -66,6 +66,7 @@ describe('CoingeckoAPI', () => {
   const coingeckoApiKey = faker.string.sample();
   const pricesTtlSeconds = faker.number.int();
   const nativeCoinPricesTtlSeconds = faker.number.int();
+  const highRefreshRateToken = faker.finance.ethereumAddress().toLowerCase();
   const highRefreshRateTokensTtlSeconds = faker.number.int();
   const notFoundPriceTtlSeconds = faker.number.int();
   const defaultExpirationTimeInSeconds = faker.number.int();
@@ -84,7 +85,7 @@ describe('CoingeckoAPI', () => {
     );
     fakeConfigurationService.set(
       `balances.providers.safe.prices.highRefreshRateTokens`,
-      [],
+      [highRefreshRateToken],
     );
     fakeConfigurationService.set(
       'balances.providers.safe.prices.pricesTtlSeconds',
@@ -545,7 +546,7 @@ describe('CoingeckoAPI', () => {
     const firstTokenAddress = faker.finance.ethereumAddress();
     const firstPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
     const firstChange = faker.number.float({ min: -1, max: 1 });
-    const secondTokenAddress = faker.finance.ethereumAddress();
+    const secondTokenAddress = highRefreshRateToken;
     const secondPrice = faker.number.float({ min: 0.01, multipleOf: 0.01 });
     const secondChange = faker.number.float({ min: -1, max: 1 });
     const thirdTokenAddress = faker.finance.ethereumAddress();
@@ -673,7 +674,7 @@ describe('CoingeckoAPI', () => {
           [`${lowerCaseFiatCode}_24h_change`]: secondChange,
         },
       }),
-      pricesTtlSeconds * 1_000, // milliseconds
+      highRefreshRateTokensTtlSeconds * 1_000, // milliseconds
     );
     // mockCacheService.hGet should have been called 2 times, once for the network and once for the cache
     expect(mockCacheService.hGet).toHaveBeenCalledTimes(2);

--- a/src/datasources/balances-api/coingecko-api.service.ts
+++ b/src/datasources/balances-api/coingecko-api.service.ts
@@ -310,12 +310,14 @@ export class CoingeckoApi implements IPricesApi {
         const cacheItem = await this.cacheService.hGet(cacheDir);
         if (cacheItem != null) {
           this.logCacheHit(cacheDir);
+          const assetPrice = AssetPriceSchema.parse(JSON.parse(cacheItem));
+          const price = assetPrice[tokenAddress]?.[args.fiatCode];
           await this.inMemoryCache.set(
             CacheRouter.getMemoryKey(cacheDir),
             cacheItem,
-            this.pricesTtlSeconds * 1_000, // Milliseconds
+            this._getTtl(price, tokenAddress) * 1_000, // Milliseconds
           );
-          result.push(AssetPriceSchema.parse(JSON.parse(cacheItem)));
+          result.push(assetPrice);
         } else {
           this.logCacheMiss(cacheDir);
         }


### PR DESCRIPTION
## Summary

We use a dynamic TTL when caching token prices - certain tokens have high refresh rates.

When populating the cache, this is [set correctly](https://github.com/safe-global/safe-client-gateway/blob/fix/in-memory-token-cache/src/datasources/balances-api/coingecko-api.service.ts#L376). When populating the in-memory cache, however, it is currently set to the defaul price TTL. This adjusts the logic in question to set the dynamic TTL

## Changes

- Populate in-memory cache according to token