### PR TITLE
fix: cache Kiln deployments relative to env.

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -596,8 +596,10 @@ export class CacheRouter {
     );
   }
 
-  static getStakingDeploymentsCacheDir(): CacheDir {
-    return new CacheDir(this.STAKING_DEPLOYMENTS_KEY, '');
+  // TODO: remove passing url and the associated configuration once Base is
+  // fully migrated to the Kiln mainnet API.
+  static getStakingDeploymentsCacheDir(url: string): CacheDir {
+    return new CacheDir(`${this.STAKING_DEPLOYMENTS_KEY}_${url}`, '');
   }
 
   static getStakingNetworkStatsCacheDir(): CacheDir {

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -99,7 +99,10 @@ describe('KilnApi', () => {
       expect(actual).toBe(deployments);
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_deployments', ''),
+        cacheDir: new CacheDir(
+          `staking_deployments_${baseUrl}/v1/deployments`,
+          '',
+        ),
         url: `${baseUrl}/v1/deployments`,
         networkRequest: {
           headers: {
@@ -132,7 +135,10 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_deployments', ''),
+        cacheDir: new CacheDir(
+          `staking_deployments_${baseUrl}/v1/deployments`,
+          '',
+        ),
         url: `${baseUrl}/v1/deployments`,
         networkRequest: {
           headers: {

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -55,7 +55,9 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDeployments(): Promise<Raw<Array<Deployment>>> {
     const url = `${this.baseUrl}/v1/deployments`;
-    const cacheDir = CacheRouter.getStakingDeploymentsCacheDir();
+    // TODO: remove passing url and the associated configuration once Base is
+    // fully migrated to the Kiln mainnet API.
+    const cacheDir = CacheRouter.getStakingDeploymentsCacheDir(url);
     return await this.get<{
       data: Array<Deployment>;
     }>({


### PR DESCRIPTION
## Summary

As vault deployments are only deployed on Base, we [dynamically use the testnet configuration of Kiln](https://github.com/safe-global/safe-client-gateway/pull/2526#discussion_r2031467964). This dynamic value is not taken into account when caching, however.

If the deployments are initially fetched on a network other than Base, the prod. deployments will be cached meaning that any subsequent deployment requests on Base are returned from the prod. cache and vice versa. This includes the dynamic URL in the cache key so as to distinguish the both.

## Changes

- Include Kiln URL in cache key for deployments