### PR TITLE
fix: also decode Vault `withdraw` transactions

### DIFF
--- a/src/routes/transactions/helpers/kiln-vault.helper.ts
+++ b/src/routes/transactions/helpers/kiln-vault.helper.ts
@@ -46,7 +46,7 @@ export class KilnVaultHelper extends Erc4262Decoder {
     };
   }
 
-  public getVaultRedeemTransaction(
+  public getVaultRedeemOrWithdrawTransaction(
     args: Pick<
       MultisigTransaction | ModuleTransaction,
       'to' | 'data' | 'value'
@@ -56,10 +56,17 @@ export class KilnVaultHelper extends Erc4262Decoder {
     data: `0x${string}`;
     assets: number;
   } | null {
-    const decoded = this.getDecodedTransaction({
-      functionName: 'redeem',
-      transaction: args,
-    });
+    const decoded =
+      // redeem = full withdrawal from Vault
+      this.getDecodedTransaction({
+        functionName: 'redeem',
+        transaction: args,
+      }) ??
+      // withdraw = partial withdrawal from Vault
+      this.getDecodedTransaction({
+        functionName: 'withdraw',
+        transaction: args,
+      });
 
     if (!decoded) {
       return null;

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -416,23 +416,23 @@ export class MultisigTransactionInfoMapper {
       return null;
     }
 
-    const vaultRedeemTransaction =
-      this.kilnVaultHelper.getVaultRedeemTransaction({
+    const vaultRedeemOrWithdrawTransaction =
+      this.kilnVaultHelper.getVaultRedeemOrWithdrawTransaction({
         to: args.transaction.to,
         data: args.transaction.data,
         value: args.transaction.value,
       });
 
-    if (!vaultRedeemTransaction?.to) {
+    if (!vaultRedeemOrWithdrawTransaction?.to) {
       return null;
     }
 
     try {
       return await this.vaultTransactionMapper.mapRedeemInfo({
         chainId: args.chainId,
-        to: vaultRedeemTransaction.to,
-        assets: vaultRedeemTransaction.assets,
-        data: vaultRedeemTransaction.data,
+        to: vaultRedeemOrWithdrawTransaction.to,
+        assets: vaultRedeemOrWithdrawTransaction.assets,
+        data: vaultRedeemOrWithdrawTransaction.data,
         safeAddress: args.transaction.safe,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Currently, we decode the `redeem` methods of Vault iteractions (full withdrawal of assets). When partially withdrawing assets, however, the `withdraw` method is used instead.

This applies the existing decoding logic to `withdraw` transactions as the function signature matches that of `redeem`. It therefore also decodes to `VaultRedeemTransactionInfo` but this is irrelevant client-side.

## Changes

- Fallback to decoding `withdraw` transactions of Vaults
- Rename methods accordingly