### PR TITLE
fix: migrate Holesky caching workarounds to Hoodi

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -148,7 +148,7 @@ export default (): ReturnType<typeof configuration> => ({
   expirationTimeInSeconds: {
     default: faker.number.int(),
     rpc: faker.number.int(),
-    holesky: faker.number.int(),
+    hoodi: faker.number.int(),
     indexing: faker.number.int(),
     staking: faker.number.int(),
     notFound: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -216,7 +216,7 @@ export default () => ({
   expirationTimeInSeconds: {
     default: parseInt(process.env.EXPIRATION_TIME_DEFAULT_SECONDS ?? `${60}`),
     rpc: parseInt(process.env.EXPIRATION_TIME_RPC_SECONDS ?? `${15}`),
-    hoodi: parseInt(process.env.HOLESKY_EXPIRATION_TIME_SECONDS ?? `${60}`),
+    hoodi: parseInt(process.env.HOODI_EXPIRATION_TIME_SECONDS ?? `${60}`),
     indexing: parseInt(process.env.EXPIRATION_TIME_INDEXING_SECONDS ?? `${5}`),
     staking: parseInt(process.env.EXPIRATION_TIME_STAKING_SECONDS ?? `${60}`),
     notFound: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -216,7 +216,7 @@ export default () => ({
   expirationTimeInSeconds: {
     default: parseInt(process.env.EXPIRATION_TIME_DEFAULT_SECONDS ?? `${60}`),
     rpc: parseInt(process.env.EXPIRATION_TIME_RPC_SECONDS ?? `${15}`),
-    holesky: parseInt(process.env.HOLESKY_EXPIRATION_TIME_SECONDS ?? `${60}`),
+    hoodi: parseInt(process.env.HOLESKY_EXPIRATION_TIME_SECONDS ?? `${60}`),
     indexing: parseInt(process.env.EXPIRATION_TIME_INDEXING_SECONDS ?? `${5}`),
     staking: parseInt(process.env.EXPIRATION_TIME_STAKING_SECONDS ?? `${60}`),
     notFound: {

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -26,7 +26,7 @@ export class SafeBalancesApi implements IBalancesApi {
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
   private static readonly DEFAULT_DECIMALS = 18;
-  private static readonly HOLESKY_CHAIN_ID = '17000';
+  private static readonly HOODI_CHAIN_ID = '560048';
 
   constructor(
     private readonly chainId: string,
@@ -37,14 +37,13 @@ export class SafeBalancesApi implements IBalancesApi {
     private readonly httpErrorFactory: HttpErrorFactory,
     private readonly coingeckoApi: IPricesApi,
   ) {
-    // TODO: Remove temporary cache times for Holesky chain.
-    if (chainId === SafeBalancesApi.HOLESKY_CHAIN_ID) {
-      const holeskyExpirationTime =
-        this.configurationService.getOrThrow<number>(
-          'expirationTimeInSeconds.holesky',
-        );
-      this.defaultExpirationTimeInSeconds = holeskyExpirationTime;
-      this.defaultNotFoundExpirationTimeSeconds = holeskyExpirationTime;
+    // TODO: Remove temporary cache times for Hoodi chain.
+    if (chainId === SafeBalancesApi.HOODI_CHAIN_ID) {
+      const hoodiExpirationTime = this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.hoodi',
+      );
+      this.defaultExpirationTimeInSeconds = hoodiExpirationTime;
+      this.defaultNotFoundExpirationTimeSeconds = hoodiExpirationTime;
     } else {
       this.defaultExpirationTimeInSeconds =
         this.configurationService.getOrThrow<number>(

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -2708,14 +2708,14 @@ describe('TransactionApi', () => {
     });
   });
 
-  // TODO: Remove temporary cache times test for Holesky chain.
-  describe('temp - Holesky expiration times', () => {
-    it('should use the Holesky expiration time for the datasource', async () => {
-      const holeskyExpirationTime = faker.number.int();
-      const holeskyChainId = '17000';
+  // TODO: Remove temporary cache times test for Hoodi chain.
+  describe('temp - Hoodi expiration times', () => {
+    it('should use the Hoodi expiration time for the datasource', async () => {
+      const hoodiExpirationTime = faker.number.int();
+      const hoodiChainId = '560048';
       mockConfigurationService.getOrThrow.mockImplementation((key) => {
-        if (key === 'expirationTimeInSeconds.holesky') {
-          return holeskyExpirationTime;
+        if (key === 'expirationTimeInSeconds.hoodi') {
+          return hoodiExpirationTime;
         }
         if (key === 'expirationTimeInSeconds.indexing') {
           return indexingExpirationTimeInSeconds;
@@ -2739,7 +2739,7 @@ describe('TransactionApi', () => {
       });
 
       service = new TransactionApi(
-        holeskyChainId, // Holesky chainId
+        hoodiChainId, // Hoodi chainId
         baseUrl,
         mockDataSource,
         mockCacheService,
@@ -2755,7 +2755,7 @@ describe('TransactionApi', () => {
       const offset = faker.number.int();
       const getTokensUrl = `${baseUrl}/api/v1/tokens/`;
       const cacheDir = new CacheDir(
-        `${holeskyChainId}_tokens`,
+        `${hoodiChainId}_tokens`,
         `${limit}_${offset}`,
       );
       mockDataSource.get.mockResolvedValueOnce(rawify(tokensPage));
@@ -2769,8 +2769,8 @@ describe('TransactionApi', () => {
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);
       expect(mockDataSource.get).toHaveBeenCalledWith({
         cacheDir,
-        expireTimeSeconds: holeskyExpirationTime,
-        notFoundExpireTimeSeconds: holeskyExpirationTime,
+        expireTimeSeconds: hoodiExpirationTime,
+        notFoundExpireTimeSeconds: hoodiExpirationTime,
         url: getTokensUrl,
         networkRequest: {
           params: {

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -34,7 +34,7 @@ import get from 'lodash/get';
 
 export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
-  private static readonly HOLESKY_CHAIN_ID = '17000';
+  private static readonly HOODI_CHAIN_ID = '560048';
 
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly indexingExpirationTimeInSeconds: number;
@@ -58,17 +58,16 @@ export class TransactionApi implements ITransactionApi {
         'expirationTimeInSeconds.indexing',
       );
 
-    // TODO: Remove temporary cache times for Holesky chain.
-    if (chainId === TransactionApi.HOLESKY_CHAIN_ID) {
-      const holeskyExpirationTime =
-        this.configurationService.getOrThrow<number>(
-          'expirationTimeInSeconds.holesky',
-        );
-      this.defaultExpirationTimeInSeconds = holeskyExpirationTime;
-      this.defaultNotFoundExpirationTimeSeconds = holeskyExpirationTime;
-      this.tokenNotFoundExpirationTimeSeconds = holeskyExpirationTime;
-      this.contractNotFoundExpirationTimeSeconds = holeskyExpirationTime;
-      this.ownersExpirationTimeSeconds = holeskyExpirationTime;
+    // TODO: Remove temporary cache times for Hoodi chain.
+    if (chainId === TransactionApi.HOODI_CHAIN_ID) {
+      const hoodiExpirationTime = this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.hoodi',
+      );
+      this.defaultExpirationTimeInSeconds = hoodiExpirationTime;
+      this.defaultNotFoundExpirationTimeSeconds = hoodiExpirationTime;
+      this.tokenNotFoundExpirationTimeSeconds = hoodiExpirationTime;
+      this.contractNotFoundExpirationTimeSeconds = hoodiExpirationTime;
+      this.ownersExpirationTimeSeconds = hoodiExpirationTime;
     } else {
       this.defaultExpirationTimeInSeconds =
         this.configurationService.getOrThrow<number>(


### PR DESCRIPTION
## Summary

We intend to use a third party deployment of Hoodi. As it superseeds Holesky, this migrates the caching workaround logic currently in place for it, e.g. for balances and the Transaction Service.

## Changes

- Update all chain IDs from 17000 to 560048
- Rename all "holesky" configuration variables to "hoodi"