### PR TITLE
feat: Add ORM query cache key and Redis integration for notifications tests

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -187,12 +187,18 @@ export default () => ({
           ? {
               type: 'redis',
               options: {
-                host: process.env.REDIS_HOST || 'localhost',
-                port: process.env.REDIS_PORT || '6379',
+                socket: {
+                  host: process.env.REDIS_HOST || 'localhost',
+                  port: process.env.REDIS_PORT || '6379',
+                },
                 username: process.env.REDIS_USER,
                 password: process.env.REDIS_PASS,
               },
               duration: parseInt(process.env.ORM_CACHE_DURATION ?? `${1000}`),
+              /**
+               * @todo Fix the underlying issue with the Redis client shutting down
+               */
+              ignoreErrors: true,
             }
           : false,
     },

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -71,6 +71,7 @@ export class CacheRouter {
   private static readonly UNSUPPORTED_CHAIN_EVENT = 'unsupported_chain_event';
   private static readonly ZERION_BALANCES_KEY = 'zerion_balances';
   private static readonly ZERION_COLLECTIBLES_KEY = 'zerion_collectibles';
+  private static readonly ORM_QUERY_CACHE_KEY = 'orm_query_cache';
 
   static getAuthNonceCacheKey(nonce: string): string {
     return `${CacheRouter.AUTH_NONCE_KEY}_${nonce}`;
@@ -786,5 +787,22 @@ export class CacheRouter {
    */
   static getMemoryKey(cacheDir: CacheDir): string {
     return `${cacheDir.key}:${cacheDir.field}`;
+  }
+
+  /**
+   * Gets Redis cache key for the ORM query cache.
+   *
+   * @param {string} prefix - Prefix for the cache key
+   * @param {string} chainId - Chain ID
+   * @param {string} safeAddress - Safe address
+   *
+   * @returns {string} - Cache key
+   */
+  static getOrnCacheKey(
+    prefix: string,
+    chainId: string,
+    safeAddress: `0x${string}`,
+  ): string {
+    return `${CacheRouter.ORM_QUERY_CACHE_KEY}:${prefix}:${chainId}:${safeAddress}`;
   }
 }

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -20,6 +20,7 @@ import { EntityManager, In } from 'typeorm';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { NotificationSubscriptionNotificationType } from '@/datasources/notifications/entities/notification-subscription-notification-type.entity.db';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
 
 @Injectable()
 export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
@@ -427,7 +428,11 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
     chainId: string;
     safeAddress: `0x${string}`;
   }): string {
-    return `getSubscribersBySafe-${args.chainId}-${args.safeAddress}`;
+    return CacheRouter.getOrnCacheKey(
+      'getSubscribersBySafe',
+      args.chainId,
+      args.safeAddress,
+    );
   }
 
   private async removeGetSubscribersBySafeCache(args: {


### PR DESCRIPTION
## Summary
This PR introduces a cache key for ORM queries and update the notification repository integration tests to utilize Redis for caching, enhancing performance and scalability.

## Changes
- Added a new cache key for the Orm query cache.
- Changed the cache engine of notification integration tests to Redis