### PR TITLE
feat: add ORM cache configuration and enable Redis caching support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -165,3 +165,10 @@
 
 # Targeted Messaging
 # TARGETED_MESSAGING_FILE_STORAGE_TYPE=
+
+# Database
+
+# The ORM query cache status
+# (value: true/false)
+# (default=false)
+# ORM_CACHE_ENABLED=

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -137,8 +137,12 @@ export class AppModule implements NestModule {
             loggingService: ILoggingService,
           ) => {
             const typeormConfig = configService.getOrThrow('db.orm');
+            const cache = configService.get('db.orm.cache');
             const postgresConfigObject = postgresConfig(
-              configService.getOrThrow('db.connection.postgres'),
+              {
+                ...configService.getOrThrow('db.connection.postgres'),
+                cache,
+              },
               loggingService,
             );
 

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -119,6 +119,7 @@ export default (): ReturnType<typeof configuration> => ({
       manualInitialization: true,
       migrationsRun: false,
       migrationsTableName: '_migrations',
+      cache: false,
     },
     connection: {
       postgres: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -182,6 +182,19 @@ export default () => ({
       // The name of the table where migrations are stored. Uses the environment variable value or defaults to '_migrations'.
       migrationsTableName:
         process.env.ORM_MIGRATION_TABLE_NAME || '_migrations',
+      cache:
+        process.env.ORM_CACHE_ENABLED?.toLowerCase() === 'true'
+          ? {
+              type: 'redis',
+              options: {
+                host: process.env.REDIS_HOST || 'localhost',
+                port: process.env.REDIS_PORT || '6379',
+                username: process.env.REDIS_USER,
+                password: process.env.REDIS_PASS,
+                duration: parseInt(process.env.ORM_CACHE_DURATION ?? `${1000}`),
+              },
+            }
+          : false,
     },
     connection: {
       postgres: {

--- a/src/config/entities/postgres.config.ts
+++ b/src/config/entities/postgres.config.ts
@@ -16,6 +16,16 @@ interface IPostgresEnvConfig {
     requestCert: boolean;
     rejectUnauthorized: boolean;
   };
+  cache?: {
+    type: 'redis';
+    options: {
+      host: string;
+      port: string;
+      username: string;
+      password: string;
+    };
+    duration: number;
+  };
 }
 
 export const postgresConfig = (
@@ -41,6 +51,7 @@ export const postgresConfig = (
     database: postgresEnvConfig.database,
     migrations: ['dist/migrations/*.js'],
     logger: logger ? new PostgresqlLogger(logger) : undefined,
+    cache: postgresEnvConfig.cache,
     ssl: isSslEnabled
       ? {
           ca: postgresCa,


### PR DESCRIPTION
## Summary 
This PR introduces configuration options for ORM caching, allowing the use of Redis for caching database queries. This change enhances performance by reducing database load through effective caching mechanisms.

## Changes
- Added cache configurations to TypeOrm Config.
- Added a new environment variable to toggle query caching.