### PR TITLE
feat: use Decoder Service for decoding data

### DIFF
--- a/src/domain/data-decoder/v2/data-decoder.repository.interface.ts
+++ b/src/domain/data-decoder/v2/data-decoder.repository.interface.ts
@@ -1,6 +1,7 @@
 import type { Contract } from '@/domain/data-decoder/v2/entities/contract.entity';
 import type { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import type { Page } from '@/domain/entities/page.entity';
+import type { Transaction } from '@/domain/safe/entities/transaction.entity';
 
 export const IDataDecoderRepository = Symbol('IDataDecoderRepository');
 
@@ -15,4 +16,9 @@ export interface IDataDecoderRepository {
     chainIds: Array<string>;
     address: `0x${string}`;
   }): Promise<Page<Contract>>;
+
+  getTransactionDataDecoded(args: {
+    chainId: string;
+    transaction: Transaction;
+  }): Promise<DataDecoded | null>;
 }

--- a/src/domain/data-decoder/v2/data-decoder.repository.ts
+++ b/src/domain/data-decoder/v2/data-decoder.repository.ts
@@ -10,12 +10,16 @@ import {
   Contract,
   ContractPageSchema,
 } from '@/domain/data-decoder/v2/entities/contract.entity';
+import { Transaction } from '@/domain/safe/entities/transaction.entity';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
 
 @Injectable()
 export class DataDecoderRepository implements IDataDecoderRepository {
   constructor(
     @Inject(IDataDecoderApi)
     private readonly dataDecoderApi: IDataDecoderApi,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   public async getDecodedData(args: {
@@ -33,5 +37,59 @@ export class DataDecoderRepository implements IDataDecoderRepository {
   }): Promise<Page<Contract>> {
     const contracts = await this.dataDecoderApi.getContracts(args);
     return ContractPageSchema.parse(contracts);
+  }
+
+  public async getTransactionDataDecoded(args: {
+    chainId: string;
+    transaction: Transaction;
+  }): Promise<DataDecoded | null> {
+    const data = this.getDataDecodedData(args.transaction);
+
+    if (!data || data === '0x') {
+      return null;
+    }
+
+    try {
+      return await this.getDecodedData({
+        chainId: args.chainId,
+        data,
+        to: this.getDataDecodedTo(args.transaction),
+      });
+    } catch (e) {
+      this.loggingService.warn(
+        `Error decoding transaction data: ${asError(e).message}`,
+      );
+      return null;
+    }
+  }
+
+  private getDataDecodedData(transaction: Transaction): `0x${string}` | null {
+    // Multisig transaction
+    if ('data' in transaction) {
+      return transaction.data;
+    }
+    // Creation
+    if ('setupData' in transaction) {
+      return transaction.setupData;
+    }
+
+    throw Error('Unrecognized transaction type');
+  }
+
+  private getDataDecodedTo(transaction: Transaction): `0x${string}` {
+    // Multisig transaction
+    if ('to' in transaction) {
+      return transaction.to;
+    }
+    // Native transfer
+    if ('from' in transaction) {
+      return transaction.from;
+    }
+    // Creation
+    if ('factoryAddress' in transaction) {
+      return transaction.factoryAddress;
+    }
+
+    throw Error('Unrecognized transaction type');
   }
 }

--- a/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/creation-transaction.builder.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
-import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import type { CreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
 import { getAddress } from 'viem';
 
@@ -13,8 +12,7 @@ export function creationTransactionBuilder(): IBuilder<CreationTransaction> {
     .with('factoryAddress', getAddress(faker.finance.ethereumAddress()))
     .with('masterCopy', getAddress(faker.finance.ethereumAddress()))
     .with('setupData', faker.string.hexadecimal() as `0x${string}`)
-    .with('saltNonce', faker.string.numeric())
-    .with('dataDecoded', dataDecodedBuilder().build());
+    .with('saltNonce', faker.string.numeric());
 }
 
 export function toJson(creationTransaction: CreationTransaction): unknown {

--- a/src/domain/safe/entities/__tests__/module-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/module-transaction.builder.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
 import type { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
@@ -10,7 +9,6 @@ export function moduleTransactionBuilder(): IBuilder<ModuleTransaction> {
     .with('blockNumber', faker.number.int())
     .with('created', faker.date.recent())
     .with('data', faker.string.hexadecimal() as `0x${string}`)
-    .with('dataDecoded', dataDecodedBuilder().build())
     .with('executionDate', faker.date.recent())
     .with('isSuccessful', faker.datatype.boolean())
     .with('module', getAddress(faker.finance.ethereumAddress()))

--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker';
 import { Builder } from '@/__tests__/builder';
-import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import {
   confirmationBuilder,
   toJson as confirmationToJson,
@@ -79,7 +78,6 @@ export function multisigTransactionBuilder(): BuilderWithConfirmations<MultisigT
       .with('blockNumber', faker.number.int())
       .with('confirmationsRequired', faker.number.int())
       .with('data', faker.string.hexadecimal() as `0x${string}`)
-      .with('dataDecoded', dataDecodedBuilder().build())
       .with('ethGasPrice', faker.string.numeric())
       .with('executor', getAddress(faker.finance.ethereumAddress()))
       .with('executionDate', faker.date.recent())

--- a/src/domain/safe/entities/__tests__/multisig-transaction.entity.spec.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.entity.spec.ts
@@ -151,7 +151,6 @@ describe('MultisigTransaction', () => {
 
     it.each([
       'data' as const,
-      'dataDecoded' as const,
       'gasToken' as const,
       'safeTxGas' as const,
       'baseGas' as const,

--- a/src/domain/safe/entities/module-transaction.entity.ts
+++ b/src/domain/safe/entities/module-transaction.entity.ts
@@ -1,4 +1,3 @@
-import { DataDecodedSchema } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -13,7 +12,6 @@ export const ModuleTransactionSchema = z.object({
   to: AddressSchema,
   value: NumericStringSchema.nullish().default(null),
   data: HexSchema.nullish().default(null),
-  dataDecoded: DataDecodedSchema.nullish().default(null),
   operation: z.nativeEnum(Operation),
   created: z.coerce.date(),
   executionDate: z.coerce.date(),

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -1,4 +1,3 @@
-import { DataDecodedSchema } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
 import { Operation } from '@/domain/safe/entities/operation.entity';
@@ -27,7 +26,6 @@ export const MultisigTransactionSchema = z.object({
   to: AddressSchema,
   value: NumericStringSchema,
   data: HexSchema.nullish().default(null),
-  dataDecoded: DataDecodedSchema.nullish().default(null),
   operation: z.nativeEnum(Operation),
   gasToken: AddressSchema.nullish().default(null),
   safeTxGas: CoercedNumberSchema.nullish().default(null),

--- a/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/creation-transaction.schema.spec.ts
@@ -44,19 +44,17 @@ describe('CreationTransactionSchema', () => {
     );
   });
 
-  it.each([
-    'masterCopy' as const,
-    'setupData' as const,
-    'dataDecoded' as const,
-    'saltNonce' as const,
-  ])('should allow an optional %s', (field) => {
-    const creationTransaction = creationTransactionBuilder().build();
-    delete creationTransaction[field];
+  it.each(['masterCopy' as const, 'setupData' as const, 'saltNonce' as const])(
+    'should allow an optional %s',
+    (field) => {
+      const creationTransaction = creationTransactionBuilder().build();
+      delete creationTransaction[field];
 
-    const result = CreationTransactionSchema.safeParse(creationTransaction);
+      const result = CreationTransactionSchema.safeParse(creationTransaction);
 
-    expect(result.success && result.data[field]).toBe(null);
-  });
+      expect(result.success && result.data[field]).toBe(null);
+    },
+  );
 
   it.each([
     'creator' as const,

--- a/src/domain/safe/entities/schemas/__tests__/module-transaction.schema.spec.ts
+++ b/src/domain/safe/entities/schemas/__tests__/module-transaction.schema.spec.ts
@@ -38,7 +38,7 @@ describe('ModuleTransaction schemas', () => {
       },
     );
 
-    it.each(['value' as const, 'data' as const, 'dataDecoded' as const])(
+    it.each(['value' as const, 'data' as const])(
       'should allow %s to be undefined, defaulting to null',
       (key) => {
         const moduleTransaction = moduleTransactionBuilder().build();

--- a/src/domain/safe/entities/schemas/creation-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/creation-transaction.schema.ts
@@ -1,4 +1,3 @@
-import { DataDecodedSchema } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import { z } from 'zod';
@@ -11,5 +10,4 @@ export const CreationTransactionSchema = z.object({
   masterCopy: AddressSchema.nullish().default(null),
   setupData: HexSchema.nullish().default(null),
   saltNonce: z.string().nullish().default(null),
-  dataDecoded: DataDecodedSchema.nullish().default(null),
 });

--- a/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-creation-transaction.transactions.controller.spec.ts
@@ -18,6 +18,7 @@ import { QueuesApiModule } from '@/datasources/queues/queues-api.module';
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import {
   creationTransactionBuilder,
   toJson as creationTransactionToJson,
@@ -35,6 +36,7 @@ import request from 'supertest';
 describe('Get creation transaction', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
+  let safeDecoderUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
@@ -62,6 +64,7 @@ describe('Get creation transaction', () => {
       IConfigurationService,
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    safeDecoderUrl = configurationService.getOrThrow('safeDataDecoder.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -76,6 +79,7 @@ describe('Get creation transaction', () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();
     const creationTransaction = creationTransactionBuilder().build();
+    const dataDecoded = dataDecodedBuilder().build();
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getCreationTransactionUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/creation/`;
     networkService.get.mockImplementation(({ url }) => {
@@ -91,6 +95,12 @@ describe('Get creation transaction', () => {
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === `${safeDecoderUrl}/api/v1/data-decoder`) {
+        return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
 
     await request(app.getHttpServer())
       .get(
@@ -100,6 +110,7 @@ describe('Get creation transaction', () => {
       .expect(({ body }) => {
         expect(body).toEqual({
           ...creationTransaction,
+          dataDecoded,
           created: creationTransaction.created.toISOString(),
         });
       });

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -51,6 +51,7 @@ import { nativeTokenTransferBuilder } from '@/domain/safe/entities/__tests__/nat
 describe('List multisig transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
+  let safeDecoderUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
 
   beforeEach(async () => {
@@ -90,6 +91,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       IConfigurationService,
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    safeDecoderUrl = configurationService.getOrThrow('safeDataDecoder.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -226,30 +228,27 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .with('isExecuted', true)
       .with('isSuccessful', true)
       .with('origin', null)
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'transfer')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('name', 'to')
-              .with('type', 'address')
-              .with('value', '0x84662112A54cC30733A0DfF864bc38905AB42fD4')
-              .build(),
-            dataDecodedParameterBuilder()
-              .with('name', 'value')
-              .with('type', 'uint256')
-              .with('value', '455753658736')
-              .build(),
-          ])
-          .build(),
-      )
       .with('confirmationsRequired', 2)
       .buildWithConfirmations({
         chainId: chain.chainId,
         safe,
         signers,
       });
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'transfer')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('name', 'to')
+          .with('type', 'address')
+          .with('value', '0x84662112A54cC30733A0DfF864bc38905AB42fD4')
+          .build(),
+        dataDecodedParameterBuilder()
+          .with('name', 'value')
+          .with('type', 'uint256')
+          .with('value', '455753658736')
+          .build(),
+      ])
+      .build();
     const token = erc20TokenBuilder()
       .with('address', getAddress(multisigTransaction.to))
       .build();
@@ -280,6 +279,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       }
       if (url === getTokenUrlPattern) {
         return Promise.resolve({ data: rawify(token), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === `${safeDecoderUrl}/api/v1/data-decoder`) {
+        return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -356,35 +361,32 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .with('isExecuted', true)
       .with('isSuccessful', true)
       .with('origin', '{}')
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'safeTransferFrom')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('name', 'from')
-              .with('type', 'address')
-              .with('value', safe.address)
-              .build(),
-            dataDecodedParameterBuilder()
-              .with('name', 'to')
-              .with('type', 'address')
-              .with('value', '0x3a55e304D9cF13E45Ead6BA3DabCcadD3a419356')
-              .build(),
-            dataDecodedParameterBuilder()
-              .with('name', 'tokenId')
-              .with('type', 'uint256')
-              .with('value', '495')
-              .build(),
-          ])
-          .build(),
-      )
       .with('confirmationsRequired', 3)
       .buildWithConfirmations({
         safe,
         chainId: chain.chainId,
         signers,
       });
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'safeTransferFrom')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('name', 'from')
+          .with('type', 'address')
+          .with('value', safe.address)
+          .build(),
+        dataDecodedParameterBuilder()
+          .with('name', 'to')
+          .with('type', 'address')
+          .with('value', '0x3a55e304D9cF13E45Ead6BA3DabCcadD3a419356')
+          .build(),
+        dataDecodedParameterBuilder()
+          .with('name', 'tokenId')
+          .with('type', 'uint256')
+          .with('value', '495')
+          .build(),
+      ])
+      .build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -412,6 +414,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       }
       if (url === getTokenUrlPattern) {
         return Promise.resolve({ data: rawify(token), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === `${safeDecoderUrl}/api/v1/data-decoder`) {
+        return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -483,28 +491,25 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .with('data', faker.string.hexadecimal({ length: 32 }) as `0x${string}`)
       .with('isExecuted', true)
       .with('isSuccessful', true)
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'multiSend')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('name', 'transactions')
-              .with('valueDecoded', [
-                multisendBuilder().build(),
-                multisendBuilder().build(),
-                multisendBuilder().build(),
-              ])
-              .build(),
-          ])
-          .build(),
-      )
       .with('confirmationsRequired', 3)
       .buildWithConfirmations({
         chainId: chain.chainId,
         safe,
         signers,
       });
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'multiSend')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('name', 'transactions')
+          .with('valueDecoded', [
+            multisendBuilder().build(),
+            multisendBuilder().build(),
+            multisendBuilder().build(),
+          ])
+          .build(),
+      ])
+      .build();
     const multisigTransactionsPage = pageBuilder()
       .with('results', [multisigTransactionToJson(domainTransaction)])
       .build();
@@ -534,6 +539,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === `${safeDecoderUrl}/api/v1/data-decoder`) {
+        return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
 
     await request(app.getHttpServer())
       .get(
@@ -559,7 +570,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
                   },
                   dataSize: '16',
                   value: domainTransaction.value,
-                  methodName: domainTransaction.dataDecoded?.method ?? null,
+                  methodName: dataDecoded.method,
                   actionCount: 3,
                   isCancellation: false,
                 },
@@ -618,6 +629,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         safe,
         signers,
       });
+    const dataDecoded = dataDecodedBuilder().build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -641,6 +653,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       }
       if (url.includes(getContractUrlPattern)) {
         return Promise.reject({ detail: 'Not found', status: 404 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === `${safeDecoderUrl}/api/v1/data-decoder`) {
+        return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -168,7 +168,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         .with('safe', safeAddress)
         .with('isExecuted', false)
         .with('nonce', nonce)
-        .with('dataDecoded', null)
         .buildWithConfirmations({
           safe: safeResponse,
           chainId: chainResponse.chainId,
@@ -331,7 +330,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         .with('safe', safeAddress)
         .with('isExecuted', false)
         .with('nonce', nonce)
-        .with('dataDecoded', null)
         .buildWithConfirmations({
           safe: safeResponse,
           chainId: chainResponse.chainId,
@@ -496,7 +494,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         .with('safe', safeAddress)
         .with('isExecuted', false)
         .with('nonce', nonce)
-        .with('dataDecoded', null)
         .buildWithConfirmations({
           safe: safeResponse,
           chainId: chainResponse.chainId,
@@ -615,7 +612,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,
@@ -718,7 +714,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,
@@ -825,7 +820,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,
@@ -912,7 +906,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,
@@ -1001,7 +994,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
             .with('safe', safeAddress)
             .with('isExecuted', false)
             .with('nonce', nonce)
-            .with('dataDecoded', null)
             .buildWithConfirmations({
               safe: safeResponse,
               chainId: chainResponse.chainId,
@@ -1097,7 +1089,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,
@@ -1184,7 +1175,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,
@@ -1275,7 +1265,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .with('safe', safeAddress)
           .with('isExecuted', false)
           .with('nonce', nonce)
-          .with('dataDecoded', null)
           .buildWithConfirmations({
             safe: safeResponse,
             chainId: chainResponse.chainId,

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -51,10 +51,12 @@ import {
 } from '@/logging/logging.interface';
 import { getSafeTxHash } from '@/domain/common/utils/safe';
 import { confirmationBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
+import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 
 describe('Propose transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
+  let safeDecoderUrl: string;
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let loggingService: jest.MockedObjectDeep<ILoggingService>;
 
@@ -89,6 +91,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       IConfigurationService,
     );
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    safeDecoderUrl = configurationService.getOrThrow('safeDataDecoder.baseUri');
     networkService = moduleFixture.get(NetworkService);
     loggingService = moduleFixture.get(LoggingService);
 
@@ -167,6 +170,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           signers: [signer],
           signatureType,
         });
+      const dataDecoded = dataDecodedBuilder().build();
       const proposeTransactionDto = proposeTransactionDtoBuilder()
         .with('to', transaction.to)
         .with('value', transaction.value)
@@ -220,9 +224,12 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       });
       networkService.post.mockImplementation(({ url }) => {
         const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+        const getDataDecodedUrl = `${safeDecoderUrl}/api/v1/data-decoder`;
         switch (url) {
           case proposeTransactionUrl:
             return Promise.resolve({ data: rawify({}), status: 200 });
+          case getDataDecodedUrl:
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -281,6 +288,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         safe,
         signers,
       });
+    const dataDecoded = dataDecodedBuilder().build();
     const proposeTransactionDto = proposeTransactionDtoBuilder()
       .with('to', transaction.to)
       .with('value', transaction.value)
@@ -337,9 +345,12 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     });
     networkService.post.mockImplementation(({ url }) => {
       const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getDataDecodedUrl = `${safeDecoderUrl}/api/v1/data-decoder`;
       switch (url) {
         case proposeTransactionUrl:
           return Promise.resolve({ data: rawify({}), status: 200 });
+        case getDataDecodedUrl:
+          return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -396,6 +407,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         safe,
         signers,
       });
+    const dataDecoded = dataDecodedBuilder().build();
     const signature = await getSignature({
       signer: delegate,
       hash: transaction.safeTxHash,
@@ -465,9 +477,12 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     });
     networkService.post.mockImplementation(({ url }) => {
       const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getDataDecodedUrl = `${safeDecoderUrl}/api/v1/data-decoder`;
       switch (url) {
         case proposeTransactionUrl:
           return Promise.resolve({ data: rawify({}), status: 200 });
+        case getDataDecodedUrl:
+          return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -579,6 +594,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           safe,
           signers: [signer],
         });
+      const dataDecoded = dataDecodedBuilder().build();
       const contractPage = pageBuilder()
         .with('results', [
           contractBuilder().with('trustedForDelegateCall', true).build(),
@@ -643,9 +659,12 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
       });
       networkService.post.mockImplementation(({ url }) => {
         const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+        const getDataDecodedUrl = `${safeDecoderUrl}/api/v1/data-decoder`;
         switch (url) {
           case proposeTransactionUrl:
             return Promise.resolve({ data: rawify({}), status: 200 });
+          case getDataDecodedUrl:
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }
@@ -1458,6 +1477,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
         .with('operation', Operation.CALL)
         .with('confirmations', [])
         .build();
+      const dataDecoded = dataDecodedBuilder().build();
       transaction.safeTxHash = getSafeTxHash({
         chainId: chain.chainId,
         safe,
@@ -1551,6 +1571,18 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
             return Promise.resolve({ data: rawify(token), status: 200 });
           case getGasTokenContractUrl:
             return Promise.resolve({ data: rawify(gasToken), status: 200 });
+          default:
+            return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+      networkService.post.mockImplementation(({ url }) => {
+        const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+        const getDataDecodedUrl = `${safeDecoderUrl}/api/v1/data-decoder`;
+        switch (url) {
+          case proposeTransactionUrl:
+            return Promise.resolve({ data: rawify({}), status: 200 });
+          case getDataDecodedUrl:
+            return Promise.resolve({ data: rawify(dataDecoded), status: 200 });
           default:
             return Promise.reject(new Error(`Could not match ${url}`));
         }

--- a/src/routes/transactions/entities/txs-creation-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-creation-transaction.entity.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { CreationTransaction as DomainCreationTransaction } from '@/domain/safe/entities/creation-transaction.entity';
 
 export class TXSCreationTransaction implements DomainCreationTransaction {
@@ -17,8 +16,8 @@ export class TXSCreationTransaction implements DomainCreationTransaction {
   setupData: `0x${string}` | null;
   @ApiProperty()
   saltNonce: string | null;
-  @ApiProperty()
-  dataDecoded: DataDecoded | null;
+  // @ApiProperty()
+  // dataDecoded: DataDecoded | null;
 
   constructor(args: {
     created: Date;
@@ -28,7 +27,6 @@ export class TXSCreationTransaction implements DomainCreationTransaction {
     masterCopy: `0x${string}` | null;
     setupData: `0x${string}` | null;
     saltNonce: string | null;
-    dataDecoded: DataDecoded | null;
   }) {
     this.created = args.created;
     this.creator = args.creator;
@@ -37,6 +35,5 @@ export class TXSCreationTransaction implements DomainCreationTransaction {
     this.masterCopy = args.masterCopy;
     this.setupData = args.setupData;
     this.saltNonce = args.saltNonce;
-    this.dataDecoded = args.dataDecoded;
   }
 }

--- a/src/routes/transactions/entities/txs-creation-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-creation-transaction.entity.ts
@@ -16,8 +16,6 @@ export class TXSCreationTransaction implements DomainCreationTransaction {
   setupData: `0x${string}` | null;
   @ApiProperty()
   saltNonce: string | null;
-  // @ApiProperty()
-  // dataDecoded: DataDecoded | null;
 
   constructor(args: {
     created: Date;

--- a/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
@@ -15,8 +15,6 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
   value: string;
   @ApiProperty()
   data: `0x${string}` | null;
-  // @ApiProperty()
-  // dataDecoded: DataDecoded | null;
   @ApiProperty()
   operation: Operation;
   @ApiProperty()

--- a/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
@@ -15,8 +15,8 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
   value: string;
   @ApiProperty()
   data: `0x${string}` | null;
-  @ApiProperty()
-  dataDecoded: DataDecoded | null;
+  // @ApiProperty()
+  // dataDecoded: DataDecoded | null;
   @ApiProperty()
   operation: Operation;
   @ApiProperty()
@@ -107,7 +107,6 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
     this.to = args.to;
     this.value = args.value;
     this.data = args.data;
-    this.dataDecoded = args.dataDecoded;
     this.operation = args.operation;
     this.gasToken = args.gasToken;
     this.safeTxGas = args.safeTxGas;

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
@@ -29,15 +29,15 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const dataSize = faker.number.int();
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', dataDecodedBuilder().build())
-      .build();
+    const transaction = multisigTransactionBuilder().build();
+    const dataDecoded = dataDecodedBuilder().build();
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
       dataSize,
       chainId,
       null,
+      dataDecoded,
     );
 
     expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
@@ -45,7 +45,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       to: toAddress,
       dataSize: dataSize.toString(),
       value: transaction.value,
-      methodName: transaction.dataDecoded?.method,
+      methodName: dataDecoded.method,
       actionCount: null,
       isCancellation: false,
     });
@@ -58,14 +58,15 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder()
       .with('value', '1000000000000000000000000') // 1e+24
-      .with('dataDecoded', dataDecodedBuilder().build())
       .build();
+    const dataDecoded = dataDecodedBuilder().build();
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
       dataSize,
       chainId,
       null,
+      dataDecoded,
     );
 
     expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
@@ -73,7 +74,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       to: toAddress,
       dataSize: dataSize.toString(),
       value: transaction.value,
-      methodName: transaction.dataDecoded?.method,
+      methodName: dataDecoded.method,
       actionCount: null,
       isCancellation: false,
     });
@@ -85,15 +86,15 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const method = 'multiSend';
     const dataSize = faker.number.int();
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with('dataDecoded', dataDecodedBuilder().with('method', method).build())
-      .build();
+    const transaction = multisigTransactionBuilder().build();
+    const dataDecoded = dataDecodedBuilder().with('method', method).build();
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
       dataSize,
       chainId,
       null,
+      dataDecoded,
     );
 
     expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
@@ -113,27 +114,23 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const method = 'multiSend';
     const dataSize = faker.number.int();
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', method)
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('name', 'transactions')
-              .with('value', [
-                faker.string.alphanumeric(),
-                faker.string.alphanumeric(),
-              ])
-              .with('valueDecoded', [
-                multisendBuilder().build(),
-                multisendBuilder().build(),
-                multisendBuilder().build(),
-              ])
-              .build(),
+    const transaction = multisigTransactionBuilder().build();
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', method)
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('name', 'transactions')
+          .with('value', [
+            faker.string.alphanumeric(),
+            faker.string.alphanumeric(),
+          ])
+          .with('valueDecoded', [
+            multisendBuilder().build(),
+            multisendBuilder().build(),
+            multisendBuilder().build(),
           ])
           .build(),
-      )
+      ])
       .build();
 
     const customTransaction = await mapper.mapCustomTransaction(
@@ -141,6 +138,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       dataSize,
       chainId,
       null,
+      dataDecoded,
     );
 
     expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
@@ -171,14 +169,15 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       .with('gasToken', NULL_ADDRESS)
       .with('refundReceiver', NULL_ADDRESS)
       .with('safeTxGas', 0)
-      .with('dataDecoded', dataDecodedBuilder().with('method', method).build())
       .build();
+    const dataDecoded = dataDecodedBuilder().with('method', method).build();
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
       dataSize,
       chainId,
       null,
+      dataDecoded,
     );
 
     expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
@@ -199,12 +198,14 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder().build();
     const humanDescription = 'Send 10 ETH to vitalik.eth';
+    const dataDecoded = dataDecodedBuilder().build();
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
       dataSize,
       chainId,
       humanDescription,
+      dataDecoded,
     );
 
     expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
@@ -10,6 +10,7 @@ import {
 } from '@/routes/transactions/constants';
 import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
 import { Operation } from '@/domain/safe/entities/operation.entity';
+import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 
 @Injectable()
 export class CustomTransactionMapper {
@@ -20,6 +21,7 @@ export class CustomTransactionMapper {
     dataSize: number,
     chainId: string,
     humanDescription: string | null,
+    dataDecoded: DataDecoded | null,
   ): Promise<CustomTransactionInfo> {
     const toAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
@@ -31,17 +33,14 @@ export class CustomTransactionMapper {
       toAddressInfo,
       dataSize.toString(),
       transaction.value,
-      transaction?.dataDecoded?.method ?? null,
-      this.getActionCount(transaction),
+      dataDecoded?.method ?? null,
+      this.getActionCount(dataDecoded),
       this.isCancellation(transaction, dataSize),
       humanDescription,
     );
   }
 
-  private getActionCount(
-    transaction: MultisigTransaction | ModuleTransaction,
-  ): number | null {
-    const { dataDecoded } = transaction;
+  private getActionCount(dataDecoded: DataDecoded | null): number | null {
     if (dataDecoded?.method === MULTI_SEND_METHOD_NAME) {
       const parameter = dataDecoded.parameters?.find(
         (parameter) => parameter.name === TRANSACTIONS_PARAMETER_NAME,

--- a/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
@@ -9,6 +9,7 @@ import { Erc20Transfer } from '@/routes/transactions/entities/transfers/erc20-tr
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { getTransferDirection } from '@/routes/transactions/mappers/common/transfer-direction.helper';
 import { getAddress } from 'viem';
+import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 
 @Injectable()
 export class Erc20TransferMapper {
@@ -22,8 +23,8 @@ export class Erc20TransferMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
     humanDescription: string | null,
+    dataDecoded: DataDecoded | null,
   ): Promise<TransferTransactionInfo> {
-    const { dataDecoded } = transaction;
     const sender = this.dataDecodedParamHelper.getFromParam(
       dataDecoded,
       transaction.safe,

--- a/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
@@ -9,6 +9,7 @@ import { Erc721Transfer } from '@/routes/transactions/entities/transfers/erc721-
 import { DataDecodedParamHelper } from '@/routes/transactions/mappers/common/data-decoded-param.helper';
 import { getTransferDirection } from '@/routes/transactions/mappers/common/transfer-direction.helper';
 import { getAddress } from 'viem';
+import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
 
 @Injectable()
 export class Erc721TransferMapper {
@@ -22,8 +23,8 @@ export class Erc721TransferMapper {
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
     humanDescription: string | null,
+    dataDecoded: DataDecoded | null,
   ): Promise<TransferTransactionInfo> {
-    const { dataDecoded } = transaction;
     const sender = this.dataDecodedParamHelper.getFromParam(
       dataDecoded,
       transaction.safe,

--- a/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.spec.ts
@@ -11,7 +11,6 @@ import { RemoveOwner } from '@/routes/transactions/entities/settings-changes/rem
 import { SetFallbackHandler } from '@/routes/transactions/entities/settings-changes/set-fallback-handler.entity';
 import { SetGuard } from '@/routes/transactions/entities/settings-changes/set-guard.entity';
 import { SwapOwner } from '@/routes/transactions/entities/settings-changes/swap-owner.entity';
-import { multisigTransactionBuilder } from '@/domain/safe/entities/__tests__/multisig-transaction.builder';
 import {
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
@@ -38,21 +37,16 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
     addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(handlerValue),
     );
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'setFallbackHandler')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', handlerValue).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'setFallbackHandler')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', handlerValue).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new SetFallbackHandler(new AddressInfo(handlerValue));
@@ -60,19 +54,14 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
   });
 
   it('should build a SetFallbackHandler setting with a null handler', async () => {
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'setFallbackHandler')
-          .with('parameters', [])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'setFallbackHandler')
+      .with('parameters', [])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     expect(actual).toBeNull();
@@ -81,22 +70,17 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
   it('should build a AddOwner setting', async () => {
     const ownerValue = faker.string.numeric();
     const thresholdValue = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'addOwnerWithThreshold')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', ownerValue).build(),
-            dataDecodedParameterBuilder().with('value', thresholdValue).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'addOwnerWithThreshold')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', ownerValue).build(),
+        dataDecodedParameterBuilder().with('value', thresholdValue).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new AddOwner(
@@ -109,25 +93,20 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
   it('should build a RemoveOwner setting', async () => {
     const ownerValue = faker.finance.ethereumAddress();
     const thresholdValue = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'removeOwner')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('value', faker.string.numeric())
-              .build(),
-            dataDecodedParameterBuilder().with('value', ownerValue).build(),
-            dataDecodedParameterBuilder().with('value', thresholdValue).build(),
-          ])
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'removeOwner')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('value', faker.string.numeric())
           .build(),
-      )
+        dataDecodedParameterBuilder().with('value', ownerValue).build(),
+        dataDecodedParameterBuilder().with('value', thresholdValue).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new RemoveOwner(
@@ -140,25 +119,20 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
   it('should build a SwapOwner setting', async () => {
     const oldOwner = faker.string.numeric();
     const newOwner = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'swapOwner')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('value', faker.string.numeric())
-              .build(),
-            dataDecodedParameterBuilder().with('value', oldOwner).build(),
-            dataDecodedParameterBuilder().with('value', newOwner).build(),
-          ])
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'swapOwner')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('value', faker.string.numeric())
           .build(),
-      )
+        dataDecodedParameterBuilder().with('value', oldOwner).build(),
+        dataDecodedParameterBuilder().with('value', newOwner).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new SwapOwner(
@@ -173,21 +147,16 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
     addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(newMasterCopy),
     );
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'changeMasterCopy')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', newMasterCopy).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'changeMasterCopy')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', newMasterCopy).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new ChangeMasterCopy(new AddressInfo(newMasterCopy));
@@ -199,21 +168,16 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
     addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(moduleAddress),
     );
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'enableModule')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', moduleAddress).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'enableModule')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', moduleAddress).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new EnableModule(new AddressInfo(moduleAddress));
@@ -225,24 +189,19 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
     addressInfoHelper.getOrDefault.mockResolvedValue(
       new AddressInfo(moduleAddress),
     );
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'disableModule')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('value', faker.finance.ethereumAddress())
-              .build(),
-            dataDecodedParameterBuilder().with('value', moduleAddress).build(),
-          ])
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'disableModule')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('value', faker.finance.ethereumAddress())
           .build(),
-      )
+        dataDecodedParameterBuilder().with('value', moduleAddress).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new DisableModule(new AddressInfo(moduleAddress));
@@ -251,21 +210,16 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
 
   it('should build a ChangeThreshold setting', async () => {
     const thresholdValue = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'changeThreshold')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', thresholdValue).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'changeThreshold')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', thresholdValue).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new ChangeThreshold(Number(thresholdValue));
@@ -276,21 +230,16 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
     const guardAddress = faker.finance.ethereumAddress();
     const guardAddressInfo = new AddressInfo(guardAddress);
     addressInfoHelper.getOrDefault.mockResolvedValue(guardAddressInfo);
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'setGuard')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', guardAddress).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'setGuard')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', guardAddress).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     const expected = new SetGuard(new AddressInfo(guardAddress));
@@ -299,39 +248,29 @@ describe('Multisig Settings Change Transaction mapper (Unit)', () => {
 
   it('should build a DeleteGuard setting', async () => {
     const guardValue = '0x0000000000000000000000000000000000000000';
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'setGuard')
-          .with('parameters', [
-            dataDecodedParameterBuilder().with('value', guardValue).build(),
-          ])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'setGuard')
+      .with('parameters', [
+        dataDecodedParameterBuilder().with('value', guardValue).build(),
+      ])
       .build();
 
     const actual = await mapper.mapSettingsChange(
       faker.string.numeric(),
-      transaction,
+      dataDecoded,
     );
 
     expect(actual).toEqual(new DeleteGuard());
   });
 
   it('should throw an error on a unknown setting', async () => {
-    const transaction = multisigTransactionBuilder()
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'unknownMethod')
-          .with('parameters', [])
-          .build(),
-      )
+    const dataDecoded = dataDecodedBuilder()
+      .with('method', 'unknownMethod')
+      .with('parameters', [])
       .build();
 
     await expect(
-      mapper.mapSettingsChange(faker.string.numeric(), transaction),
+      mapper.mapSettingsChange(faker.string.numeric(), dataDecoded),
     ).rejects.toThrow();
   });
 });

--- a/src/routes/transactions/mappers/common/settings-change.mapper.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.ts
@@ -1,6 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { ModuleTransaction } from '@/domain/safe/entities/module-transaction.entity';
-import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import { NULL_ADDRESS } from '@/routes/common/constants';
@@ -205,10 +203,8 @@ export class SettingsChangeMapper {
 
   async mapSettingsChange(
     chainId: string,
-    transaction: MultisigTransaction | ModuleTransaction,
+    dataDecoded: DataDecoded | null,
   ): Promise<SettingsChange | null> {
-    const { dataDecoded } = transaction;
-
     switch (dataDecoded?.method) {
       case SettingsChangeMapper.SET_FALLBACK_HANDLER:
         return this.handleFallbackHandler(chainId, dataDecoded);

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
@@ -11,6 +11,7 @@ import type { MultisigTransactionInfoMapper } from '@/routes/transactions/mapper
 import { ModuleTransactionDetailsMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction-details.mapper';
 import type { ModuleTransactionStatusMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction-status.mapper';
 import { getAddress } from 'viem';
+import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 
 describe('ModuleTransactionDetails mapper (Unit)', () => {
   let mapper: ModuleTransactionDetailsMapper;
@@ -49,6 +50,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
     const transaction = moduleTransactionBuilder()
       .with('safe', getAddress(safe.address))
       .build();
+    const dataDecoded = dataDecodedBuilder().build();
     const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
@@ -61,7 +63,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       trustedDelegateCallTarget,
     );
 
-    const actual = await mapper.mapDetails(chainId, transaction);
+    const actual = await mapper.mapDetails(chainId, transaction, dataDecoded);
 
     expect(actual).toEqual({
       safeAddress: getAddress(safe.address),
@@ -71,7 +73,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       txInfo,
       txData: expect.objectContaining({
         hexData: transaction.data,
-        dataDecoded: transaction.dataDecoded,
+        dataDecoded,
         to: addressInfo,
         value: transaction.value,
         operation: transaction.operation,
@@ -92,6 +94,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
     const transaction = moduleTransactionBuilder()
       .with('safe', getAddress(safe.address))
       .build();
+    const dataDecoded = dataDecodedBuilder().build();
     const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
@@ -110,7 +113,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       trustedDelegateCallTarget,
     );
 
-    const actual = await mapper.mapDetails(chainId, transaction);
+    const actual = await mapper.mapDetails(chainId, transaction, dataDecoded);
 
     expect(actual).toEqual({
       safeAddress: getAddress(safe.address),
@@ -120,7 +123,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       txInfo,
       txData: expect.objectContaining({
         hexData: transaction.data,
-        dataDecoded: transaction.dataDecoded,
+        dataDecoded,
         to: addressInfo,
         value: transaction.value,
         operation: transaction.operation,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
@@ -12,6 +12,7 @@ import { TransactionDetails } from '@/routes/transactions/entities/transaction-d
 import { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
 import { ModuleTransactionStatusMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction-status.mapper';
 import { TransactionDataMapper } from '@/routes/transactions/mappers/common/transaction-data.mapper';
+import { DataDecoded } from '@/routes/data-decode/entities/data-decoded.entity';
 
 @Injectable()
 export class ModuleTransactionDetailsMapper {
@@ -25,13 +26,18 @@ export class ModuleTransactionDetailsMapper {
   async mapDetails(
     chainId: string,
     transaction: ModuleTransaction,
+    dataDecoded: DataDecoded | null,
   ): Promise<TransactionDetails> {
     const [moduleAddress, txInfo, txData] = await Promise.all([
       this.addressInfoHelper.getOrDefault(chainId, transaction.module, [
         'CONTRACT',
       ]),
-      this.transactionInfoMapper.mapTransactionInfo(chainId, transaction),
-      this.mapTransactionData(chainId, transaction),
+      this.transactionInfoMapper.mapTransactionInfo(
+        chainId,
+        transaction,
+        dataDecoded,
+      ),
+      this.mapTransactionData(chainId, transaction, dataDecoded),
     ]);
 
     return {
@@ -51,6 +57,7 @@ export class ModuleTransactionDetailsMapper {
   private async mapTransactionData(
     chainId: string,
     transaction: ModuleTransaction,
+    dataDecoded: DataDecoded | null,
   ): Promise<TransactionData> {
     const [
       addressInfoIndex,
@@ -58,15 +65,12 @@ export class ModuleTransactionDetailsMapper {
       toAddress,
       tokenInfoIndex,
     ] = await Promise.all([
-      this.transactionDataMapper.buildAddressInfoIndex(
-        chainId,
-        transaction.dataDecoded,
-      ),
+      this.transactionDataMapper.buildAddressInfoIndex(chainId, dataDecoded),
       this.transactionDataMapper.isTrustedDelegateCall(
         chainId,
         transaction.operation,
         transaction.to,
-        transaction.dataDecoded,
+        dataDecoded,
       ),
       this.addressInfoHelper.getOrDefault(chainId, transaction.to, [
         'TOKEN',
@@ -75,7 +79,7 @@ export class ModuleTransactionDetailsMapper {
       this.transactionDataMapper.buildTokenInfoIndex({
         chainId,
         safeAddress: transaction.safe,
-        dataDecoded: transaction.dataDecoded,
+        dataDecoded,
       }),
     ]);
 
@@ -83,7 +87,7 @@ export class ModuleTransactionDetailsMapper {
       to: toAddress,
       value: transaction.value,
       hexData: transaction.data,
-      dataDecoded: transaction.dataDecoded,
+      dataDecoded,
       operation: transaction.operation,
       addressInfoIndex: isEmpty(addressInfoIndex) ? null : addressInfoIndex,
       trustedDelegateCallTarget,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -9,6 +9,7 @@ import { ModuleExecutionInfo } from '@/routes/transactions/entities/module-execu
 import { Transaction } from '@/routes/transactions/entities/transaction.entity';
 import { MultisigTransactionInfoMapper } from '@/routes/transactions/mappers/common/transaction-info.mapper';
 import { ModuleTransactionStatusMapper } from '@/routes/transactions/mappers/module-transactions/module-transaction-status.mapper';
+import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 
 @Injectable()
 export class ModuleTransactionMapper {
@@ -21,11 +22,13 @@ export class ModuleTransactionMapper {
   async mapTransaction(
     chainId: string,
     transaction: ModuleTransaction,
+    dataDecoded: DataDecoded | null,
   ): Promise<Transaction> {
     const txStatus = this.statusMapper.mapTransactionStatus(transaction);
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
       chainId,
       transaction,
+      dataDecoded,
     );
     const executionInfo = new ModuleExecutionInfo(
       await this.addressInfoHelper.getOrDefault(chainId, transaction.module, [

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -20,6 +20,7 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import type { ILoggingService } from '@/logging/logging.interface';
 import type { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Operation } from '@/domain/safe/entities/operation.entity';
+import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 
 const addressInfoHelper = jest.mocked({
   getOrDefault: jest.fn(),
@@ -122,6 +123,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
         safe,
         signers: [signer],
       });
+    const dataDecoded = dataDecodedBuilder().build();
     const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
@@ -137,7 +139,12 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const to = addressInfoBuilder().build();
     addressInfoHelper.getOrDefault.mockResolvedValue(to);
 
-    const actual = await mapper.mapDetails(chainId, transaction, safe);
+    const actual = await mapper.mapDetails(
+      chainId,
+      transaction,
+      safe,
+      dataDecoded,
+    );
 
     expect(actual).toEqual({
       safeAddress: safe.address,
@@ -147,7 +154,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
       txInfo,
       txData: expect.objectContaining({
         hexData: transaction.data,
-        dataDecoded: transaction.dataDecoded,
+        dataDecoded,
         to,
         value: transaction.value,
         operation: transaction.operation,
@@ -176,6 +183,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
         safe,
         signers: [signer],
       });
+    const dataDecoded = dataDecodedBuilder().build();
     const txStatus = faker.helpers.objectValue(TransactionStatus);
     statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
     const txInfo = transferTransactionInfoBuilder().build();
@@ -197,7 +205,12 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
     const to = addressInfoBuilder().build();
     addressInfoHelper.getOrDefault.mockResolvedValue(to);
 
-    const actual = await mapper.mapDetails(chainId, transaction, safe);
+    const actual = await mapper.mapDetails(
+      chainId,
+      transaction,
+      safe,
+      dataDecoded,
+    );
 
     expect(actual).toEqual({
       safeAddress: safe.address,
@@ -207,7 +220,7 @@ describe('MultisigTransactionDetails mapper (Unit)', () => {
       txInfo,
       txData: expect.objectContaining({
         hexData: transaction.data,
-        dataDecoded: transaction.dataDecoded,
+        dataDecoded,
         to,
         value: transaction.value,
         operation: transaction.operation,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -17,6 +17,7 @@ import { MultisigTransactionExecutionDetailsMapper } from '@/routes/transactions
 import { MultisigTransactionStatusMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper';
 import { MultisigTransactionNoteMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-note.mapper';
 import { TransactionVerifierHelper } from '@/routes/transactions/helpers/transaction-verifier.helper';
+import { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 
 @Injectable()
 export class MultisigTransactionDetailsMapper {
@@ -35,6 +36,7 @@ export class MultisigTransactionDetailsMapper {
     chainId: string,
     transaction: MultisigTransaction,
     safe: Safe,
+    dataDecoded: DataDecoded | null,
   ): Promise<TransactionDetails> {
     // TODO: This should be located on the domain layer but only route layer exists
     this.transactionVerifier.verifyApiTransaction({
@@ -58,14 +60,15 @@ export class MultisigTransactionDetailsMapper {
         chainId,
         transaction.operation,
         transaction.to,
-        transaction.dataDecoded,
+        dataDecoded,
       ),
-      this.transactionDataMapper.buildAddressInfoIndex(
-        chainId,
-        transaction.dataDecoded,
-      ),
+      this.transactionDataMapper.buildAddressInfoIndex(chainId, dataDecoded),
       this.safeAppInfoMapper.mapSafeAppInfo(chainId, transaction),
-      this.transactionInfoMapper.mapTransactionInfo(chainId, transaction),
+      this.transactionInfoMapper.mapTransactionInfo(
+        chainId,
+        transaction,
+        dataDecoded,
+      ),
       this.multisigTransactionExecutionDetailsMapper.mapMultisigExecutionDetails(
         chainId,
         transaction,
@@ -75,7 +78,7 @@ export class MultisigTransactionDetailsMapper {
       this.transactionDataMapper.buildTokenInfoIndex({
         chainId,
         safeAddress: transaction.safe,
-        dataDecoded: transaction.dataDecoded,
+        dataDecoded,
       }),
     ]);
 
@@ -87,7 +90,7 @@ export class MultisigTransactionDetailsMapper {
       txInfo,
       txData: new TransactionData(
         transaction.data,
-        transaction.dataDecoded,
+        dataDecoded,
         recipientAddressInfo,
         transaction.value,
         transaction.operation,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.spec.ts
@@ -15,6 +15,12 @@ import type { MultisigTransactionInfoMapper } from '@/routes/transactions/mapper
 import type { MultisigTransactionExecutionInfoMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-info.mapper';
 import type { MultisigTransactionStatusMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction-status.mapper';
 import { MultisigTransactionMapper } from '@/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper';
+import type { IDataDecoderRepository } from '@/domain/data-decoder/v2/data-decoder.repository.interface';
+import type { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
+
+const mockDataDecodedRepository = {
+  getTransactionDataDecoded: jest.fn(),
+} as jest.MockedObjectDeep<IDataDecoderRepository>;
 
 describe('MultisigTransactionMapper', () => {
   let mapper: MultisigTransactionMapper;
@@ -24,7 +30,10 @@ describe('MultisigTransactionMapper', () => {
   } as jest.MockedObjectDeep<AddressInfoHelper>);
 
   beforeEach(() => {
+    jest.resetAllMocks();
+
     mapper = new MultisigTransactionMapper(
+      mockDataDecodedRepository,
       jest.mocked({} as jest.Mocked<MultisigTransactionStatusMapper>),
       jest.mocked({} as jest.Mocked<MultisigTransactionInfoMapper>),
       jest.mocked({} as jest.Mocked<MultisigTransactionExecutionInfoMapper>),
@@ -41,63 +50,67 @@ describe('MultisigTransactionMapper', () => {
       const safe = safeBuilder().build();
       const tokens = [tokenBuilder().build(), tokenBuilder().build()];
       const contracts = [contractBuilder().build(), contractBuilder().build()];
-      const transactions = [
-        multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('to', tokens[0].address)
-          .with(
-            'dataDecoded',
-            dataDecodedBuilder()
-              .with('method', 'transferFrom')
-              .with('parameters', [
-                dataDecodedParameterBuilder()
-                  .with('name', 'from')
-                  .with('value', contracts[0].address)
-                  .build(),
-                dataDecodedParameterBuilder()
-                  .with('name', 'to')
-                  .with('value', contracts[1].address)
-                  .build(),
-              ])
-              .build(),
-          )
-          .build(),
-        multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('to', tokens[1].address)
-          .with(
-            'dataDecoded',
-            dataDecodedBuilder()
-              .with('method', 'transfer')
-              .with('parameters', [
-                dataDecodedParameterBuilder()
-                  .with('name', 'to')
-                  .with('value', tokens[0].address)
-                  .build(),
-              ])
-              .build(),
-          )
-          .build(),
-        multisigTransactionBuilder()
-          .with('safe', safe.address)
-          .with('to', tokens[1].address)
-          .with(
-            'dataDecoded',
-            dataDecodedBuilder()
-              .with('method', 'transfer')
-              .with('parameters', [
-                dataDecodedParameterBuilder()
-                  .with('name', 'to')
-                  .with('value', tokens[0].address)
-                  .build(),
-              ])
-              .build(),
-          )
-          .build(),
-      ];
+      const transaction1 = multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('to', tokens[0].address)
+        .build();
+      const decodedData1 = dataDecodedBuilder()
+        .with('method', 'transferFrom')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'from')
+            .with('value', contracts[0].address)
+            .build(),
+          dataDecodedParameterBuilder()
+            .with('name', 'to')
+            .with('value', contracts[1].address)
+            .build(),
+        ])
+        .build();
+      const transaction2 = multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('to', tokens[1].address)
+        .build();
+      const decodedData2 = dataDecodedBuilder()
+        .with('method', 'transfer')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'to')
+            .with('value', tokens[0].address)
+            .build(),
+        ])
+        .build();
+      const transaction3 = multisigTransactionBuilder()
+        .with('safe', safe.address)
+        .with('to', tokens[1].address)
+        .build();
+      const decodedData3 = dataDecodedBuilder()
+        .with('method', 'transfer')
+        .with('parameters', [
+          dataDecodedParameterBuilder()
+            .with('name', 'to')
+            .with('value', tokens[0].address)
+            .build(),
+        ])
+        .build();
+      mockDataDecodedRepository.getTransactionDataDecoded.mockImplementation(
+        (args) => {
+          const tx = args.transaction as MultisigTransaction;
+          if (tx.data === transaction1.data) {
+            return Promise.resolve(decodedData1);
+          }
+          if (tx.data === transaction2.data) {
+            return Promise.resolve(decodedData2);
+          }
+          if (tx.data === transaction3.data) {
+            return Promise.resolve(decodedData3);
+          }
+          return Promise.reject(new Error('Unknown transaction data'));
+        },
+      );
       await mapper.prefetchAddressInfos({
         chainId: chain.chainId,
-        transactions,
+        transactions: [transaction1, transaction2, transaction3],
       });
 
       // Check that the addressInfoHelper.getCollection was called with deduplicated addresses

--- a/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
+++ b/src/routes/transactions/mappers/queued-items/queued-items.mapper.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import groupBy from 'lodash/groupBy';
 import { MultisigTransaction } from '@/domain/safe/entities/multisig-transaction.entity';
 import { Safe } from '@/domain/safe/entities/safe.entity';
@@ -13,6 +13,7 @@ import {
 } from '@/routes/transactions/entities/queued-items/label-queued-item.entity';
 import { TransactionQueuedItem } from '@/routes/transactions/entities/queued-items/transaction-queued-item.entity';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
+import { IDataDecoderRepository } from '@/domain/data-decoder/v2/data-decoder.repository.interface';
 
 class TransactionGroup {
   nonce!: number;
@@ -22,6 +23,8 @@ class TransactionGroup {
 @Injectable()
 export class QueuedItemsMapper {
   constructor(
+    @Inject(IDataDecoderRepository)
+    private readonly dataDecoderRepository: IDataDecoderRepository,
     private readonly mapper: MultisigTransactionMapper,
     private readonly addressInfoHelper: AddressInfoHelper,
   ) {}
@@ -88,8 +91,18 @@ export class QueuedItemsMapper {
       transactionGroup.transactions.map(async (transaction, idx) => {
         const isFirstInGroup = idx === 0;
         const isLastInGroup = idx === transactionGroup.transactions.length - 1;
+        const dataDecoded =
+          await this.dataDecoderRepository.getTransactionDataDecoded({
+            chainId,
+            transaction,
+          });
         return new TransactionQueuedItem(
-          await this.mapper.mapTransaction(chainId, transaction, safe),
+          await this.mapper.mapTransaction(
+            chainId,
+            transaction,
+            safe,
+            dataDecoded,
+          ),
           this.getConflictType(
             isFirstInGroup,
             isLastInGroup,

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -73,6 +73,7 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string | undefined;
+  let safeDecoderUrl: string | undefined;
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let configurationService: jest.MockedObjectDeep<IConfigurationService>;
 
@@ -110,6 +111,7 @@ describe('Transactions History Controller (Unit)', () => {
 
     configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    safeDecoderUrl = configurationService.get('safeDataDecoder.baseUri');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -301,13 +303,11 @@ describe('Transactions History Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const moduleTransaction = moduleTransactionToJson(
       moduleTransactionBuilder()
-        .with('dataDecoded', null)
         .with('executionDate', new Date('2022-12-06T23:00:00Z'))
         .build(),
     );
     const multisigTransaction = await multisigTransactionBuilder()
       .with('safe', safe.address)
-      .with('dataDecoded', null)
       .with('origin', null)
       .with('executionDate', new Date('2022-12-25T00:00:00Z'))
       .buildWithConfirmations({
@@ -383,7 +383,6 @@ describe('Transactions History Controller (Unit)', () => {
     const chainId = chainResponse.chainId;
     const moduleTransaction = moduleTransactionToJson(
       moduleTransactionBuilder()
-        .with('dataDecoded', null)
         .with('executionDate', new Date('2022-12-31T22:09:36Z'))
         .build(),
     );
@@ -433,11 +432,9 @@ describe('Transactions History Controller (Unit)', () => {
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
     const moduleTransaction1 = moduleTransactionBuilder()
-      .with('dataDecoded', null)
       .with('executionDate', new Date('2022-12-31T21:09:36Z'))
       .build();
     const moduleTransaction2 = moduleTransactionBuilder()
-      .with('dataDecoded', null)
       .with('executionDate', new Date('2022-12-31T23:09:36Z'))
       .build();
     const safe = safeBuilder().build();
@@ -503,11 +500,9 @@ describe('Transactions History Controller (Unit)', () => {
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
     const moduleTransaction1 = moduleTransactionBuilder()
-      .with('dataDecoded', null)
       .with('executionDate', new Date('2022-12-31T21:09:36Z'))
       .build();
     const moduleTransaction2 = moduleTransactionBuilder()
-      .with('dataDecoded', null)
       .with('executionDate', new Date('2022-12-31T23:09:36Z'))
       .build();
     const safe = safeBuilder().build();
@@ -586,30 +581,27 @@ describe('Transactions History Controller (Unit)', () => {
       .with('isExecuted', true)
       .with('isSuccessful', true)
       .with('origin', null)
-      .with(
-        'dataDecoded',
-        dataDecodedBuilder()
-          .with('method', 'transfer')
-          .with('parameters', [
-            dataDecodedParameterBuilder()
-              .with('name', 'to')
-              .with('type', 'address')
-              .with('value', multisigTransactionToAddress)
-              .build(),
-            dataDecodedParameterBuilder()
-              .with('name', 'value')
-              .with('type', 'uint256')
-              .with('value', multisigTransactionValue)
-              .build(),
-          ])
-          .build(),
-      )
       .with('confirmationsRequired', 2)
       .buildWithConfirmations({
         safe,
         signers,
         chainId: chain.chainId,
       });
+    const multisigTransactionDataDecoded = dataDecodedBuilder()
+      .with('method', 'transfer')
+      .with('parameters', [
+        dataDecodedParameterBuilder()
+          .with('name', 'to')
+          .with('type', 'address')
+          .with('value', multisigTransactionToAddress)
+          .build(),
+        dataDecodedParameterBuilder()
+          .with('name', 'value')
+          .with('type', 'uint256')
+          .with('value', multisigTransactionValue)
+          .build(),
+      ])
+      .build();
     const nativeTokenTransfer = nativeTokenTransferBuilder()
       .with('executionDate', new Date('2022-08-04T12:44:22Z'))
       .with('to', safe.address)
@@ -650,6 +642,19 @@ describe('Transactions History Controller (Unit)', () => {
       }
       if (url === getTokenUrlPattern) {
         return Promise.resolve({ data: rawify(tokenResponse), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+    networkService.post.mockImplementation(({ url, data }) => {
+      if (
+        url === `${safeDecoderUrl}/api/v1/data-decoder` &&
+        'data' in data &&
+        data.data === multisigTransaction.data
+      ) {
+        return Promise.resolve({
+          data: rawify(multisigTransactionDataDecoded),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -766,9 +771,7 @@ describe('Transactions History Controller (Unit)', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
-    const moduleTransaction = moduleTransactionBuilder()
-      .with('dataDecoded', null)
-      .build();
+    const moduleTransaction = moduleTransactionBuilder().build();
     const safe = safeBuilder().build();
     const allTransactionsResponse = {
       count: 2,
@@ -850,7 +853,7 @@ describe('Transactions History Controller (Unit)', () => {
     const limit = 5;
     const offset = 5;
     const moduleTransaction = moduleTransactionToJson(
-      moduleTransactionBuilder().with('dataDecoded', null).build(),
+      moduleTransactionBuilder().build(),
     );
     const safe = safeBuilder().build();
     const clientNextCursor = `cursor=limit%3D${limit}%26offset%3D10`;

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -51,6 +51,7 @@ import { TXSMultisigTransactionPage } from '@/routes/transactions/entities/txs-m
 import { TXSCreationTransaction } from '@/routes/transactions/entities/txs-creation-transaction.entity';
 import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { IDataDecoderRepository } from '@/domain/data-decoder/v2/data-decoder.repository.interface';
 
 @Injectable()
 export class TransactionsService {
@@ -58,6 +59,8 @@ export class TransactionsService {
 
   constructor(
     @Inject(ISafeRepository) private readonly safeRepository: SafeRepository,
+    @Inject(IDataDecoderRepository)
+    private readonly dataDecoderRepository: IDataDecoderRepository,
     private readonly multisigTransactionMapper: MultisigTransactionMapper,
     private readonly transferMapper: TransferMapper,
     private readonly moduleTransactionMapper: ModuleTransactionMapper,
@@ -87,13 +90,20 @@ export class TransactionsService {
 
     switch (txType) {
       case MODULE_TRANSACTION_PREFIX: {
-        const [tx] = await Promise.all([
-          this.safeRepository.getModuleTransaction({
+        const tx = await this.safeRepository.getModuleTransaction({
+          chainId: args.chainId,
+          moduleTransactionId: id,
+        });
+        const dataDecoded =
+          await this.dataDecoderRepository.getTransactionDataDecoded({
             chainId: args.chainId,
-            moduleTransactionId: id,
-          }),
-        ]);
-        return this.moduleTransactionDetailsMapper.mapDetails(args.chainId, tx);
+            transaction: tx,
+          });
+        return this.moduleTransactionDetailsMapper.mapDetails(
+          args.chainId,
+          tx,
+          dataDecoded,
+        );
       }
 
       case TRANSFER_PREFIX: {
@@ -140,10 +150,17 @@ export class TransactionsService {
           throw new BadRequestException('Invalid transaction ID');
         }
 
+        const dataDecoded =
+          await this.dataDecoderRepository.getTransactionDataDecoded({
+            chainId: args.chainId,
+            transaction: tx,
+          });
+
         return this.multisigTransactionDetailsMapper.mapDetails(
           args.chainId,
           tx,
           safe,
+          dataDecoded,
         );
       }
 
@@ -153,14 +170,21 @@ export class TransactionsService {
           chainId: args.chainId,
           safeTransactionHash: args.txId,
         });
-        const safe = await this.safeRepository.getSafe({
-          chainId: args.chainId,
-          address: tx.safe,
-        });
+        const [safe, dataDecoded] = await Promise.all([
+          this.safeRepository.getSafe({
+            chainId: args.chainId,
+            address: tx.safe,
+          }),
+          this.dataDecoderRepository.getTransactionDataDecoded({
+            chainId: args.chainId,
+            transaction: tx,
+          }),
+        ]);
         return this.multisigTransactionDetailsMapper.mapDetails(
           args.chainId,
           tx,
           safe,
+          dataDecoded,
         );
       }
     }
@@ -174,7 +198,12 @@ export class TransactionsService {
       chainId: args.chainId,
       safeTransactionHash: args.safeTxHash,
     });
-    return new TXSMultisigTransaction(tx);
+    const dataDecoded =
+      await this.dataDecoderRepository.getTransactionDataDecoded({
+        chainId: args.chainId,
+        transaction: tx,
+      });
+    return new TXSMultisigTransaction({ ...tx, dataDecoded });
   }
 
   async getMultisigTransactions(args: {
@@ -212,17 +241,22 @@ export class TransactionsService {
       transactions: domainTransactions.results,
     });
     const results = await Promise.all(
-      domainTransactions.results.map(
-        async (domainTransaction) =>
-          new MultisigTransaction(
-            await this.multisigTransactionMapper.mapTransaction(
-              args.chainId,
-              domainTransaction,
-              safeInfo,
-            ),
-            ConflictType.None,
+      domainTransactions.results.map(async (domainTransaction) => {
+        const dataDecoded =
+          await this.dataDecoderRepository.getTransactionDataDecoded({
+            chainId: args.chainId,
+            transaction: domainTransaction,
+          });
+        return new MultisigTransaction(
+          await this.multisigTransactionMapper.mapTransaction(
+            args.chainId,
+            domainTransaction,
+            safeInfo,
+            dataDecoded,
           ),
-      ),
+          ConflictType.None,
+        );
+      }),
     );
     const nextURL = cursorUrlFromLimitAndOffset(
       args.routeUrl,
@@ -292,15 +326,22 @@ export class TransactionsService {
       chainId: args.chainId,
       safeTransactionHash: args.safeTxHash,
     });
-    const safe = await this.safeRepository.getSafe({
-      chainId: args.chainId,
-      address: transaction.safe,
-    });
+    const [safe, dataDecoded] = await Promise.all([
+      this.safeRepository.getSafe({
+        chainId: args.chainId,
+        address: transaction.safe,
+      }),
+      this.dataDecoderRepository.getTransactionDataDecoded({
+        chainId: args.chainId,
+        transaction,
+      }),
+    ]);
 
     return this.multisigTransactionDetailsMapper.mapDetails(
       args.chainId,
       transaction,
       safe,
+      dataDecoded,
     );
   }
 
@@ -320,15 +361,20 @@ export class TransactionsService {
     });
 
     const results = await Promise.all(
-      domainTransactions.results.map(
-        async (domainTransaction) =>
-          new ModuleTransaction(
-            await this.moduleTransactionMapper.mapTransaction(
-              args.chainId,
-              domainTransaction,
-            ),
+      domainTransactions.results.map(async (domainTransaction) => {
+        const dataDecoded =
+          await this.dataDecoderRepository.getTransactionDataDecoded({
+            chainId: args.chainId,
+            transaction: domainTransaction,
+          });
+        return new ModuleTransaction(
+          await this.moduleTransactionMapper.mapTransaction(
+            args.chainId,
+            domainTransaction,
+            dataDecoded,
           ),
-      ),
+        );
+      }),
     );
     const nextURL = cursorUrlFromLimitAndOffset(
       args.routeUrl,
@@ -532,19 +578,26 @@ export class TransactionsService {
     );
     await this.safeRepository.proposeTransaction(args);
 
-    const safe = await this.safeRepository.getSafe({
-      chainId: args.chainId,
-      address: args.safeAddress,
-    });
     const domainTransaction = await this.safeRepository.getMultiSigTransaction({
       chainId: args.chainId,
       safeTransactionHash: args.proposeTransactionDto.safeTxHash,
     });
+    const [safe, dataDecoded] = await Promise.all([
+      this.safeRepository.getSafe({
+        chainId: args.chainId,
+        address: args.safeAddress,
+      }),
+      this.dataDecoderRepository.getTransactionDataDecoded({
+        chainId: args.chainId,
+        transaction: domainTransaction,
+      }),
+    ]);
 
     return this.multisigTransactionDetailsMapper.mapDetails(
       args.chainId,
       domainTransaction,
       safe,
+      dataDecoded,
     );
   }
 
@@ -552,7 +605,16 @@ export class TransactionsService {
     chainId: string;
     safeAddress: `0x${string}`;
   }): Promise<CreationTransaction> {
-    return this.safeRepository.getCreationTransaction(args);
+    const tx = await this.safeRepository.getCreationTransaction(args);
+    const dataDecoded =
+      await this.dataDecoderRepository.getTransactionDataDecoded({
+        chainId: args.chainId,
+        transaction: tx,
+      });
+    return {
+      ...tx,
+      dataDecoded,
+    };
   }
 
   async getDomainCreationTransaction(args: {


### PR DESCRIPTION
## Summary

Resolves #2533

The `dataDecoded` of a transaction entity is decoded by the Transaction Service, whereas we should be using the Decoder Service.

This removes validation of the aforementioned `dataDecoded`, replacing usage of it with that fetched from the Decoder Service.

## Changes

- Do not validated, ergo remove, `dataDecoded` from multisig, module and creation transactions.
- Replace all usage of `transaction.dataDecoded` with that fetched from the Decoder Service.
- Update tests accordingly.