### PR TITLE
fix: reduce caching on staging Base

### DIFF
--- a/src/datasources/balances-api/balances-api.manager.spec.ts
+++ b/src/datasources/balances-api/balances-api.manager.spec.ts
@@ -74,6 +74,8 @@ beforeEach(() => {
     if (key === 'features.zerionBalancesChainIds')
       return ZERION_BALANCES_CHAIN_IDS;
     if (key === 'features.counterfactualBalances') return true;
+    // TODO: Remove after Vault decoding has been released
+    else if (key === 'application.isProduction') return true;
   });
 });
 
@@ -154,6 +156,8 @@ describe('Balances API Manager Tests', () => {
         else if (key === 'features.zerionBalancesChainIds')
           return ZERION_BALANCES_CHAIN_IDS;
         else if (key === 'features.counterfactualBalances') return true;
+        // TODO: Remove after Vault decoding has been released
+        else if (key === 'application.isProduction') return true;
         throw new Error(`Unexpected key: ${key}`);
       });
       configApiMock.getChain.mockResolvedValue(rawify(chain));

--- a/src/datasources/balances-api/safe-balances-api.service.ts
+++ b/src/datasources/balances-api/safe-balances-api.service.ts
@@ -27,6 +27,7 @@ export class SafeBalancesApi implements IBalancesApi {
   private readonly defaultNotFoundExpirationTimeSeconds: number;
   private static readonly DEFAULT_DECIMALS = 18;
   private static readonly HOODI_CHAIN_ID = '560048';
+  private static readonly BASE_CHAIN_ID = '8453';
 
   constructor(
     private readonly chainId: string,
@@ -37,8 +38,15 @@ export class SafeBalancesApi implements IBalancesApi {
     private readonly httpErrorFactory: HttpErrorFactory,
     private readonly coingeckoApi: IPricesApi,
   ) {
+    const isProduction = this.configurationService.getOrThrow<boolean>(
+      'application.isProduction',
+    );
     // TODO: Remove temporary cache times for Hoodi chain.
-    if (chainId === SafeBalancesApi.HOODI_CHAIN_ID) {
+    if (
+      chainId === SafeBalancesApi.HOODI_CHAIN_ID ||
+      // TODO: Remove after Vault decoding has been released
+      (!isProduction && chainId === SafeBalancesApi.BASE_CHAIN_ID)
+    ) {
       const hoodiExpirationTime = this.configurationService.getOrThrow<number>(
         'expirationTimeInSeconds.hoodi',
       );

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -75,6 +75,8 @@ describe('Transaction API Manager Tests', () => {
       else if (key === 'expirationTimeInSeconds.notFound.token')
         return notFoundExpireTimeSeconds;
       else if (key === 'owners.ownersTtlSeconds') return ownersTtlSeconds;
+      // TODO: Remove after Vault decoding has been released
+      else if (key === 'application.isProduction') return true;
 
       throw new Error(`Unexpected key: ${key}`);
     });

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -93,6 +93,10 @@ describe('TransactionApi', () => {
       if (key === 'owners.ownersTtlSeconds') {
         return ownersTtlSeconds;
       }
+      // TODO: Remove after Vault decoding has been released
+      if (key === 'application.isProduction') {
+        return true;
+      }
       throw Error(`Unexpected key: ${key}`);
     });
 
@@ -2734,6 +2738,10 @@ describe('TransactionApi', () => {
         }
         if (key === 'owners.ownersTtlSeconds') {
           return ownersTtlSeconds;
+        }
+        // TODO: Remove after Vault decoding has been released
+        if (key === 'application.isProduction') {
+          return true;
         }
         throw Error(`Unexpected key: ${key}`);
       });

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -36,6 +36,9 @@ export class TransactionApi implements ITransactionApi {
   private static readonly ERROR_ARRAY_PATH = 'nonFieldErrors';
   private static readonly HOODI_CHAIN_ID = '560048';
 
+  // TODO: Remove after Vault decoding has been released
+  private static readonly BASE_CHAIN_ID = '8453';
+
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly indexingExpirationTimeInSeconds: number;
   private readonly defaultNotFoundExpirationTimeSeconds: number;
@@ -58,8 +61,15 @@ export class TransactionApi implements ITransactionApi {
         'expirationTimeInSeconds.indexing',
       );
 
+    const isProduction = this.configurationService.getOrThrow<boolean>(
+      'application.isProduction',
+    );
     // TODO: Remove temporary cache times for Hoodi chain.
-    if (chainId === TransactionApi.HOODI_CHAIN_ID) {
+    if (
+      chainId === TransactionApi.HOODI_CHAIN_ID ||
+      // TODO: Remove after Vault decoding has been released
+      (!isProduction && chainId === TransactionApi.BASE_CHAIN_ID)
+    ) {
       const hoodiExpirationTime = this.configurationService.getOrThrow<number>(
         'expirationTimeInSeconds.hoodi',
       );


### PR DESCRIPTION
## Summary

We reduce caching for Hoodi (prev. Holesky) as the Transaction Service is not maintained by us, meaning we receive no hooks used for invalidation.

As we need to temporarily test with Base on staging, this propagates the cache reduction for non-production Base.

## Changes

- Reduce caching of balances/Transaction Service on non-production Base.