### PR TITLE
feat: add endpoint to leave a space

### DIFF
--- a/src/domain/users/members.repository.integration.spec.ts
+++ b/src/domain/users/members.repository.integration.spec.ts
@@ -2327,5 +2327,345 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow('Cannot remove last admin.');
     });
+
+    it('should throw an error if the space does not exist', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const user = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      await dbWalletRepo.insert({
+        user: user.generatedMaps[0],
+        address: authPayloadDto.signer_address,
+      });
+      const spaceId = faker.number.int({
+        min: 69420,
+        max: DB_MAX_SAFE_INTEGER,
+      });
+      const userId = user.generatedMaps[0].id;
+
+      await expect(
+        membersRepository.removeUser({
+          authPayload: new AuthPayload(authPayloadDto),
+          spaceId,
+          userId,
+        }),
+      ).rejects.toThrow('No members found.');
+    });
+
+    it('should throw an error if the user is not a member of the space', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const spaceName = nameBuilder();
+      const adminName = nameBuilder();
+      const user = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      await dbWalletRepo.insert({
+        user: user.generatedMaps[0],
+        address: authPayloadDto.signer_address,
+      });
+      const nonMember = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      const nonMemberUserId = nonMember.generatedMaps[0].id;
+      await dbWalletRepo.insert({
+        user: nonMember.generatedMaps[0],
+        address: getAddress(faker.finance.ethereumAddress()),
+      });
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: user.generatedMaps[0],
+        space: space.generatedMaps[0],
+        name: adminName,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      await expect(
+        membersRepository.removeUser({
+          authPayload: new AuthPayload(authPayloadDto),
+          spaceId,
+          userId: nonMemberUserId,
+        }),
+      ).rejects.toThrow('Member not found.');
+    });
+
+    describe('when removing the signer themselves', () => {
+      it('should remove the signer', async () => {
+        const authPayloadDto = authPayloadDtoBuilder().build();
+        const spaceName = nameBuilder();
+        const adminName = nameBuilder();
+        const memberName = nameBuilder();
+        const signer = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: signer.generatedMaps[0],
+          address: authPayloadDto.signer_address,
+        });
+        const otherAdmin = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: otherAdmin.generatedMaps[0],
+          address: getAddress(faker.finance.ethereumAddress()),
+        });
+        const space = await dbSpacesRepository.insert({
+          name: spaceName,
+          status: 'ACTIVE',
+        });
+        const spaceId = space.generatedMaps[0].id;
+        await dbMembersRepository.insert({
+          user: otherAdmin.generatedMaps[0],
+          space: space.generatedMaps[0],
+          name: memberName,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+        const signerMember = await dbMembersRepository.insert({
+          user: signer.generatedMaps[0],
+          space: space.generatedMaps[0],
+          name: adminName,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+        const signerMemberId = signerMember.identifiers[0].id;
+
+        await expect(
+          membersRepository.removeUser({
+            authPayload: new AuthPayload(authPayloadDto),
+            spaceId,
+          }),
+        ).resolves.not.toThrow();
+
+        await expect(
+          dbMembersRepository.findOne({ where: { id: signerMemberId } }),
+        ).resolves.toBeNull();
+      });
+
+      it('should remove the signer even if they are not an ACTIVE ADMIN', async () => {
+        const authPayloadDto = authPayloadDtoBuilder().build();
+        const spaceName = nameBuilder();
+        const memberName = nameBuilder();
+        const adminName = nameBuilder();
+        const signer = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: signer.generatedMaps[0],
+          address: authPayloadDto.signer_address,
+        });
+        const admin = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: admin.generatedMaps[0],
+          address: getAddress(faker.finance.ethereumAddress()),
+        });
+        const space = await dbSpacesRepository.insert({
+          name: spaceName,
+          status: 'ACTIVE',
+        });
+        const spaceId = space.generatedMaps[0].id;
+        await dbMembersRepository.insert({
+          user: admin.generatedMaps[0],
+          space: space.generatedMaps[0],
+          name: adminName,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+        const signerMember = await dbMembersRepository.insert({
+          user: signer.generatedMaps[0],
+          space: space.generatedMaps[0],
+          name: memberName,
+          role: 'MEMBER',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+        const signerMemberId = signerMember.identifiers[0].id;
+
+        await expect(
+          membersRepository.removeUser({
+            authPayload: new AuthPayload(authPayloadDto),
+            spaceId,
+          }),
+        ).resolves.not.toThrow();
+
+        await expect(
+          dbMembersRepository.findOne({ where: { id: signerMemberId } }),
+        ).resolves.toBeNull();
+      });
+
+      it('should keep the signer as a member of other spaces', async () => {
+        const authPayloadDto = authPayloadDtoBuilder().build();
+        const space1Name = nameBuilder();
+        const space2Name = faker.word.noun();
+        const member1Name = nameBuilder();
+        const member2Name = nameBuilder();
+        const adminName = nameBuilder();
+        const signer = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: signer.generatedMaps[0],
+          address: authPayloadDto.signer_address,
+        });
+        const admin = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: admin.generatedMaps[0],
+          address: getAddress(faker.finance.ethereumAddress()),
+        });
+        const space1 = await dbSpacesRepository.insert({
+          name: space1Name,
+          status: 'ACTIVE',
+        });
+        const space2 = await dbSpacesRepository.insert({
+          name: space2Name,
+          status: 'ACTIVE',
+        });
+        const spaceId1 = space1.generatedMaps[0].id;
+
+        // Add to first space
+        await dbMembersRepository.insert({
+          user: admin.generatedMaps[0],
+          space: space1.generatedMaps[0],
+          name: adminName,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+        const signerMember1 = await dbMembersRepository.insert({
+          user: signer.generatedMaps[0],
+          space: space1.generatedMaps[0],
+          name: member1Name,
+          role: 'MEMBER',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+        const signerMemberId1 = signerMember1.identifiers[0].id;
+
+        // Add to second space
+        const signerMember2InvitedBy = getAddress(
+          faker.finance.ethereumAddress(),
+        );
+        const signerMember2 = await dbMembersRepository.insert({
+          user: signer.generatedMaps[0],
+          space: space2.generatedMaps[0],
+          name: member2Name,
+          role: 'MEMBER',
+          status: 'ACTIVE',
+          invitedBy: signerMember2InvitedBy,
+        });
+        const signerMemberId2 = signerMember2.identifiers[0].id;
+
+        await expect(
+          membersRepository.removeUser({
+            authPayload: new AuthPayload(authPayloadDto),
+            spaceId: spaceId1,
+          }),
+        ).resolves.not.toThrow();
+
+        // Should be removed from first space
+        await expect(
+          dbMembersRepository.findOne({ where: { id: signerMemberId1 } }),
+        ).resolves.toBeNull();
+
+        // Should still be in second space
+        await expect(
+          dbMembersRepository.findOne({ where: { id: signerMemberId2 } }),
+        ).resolves.toEqual({
+          createdAt: expect.any(Date),
+          id: signerMemberId2,
+          name: member2Name,
+          role: 'MEMBER',
+          status: 'ACTIVE',
+          invitedBy: signerMember2InvitedBy,
+          updatedAt: expect.any(Date),
+        });
+      });
+
+      it('should throw an error if the signer is the last ACTIVE ADMIN', async () => {
+        const authPayloadDto = authPayloadDtoBuilder().build();
+        const spaceName = nameBuilder();
+        const signerMemberName = nameBuilder();
+        const signer = await dbUserRepo.insert({
+          status: 'ACTIVE',
+        });
+        await dbWalletRepo.insert({
+          user: signer.generatedMaps[0],
+          address: authPayloadDto.signer_address,
+        });
+        const space = await dbSpacesRepository.insert({
+          name: spaceName,
+          status: 'ACTIVE',
+        });
+        const spaceId = space.generatedMaps[0].id;
+        await dbMembersRepository.insert({
+          user: signer.generatedMaps[0],
+          space: space.generatedMaps[0],
+          name: signerMemberName,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          invitedBy: getAddress(faker.finance.ethereumAddress()),
+        });
+
+        await expect(
+          membersRepository.removeUser({
+            authPayload: new AuthPayload(authPayloadDto),
+            spaceId,
+          }),
+        ).rejects.toThrow('Cannot remove last admin.');
+      });
+    });
+  });
+
+  it('should throw an error if the signer is not a member of the space', async () => {
+    const authPayloadDto = authPayloadDtoBuilder().build();
+    const spaceName = nameBuilder();
+    const adminName = nameBuilder();
+    const signer = await dbUserRepo.insert({
+      status: 'ACTIVE',
+    });
+    await dbWalletRepo.insert({
+      user: signer.generatedMaps[0],
+      address: authPayloadDto.signer_address,
+    });
+    const member = await dbUserRepo.insert({
+      status: 'ACTIVE',
+    });
+    const memberUserId = member.generatedMaps[0].id;
+    await dbWalletRepo.insert({
+      user: member.generatedMaps[0],
+      address: getAddress(faker.finance.ethereumAddress()),
+    });
+    const space = await dbSpacesRepository.insert({
+      name: spaceName,
+      status: 'ACTIVE',
+    });
+    const spaceId = space.generatedMaps[0].id;
+    await dbMembersRepository.insert({
+      user: member.generatedMaps[0],
+      space: space.generatedMaps[0],
+      name: adminName,
+      role: 'ADMIN',
+      status: 'ACTIVE',
+      invitedBy: getAddress(faker.finance.ethereumAddress()),
+    });
+
+    await expect(
+      membersRepository.removeUser({
+        authPayload: new AuthPayload(authPayloadDto),
+        spaceId,
+      }),
+    ).rejects.toThrow('Member not found.');
   });
 });

--- a/src/domain/users/members.repository.integration.spec.ts
+++ b/src/domain/users/members.repository.integration.spec.ts
@@ -2642,7 +2642,6 @@ describe('MembersRepository', () => {
     const member = await dbUserRepo.insert({
       status: 'ACTIVE',
     });
-    const memberUserId = member.generatedMaps[0].id;
     await dbWalletRepo.insert({
       user: member.generatedMaps[0],
       address: getAddress(faker.finance.ethereumAddress()),

--- a/src/domain/users/members.repository.interface.ts
+++ b/src/domain/users/members.repository.interface.ts
@@ -65,6 +65,6 @@ export interface IMembersRepository {
   removeUser(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    userId: User['id'];
+    userId?: User['id'];
   }): Promise<void>;
 }

--- a/src/routes/spaces/members.controller.ts
+++ b/src/routes/spaces/members.controller.ts
@@ -3,6 +3,7 @@ import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
+  ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -180,6 +181,29 @@ export class MembersController {
       authPayload,
       spaceId,
       userId,
+    });
+  }
+
+  @ApiOperation({ summary: 'Leave a space', description: 'Remove own membership from a space.' })
+  @ApiOkResponse({ description: 'Membership deleted' })
+  @ApiForbiddenResponse({ description: 'Signer not authorized' })
+  @ApiNotFoundResponse({
+    description: 'Signer or space not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Signer address not provided',
+  })
+  @ApiConflictResponse({ description: 'Cannot remove last admin' })
+  @Delete('/:spaceId/members')
+  @UseGuards(AuthGuard)
+  public async selfRemove(
+    @Auth() authPayload: AuthPayload,
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: number,
+  ): Promise<void> {
+    return await this.membersService.selfRemove({
+      authPayload,
+      spaceId,
     });
   }
 }

--- a/src/routes/spaces/members.service.ts
+++ b/src/routes/spaces/members.service.ts
@@ -97,4 +97,14 @@ export class MembersService {
       spaceId: args.spaceId,
     });
   }
+
+  public async selfRemove(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<void> {
+    return await this.membersRepository.removeUser({
+      authPayload: args.authPayload,
+      spaceId: args.spaceId,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

Resolves: [#116](https://github.com/safe-global/wallet-private-tasks/issues/116)

## Changes
Adds a new endpoint to allow a signer to remove themselves as a member from a specified Space:
```
DELETE /:spaceId/members
```

* Utilizes the `removeUser` method in `MembersRepository`.
* The `userId` parameter is now optional:
  * If userId is not provided, the signer ID from the auth payload is used as a fallback.