### PR TITLE
fix: use mainnet staking for Base on prod.

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -296,7 +296,6 @@ export default (): ReturnType<typeof configuration> => ({
       baseUri: faker.internet.url({ appendSlash: false }),
       apiKey: faker.string.hexadecimal({ length: 32 }),
     },
-    isBaseProductionActive: faker.datatype.boolean(),
   },
   swaps: {
     api: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -437,9 +437,6 @@ export default () => ({
       baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
       apiKey: process.env.STAKING_API_KEY,
     },
-    // TODO: activate this to point Base vault deployments to Kiln mainnet API.
-    isBaseProductionActive:
-      process.env.STAKING_BASE_PRODUCTION_ACTIVE?.toLowerCase() === 'true',
   },
   swaps: {
     api: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -600,8 +600,7 @@ export class CacheRouter {
     );
   }
 
-  // TODO: remove passing url and the associated configuration once Base is
-  // fully migrated to the Kiln mainnet API.
+  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDeploymentsCacheDir(url: string): CacheDir {
     return new CacheDir(`${this.STAKING_DEPLOYMENTS_KEY}_${url}`, '');
   }

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -57,8 +57,6 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDeployments(): Promise<Raw<Array<Deployment>>> {
     const url = `${this.baseUrl}/v1/deployments`;
-    // TODO: remove passing url and the associated configuration once Base is
-    // fully migrated to the Kiln mainnet API.
     const cacheDir = CacheRouter.getStakingDeploymentsCacheDir(url);
     return await this.get<{
       data: Array<Deployment>;

--- a/src/datasources/staking-api/staking-api.manager.ts
+++ b/src/datasources/staking-api/staking-api.manager.ts
@@ -15,8 +15,6 @@ import { Inject, Injectable } from '@nestjs/common';
 @Injectable()
 export class StakingApiManager implements IStakingApiManager {
   private readonly apis: Record<string, IStakingApi> = {};
-  private readonly BASE_CHAIN_ID = '8453';
-  private readonly isBaseProductionActive: boolean;
 
   constructor(
     private readonly dataSource: CacheFirstDataSource,
@@ -26,11 +24,7 @@ export class StakingApiManager implements IStakingApiManager {
     private readonly httpErrorFactory: HttpErrorFactory,
     @Inject(CacheService)
     private readonly cacheService: ICacheService,
-  ) {
-    this.isBaseProductionActive = this.configurationService.getOrThrow<boolean>(
-      'staking.isBaseProductionActive',
-    );
-  }
+  ) {}
 
   async getApi(chainId: string): Promise<IStakingApi> {
     if (this.apis[chainId]) {
@@ -41,11 +35,7 @@ export class StakingApiManager implements IStakingApiManager {
       .getChain(chainId)
       .then(ChainSchema.parse);
 
-    // TODO: remove this check and the associated configuration once Base is
-    // fully migrated to the Kiln mainnet API.
-    const isBaseTestnet =
-      chainId === this.BASE_CHAIN_ID && !this.isBaseProductionActive;
-    const env = isBaseTestnet || chain.isTestnet ? 'testnet' : 'mainnet';
+    const env = chain.isTestnet ? 'testnet' : 'mainnet';
 
     const baseUrl = this.configurationService.getOrThrow<string>(
       `staking.${env}.baseUri`,


### PR DESCRIPTION
## Summary

Due to Kiln deployment restrictions, we temporarily set Base to use their testnet deployments on prod. As we are now able to successfully test this by using a separate Transaction Service deployment, this removes the workaround code.

Note: we need to remove the `STAKING_BASE_PRODUCTION_ACTIVE` env. var. as well.

## Changes

- Remove usage of Kiln testnet deployment on prod. from `StakingApiManager`
- Remove all associated config.