### PR TITLE
fix: update amqplib dependency from 0.10.5 to 0.10.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@nestjs/typeorm": "11.0.0",
     "@safe-global/safe-deployments": "1.37.30",
     "amqp-connection-manager": "4.1.14",
-    "amqplib": "0.10.5",
+    "amqplib": "0.10.8",
     "cache-manager": "6.4.1",
     "cookie-parser": "1.4.7",
     "jsonwebtoken": "9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,17 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@acuminous/bitsyntax@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "@acuminous/bitsyntax@npm:0.1.2"
-  dependencies:
-    buffer-more-ints: "npm:~1.0.0"
-    debug: "npm:^4.3.4"
-    safe-buffer: "npm:~5.1.2"
-  checksum: 10/abdc4313ae08e52fb8eeaebf53759c3b9a38983a696d77c46c24de1c065247355a1b5c02ad3618700d3fb3628ccf3ec39227a080bd1fe7adc864144ccf84b0cc
-  languageName: node
-  linkType: hard
-
 "@adraffy/ens-normalize@npm:^1.10.1":
   version: 1.11.0
   resolution: "@adraffy/ens-normalize@npm:1.11.0"
@@ -4130,14 +4119,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"amqplib@npm:0.10.5":
-  version: 0.10.5
-  resolution: "amqplib@npm:0.10.5"
+"amqplib@npm:0.10.8":
+  version: 0.10.8
+  resolution: "amqplib@npm:0.10.8"
   dependencies:
-    "@acuminous/bitsyntax": "npm:^0.1.2"
     buffer-more-ints: "npm:~1.0.0"
     url-parse: "npm:~1.5.10"
-  checksum: 10/bcf4bda790f8a356ba4c7d3054ae3ee397a48d6c4d51f1015f703dd7205c097ba9772577567a06eb470d13e0becdc4163c857299e50eb5a4bc888e3007832f87
+  checksum: 10/63f4ca383d76746746f4c2559062caa08de201fdb5d8c3263582500ae43eb07c2053ffe1c1a0bd4c615ddf67655d9e632646f7bc43e71cc99a66f76138c47202
   languageName: node
   linkType: hard
 
@@ -8907,7 +8895,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1, safe-buffer@npm:~5.1.2":
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: 10/7eb5b48f2ed9a594a4795677d5a150faa7eb54483b2318b568dc0c4fc94092a6cce5be02c7288a0500a156282f5276d5688bce7259299568d1053b2150ef374a
@@ -8947,7 +8935,7 @@ __metadata:
     "@types/semver": "npm:7.7.0"
     "@types/supertest": "npm:6.0.2"
     amqp-connection-manager: "npm:4.1.14"
-    amqplib: "npm:0.10.5"
+    amqplib: "npm:0.10.8"
     aws-sdk-client-mock: "npm:4.1.0"
     cache-manager: "npm:6.4.1"
     cookie-parser: "npm:1.4.7"


### PR DESCRIPTION
## Summary
This PR resolves a connection error with the newest RabbitMQ version:
`negotiated frame_max = 4096 is lower than the minimum allowed value (8192)`
The previous version of amqplib hardcoded or defaulted to a frame_max of `4096`, which is below the minimum accepted by newer RabbitMQ versions. As a result, AMQP connection attempts failed during negotiation. This fix ensures compatibility with the server’s minimum frame size requirement.

## Changes
- Upgraded amqplib to the latest version to avoid hardcoded low frame_max defaults.
- Verified successful connection negotiation with frame_max ≥ 8192.