### PR TITLE
feat: add earn datasource and domain for vault mapping

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -139,6 +139,16 @@ export default (): ReturnType<typeof configuration> => ({
       },
     },
   },
+  earn: {
+    testnet: {
+      baseUri: faker.internet.url({ appendSlash: false }),
+      apiKey: faker.string.hexadecimal({ length: 32 }),
+    },
+    mainnet: {
+      baseUri: faker.internet.url({ appendSlash: false }),
+      apiKey: faker.string.hexadecimal({ length: 32 }),
+    },
+  },
   email: {
     applicationCode: faker.string.alphanumeric(),
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -155,6 +155,10 @@ export default () => ({
       apiKey: process.env.INFURA_API_KEY,
     },
   },
+  bridge: {
+    baseUri: 'https://li.quest',
+    apiKey: process.env.BRIDGE_API_KEY,
+  },
   contracts: {
     trustedForDelegateCall: {
       maxSequentialPages: parseInt(
@@ -223,19 +227,6 @@ export default () => ({
           caPath: process.env.POSTGRES_SSL_CA_PATH,
         },
       },
-    },
-  },
-  // TODO: Unify base URLs with staking
-  earn: {
-    testnet: {
-      baseUri:
-        process.env.STAKING_TESTNET_API_BASE_URI ||
-        'https://api.testnet.kiln.fi',
-      apiKey: process.env.EARN_TESTNET_API_KEY,
-    },
-    mainnet: {
-      baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
-      apiKey: process.env.EARN_MAINNET_API_KEY,
     },
   },
   email: {
@@ -340,7 +331,7 @@ export default () => ({
   },
   log: {
     level: process.env.LOG_LEVEL || 'debug',
-    silent: true,
+    silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
     prettyColorize: process.env.LOG_PRETTY_COLORIZE?.toLowerCase() === 'true',
   },
   owners: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -26,18 +26,6 @@ export default () => ({
         process.env.COUNTERFACTUAL_SAFES_CREATION_RATE_LIMIT_CALLS_BY_PERIOD ??
           `${25}`,
       ),
-    }, // TODO: Unify base URLs with staking
-    earn: {
-      testnet: {
-        baseUri:
-          process.env.STAKING_TESTNET_API_BASE_URI ||
-          'https://api.testnet.kiln.fi',
-        apiKey: process.env.EARN_TESTNET_API_KEY,
-      },
-      mainnet: {
-        baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
-        apiKey: process.env.EARN_MAINNET_API_KEY,
-      },
     },
     encryption: {
       // The encryption type to use. Defaults to 'local'.
@@ -235,6 +223,18 @@ export default () => ({
           caPath: process.env.POSTGRES_SSL_CA_PATH,
         },
       },
+    },
+  }, // TODO: Unify base URLs with staking
+  earn: {
+    testnet: {
+      baseUri:
+        process.env.STAKING_TESTNET_API_BASE_URI ||
+        'https://api.testnet.kiln.fi',
+      apiKey: process.env.EARN_TESTNET_API_KEY,
+    },
+    mainnet: {
+      baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
+      apiKey: process.env.EARN_MAINNET_API_KEY,
     },
   },
   email: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -26,6 +26,18 @@ export default () => ({
         process.env.COUNTERFACTUAL_SAFES_CREATION_RATE_LIMIT_CALLS_BY_PERIOD ??
           `${25}`,
       ),
+    }, // TODO: Unify base URLs with staking
+    earn: {
+      testnet: {
+        baseUri:
+          process.env.STAKING_TESTNET_API_BASE_URI ||
+          'https://api.testnet.kiln.fi',
+        apiKey: process.env.EARN_TESTNET_API_KEY,
+      },
+      mainnet: {
+        baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
+        apiKey: process.env.EARN_MAINNET_API_KEY,
+      },
     },
     encryption: {
       // The encryption type to use. Defaults to 'local'.
@@ -154,10 +166,6 @@ export default () => ({
     infura: {
       apiKey: process.env.INFURA_API_KEY,
     },
-  },
-  bridge: {
-    baseUri: 'https://li.quest',
-    apiKey: process.env.BRIDGE_API_KEY,
   },
   contracts: {
     trustedForDelegateCall: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -225,6 +225,19 @@ export default () => ({
       },
     },
   },
+  // TODO: Unify base URLs with staking
+  earn: {
+    testnet: {
+      baseUri:
+        process.env.STAKING_TESTNET_API_BASE_URI ||
+        'https://api.testnet.kiln.fi',
+      apiKey: process.env.EARN_TESTNET_API_KEY,
+    },
+    mainnet: {
+      baseUri: process.env.STAKING_API_BASE_URI || 'https://api.kiln.fi',
+      apiKey: process.env.EARN_MAINNET_API_KEY,
+    },
+  },
   email: {
     applicationCode: process.env.EMAIL_API_APPLICATION_CODE,
     baseUri: process.env.EMAIL_API_BASE_URI || 'https://api.pushwoosh.com',
@@ -327,7 +340,7 @@ export default () => ({
   },
   log: {
     level: process.env.LOG_LEVEL || 'debug',
-    silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
+    silent: true,
     prettyColorize: process.env.LOG_PRETTY_COLORIZE?.toLowerCase() === 'true',
   },
   owners: {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -601,50 +601,71 @@ export class CacheRouter {
     );
   }
 
+  // TODO: Remove url from the following cache keys where it isn't required
+  // e.g. when fetching a specific address
+
   // Kiln uses different endpoints for mainnet/testnet
   static getStakingDeploymentsCacheDir(url: string): CacheDir {
     return new CacheDir(`${this.STAKING_DEPLOYMENTS_KEY}_${url}`, '');
   }
 
-  static getStakingNetworkStatsCacheDir(): CacheDir {
-    return new CacheDir(this.STAKING_NETWORK_STATS_KEY, '');
+  // Kiln uses different endpoints for mainnet/testnet
+  static getStakingNetworkStatsCacheDir(url: string): CacheDir {
+    return new CacheDir(`${this.STAKING_NETWORK_STATS_KEY}_${url}`, '');
   }
 
-  static getStakingDedicatedStakingStatsCacheDir(): CacheDir {
-    return new CacheDir(this.STAKING_DEDICATED_STAKING_STATS_KEY, '');
+  // Kiln uses different endpoints for mainnet/testnet
+  static getStakingDedicatedStakingStatsCacheDir(url: string): CacheDir {
+    return new CacheDir(
+      `${this.STAKING_DEDICATED_STAKING_STATS_KEY}_${url}`,
+      '',
+    );
   }
 
-  static getStakingPooledStakingStatsCacheDir(pool: `0x${string}`): CacheDir {
-    return new CacheDir(`${this.STAKING_POOLED_STAKING_STATS_KEY}_${pool}`, '');
+  // Kiln uses different endpoints for mainnet/testnet
+  static getStakingPooledStakingStatsCacheDir(args: {
+    url: string;
+    pool: `0x${string}`;
+  }): CacheDir {
+    return new CacheDir(
+      `${this.STAKING_POOLED_STAKING_STATS_KEY}_${args.url}_${args.pool}`,
+      '',
+    );
   }
 
+  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDefiVaultStatsCacheDir(args: {
+    url: string;
     chainId: string;
     vault: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainId}_${this.STAKING_DEFI_VAULT_STATS_KEY}_${args.vault}`,
+      `${args.chainId}_${this.STAKING_DEFI_VAULT_STATS_KEY}_${args.url}_${args.vault}`,
       '',
     );
   }
 
+  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDefiVaultStakesCacheDir(args: {
+    url: string;
     chainId: string;
     safeAddress: `0x${string}`;
     vault: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainId}_${this.STAKING_DEFI_VAULT_STAKES_KEY}_${args.safeAddress}_${args.vault}`,
+      `${args.chainId}_${this.STAKING_DEFI_VAULT_STAKES_KEY}_${args.url}_${args.safeAddress}_${args.vault}`,
       '',
     );
   }
 
+  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDefiMorphoExtraRewardsCacheDir(args: {
+    url: string;
     chainId: string;
     safeAddress: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainId}_${this.STAKING_DEFI_MORPHO_EXTRA_REWARDS_KEY}_${args.safeAddress}`,
+      `${args.chainId}_${this.STAKING_DEFI_MORPHO_EXTRA_REWARDS_KEY}_${args.url}_${args.safeAddress}`,
       '',
     );
   }

--- a/src/datasources/earn-api/earn-api.manager.ts
+++ b/src/datasources/earn-api/earn-api.manager.ts
@@ -1,0 +1,70 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { KilnApi } from '@/datasources/staking-api/kiln-api.service';
+import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
+import { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import { IStakingApi } from '@/domain/interfaces/staking-api.interface';
+import { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
+import { Inject, Injectable } from '@nestjs/common';
+
+// Note: This mirrors that of StakingApiManager but as each widget deployment
+// is its own Kiln "organization", deployments have different base URLs when
+// compared to the staking API.
+
+@Injectable()
+export class EarnApiManager implements IStakingApiManager {
+  private readonly apis: Record<string, IStakingApi> = {};
+
+  constructor(
+    private readonly dataSource: CacheFirstDataSource,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(IConfigApi) private readonly configApi: IConfigApi,
+    private readonly httpErrorFactory: HttpErrorFactory,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
+  ) {}
+
+  async getApi(chainId: string): Promise<IStakingApi> {
+    if (this.apis[chainId]) {
+      return Promise.resolve(this.apis[chainId]);
+    }
+
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
+
+    const env = chain.isTestnet ? 'testnet' : 'mainnet';
+
+    // Note: only difference to StakingApiManager logic
+    const baseUrl = this.configurationService.getOrThrow<string>(
+      `earn.${env}.baseUri`,
+    );
+    const apiKey = this.configurationService.getOrThrow<string>(
+      `earn.${env}.apiKey`,
+    );
+
+    this.apis[chainId] = new KilnApi(
+      baseUrl,
+      apiKey,
+      this.dataSource,
+      this.httpErrorFactory,
+      this.configurationService,
+      this.cacheService,
+      chain.chainId,
+    );
+
+    return Promise.resolve(this.apis[chainId]);
+  }
+
+  destroyApi(chainId: string): void {
+    if (this.apis[chainId] !== undefined) {
+      delete this.apis[chainId];
+    }
+  }
+}

--- a/src/datasources/earn-api/earn-api.module.ts
+++ b/src/datasources/earn-api/earn-api.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
+import { EarnApiManager } from '@/datasources/earn-api/earn-api.manager';
+import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data.source.module';
+
+@Module({
+  imports: [CacheFirstDataSourceModule, ConfigApiModule],
+  providers: [EarnApiManager, HttpErrorFactory],
+  exports: [EarnApiManager],
+})
+export class EarnApiModule {}

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -168,7 +168,10 @@ describe('KilnApi', () => {
       expect(actual).toBe(networkStats);
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_network_stats', ''),
+        cacheDir: new CacheDir(
+          `staking_network_stats_${baseUrl}/v1/eth/network-stats`,
+          '',
+        ),
         url: `${baseUrl}/v1/eth/network-stats`,
         networkRequest: {
           headers: {
@@ -201,7 +204,10 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_network_stats', ''),
+        cacheDir: new CacheDir(
+          `staking_network_stats_${baseUrl}/v1/eth/network-stats`,
+          '',
+        ),
         url: `${baseUrl}/v1/eth/network-stats`,
         networkRequest: {
           headers: {
@@ -231,7 +237,10 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_dedicated_staking_stats', ''),
+        cacheDir: new CacheDir(
+          `staking_dedicated_staking_stats_${baseUrl}/v1/eth/kiln-stats`,
+          '',
+        ),
         url: `${baseUrl}/v1/eth/kiln-stats`,
         networkRequest: {
           headers: {
@@ -263,7 +272,10 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_dedicated_staking_stats', ''),
+        cacheDir: new CacheDir(
+          `staking_dedicated_staking_stats_${baseUrl}/v1/eth/kiln-stats`,
+          '',
+        ),
         url: getDedicatedStakingStats,
         networkRequest: {
           headers: {
@@ -296,7 +308,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `staking_pooled_staking_stats_${pooledStakingStats.address}`,
+          `staking_pooled_staking_stats_${baseUrl}/v1/eth/onchain/v2/network-stats_${pooledStakingStats.address}`,
           '',
         ),
         url: `${baseUrl}/v1/eth/onchain/v2/network-stats`,
@@ -337,7 +349,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `staking_pooled_staking_stats_${pooledStakingStats.address}`,
+          `staking_pooled_staking_stats_${baseUrl}/v1/eth/onchain/v2/network-stats_${pooledStakingStats.address}`,
           '',
         ),
         url: `${baseUrl}/v1/eth/onchain/v2/network-stats`,
@@ -388,7 +400,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${defiVaultStats.vault}`,
+          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${baseUrl}/v1/defi/network-stats_${defiVaultStats.vault}`,
           '',
         ),
         url: `${baseUrl}/v1/defi/network-stats`,
@@ -460,7 +472,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${defiVaultStats.vault}`,
+          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${baseUrl}/v1/defi/network-stats_${defiVaultStats.vault}`,
           '',
         ),
         url: `${baseUrl}/v1/defi/network-stats`,
@@ -515,7 +527,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${safeAddress}_${defiVaultStake.vault}`,
+          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${baseUrl}/v1/defi/stakes_${safeAddress}_${defiVaultStake.vault}`,
           '',
         ),
         url: `${baseUrl}/v1/defi/stakes`,
@@ -597,7 +609,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${safeAddress}_${defiVaultStake.vault}`,
+          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${baseUrl}/v1/defi/stakes_${safeAddress}_${defiVaultStake.vault}`,
           '',
         ),
         url: `${baseUrl}/v1/defi/stakes`,
@@ -652,7 +664,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${chain_id}_staking_defi_morpho_extra_rewards_${safeAddress}`,
+          `${chain_id}_staking_defi_morpho_extra_rewards_${baseUrl}/v1/defi/extra-rewards/morpho_${safeAddress}`,
           '',
         ),
         url: `${baseUrl}/v1/defi/extra-rewards/morpho`,
@@ -706,7 +718,7 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${chain_id}_staking_defi_morpho_extra_rewards_${safeAddress}`,
+          `${chain_id}_staking_defi_morpho_extra_rewards_${baseUrl}/v1/defi/extra-rewards/morpho_${safeAddress}`,
           '',
         ),
         url: `${baseUrl}/v1/defi/extra-rewards/morpho`,

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -77,7 +77,7 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getNetworkStats(): Promise<Raw<NetworkStats>> {
     const url = `${this.baseUrl}/v1/eth/network-stats`;
-    const cacheDir = CacheRouter.getStakingNetworkStatsCacheDir();
+    const cacheDir = CacheRouter.getStakingNetworkStatsCacheDir(url);
     return await this.get<{ data: NetworkStats }>({
       cacheDir,
       url,
@@ -95,7 +95,7 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDedicatedStakingStats(): Promise<Raw<DedicatedStakingStats>> {
     const url = `${this.baseUrl}/v1/eth/kiln-stats`;
-    const cacheDir = CacheRouter.getStakingDedicatedStakingStatsCacheDir();
+    const cacheDir = CacheRouter.getStakingDedicatedStakingStatsCacheDir(url);
     return await this.get<{
       data: DedicatedStakingStats;
     }>({
@@ -117,7 +117,10 @@ export class KilnApi implements IStakingApi {
     pool: `0x${string}`,
   ): Promise<Raw<PooledStakingStats>> {
     const url = `${this.baseUrl}/v1/eth/onchain/v2/network-stats`;
-    const cacheDir = CacheRouter.getStakingPooledStakingStatsCacheDir(pool);
+    const cacheDir = CacheRouter.getStakingPooledStakingStatsCacheDir({
+      url,
+      pool,
+    });
     return await this.get<{
       data: PooledStakingStats;
     }>({
@@ -143,6 +146,7 @@ export class KilnApi implements IStakingApi {
   ): Promise<Raw<Array<DefiVaultStats>>> {
     const url = `${this.baseUrl}/v1/defi/network-stats`;
     const cacheDir = CacheRouter.getStakingDefiVaultStatsCacheDir({
+      url,
       chainId: this.chainId,
       vault,
     });
@@ -172,6 +176,7 @@ export class KilnApi implements IStakingApi {
   }): Promise<Raw<Array<DefiVaultStake>>> {
     const url = `${this.baseUrl}/v1/defi/stakes`;
     const cacheDir = CacheRouter.getStakingDefiVaultStakesCacheDir({
+      url,
       chainId: this.chainId,
       safeAddress: args.safeAddress,
       vault: args.vault,
@@ -202,6 +207,7 @@ export class KilnApi implements IStakingApi {
   ): Promise<Raw<Array<DefiMorphoExtraReward>>> {
     const url = `${this.baseUrl}/v1/defi/extra-rewards/morpho`;
     const cacheDir = CacheRouter.getStakingDefiMorphoExtraRewardsCacheDir({
+      url,
       chainId: this.chainId,
       safeAddress,
     });

--- a/src/domain/earn/earn.repository.module.ts
+++ b/src/domain/earn/earn.repository.module.ts
@@ -1,0 +1,10 @@
+import { EarnApiModule } from '@/datasources/earn-api/earn-api.module';
+import { EarnRepository } from '@/domain/earn/earn.repository';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [EarnApiModule],
+  providers: [EarnRepository],
+  exports: [EarnRepository],
+})
+export class EarnRepositoryModule {}

--- a/src/domain/hooks/helpers/event-cache.helper.module.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.module.ts
@@ -3,6 +3,7 @@ import { BalancesRepositoryModule } from '@/domain/balances/balances.repository.
 import { BlockchainRepositoryModule } from '@/domain/blockchain/blockchain.repository.interface';
 import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
 import { CollectiblesRepositoryModule } from '@/domain/collectibles/collectibles.repository.interface';
+import { EarnRepositoryModule } from '@/domain/earn/earn.repository.module';
 import { EventCacheHelper } from '@/domain/hooks/helpers/event-cache.helper';
 import { MessagesRepositoryModule } from '@/domain/messages/messages.repository.interface';
 import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repository.interface';
@@ -18,6 +19,7 @@ import { DelegatesV2RepositoryModule } from '@/domain/delegate/v2/delegates.v2.r
     ChainsRepositoryModule,
     CollectiblesRepositoryModule,
     DelegatesV2RepositoryModule,
+    EarnRepositoryModule,
     MessagesRepositoryModule,
     SafeAppsRepositoryModule,
     SafeRepositoryModule,

--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -24,6 +24,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import memoize from 'lodash/memoize';
 import type { MemoizedFunction } from 'lodash';
+import { EarnRepository } from '@/domain/earn/earn.repository';
 
 @Injectable()
 export class EventCacheHelper {
@@ -52,6 +53,8 @@ export class EventCacheHelper {
     private readonly safeRepository: ISafeRepository,
     @Inject(IStakingRepository)
     private readonly stakingRepository: IStakingRepository,
+    @Inject(EarnRepository)
+    private readonly earnRepository: EarnRepository,
     @Inject(ITransactionsRepository)
     private readonly transactionsRepository: ITransactionsRepository,
     @Inject(LoggingService)
@@ -256,6 +259,10 @@ export class EventCacheHelper {
         chainId: event.chainId,
         safeAddress: event.address,
       }),
+      this.earnRepository.clearStakes({
+        chainId: event.chainId,
+        safeAddress: event.address,
+      }),
       this.safeRepository.clearModuleTransactions({
         chainId: event.chainId,
         safeAddress: event.address,
@@ -307,6 +314,10 @@ export class EventCacheHelper {
         address: event.address,
       }),
       this.stakingRepository.clearStakes({
+        chainId: event.chainId,
+        safeAddress: event.address,
+      }),
+      this.earnRepository.clearStakes({
         chainId: event.chainId,
         safeAddress: event.address,
       }),
@@ -511,6 +522,7 @@ export class EventCacheHelper {
         this.blockchainRepository.clearApi(event.chainId);
         // Testnet status may have changed
         this.stakingRepository.clearApi(event.chainId);
+        this.earnRepository.clearApi(event.chainId);
         // Transaction Service may have changed
         this.transactionsRepository.clearApi(event.chainId);
         this.balancesRepository.clearApi(event.chainId);

--- a/src/domain/hooks/hooks.repository.spec.ts
+++ b/src/domain/hooks/hooks.repository.spec.ts
@@ -6,6 +6,7 @@ import type { ChainsRepository } from '@/domain/chains/chains.repository';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import type { CollectiblesRepository } from '@/domain/collectibles/collectibles.repository';
 import type { DelegatesV2Repository } from '@/domain/delegate/v2/delegates.v2.repository';
+import type { EarnRepository } from '@/domain/earn/earn.repository';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { EventCacheHelper } from '@/domain/hooks/helpers/event-cache.helper';
 import type { EventNotificationsHelper } from '@/domain/hooks/helpers/event-notifications.helper';
@@ -66,6 +67,10 @@ const mockStakingRepository = jest.mocked({
   clearApi: jest.fn(),
 } as jest.MockedObjectDeep<StakingRepository>);
 
+const mockEarnRepository = jest.mocked({
+  clearApi: jest.fn(),
+} as jest.MockedObjectDeep<EarnRepository>);
+
 const mockTransactionsRepository = jest.mocked({
   clearApi: jest.fn(),
 } as jest.MockedObjectDeep<TransactionsRepository>);
@@ -107,6 +112,7 @@ describe('HooksRepository (Unit)', () => {
       mockSafeAppsRepository,
       mockSafeRepository,
       mockStakingRepository,
+      mockEarnRepository,
       mockTransactionsRepository,
       mockLoggingService,
       fakeCacheService,
@@ -176,6 +182,7 @@ describe('HooksRepository (Unit)', () => {
     expect(mockChainsRepository.clearChain).toHaveBeenCalledTimes(3);
     expect(mockBlockchainRepository.clearApi).toHaveBeenCalledTimes(3);
     expect(mockStakingRepository.clearApi).toHaveBeenCalledTimes(3);
+    expect(mockEarnRepository.clearApi).toHaveBeenCalledTimes(3);
     expect(mockTransactionsRepository.clearApi).toHaveBeenCalledTimes(3);
     expect(mockBalancesRepository.clearApi).toHaveBeenCalledTimes(3);
   });

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -395,6 +395,7 @@ export class MultisigTransactionInfoMapper {
         safeAddress: args.transaction.safe,
       });
     } catch (error) {
+      console.log('Error mapping vault deposit:', error);
       this.loggingService.warn(error);
       return null;
     }
@@ -428,6 +429,7 @@ export class MultisigTransactionInfoMapper {
         safeAddress: args.transaction.safe,
       });
     } catch (error) {
+      console.log('Error mapping vault redeem:', error);
       this.loggingService.warn(error);
       return null;
     }

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -395,7 +395,6 @@ export class MultisigTransactionInfoMapper {
         safeAddress: args.transaction.safe,
       });
     } catch (error) {
-      console.log('Error mapping vault deposit:', error);
       this.loggingService.warn(error);
       return null;
     }
@@ -429,7 +428,6 @@ export class MultisigTransactionInfoMapper {
         safeAddress: args.transaction.safe,
       });
     } catch (error) {
-      console.log('Error mapping vault redeem:', error);
       this.loggingService.warn(error);
       return null;
     }

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder';
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import type { StakingRepository } from '@/domain/staking/staking.repository';
+import type { EarnRepository } from '@/domain/earn/earn.repository';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import type { ITokenRepository } from '@/domain/tokens/token.repository.interface';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
@@ -17,12 +17,12 @@ import { faker } from '@faker-js/faker/.';
 import { NotFoundException } from '@nestjs/common';
 import { getAddress } from 'viem';
 
-const mockStakingRepository = jest.mocked({
+const mockEarnRepository = jest.mocked({
   getDeployment: jest.fn(),
   getDefiVaultStats: jest.fn(),
   getDefiVaultStake: jest.fn(),
   getDefiMorphoExtraRewards: jest.fn(),
-} as jest.MockedObjectDeep<StakingRepository>);
+} as jest.MockedObjectDeep<EarnRepository>);
 
 const mockTokenRepository = {
   getToken: jest.fn(),
@@ -35,7 +35,7 @@ describe('VaultTransactionMapper', () => {
     jest.resetAllMocks();
 
     target = new VaultTransactionMapper(
-      mockStakingRepository,
+      mockEarnRepository,
       mockTokenRepository,
     );
   });
@@ -79,9 +79,9 @@ describe('VaultTransactionMapper', () => {
       const cumulativeNrr =
         defiVaultStats.nrr + defiVaultStats.additional_rewards_nrr;
       const expectedAnnualReward = (cumulativeNrr / 100) * assets;
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getDefiVaultStats.mockResolvedValue(defiVaultStats);
-      mockStakingRepository.getDefiMorphoExtraRewards.mockResolvedValue([
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDefiVaultStats.mockResolvedValue(defiVaultStats);
+      mockEarnRepository.getDefiMorphoExtraRewards.mockResolvedValue([
         morphoExtraReward,
       ]);
       mockTokenRepository.getToken.mockImplementation((args) => {
@@ -158,7 +158,7 @@ describe('VaultTransactionMapper', () => {
         .with('status', 'active')
         .with('chain_id', Number(chain.chainId))
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
 
       await expect(
         target.mapDepositInfo({
@@ -181,7 +181,7 @@ describe('VaultTransactionMapper', () => {
         .with('status', 'disabled')
         .with('chain_id', Number(chain.chainId))
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
 
       await expect(
         target.mapDepositInfo({
@@ -207,7 +207,7 @@ describe('VaultTransactionMapper', () => {
           Number(faker.string.numeric({ exclude: [chain.chainId] })),
         )
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
 
       await expect(
         target.mapDepositInfo({
@@ -258,10 +258,10 @@ describe('VaultTransactionMapper', () => {
       const morphoExtraReward = defiMorphoExtraRewardBuilder()
         .with('asset', additionalRewards[0].asset)
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
-      mockStakingRepository.getDefiVaultStats.mockResolvedValue(defiVaultStats);
-      mockStakingRepository.getDefiVaultStake.mockResolvedValue(defiVaultStake);
-      mockStakingRepository.getDefiMorphoExtraRewards.mockResolvedValue([
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDefiVaultStats.mockResolvedValue(defiVaultStats);
+      mockEarnRepository.getDefiVaultStake.mockResolvedValue(defiVaultStake);
+      mockEarnRepository.getDefiMorphoExtraRewards.mockResolvedValue([
         morphoExtraReward,
       ]);
       mockTokenRepository.getToken.mockImplementation((args) => {
@@ -336,7 +336,7 @@ describe('VaultTransactionMapper', () => {
         .with('status', 'disabled')
         .with('chain_id', Number(chain.chainId))
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
 
       await expect(
         target.mapRedeemInfo({
@@ -359,7 +359,7 @@ describe('VaultTransactionMapper', () => {
         .with('status', 'disabled')
         .with('chain_id', Number(chain.chainId))
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
 
       await expect(
         target.mapRedeemInfo({
@@ -386,7 +386,7 @@ describe('VaultTransactionMapper', () => {
           Number(faker.string.numeric({ exclude: [chain.chainId] })),
         )
         .build();
-      mockStakingRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getDeployment.mockResolvedValue(deployment);
 
       await expect(
         target.mapRedeemInfo({

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.ts
@@ -4,7 +4,7 @@ import {
 } from '@/datasources/staking-api/entities/defi-vault-stats.entity';
 import { Deployment } from '@/datasources/staking-api/entities/deployment.entity';
 import { getNumberString } from '@/domain/common/utils/utils';
-import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
+import { EarnRepository } from '@/domain/earn/earn.repository';
 import { ITokenRepository } from '@/domain/tokens/token.repository.interface';
 import { TokenInfo } from '@/routes/transactions/entities/swaps/token-info.entity';
 import { VaultExtraReward } from '@/routes/transactions/entities/vaults/vault-extra-reward.entity';
@@ -18,8 +18,8 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 @Injectable()
 export class VaultTransactionMapper {
   constructor(
-    @Inject(IStakingRepository)
-    private readonly stakingRepository: IStakingRepository,
+    @Inject(EarnRepository)
+    private readonly earnRepository: EarnRepository,
     @Inject(ITokenRepository)
     private readonly tokenRepository: ITokenRepository,
   ) {}
@@ -31,12 +31,12 @@ export class VaultTransactionMapper {
     data: `0x${string}`;
     safeAddress: `0x${string}`;
   }): Promise<VaultDepositTransactionInfo> {
-    const deployment = await this.stakingRepository.getDeployment({
+    const deployment = await this.earnRepository.getDeployment({
       chainId: args.chainId,
       address: args.to,
     });
     this.validateDeployment({ chainId: args.chainId, deployment });
-    const defiVaultStats = await this.stakingRepository.getDefiVaultStats({
+    const defiVaultStats = await this.earnRepository.getDefiVaultStats({
       chainId: args.chainId,
       vault: args.to,
     });
@@ -78,12 +78,12 @@ export class VaultTransactionMapper {
     data: `0x${string}`;
     safeAddress: `0x${string}`;
   }): Promise<VaultRedeemTransactionInfo> {
-    const deployment = await this.stakingRepository.getDeployment({
+    const deployment = await this.earnRepository.getDeployment({
       chainId: args.chainId,
       address: args.to,
     });
     this.validateDeployment({ chainId: args.chainId, deployment });
-    const defiVaultStats = await this.stakingRepository.getDefiVaultStats({
+    const defiVaultStats = await this.earnRepository.getDefiVaultStats({
       chainId: args.chainId,
       vault: args.to,
     });
@@ -97,7 +97,7 @@ export class VaultTransactionMapper {
         safeAddress: args.safeAddress,
         additionalRewards: defiVaultStats.additional_rewards,
       }),
-      this.stakingRepository.getDefiVaultStake({
+      this.earnRepository.getDefiVaultStake({
         chainId: args.chainId,
         safeAddress: args.safeAddress,
         vault: args.to,
@@ -140,7 +140,7 @@ export class VaultTransactionMapper {
       return [];
     }
 
-    const morphoExtraRewards = await this.stakingRepository
+    const morphoExtraRewards = await this.earnRepository
       .getDefiMorphoExtraRewards(args)
       .catch(() => []);
 

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -1,6 +1,7 @@
 import { ChainsRepositoryModule } from '@/domain/chains/chains.repository.interface';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
 import { DataDecoderRepositoryModule } from '@/domain/data-decoder/v2/data-decoder.repository.module';
+import { EarnRepositoryModule } from '@/domain/earn/earn.repository.module';
 import { HumanDescriptionRepositoryModule } from '@/domain/human-description/human-description.repository.interface';
 import { SafeAppsRepositoryModule } from '@/domain/safe-apps/safe-apps.repository.interface';
 import { SafeRepositoryModule } from '@/domain/safe/safe.repository.interface';
@@ -61,6 +62,7 @@ import { VaultTransactionMapper } from '@/routes/transactions/mappers/common/vau
     ContractsRepositoryModule,
     DataDecoderRepositoryModule,
     DelegatesV2RepositoryModule,
+    EarnRepositoryModule,
     GPv2DecoderModule,
     HumanDescriptionRepositoryModule,
     KilnNativeStakingHelperModule,


### PR DESCRIPTION
## Summary

Earn mapping branches off of the existing staking datasource/domain. The APIs, however, need to be different in order to retrieve the earn deployments.

This duplicates the staking datasource and domain, creating a new earn-specific API key-focused one instead. This is then used within earn transaction mapping.

Note: the logic is mostly duplicated and to-be-later cleaned up.

## Changes

- Add earn datasource
- Add earn domain
- Replace staking domain usage with earn for earn transaction mapping
- Update tests accordingly