### PR TITLE
feat: update rabbitmq image to management-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,10 @@ services:
       -c hba_file=/etc/pg_hba.conf
 
   rabbitmq:
-    image: rabbitmq:alpine
+    image: rabbitmq:management-alpine
     ports:
       - '5672:5672'
+      - '15672:15672'
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 15s


### PR DESCRIPTION
## Summary
This PR switches the RabbitMQ service to use the `management-alpine` image, enabling the management plugin and exposing the management interface.

## Changes
- Changed the rabbitmq docker image to the `management-alpine` image