### PR TITLE
feat: enable query caching for notifications and remove deprecated methods

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -235,6 +235,7 @@ export default (): ReturnType<typeof configuration> => ({
       clientEmail: faker.internet.email(),
       privateKey: faker.string.alphanumeric(),
     },
+    getSubscribersBySafeTtlMilliseconds: faker.number.int({ min: 1, max: 100 }),
   },
   redis: {
     user: process.env.REDIS_USER,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -191,8 +191,8 @@ export default () => ({
                 port: process.env.REDIS_PORT || '6379',
                 username: process.env.REDIS_USER,
                 password: process.env.REDIS_PASS,
-                duration: parseInt(process.env.ORM_CACHE_DURATION ?? `${1000}`),
               },
+              duration: parseInt(process.env.ORM_CACHE_DURATION ?? `${1000}`),
             }
           : false,
     },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -361,6 +361,10 @@ export default () => ({
       privateKey:
         process.env.PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY,
     },
+    getSubscribersBySafeTtlMilliseconds: +(
+      process.env.PUSH_NOTIFICATIONS_GET_SUBSCRIBERS_BY_SAFE_TTL_MILLISECONDS ||
+      60 * 1_000
+    ),
   },
   redis: {
     user: process.env.REDIS_USER,

--- a/src/datasources/db/v2/__tests__/entity-manager.mock.ts
+++ b/src/datasources/db/v2/__tests__/entity-manager.mock.ts
@@ -1,10 +1,13 @@
+import { mockPostgresDataSource } from '@/datasources/db/v2/__tests__/postgresql-datasource.mock';
 import { mockQueryBuilder } from '@/datasources/db/v2/__tests__/querybuilder.mock';
 import type { EntityManager } from 'typeorm';
 
 export const mockEntityManager = {
   find: jest.fn(),
+  findOneOrFail: jest.fn(),
   query: jest.fn(),
   upsert: jest.fn(),
   createQueryBuilder: jest.fn().mockImplementation(() => mockQueryBuilder),
   getRepository: jest.fn(),
+  connection: mockPostgresDataSource,
 } as jest.MockedObjectDeep<EntityManager>;

--- a/src/datasources/db/v2/__tests__/postgresql-datasource.mock.ts
+++ b/src/datasources/db/v2/__tests__/postgresql-datasource.mock.ts
@@ -1,7 +1,13 @@
 import type { DataSource } from 'typeorm';
+import { type QueryResultCache } from 'typeorm/cache/QueryResultCache';
+
+export const mockQueryResultCache = {
+  remove: jest.fn(),
+} as jest.MockedObjectDeep<QueryResultCache>;
 
 export const mockPostgresDataSource = {
   query: jest.fn(),
   runMigrations: jest.fn(),
   initialize: jest.fn(),
+  queryResultCache: mockQueryResultCache,
 } as jest.MockedObjectDeep<DataSource>;

--- a/src/domain/notifications/v2/entities/__tests__/notification.repository.mock.ts
+++ b/src/domain/notifications/v2/entities/__tests__/notification.repository.mock.ts
@@ -6,7 +6,6 @@ export const MockNotificationRepositoryV2: jest.MockedObjectDeep<INotificationsR
     upsertSubscriptions: jest.fn(),
     getSafeSubscription: jest.fn(),
     getSubscribersBySafe: jest.fn(),
-    deleteDeviceAndSubscriptions: jest.fn(),
     deleteSubscription: jest.fn(),
     deleteDevice: jest.fn(),
   };

--- a/src/domain/notifications/v2/notifications.repository.integration.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.integration.spec.ts
@@ -39,8 +39,15 @@ describe('NotificationsRepositoryV2', () => {
       if (key === 'db.migrator.retryAfterMs') {
         return config.db.migrator.retryAfterMs;
       }
+      if (key === 'pushNotifications.getSubscribersBySafeTtlMilliseconds') {
+        return faker.number.int({
+          min: 10000,
+          max: 70000,
+        });
+      }
     }),
   } as jest.MockedObjectDeep<ConfigService>;
+  const databaseCacheTableName = 'query-result-cache';
 
   const config = configuration();
   const testDatabaseName = faker.string.alpha({ length: 10, casing: 'lower' });
@@ -50,6 +57,14 @@ describe('NotificationsRepositoryV2', () => {
       type: 'postgres',
       database: testDatabaseName,
     }),
+    cache: {
+      type: 'database',
+      tableName: databaseCacheTableName,
+      duration: mockConfigService.getOrThrow(
+        'pushNotifications.getSubscribersBySafeTtlMilliseconds',
+      ),
+    },
+    synchronize: true,
     migrationsTableName: config.db.orm.migrationsTableName,
     entities: [
       NotificationType,
@@ -182,6 +197,7 @@ describe('NotificationsRepositoryV2', () => {
       mockPushNotificationsApi,
       mockLoggingService,
       postgresDatabaseService,
+      mockConfigService,
     );
   });
 
@@ -217,6 +233,111 @@ describe('NotificationsRepositoryV2', () => {
       expect(dataSource.transaction).toHaveBeenCalledTimes(1);
       expect(device).toHaveProperty('device_uuid');
       expect(device?.device_uuid).toBe(upsertSubscriptionsDto.deviceUuid);
+    });
+
+    it('Should remove subscriptions cache when upserting a subscription', async () => {
+      jest.spyOn(dataSource, 'transaction');
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayload = new AuthPayload(authPayloadDto);
+      const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+      const cacheKeys: Array<string> = [];
+      for (const safe of upsertSubscriptionsDto.safes) {
+        cacheKeys.push(`getSubscribersBySafe-${safe.chainId}-${safe.address}`);
+        await notificationsRepositoryService.getSubscribersBySafe({
+          chainId: safe.chainId,
+          safeAddress: safe.address,
+        });
+      }
+      const cacheKeysArray = cacheKeys.join("','");
+      const cacheResult: Array<{ id: number }> = await postgresDatabaseService
+        .getDataSource()
+        .query(
+          `SELECT id FROM "${databaseCacheTableName}" WHERE identifier IN('${cacheKeysArray}');`,
+        );
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+      const cacheResultNew: Array<{ id: number }> =
+        await postgresDatabaseService
+          .getDataSource()
+          .query(`SELECT id FROM "${databaseCacheTableName}";`);
+
+      expect(cacheResult).toHaveLength(upsertSubscriptionsDto.safes.length);
+      expect(cacheResultNew).toHaveLength(0);
+    });
+
+    it('Should not remove other devices subscriptions cache when upserting a new subscription', async () => {
+      jest.spyOn(dataSource, 'transaction');
+      const authPayloadDto_1 = authPayloadDtoBuilder().build();
+      const authPayloadDto_2 = authPayloadDtoBuilder().build();
+      const authPayload_1 = new AuthPayload(authPayloadDto_1);
+      const upsertSubscriptionsDto_1 = upsertSubscriptionsDtoBuilder().build();
+      const authPayload_2 = new AuthPayload(authPayloadDto_2);
+      const upsertSubscriptionsDto_2 = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload: authPayload_1,
+        upsertSubscriptionsDto: upsertSubscriptionsDto_1,
+      });
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload: authPayload_2,
+        upsertSubscriptionsDto: upsertSubscriptionsDto_2,
+      });
+
+      const cacheKeys_1: Array<string> = [];
+      for (const safe of upsertSubscriptionsDto_1.safes) {
+        cacheKeys_1.push(
+          `getSubscribersBySafe-${safe.chainId}-${safe.address}`,
+        );
+        await notificationsRepositoryService.getSubscribersBySafe({
+          chainId: safe.chainId,
+          safeAddress: safe.address,
+        });
+      }
+      const cacheKeys_2: Array<string> = [];
+      for (const safe of upsertSubscriptionsDto_2.safes) {
+        cacheKeys_2.push(
+          `getSubscribersBySafe-${safe.chainId}-${safe.address}`,
+        );
+        await notificationsRepositoryService.getSubscribersBySafe({
+          chainId: safe.chainId,
+          safeAddress: safe.address,
+        });
+      }
+      const cacheKeysArray_1 = cacheKeys_1.join("','");
+      const cacheResult_1_old: Array<{ id: number }> =
+        await postgresDatabaseService
+          .getDataSource()
+          .query(
+            `SELECT id FROM "${databaseCacheTableName}" WHERE identifier IN('${cacheKeysArray_1}');`,
+          );
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload: authPayload_1,
+        upsertSubscriptionsDto: upsertSubscriptionsDto_1,
+      });
+      const cacheResult_1_new: Array<{ id: number }> =
+        await postgresDatabaseService
+          .getDataSource()
+          .query(
+            `SELECT id FROM "${databaseCacheTableName}" WHERE identifier IN('${cacheKeysArray_1}');`,
+          );
+      const cacheResult_2: Array<{ id: number }> = await postgresDatabaseService
+        .getDataSource()
+        .query(`SELECT id FROM "${databaseCacheTableName}";`);
+
+      expect(cacheResult_1_old).toHaveLength(
+        upsertSubscriptionsDto_1.safes.length,
+      );
+      expect(cacheResult_1_new).toHaveLength(0);
+      expect(cacheResult_2).toHaveLength(upsertSubscriptionsDto_2.safes.length);
     });
 
     it('Should deletePreviousSubscriptions() when upserting a subscription', async () => {
@@ -483,6 +604,38 @@ describe('NotificationsRepositoryV2', () => {
 
       expect(safeSubscription).toHaveProperty('subscriber');
       expect(secondSafeSubscription).toHaveProperty('subscriber');
+    });
+
+    it('Should cache safe subscribers successfully', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayload = new AuthPayload(authPayloadDto);
+      const secondAuthPayloadDto = authPayloadDtoBuilder().build();
+      const secondAuthPayload = new AuthPayload(secondAuthPayloadDto);
+      const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload: secondAuthPayload,
+        upsertSubscriptionsDto,
+      });
+
+      await notificationsRepositoryService.getSubscribersBySafe({
+        chainId: upsertSubscriptionsDto.safes[0].chainId,
+        safeAddress: upsertSubscriptionsDto.safes[0].address,
+      });
+
+      const cacheKey = `getSubscribersBySafe-${upsertSubscriptionsDto.safes[0].chainId}-${upsertSubscriptionsDto.safes[0].address}`;
+
+      const cacheResult = await postgresDatabaseService
+        .getDataSource()
+        .query(
+          `SELECT id FROM "${databaseCacheTableName}" WHERE identifier = '${cacheKey}';`,
+        );
+
+      expect(cacheResult).toHaveLength(1);
     });
 
     it('Should return an empty array if no subscriber exists', async () => {

--- a/src/domain/notifications/v2/notifications.repository.integration.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.integration.spec.ts
@@ -58,6 +58,9 @@ describe('NotificationsRepositoryV2', () => {
       database: testDatabaseName,
     }),
     cache: {
+      /**
+       * @todo Test against Redis
+       */
       type: 'database',
       tableName: databaseCacheTableName,
       duration: mockConfigService.getOrThrow(

--- a/src/domain/notifications/v2/notifications.repository.interface.ts
+++ b/src/domain/notifications/v2/notifications.repository.interface.ts
@@ -27,8 +27,6 @@ export interface INotificationsRepositoryV2 {
     safeAddress: `0x${string}`;
   }): Promise<Array<NotificationType>>;
 
-  deleteDeviceAndSubscriptions(deviceUUid: UUID): Promise<void>;
-
   getSubscribersBySafe(args: {
     chainId: string;
     safeAddress: `0x${string}`;

--- a/src/routes/notifications/v1/notifications.controller.ts
+++ b/src/routes/notifications/v1/notifications.controller.ts
@@ -57,9 +57,7 @@ export class NotificationsController {
       // Some clients, such as the mobile app, do not call the delete endpoint to remove an owner key.
       // Instead, they resend the updated list of owners without the key they want to delete.
       // In such cases, we need to clear all the previous owners to ensure the update is applied correctly.
-      await this.notificationServiceV2.deleteDeviceAndSubscriptions(
-        registerDeviceDto.uuid,
-      );
+      await this.notificationServiceV2.deleteDevice(registerDeviceDto.uuid);
     }
 
     for (const compatibleV2Request of compatibleV2Requests) {

--- a/src/routes/notifications/v2/notifications.service.ts
+++ b/src/routes/notifications/v2/notifications.service.ts
@@ -21,12 +21,6 @@ export class NotificationsServiceV2 {
     return this.notificationsRepository.upsertSubscriptions(args);
   }
 
-  async deleteDeviceAndSubscriptions(deviceUuidd: UUID): Promise<void> {
-    await this.notificationsRepository.deleteDeviceAndSubscriptions(
-      deviceUuidd,
-    );
-  }
-
   async getSafeSubscription(args: {
     authPayload: AuthPayload;
     deviceUuid: UUID;

--- a/src/routes/notifications/v2/test.notifications.module.ts
+++ b/src/routes/notifications/v2/test.notifications.module.ts
@@ -6,7 +6,6 @@ const MockedNotificationsServiceV2 = {
   getSafeSubscription: jest.fn(),
   deleteSubscription: jest.fn(),
   deleteDevice: jest.fn(),
-  deleteDeviceAndSubscriptions: jest.fn(),
 } as jest.MockedObjectDeep<NotificationsServiceV2>;
 
 @Module({


### PR DESCRIPTION
## Summary

This PR introduces query caching for fetching notificaiton subscribers by safe, enhancing performance. Remove the deprecated `deleteDeviceAndSubscriptions` method.

## Changes

- Enabled notification query caching
- Covered the caching logic by tests
- Adjusted unit tests
- Added a new flag to upsert ORM queries to skip the update step if no values have changed