### PR TITLE
fix: prevent earn/staking cache collision

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -640,72 +640,65 @@ export class CacheRouter {
     );
   }
 
-  // TODO: Remove url from the following cache keys where it isn't required
-  // e.g. when fetching a specific address
-
-  // Kiln uses different endpoints for mainnet/testnet
-  static getStakingDeploymentsCacheDir(url: string): CacheDir {
-    return new CacheDir(`${this.STAKING_DEPLOYMENTS_KEY}_${url}`, '');
+  static getStakingDeploymentsCacheDir(
+    cacheType: 'earn' | 'staking',
+  ): CacheDir {
+    return new CacheDir(this.STAKING_DEPLOYMENTS_KEY, cacheType);
   }
 
-  // Kiln uses different endpoints for mainnet/testnet
-  static getStakingNetworkStatsCacheDir(url: string): CacheDir {
-    return new CacheDir(`${this.STAKING_NETWORK_STATS_KEY}_${url}`, '');
+  static getStakingNetworkStatsCacheDir(
+    cacheType: 'earn' | 'staking',
+  ): CacheDir {
+    return new CacheDir(this.STAKING_NETWORK_STATS_KEY, cacheType);
   }
 
-  // Kiln uses different endpoints for mainnet/testnet
-  static getStakingDedicatedStakingStatsCacheDir(url: string): CacheDir {
-    return new CacheDir(
-      `${this.STAKING_DEDICATED_STAKING_STATS_KEY}_${url}`,
-      '',
-    );
+  static getStakingDedicatedStakingStatsCacheDir(
+    cacheType: 'earn' | 'staking',
+  ): CacheDir {
+    return new CacheDir(this.STAKING_DEDICATED_STAKING_STATS_KEY, cacheType);
   }
 
-  // Kiln uses different endpoints for mainnet/testnet
   static getStakingPooledStakingStatsCacheDir(args: {
-    url: string;
+    cacheType: 'earn' | 'staking';
     pool: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${this.STAKING_POOLED_STAKING_STATS_KEY}_${args.url}_${args.pool}`,
-      '',
+      `${this.STAKING_POOLED_STAKING_STATS_KEY}_${args.pool}`,
+      args.cacheType,
     );
   }
 
-  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDefiVaultStatsCacheDir(args: {
-    url: string;
+    cacheType: 'earn' | 'staking';
     chainId: string;
     vault: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainId}_${this.STAKING_DEFI_VAULT_STATS_KEY}_${args.url}_${args.vault}`,
-      '',
+      `${args.chainId}_${this.STAKING_DEFI_VAULT_STATS_KEY}_${args.vault}`,
+      args.cacheType,
     );
   }
 
-  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDefiVaultStakesCacheDir(args: {
-    url: string;
+    cacheType: 'earn' | 'staking';
     chainId: string;
     safeAddress: `0x${string}`;
     vault: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainId}_${this.STAKING_DEFI_VAULT_STAKES_KEY}_${args.url}_${args.safeAddress}_${args.vault}`,
-      '',
+      `${args.chainId}_${this.STAKING_DEFI_VAULT_STAKES_KEY}_${args.safeAddress}_${args.vault}`,
+      args.cacheType,
     );
   }
 
-  // Kiln uses different endpoints for mainnet/testnet
   static getStakingDefiMorphoExtraRewardsCacheDir(args: {
-    url: string;
+    cacheType: 'earn' | 'staking';
     chainId: string;
     safeAddress: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
-      `${args.chainId}_${this.STAKING_DEFI_MORPHO_EXTRA_REWARDS_KEY}_${args.url}_${args.safeAddress}`,
-      '',
+      `${args.chainId}_${this.STAKING_DEFI_MORPHO_EXTRA_REWARDS_KEY}_${args.safeAddress}`,
+      args.cacheType,
     );
   }
 
@@ -730,12 +723,14 @@ export class CacheRouter {
    * cache field short and deterministic. Redis and other cache systems
    * may experience performance degradation with long fields.
    *
+   * @param {string} args.cacheType - Cache type (earn or staking)
    * @param {string} args.chainId - Chain ID
    * @param {string} args.safeAddress - Safe address
    * @param {string} args.validatorsPublicKeys - Array of validators public keys
    * @returns {@link CacheDir} - Cache directory
    */
   static getStakingStakesCacheDir(args: {
+    cacheType: 'earn' | 'staking';
     chainId: string;
     safeAddress: `0x${string}`;
     validatorsPublicKeys: Array<`0x${string}`>;
@@ -744,7 +739,7 @@ export class CacheRouter {
     hash.update(args.validatorsPublicKeys.join('_'));
     return new CacheDir(
       CacheRouter.getStakingStakesCacheKey(args),
-      hash.digest('hex'),
+      `${args.cacheType}_${hash.digest('hex')}`,
     );
   }
 
@@ -753,12 +748,13 @@ export class CacheRouter {
   }
 
   static getStakingTransactionStatusCacheDir(args: {
+    cacheType: 'earn' | 'staking';
     chainId: string;
     txHash: `0x${string}`;
   }): CacheDir {
     return new CacheDir(
       `${args.chainId}_${CacheRouter.STAKING_TRANSACTION_STATUS_KEY}_${args.txHash}`,
-      '',
+      args.cacheType,
     );
   }
 

--- a/src/datasources/earn-api/earn-api.manager.ts
+++ b/src/datasources/earn-api/earn-api.manager.ts
@@ -57,6 +57,7 @@ export class EarnApiManager implements IStakingApiManager {
       this.configurationService,
       this.cacheService,
       chain.chainId,
+      'earn',
     );
 
     return Promise.resolve(this.apis[chainId]);

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -46,6 +46,7 @@ describe('KilnApi', () => {
   let httpErrorFactory: HttpErrorFactory;
   let stakingExpirationTimeInSeconds: number;
   let notFoundExpireTimeSeconds: number;
+  let cacheType: 'earn' | 'staking';
 
   function createTarget(_chainId = faker.string.numeric()): void {
     chainId = _chainId;
@@ -54,6 +55,7 @@ describe('KilnApi', () => {
     httpErrorFactory = new HttpErrorFactory();
     stakingExpirationTimeInSeconds = faker.number.int();
     notFoundExpireTimeSeconds = faker.number.int();
+    cacheType = faker.helpers.arrayElement(['earn', 'staking']);
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'expirationTimeInSeconds.staking') {
         return stakingExpirationTimeInSeconds;
@@ -72,6 +74,7 @@ describe('KilnApi', () => {
       mockConfigurationService,
       mockCacheService,
       chainId,
+      cacheType,
     );
   }
 
@@ -100,10 +103,7 @@ describe('KilnApi', () => {
       expect(actual).toBe(deployments);
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir(
-          `staking_deployments_${baseUrl}/v1/deployments`,
-          '',
-        ),
+        cacheDir: new CacheDir('staking_deployments', cacheType),
         url: `${baseUrl}/v1/deployments`,
         networkRequest: {
           headers: {
@@ -136,10 +136,7 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir(
-          `staking_deployments_${baseUrl}/v1/deployments`,
-          '',
-        ),
+        cacheDir: new CacheDir('staking_deployments', cacheType),
         url: `${baseUrl}/v1/deployments`,
         networkRequest: {
           headers: {
@@ -168,10 +165,7 @@ describe('KilnApi', () => {
       expect(actual).toBe(networkStats);
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir(
-          `staking_network_stats_${baseUrl}/v1/eth/network-stats`,
-          '',
-        ),
+        cacheDir: new CacheDir('staking_network_stats', cacheType),
         url: `${baseUrl}/v1/eth/network-stats`,
         networkRequest: {
           headers: {
@@ -204,10 +198,7 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir(
-          `staking_network_stats_${baseUrl}/v1/eth/network-stats`,
-          '',
-        ),
+        cacheDir: new CacheDir('staking_network_stats', cacheType),
         url: `${baseUrl}/v1/eth/network-stats`,
         networkRequest: {
           headers: {
@@ -237,10 +228,7 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir(
-          `staking_dedicated_staking_stats_${baseUrl}/v1/eth/kiln-stats`,
-          '',
-        ),
+        cacheDir: new CacheDir('staking_dedicated_staking_stats', cacheType),
         url: `${baseUrl}/v1/eth/kiln-stats`,
         networkRequest: {
           headers: {
@@ -272,10 +260,7 @@ describe('KilnApi', () => {
 
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir(
-          `staking_dedicated_staking_stats_${baseUrl}/v1/eth/kiln-stats`,
-          '',
-        ),
+        cacheDir: new CacheDir('staking_dedicated_staking_stats', cacheType),
         url: getDedicatedStakingStats,
         networkRequest: {
           headers: {
@@ -308,8 +293,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `staking_pooled_staking_stats_${baseUrl}/v1/eth/onchain/v2/network-stats_${pooledStakingStats.address}`,
-          '',
+          `staking_pooled_staking_stats_${pooledStakingStats.address}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/eth/onchain/v2/network-stats`,
         networkRequest: {
@@ -349,8 +334,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `staking_pooled_staking_stats_${baseUrl}/v1/eth/onchain/v2/network-stats_${pooledStakingStats.address}`,
-          '',
+          `staking_pooled_staking_stats_${pooledStakingStats.address}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/eth/onchain/v2/network-stats`,
         networkRequest: {
@@ -400,8 +385,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${baseUrl}/v1/defi/network-stats_${defiVaultStats.vault}`,
-          '',
+          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${defiVaultStats.vault}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/defi/network-stats`,
         networkRequest: {
@@ -472,8 +457,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${baseUrl}/v1/defi/network-stats_${defiVaultStats.vault}`,
-          '',
+          `${defiVaultStats.chain_id.toString()}_staking_defi_vault_stats_${defiVaultStats.vault}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/defi/network-stats`,
         networkRequest: {
@@ -527,8 +512,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${baseUrl}/v1/defi/stakes_${safeAddress}_${defiVaultStake.vault}`,
-          '',
+          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${safeAddress}_${defiVaultStake.vault}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/defi/stakes`,
         networkRequest: {
@@ -609,8 +594,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${baseUrl}/v1/defi/stakes_${safeAddress}_${defiVaultStake.vault}`,
-          '',
+          `${defiVaultStake.chain_id}_staking_defi_vault_stakes_${safeAddress}_${defiVaultStake.vault}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/defi/stakes`,
         networkRequest: {
@@ -664,8 +649,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${chain_id}_staking_defi_morpho_extra_rewards_${baseUrl}/v1/defi/extra-rewards/morpho_${safeAddress}`,
-          '',
+          `${chain_id}_staking_defi_morpho_extra_rewards_${safeAddress}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/defi/extra-rewards/morpho`,
         networkRequest: {
@@ -718,8 +703,8 @@ describe('KilnApi', () => {
       expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir(
-          `${chain_id}_staking_defi_morpho_extra_rewards_${baseUrl}/v1/defi/extra-rewards/morpho_${safeAddress}`,
-          '',
+          `${chain_id}_staking_defi_morpho_extra_rewards_${safeAddress}`,
+          cacheType,
         ),
         url: `${baseUrl}/v1/defi/extra-rewards/morpho`,
         networkRequest: {
@@ -772,6 +757,7 @@ describe('KilnApi', () => {
           chainId,
           safeAddress,
           validatorsPublicKeys,
+          cacheType,
         }),
         url: getStakesUrl,
         networkRequest: {
@@ -826,6 +812,7 @@ describe('KilnApi', () => {
           chainId,
           safeAddress,
           validatorsPublicKeys,
+          cacheType,
         }),
         url: getStakesUrl,
         networkRequest: {
@@ -879,6 +866,7 @@ describe('KilnApi', () => {
         cacheDir: CacheRouter.getStakingTransactionStatusCacheDir({
           chainId,
           txHash,
+          cacheType,
         }),
         url: getTransactionStatusUrl,
         networkRequest: {
@@ -920,6 +908,7 @@ describe('KilnApi', () => {
         cacheDir: CacheRouter.getStakingTransactionStatusCacheDir({
           chainId,
           txHash,
+          cacheType,
         }),
         url: getTransactionStatusUrl,
         networkRequest: {

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -42,6 +42,7 @@ export class KilnApi implements IStakingApi {
     private readonly configurationService: IConfigurationService,
     private readonly cacheService: ICacheService,
     private readonly chainId: string,
+    private readonly cacheType: 'earn' | 'staking',
   ) {
     this.stakingExpirationTimeInSeconds =
       this.configurationService.getOrThrow<number>(
@@ -57,7 +58,7 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDeployments(): Promise<Raw<Array<Deployment>>> {
     const url = `${this.baseUrl}/v1/deployments`;
-    const cacheDir = CacheRouter.getStakingDeploymentsCacheDir(url);
+    const cacheDir = CacheRouter.getStakingDeploymentsCacheDir(this.cacheType);
     return await this.get<{
       data: Array<Deployment>;
     }>({
@@ -77,7 +78,7 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getNetworkStats(): Promise<Raw<NetworkStats>> {
     const url = `${this.baseUrl}/v1/eth/network-stats`;
-    const cacheDir = CacheRouter.getStakingNetworkStatsCacheDir(url);
+    const cacheDir = CacheRouter.getStakingNetworkStatsCacheDir(this.cacheType);
     return await this.get<{ data: NetworkStats }>({
       cacheDir,
       url,
@@ -95,7 +96,9 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getDedicatedStakingStats(): Promise<Raw<DedicatedStakingStats>> {
     const url = `${this.baseUrl}/v1/eth/kiln-stats`;
-    const cacheDir = CacheRouter.getStakingDedicatedStakingStatsCacheDir(url);
+    const cacheDir = CacheRouter.getStakingDedicatedStakingStatsCacheDir(
+      this.cacheType,
+    );
     return await this.get<{
       data: DedicatedStakingStats;
     }>({
@@ -118,7 +121,7 @@ export class KilnApi implements IStakingApi {
   ): Promise<Raw<PooledStakingStats>> {
     const url = `${this.baseUrl}/v1/eth/onchain/v2/network-stats`;
     const cacheDir = CacheRouter.getStakingPooledStakingStatsCacheDir({
-      url,
+      cacheType: this.cacheType,
       pool,
     });
     return await this.get<{
@@ -146,7 +149,7 @@ export class KilnApi implements IStakingApi {
   ): Promise<Raw<Array<DefiVaultStats>>> {
     const url = `${this.baseUrl}/v1/defi/network-stats`;
     const cacheDir = CacheRouter.getStakingDefiVaultStatsCacheDir({
-      url,
+      cacheType: this.cacheType,
       chainId: this.chainId,
       vault,
     });
@@ -176,7 +179,7 @@ export class KilnApi implements IStakingApi {
   }): Promise<Raw<Array<DefiVaultStake>>> {
     const url = `${this.baseUrl}/v1/defi/stakes`;
     const cacheDir = CacheRouter.getStakingDefiVaultStakesCacheDir({
-      url,
+      cacheType: this.cacheType,
       chainId: this.chainId,
       safeAddress: args.safeAddress,
       vault: args.vault,
@@ -207,7 +210,7 @@ export class KilnApi implements IStakingApi {
   ): Promise<Raw<Array<DefiMorphoExtraReward>>> {
     const url = `${this.baseUrl}/v1/defi/extra-rewards/morpho`;
     const cacheDir = CacheRouter.getStakingDefiMorphoExtraRewardsCacheDir({
-      url,
+      cacheType: this.cacheType,
       chainId: this.chainId,
       safeAddress,
     });
@@ -246,6 +249,7 @@ export class KilnApi implements IStakingApi {
   }): Promise<Raw<Array<Stake>>> {
     const url = `${this.baseUrl}/v1/eth/stakes`;
     const cacheDir = CacheRouter.getStakingStakesCacheDir({
+      cacheType: this.cacheType,
       chainId: this.chainId,
       safeAddress: args.safeAddress,
       validatorsPublicKeys: args.validatorsPublicKeys,
@@ -288,6 +292,7 @@ export class KilnApi implements IStakingApi {
   ): Promise<Raw<TransactionStatus>> {
     const url = `${this.baseUrl}/v1/eth/transaction/status`;
     const cacheDir = CacheRouter.getStakingTransactionStatusCacheDir({
+      cacheType: this.cacheType,
       chainId: this.chainId,
       txHash,
     });

--- a/src/datasources/staking-api/staking-api.manager.ts
+++ b/src/datasources/staking-api/staking-api.manager.ts
@@ -52,6 +52,7 @@ export class StakingApiManager implements IStakingApiManager {
       this.configurationService,
       this.cacheService,
       chain.chainId,
+      'staking',
     );
 
     return Promise.resolve(this.apis[chainId]);


### PR DESCRIPTION
## Summary

The datasources of stake and earn use the same API with differing API keys. The caches for each are, however, the same. This results in cache collision with data of one request being returned for the other.

This adds a new domain-specific field to the respective `CacheDir`s.

## Changes

- Add new `cacheType` field to the the cache routing.
- Instantiate/cache separate `KilnApi`s with the aforementioned field.
- Update tests accordingly.