### PR TITLE
feat: add priority:high to android push notification

### DIFF
--- a/src/datasources/push-notifications-api/entities/firebase-notification.entity.ts
+++ b/src/datasources/push-notifications-api/entities/firebase-notification.entity.ts
@@ -24,3 +24,9 @@ export type FireabaseNotificationApn = {
     };
   };
 };
+
+export type FirebaseAndroidMessageConfig = {
+  android: {
+    priority: 'high' | 'normal';
+  };
+};

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -109,6 +109,9 @@ describe('FirebaseCloudMessagingApiService', () => {
               },
             },
           },
+          android: {
+            priority: 'high',
+          },
         },
       },
       networkRequest: {
@@ -157,6 +160,9 @@ describe('FirebaseCloudMessagingApiService', () => {
                 'mutable-content': 1,
               },
             },
+          },
+          android: {
+            priority: 'high',
           },
         },
       },

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -11,6 +11,7 @@ import {
 import { IPushNotificationsApi } from '@/domain/interfaces/push-notifications-api.interface';
 import { Inject, Injectable } from '@nestjs/common';
 import {
+  FirebaseAndroidMessageConfig,
   FireabaseNotificationApn,
   FirebaseNotification,
   NotificationContent,
@@ -104,6 +105,17 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
   }
 
   /**
+   * Returns the Android message config for the notification.
+   *
+   * @returns {FirebaseAndroidMessageConfig} - Android message config
+   **/
+  private getAndroidMessageConfig(): FirebaseAndroidMessageConfig {
+    return {
+      android: { priority: 'high' },
+    };
+  }
+
+  /**
    * Enqueues a notification to be sent to a device with given FCM token.
    *
    * @param fcmToken - device's FCM token
@@ -123,6 +135,7 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
             token: fcmToken,
             ...notification,
             ...this.getIosNotificationData(notification.notification),
+            ...this.getAndroidMessageConfig(),
           },
         },
         networkRequest: {


### PR DESCRIPTION
## Summary
Ads a priority high flag on the push notification sent to android.

Resolves https://github.com/safe-global/safe-client-gateway/issues/2578

## Changes
By adding high priority to the push notification Android passes the notification to the app even when it is in the background. 