### PR TITLE
feat: add a delete notifications endpoint

### DIFF
--- a/src/domain/notifications/v2/entities/__tests__/delete-subscriptions-dto.entity.spec.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-subscriptions-dto.entity.spec.ts
@@ -1,0 +1,78 @@
+import { deleteSubscriptionsDtoBuilder } from '@/routes/notifications/v2/entities/__tests__/delete-subscriptions.dto.builder';
+import { DeleteSubscriptionsDtoSchema } from '@/domain/notifications/v2/entities/delete-subscriptions.dto.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+describe('DeleteSubscriptionsDtoSchema', () => {
+  it('should validate a valid DeleteSubscriptionsDto', () => {
+    const dto = deleteSubscriptionsDtoBuilder().build();
+
+    const result = DeleteSubscriptionsDtoSchema.safeParse(dto);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should require safes', () => {
+    const dto = deleteSubscriptionsDtoBuilder().build();
+    // @ts-expect-error test missing property
+    delete dto.safes;
+
+    const result = DeleteSubscriptionsDtoSchema.safeParse(dto);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'array',
+        message: 'Required',
+        path: ['safes'],
+        received: 'undefined',
+      },
+    ]);
+  });
+
+  it.each([
+    ['chainId' as const, 'string'],
+    ['address' as const, 'string'],
+  ])('should require safes[number].%s', (key, expected) => {
+    const dto = deleteSubscriptionsDtoBuilder()
+      .with('safes', [
+        {
+          chainId: faker.string.numeric(),
+          address: getAddress(faker.finance.ethereumAddress()),
+        },
+      ])
+      .build();
+
+    delete dto.safes[0][key];
+
+    const result = DeleteSubscriptionsDtoSchema.safeParse(dto);
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected,
+        message: 'Required',
+        path: ['safes', 0, key],
+        received: 'undefined',
+      },
+    ]);
+  });
+
+  it('should checksum safes[number].address', () => {
+    const nonChecksum = faker.finance.ethereumAddress().toLowerCase();
+    const dto = deleteSubscriptionsDtoBuilder()
+      .with('safes', [
+        {
+          chainId: faker.string.numeric(),
+          address: nonChecksum as `0x${string}`,
+        },
+      ])
+      .build();
+
+    const result = DeleteSubscriptionsDtoSchema.safeParse(dto);
+
+    expect(result.success && result.data.safes[0].address).toBe(
+      getAddress(nonChecksum),
+    );
+  });
+});

--- a/src/domain/notifications/v2/entities/delete-subscriptions.dto.entity.ts
+++ b/src/domain/notifications/v2/entities/delete-subscriptions.dto.entity.ts
@@ -1,0 +1,29 @@
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { ApiProperty } from '@nestjs/swagger';
+import { z } from 'zod';
+
+export const DeleteSubscriptionsDtoSafesSchema = z.object({
+  chainId: z.string(),
+  address: AddressSchema,
+});
+
+export const DeleteSubscriptionsDtoSchema = z.object({
+  safes: z.array(DeleteSubscriptionsDtoSafesSchema),
+});
+
+export class DeleteSubscriptionsSafesDto
+  implements z.infer<typeof DeleteSubscriptionsDtoSafesSchema>
+{
+  @ApiProperty()
+  chainId!: string;
+
+  @ApiProperty()
+  address!: `0x${string}`;
+}
+
+export class DeleteSubscriptionsDto
+  implements z.infer<typeof DeleteSubscriptionsDtoSchema>
+{
+  @ApiProperty({ type: [DeleteSubscriptionsSafesDto] })
+  safes!: Array<DeleteSubscriptionsSafesDto>;
+}

--- a/src/routes/notifications/v2/entities/__tests__/delete-subscriptions.dto.builder.ts
+++ b/src/routes/notifications/v2/entities/__tests__/delete-subscriptions.dto.builder.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import { getAddress } from 'viem';
+import type { DeleteSubscriptionsDto } from '@/domain/notifications/v2/entities/delete-subscriptions.dto.entity';
+
+export function deleteSubscriptionsDtoBuilder(): IBuilder<DeleteSubscriptionsDto> {
+  return new Builder<DeleteSubscriptionsDto>().with(
+    'safes',
+    Array.from({ length: faker.number.int({ min: 1, max: 5 }) }, () => ({
+      chainId: faker.string.numeric(),
+      address: getAddress(faker.finance.ethereumAddress()),
+    })),
+  );
+}

--- a/src/routes/notifications/v2/notifications.service.ts
+++ b/src/routes/notifications/v2/notifications.service.ts
@@ -38,6 +38,19 @@ export class NotificationsServiceV2 {
     await this.notificationsRepository.deleteSubscription(args);
   }
 
+  async deleteSubscriptions(args: {
+    deviceUuid: UUID;
+    safes: Array<{ chainId: string; safeAddress: `0x${string}` }>;
+  }): Promise<void> {
+    for (const safe of args.safes) {
+      await this.notificationsRepository.deleteSubscription({
+        deviceUuid: args.deviceUuid,
+        chainId: safe.chainId,
+        safeAddress: safe.safeAddress,
+      });
+    }
+  }
+
   async deleteDevice(deviceUuid: UUID): Promise<void> {
     await this.notificationsRepository.deleteDevice(deviceUuid);
   }


### PR DESCRIPTION
## Summary
The endpoint allows the deletion of multiple safe push notification subscriptions at once, similar to the register endpoint where one can provide multiple safes to subscribe to.
fixes #2597

## Changes
