### PR TITLE
fix: map `performance_fee` to vault `fee`

### DIFF
--- a/src/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder.ts
@@ -35,6 +35,7 @@ export function defiVaultStatsBuilder(): IBuilder<DefiVaultStats> {
     .with('chain_id', faker.number.int())
     .with('asset_decimals', faker.number.int())
     .with('updated_at_block', faker.number.int())
+    .with('performance_fee', faker.number.float())
     .with('additional_rewards_nrr', faker.number.float())
     .with(
       'additional_rewards',

--- a/src/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.spec.ts
@@ -223,6 +223,13 @@ describe('DefiVaultStatsSchema', () => {
         code: 'invalid_type',
         expected: 'number',
         message: 'Required',
+        path: ['performance_fee'],
+        received: 'undefined',
+      },
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        message: 'Required',
         path: ['additional_rewards_nrr'],
         received: 'undefined',
       },

--- a/src/datasources/staking-api/entities/defi-vault-stats.entity.ts
+++ b/src/datasources/staking-api/entities/defi-vault-stats.entity.ts
@@ -43,6 +43,7 @@ export const DefiVaultStatsSchema = z.object({
   chain_id: z.number(),
   asset_decimals: z.number(),
   updated_at_block: z.number(),
+  performance_fee: z.number(),
   additional_rewards_nrr: z.number(),
   additional_rewards: z
     .array(DefiVaultStatsAdditionalRewardSchema)

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
@@ -109,7 +109,7 @@ describe('VaultTransactionMapper', () => {
         type: TransactionInfoType.VaultDeposit,
         humanDescription: null,
         value: '10000', // 1_000_000 / 10 ** 2
-        fee: deployment.product_fee ? Number(deployment.product_fee) : 0,
+        fee: defiVaultStats.performance_fee,
         baseNrr: defiVaultStats.nrr,
         tokenInfo: new TokenInfo({ ...token, trusted: true }),
         vaultInfo: new VaultInfo({
@@ -289,7 +289,7 @@ describe('VaultTransactionMapper', () => {
         type: TransactionInfoType.VaultRedeem,
         humanDescription: null,
         value: '10000', // 1_000_000 / 10 ** 2
-        fee: deployment.product_fee ? Number(deployment.product_fee) : 0,
+        fee: defiVaultStats.performance_fee,
         baseNrr: defiVaultStats.nrr,
         tokenInfo: new TokenInfo({ ...token, trusted: true }),
         vaultInfo: new VaultInfo({

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.ts
@@ -146,9 +146,6 @@ export class VaultTransactionMapper {
       value: args.assets,
       decimals: args.token.decimals,
     });
-    const fee = args.deployment.product_fee
-      ? Number(args.deployment.product_fee)
-      : 0;
     const cumulativeNrr =
       args.defiVaultStats.nrr + args.defiVaultStats.additional_rewards_nrr;
     const expectedAnnualReward = (cumulativeNrr / 100) * value;
@@ -156,7 +153,7 @@ export class VaultTransactionMapper {
 
     return {
       value,
-      fee,
+      fee: args.defiVaultStats.performance_fee,
       expectedMonthlyReward,
       expectedAnnualReward,
     };


### PR DESCRIPTION
## Summary

We currently map the `product_fee` of a deployment as a Vault's `fee`. This is, however, incorrect and shouldn't relied upon. The `performance_fee` stats is the fee that should be shown.

This adds validation, and therefore infers into the type, the `performance_fee` to the `DefiVaultStats` and maps it to the `fee` of mapped Vault transactions.

## Changes

- Add validation of `performance_fee`, inferring it into the type
- Switch mapping of `fee` to be `performance_fee`
- Add/update tests accordingly