### PR TITLE
feat: mark several API endpoints as deprecated in notifications, owners, and transactions controllers

### DIFF
--- a/src/routes/notifications/v1/notifications.controller.ts
+++ b/src/routes/notifications/v1/notifications.controller.ts
@@ -8,7 +8,7 @@ import {
   Param,
   Post,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { RegisterDeviceDto } from '@/routes/notifications/v1/entities/register-device.dto.entity';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -36,6 +36,7 @@ export class NotificationsController {
   ) {}
 
   @ApiOkResponse()
+  @ApiOperation({ deprecated: true })
   @Post('register/notifications')
   @HttpCode(200)
   async registerDevice(
@@ -188,6 +189,7 @@ export class NotificationsController {
     }
   }
 
+  @ApiOperation({ deprecated: true })
   @Delete('chains/:chainId/notifications/devices/:uuid')
   async unregisterDevice(
     @Param('chainId') _: string, // We need to keep this parameter for the swagger documentation
@@ -196,6 +198,7 @@ export class NotificationsController {
     await this.notificationServiceV2.deleteDevice(uuid);
   }
 
+  @ApiOperation({ deprecated: true })
   @Delete('chains/:chainId/notifications/devices/:uuid/safes/:safeAddress')
   async unregisterSafe(
     @Param('chainId') chainId: string,

--- a/src/routes/owners/owners.controller.v1.ts
+++ b/src/routes/owners/owners.controller.v1.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SafeList } from '@/routes/owners/entities/safe-list.entity';
 import { OwnersService } from '@/routes/owners/owners.service';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
@@ -24,6 +24,7 @@ export class OwnersControllerV1 {
   }
 
   @ApiOkResponse({ type: SafeList })
+  @ApiOperation({ deprecated: true, summary: 'Deprecated' })
   @Get('owners/:ownerAddress/safes')
   async getAllSafesByOwner(
     @Param('ownerAddress', new ValidationPipe(AddressSchema))

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -11,7 +11,12 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
 import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
 import { Page } from '@/routes/common/entities/page.entity';
@@ -66,6 +71,7 @@ export class TransactionsController {
   }
 
   @ApiOkResponse({ type: TXSMultisigTransaction })
+  @ApiOperation({ deprecated: true, summary: 'Deprecated' })
   @Get('chains/:chainId/multisig-transactions/:safeTxHash/raw')
   async getDomainMultisigTransactionBySafeTxHash(
     @Param('chainId') chainId: string,
@@ -104,6 +110,7 @@ export class TransactionsController {
   @ApiQuery({ name: 'ordering', required: false, type: String })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiOperation({ deprecated: true, summary: 'Deprecated' })
   @Get('chains/:chainId/safes/:safeAddress/multisig-transactions/raw')
   async getDomainMultisigTransactions(
     @Param('chainId') chainId: string,
@@ -421,6 +428,7 @@ export class TransactionsController {
 
   @HttpCode(200)
   @ApiOkResponse({ type: TXSCreationTransaction })
+  @ApiOperation({ deprecated: true, summary: 'Deprecated' })
   @Get('chains/:chainId/safes/:safeAddress/creation/raw')
   async getDomainCreationTransaction(
     @Param('chainId') chainId: string,


### PR DESCRIPTION
## Summary
This PR marks outdated or legacy API endpoints as deprecated across the notifications, owners, and transactions controllers to signal their upcoming removal and guide clients towards newer alternatives.

## Changes
- Added deprecated: true to Swagger @ApiOperation() metadata for selected endpoints
- Updated descriptions to include deprecation notes
- No changes to business logic or functionality — only Swagger documentation updated