### PR TITLE
feat: Switch contract fetching from Tx Service to Decoder Service

### DIFF
--- a/src/domain/contracts/contracts.repository.interface.ts
+++ b/src/domain/contracts/contracts.repository.interface.ts
@@ -2,6 +2,9 @@ import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { Module } from '@nestjs/common';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
+import type { Page } from '@/domain/entities/page.entity';
+import type { Contract as DataDecodedContract } from '@/domain/data-decoder/v2/entities/contract.entity';
+import { DataDecodedApiModule } from '@/datasources/data-decoder-api/data-decoder-api.module';
 
 export const IContractsRepository = Symbol('IContractsRepository');
 
@@ -15,6 +18,14 @@ export interface IContractsRepository {
   }): Promise<Contract>;
 
   /**
+   * Gets the page containing {@link DataDecodedContract} associated with the {@link chainId} and the {@link contractAddress}.
+   */
+  getContracts(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<Page<DataDecodedContract>>;
+
+  /**
    * Determines if the contract at the {@link contractAddress} is trusted for delegate calls.
    */
   isTrustedForDelegateCall(args: {
@@ -24,7 +35,7 @@ export interface IContractsRepository {
 }
 
 @Module({
-  imports: [TransactionApiManagerModule],
+  imports: [TransactionApiManagerModule, DataDecodedApiModule],
   providers: [
     {
       provide: IContractsRepository,

--- a/src/domain/contracts/contracts.repository.interface.ts
+++ b/src/domain/contracts/contracts.repository.interface.ts
@@ -1,9 +1,7 @@
-import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { Module } from '@nestjs/common';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
-import type { Page } from '@/domain/entities/page.entity';
-import type { Contract as DataDecodedContract } from '@/domain/data-decoder/v2/entities/contract.entity';
+import type { Contract } from '@/domain/data-decoder/v2/entities/contract.entity';
 import { DataDecodedApiModule } from '@/datasources/data-decoder-api/data-decoder-api.module';
 
 export const IContractsRepository = Symbol('IContractsRepository');
@@ -16,14 +14,6 @@ export interface IContractsRepository {
     chainId: string;
     contractAddress: `0x${string}`;
   }): Promise<Contract>;
-
-  /**
-   * Gets the page containing {@link DataDecodedContract} associated with the {@link chainId} and the {@link contractAddress}.
-   */
-  getContracts(args: {
-    chainId: string;
-    contractAddress: `0x${string}`;
-  }): Promise<Page<DataDecodedContract>>;
 
   /**
    * Determines if the contract at the {@link contractAddress} is trusted for delegate calls.

--- a/src/domain/contracts/contracts.repository.spec.ts
+++ b/src/domain/contracts/contracts.repository.spec.ts
@@ -23,7 +23,6 @@ const mockTransactionApiManager = {
   getApi: jest.fn(),
 } as jest.MockedObjectDeep<ITransactionApiManager>;
 const mockTransactionApi = {
-  getContract: jest.fn(),
   getTrustedForDelegateCallContracts: jest.fn(),
 } as jest.MockedObjectDeep<ITransactionApi>;
 const mockDataDecoderApi = {

--- a/src/domain/contracts/contracts.repository.spec.ts
+++ b/src/domain/contracts/contracts.repository.spec.ts
@@ -3,6 +3,7 @@ import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import { SAFE_TRANSACTION_SERVICE_MAX_LIMIT as LIMIT } from '@/domain/common/constants';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder as decoderContractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
 import {
   limitAndOffsetUrlFactory,
   pageBuilder,
@@ -60,11 +61,13 @@ describe('ContractsRepository', () => {
   describe('trustedForDelegateCallContractsList disabled', () => {
     it('should return false if the contract is not trusted for delegate call', async () => {
       const chain = chainBuilder().build();
-      const contract = contractBuilder()
+      const contract = decoderContractBuilder()
         .with('trustedForDelegateCall', false)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
+
       mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
-      mockTransactionApi.getContract.mockResolvedValue(rawify(contract));
+      mockDataDecoderApi.getContracts.mockResolvedValue(rawify(contractPage));
 
       const actual = await target.isTrustedForDelegateCall({
         chainId: chain.chainId,
@@ -72,10 +75,11 @@ describe('ContractsRepository', () => {
       });
 
       expect(actual).toBe(false);
-      expect(mockTransactionApi.getContract).toHaveBeenCalledTimes(1);
-      expect(mockTransactionApi.getContract).toHaveBeenCalledWith(
-        contract.address,
-      );
+      expect(mockDataDecoderApi.getContracts).toHaveBeenCalledTimes(1);
+      expect(mockDataDecoderApi.getContracts).toHaveBeenCalledWith({
+        address: contract.address,
+        chainIds: [chain.chainId],
+      });
       expect(
         mockTransactionApi.getTrustedForDelegateCallContracts,
       ).not.toHaveBeenCalled();
@@ -83,11 +87,13 @@ describe('ContractsRepository', () => {
 
     it('should return true if the contract is trusted for delegate call', async () => {
       const chain = chainBuilder().build();
-      const contract = contractBuilder()
+      const contract = decoderContractBuilder()
         .with('trustedForDelegateCall', true)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
+
       mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
-      mockTransactionApi.getContract.mockResolvedValue(rawify(contract));
+      mockDataDecoderApi.getContracts.mockResolvedValue(rawify(contractPage));
 
       const actual = await target.isTrustedForDelegateCall({
         chainId: chain.chainId,
@@ -95,10 +101,11 @@ describe('ContractsRepository', () => {
       });
 
       expect(actual).toBe(true);
-      expect(mockTransactionApi.getContract).toHaveBeenCalledTimes(1);
-      expect(mockTransactionApi.getContract).toHaveBeenCalledWith(
-        contract.address,
-      );
+      expect(mockDataDecoderApi.getContracts).toHaveBeenCalledTimes(1);
+      expect(mockDataDecoderApi.getContracts).toHaveBeenCalledWith({
+        address: contract.address,
+        chainIds: [chain.chainId],
+      });
       expect(
         mockTransactionApi.getTrustedForDelegateCallContracts,
       ).not.toHaveBeenCalled();

--- a/src/domain/contracts/contracts.repository.spec.ts
+++ b/src/domain/contracts/contracts.repository.spec.ts
@@ -7,6 +7,7 @@ import {
   limitAndOffsetUrlFactory,
   pageBuilder,
 } from '@/domain/entities/__tests__/page.builder';
+import type { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
 import type { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
 import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import type { ILoggingService } from '@/logging/logging.interface';
@@ -24,6 +25,9 @@ const mockTransactionApi = {
   getContract: jest.fn(),
   getTrustedForDelegateCallContracts: jest.fn(),
 } as jest.MockedObjectDeep<ITransactionApi>;
+const mockDataDecoderApi = {
+  getContracts: jest.fn(),
+} as jest.MockedObjectDeep<IDataDecoderApi>;
 const mockConfigurationService = jest.mocked({
   getOrThrow: jest.fn(),
 } as jest.MockedObjectDeep<IConfigurationService>);
@@ -42,6 +46,7 @@ describe('ContractsRepository', () => {
 
     target = new ContractsRepository(
       mockTransactionApiManager,
+      mockDataDecoderApi,
       mockConfigurationService,
       mockLoggingService,
     );

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -11,6 +11,12 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { SAFE_TRANSACTION_SERVICE_MAX_LIMIT } from '@/domain/common/constants';
+import { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
+import { Page } from '@/domain/entities/page.entity';
+import {
+  Contract as DataDecoderContract,
+  ContractPageSchema as DataDecoderContractPageSchema,
+} from '@/domain/data-decoder/v2/entities/contract.entity';
 
 @Injectable()
 export class ContractsRepository implements IContractsRepository {
@@ -20,6 +26,8 @@ export class ContractsRepository implements IContractsRepository {
   constructor(
     @Inject(ITransactionApiManager)
     private readonly transactionApiManager: ITransactionApiManager,
+    @Inject(IDataDecoderApi)
+    private readonly dataDecoderApi: IDataDecoderApi,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
@@ -40,6 +48,17 @@ export class ContractsRepository implements IContractsRepository {
     const api = await this.transactionApiManager.getApi(args.chainId);
     const data = await api.getContract(args.contractAddress);
     return ContractSchema.parse(data);
+  }
+
+  async getContracts(args: {
+    chainId: string;
+    contractAddress: `0x${string}`;
+  }): Promise<Page<DataDecoderContract>> {
+    const contracts = await this.dataDecoderApi.getContracts({
+      address: args.contractAddress,
+      chainIds: [args.chainId],
+    });
+    return DataDecoderContractPageSchema.parse(contracts);
   }
 
   async isTrustedForDelegateCall(args: {

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -47,7 +47,7 @@ export class ContractsRepository implements IContractsRepository {
   }): Promise<Contract> {
     const api = await this.transactionApiManager.getApi(args.chainId);
     const data = await api.getContract(args.contractAddress);
-    return ContractSchema.parse(data);
+    return ContractSchema.parse(data); //TODO: handle old entity 
   }
 
   async getContracts(args: {

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -49,6 +49,7 @@ export class ContractsRepository implements IContractsRepository {
     if (count === 0) {
       throw new NotFoundException('Error fetching the contract data.');
     }
+    // We fetch index 0 as the Decoder API returns a page with a single contract for a given address and chainId
     return results[0];
   }
 

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -2,9 +2,7 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
-import {
-  ContractPageSchema,
-} from '@/domain/contracts/entities/schemas/contract.schema';
+import { ContractPageSchema } from '@/domain/contracts/entities/schemas/contract.schema';
 import { isAddressEqual } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';

--- a/src/domain/data-decoder/v2/data-decoder.repository.interface.ts
+++ b/src/domain/data-decoder/v2/data-decoder.repository.interface.ts
@@ -1,6 +1,4 @@
-// import type { Contract } from '@/domain/data-decoder/v2/entities/contract.entity';
 import type { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
-// import type { Page } from '@/domain/entities/page.entity';
 import type { Transaction } from '@/domain/safe/entities/transaction.entity';
 
 export const IDataDecoderRepository = Symbol('IDataDecoderRepository');
@@ -11,11 +9,6 @@ export interface IDataDecoderRepository {
     data: `0x${string}`;
     to: `0x${string}`;
   }): Promise<DataDecoded>;
-
-  // getContracts(args: {
-  //   chainIds: Array<string>;
-  //   address: `0x${string}`;
-  // }): Promise<Page<Contract>>;
 
   getTransactionDataDecoded(args: {
     chainId: string;

--- a/src/domain/data-decoder/v2/data-decoder.repository.interface.ts
+++ b/src/domain/data-decoder/v2/data-decoder.repository.interface.ts
@@ -1,6 +1,6 @@
-import type { Contract } from '@/domain/data-decoder/v2/entities/contract.entity';
+// import type { Contract } from '@/domain/data-decoder/v2/entities/contract.entity';
 import type { DataDecoded } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
-import type { Page } from '@/domain/entities/page.entity';
+// import type { Page } from '@/domain/entities/page.entity';
 import type { Transaction } from '@/domain/safe/entities/transaction.entity';
 
 export const IDataDecoderRepository = Symbol('IDataDecoderRepository');
@@ -12,10 +12,10 @@ export interface IDataDecoderRepository {
     to: `0x${string}`;
   }): Promise<DataDecoded>;
 
-  getContracts(args: {
-    chainIds: Array<string>;
-    address: `0x${string}`;
-  }): Promise<Page<Contract>>;
+  // getContracts(args: {
+  //   chainIds: Array<string>;
+  //   address: `0x${string}`;
+  // }): Promise<Page<Contract>>;
 
   getTransactionDataDecoded(args: {
     chainId: string;

--- a/src/domain/data-decoder/v2/data-decoder.repository.ts
+++ b/src/domain/data-decoder/v2/data-decoder.repository.ts
@@ -5,11 +5,11 @@ import {
 } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { IDataDecoderRepository } from '@/domain/data-decoder/v2/data-decoder.repository.interface';
 import { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
-import { Page } from '@/domain/entities/page.entity';
-import {
-  Contract,
-  ContractPageSchema,
-} from '@/domain/data-decoder/v2/entities/contract.entity';
+// import { Page } from '@/domain/entities/page.entity';
+// import {
+//   Contract,
+//   ContractPageSchema,
+// } from '@/domain/data-decoder/v2/entities/contract.entity';
 import { Transaction } from '@/domain/safe/entities/transaction.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
@@ -31,13 +31,13 @@ export class DataDecoderRepository implements IDataDecoderRepository {
     return DataDecodedSchema.parse(dataDecoded);
   }
 
-  public async getContracts(args: {
-    chainIds: Array<string>;
-    address: `0x${string}`;
-  }): Promise<Page<Contract>> {
-    const contracts = await this.dataDecoderApi.getContracts(args);
-    return ContractPageSchema.parse(contracts);
-  }
+  // public async getContracts(args: {
+  //   chainIds: Array<string>;
+  //   address: `0x${string}`;
+  // }): Promise<Page<Contract>> {
+  //   const contracts = await this.dataDecoderApi.getContracts(args);
+  //   return ContractPageSchema.parse(contracts);
+  // }
 
   public async getTransactionDataDecoded(args: {
     chainId: string;

--- a/src/domain/data-decoder/v2/data-decoder.repository.ts
+++ b/src/domain/data-decoder/v2/data-decoder.repository.ts
@@ -5,11 +5,6 @@ import {
 } from '@/domain/data-decoder/v2/entities/data-decoded.entity';
 import { IDataDecoderRepository } from '@/domain/data-decoder/v2/data-decoder.repository.interface';
 import { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
-// import { Page } from '@/domain/entities/page.entity';
-// import {
-//   Contract,
-//   ContractPageSchema,
-// } from '@/domain/data-decoder/v2/entities/contract.entity';
 import { Transaction } from '@/domain/safe/entities/transaction.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
@@ -30,14 +25,6 @@ export class DataDecoderRepository implements IDataDecoderRepository {
     const dataDecoded = await this.dataDecoderApi.getDecodedData(args);
     return DataDecodedSchema.parse(dataDecoded);
   }
-
-  // public async getContracts(args: {
-  //   chainIds: Array<string>;
-  //   address: `0x${string}`;
-  // }): Promise<Page<Contract>> {
-  //   const contracts = await this.dataDecoderApi.getContracts(args);
-  //   return ContractPageSchema.parse(contracts);
-  // }
 
   public async getTransactionDataDecoded(args: {
     chainId: string;

--- a/src/domain/data-decoder/v2/entities/__tests__/contract.builder.ts
+++ b/src/domain/data-decoder/v2/entities/__tests__/contract.builder.ts
@@ -26,5 +26,7 @@ export function contractBuilder(): IBuilder<Contract> {
     .with('chainId', faker.number.int() as unknown as string)
     .with('project', projectBuilder().build())
     .with('abi', abiBuilder().build())
-    .with('modified', faker.date.past());
+    .with('modified', faker.date.past())
+    .with('logoUrl', faker.internet.url({ appendSlash: false }))
+    .with('trustedForDelegateCall', faker.datatype.boolean());
 }

--- a/src/domain/data-decoder/v2/entities/__tests__/contract.builder.ts
+++ b/src/domain/data-decoder/v2/entities/__tests__/contract.builder.ts
@@ -11,8 +11,8 @@ export function projectBuilder(): IBuilder<NonNullable<Contract['project']>> {
     .with('logoFile', faker.internet.url());
 }
 
-export function abiBuilder(): IBuilder<Contract['abi']> {
-  return new Builder<Contract['abi']>()
+export function abiBuilder(): IBuilder<NonNullable<Contract['abi']>> {
+  return new Builder<NonNullable<Contract['abi']>>()
     .with('abiJson', [JSON.parse(fakeJson()) as Record<string, unknown>])
     .with('abiHash', faker.string.hexadecimal() as `0x${string}`)
     .with('modified', faker.date.past());

--- a/src/domain/data-decoder/v2/entities/contract.entity.spec.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.spec.ts
@@ -246,6 +246,13 @@ describe('Contract', () => {
           message: 'Invalid date',
           path: ['modified'],
         },
+        {
+          code: 'invalid_type',
+          expected: 'boolean',
+          message: 'Required',
+          path: ['trustedForDelegateCall'],
+          received: 'undefined',
+        },
       ]);
     });
   });

--- a/src/domain/data-decoder/v2/entities/contract.entity.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.ts
@@ -21,7 +21,7 @@ export const ContractSchema = z.object({
   displayName: z.string().nullable(),
   chainId: z.number().transform(String),
   project: ProjectSchema.nullable(),
-  abi: AbiSchema,
+  abi: AbiSchema.nullable(),
   modified: z.coerce.date(),
   trustedForDelegateCall: z.boolean(),
   logoUrl: z.string().nullish().default(null),

--- a/src/domain/data-decoder/v2/entities/contract.entity.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.ts
@@ -23,6 +23,8 @@ export const ContractSchema = z.object({
   project: ProjectSchema.nullable(),
   abi: AbiSchema,
   modified: z.coerce.date(),
+  trustedForDelegateCall: z.boolean(),
+  logoUrl: z.string().nullish().default(null),
 });
 
 export type Contract = z.infer<typeof ContractSchema>;

--- a/src/domain/data-decoder/v2/entities/contract.entity.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.ts
@@ -10,7 +10,7 @@ export const ProjectSchema = z.object({
 
 export const AbiSchema = z.object({
   // We could use abitype here, but we don't consume the ABI/it would increase entity complexity
-  abiJson: z.array(z.record(z.unknown())),
+  abiJson: z.array(z.record(z.unknown())).nullable(),
   abiHash: HexSchema,
   modified: z.coerce.date(),
 });

--- a/src/domain/interfaces/data-decoder-api.interface.ts
+++ b/src/domain/interfaces/data-decoder-api.interface.ts
@@ -13,6 +13,7 @@ export interface IDataDecoderApi {
 
   getContracts(args: {
     address: `0x${string}`;
+    chainIds: Array<string>;
     limit?: number;
     offset?: number;
   }): Promise<Raw<Page<Contract>>>;

--- a/src/routes/common/__tests__/address-info.helper.spec.ts
+++ b/src/routes/common/__tests__/address-info.helper.spec.ts
@@ -1,5 +1,5 @@
 import type { ContractsRepository } from '@/domain/contracts/contracts.repository';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
 import type { TokenRepository } from '@/domain/tokens/token.repository';
 import type { ILoggingService } from '@/logging/logging.interface';
@@ -45,7 +45,7 @@ describe('AddressInfoHelper', () => {
       expect(result).toEqual({
         value: contract.address,
         name: contract.displayName,
-        logoUri: contract.logoUri,
+        logoUri: contract.logoUrl,
       });
       expect(contractsRepository.getContract).toHaveBeenCalledWith({
         chainId,
@@ -89,7 +89,7 @@ describe('AddressInfoHelper', () => {
       expect(result).toEqual({
         value: contract.address,
         name: contract.name,
-        logoUri: contract.logoUri,
+        logoUri: contract.logoUrl,
       });
       expect(contractsRepository.getContract).toHaveBeenCalledWith({
         chainId,
@@ -144,7 +144,7 @@ describe('AddressInfoHelper', () => {
         {
           value: contract.address,
           name: contract.displayName,
-          logoUri: contract.logoUri,
+          logoUri: contract.logoUrl,
         },
         {
           value: token.address,

--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -63,7 +63,7 @@ export class AddressInfoHelper {
    * @param address - the address of the source to which we want to retrieve its metadata
    * @param sources - a collection of {@link Source} to which we want to retrieve its metadata
    */
-  getOrDefault(
+  async getOrDefault(
     chainId: string,
     address: `0x${string}`,
     sources: Array<Source>,
@@ -80,7 +80,7 @@ export class AddressInfoHelper {
    * @param addresses - the collection of addresses to which we want to retrieve the respective metadata
    * @param sources - a collection of {@link Source} to which we want to retrieve its metadata
    */
-  getCollection(
+  async getCollection(
     chainId: string,
     addresses: Array<`0x${string}`>,
     sources: Array<Source>,
@@ -95,7 +95,7 @@ export class AddressInfoHelper {
     );
   }
 
-  private _getFromSource(
+  private async _getFromSource(
     chainId: string,
     address: `0x${string}`,
     source: Source,
@@ -106,7 +106,7 @@ export class AddressInfoHelper {
           .getContract({ chainId, contractAddress: address })
           .then((c) => {
             const name = c.displayName || c.name;
-            return new AddressInfo(c.address, name, c.logoUri);
+            return new AddressInfo(c.address, name, c.logoUrl);
           });
       case 'TOKEN':
         return this.tokenRepository

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -87,9 +87,9 @@ describe('Contracts controller', () => {
         .with('address', decoderContract.address)
         .with('name', decoderContract.name)
         .with('displayName', decoderContract.displayName ?? '')
-        .with('logoUri', decoderContract.project?.logoFile ?? null)
+        .with('logoUri', decoderContract.logoUrl)
         .with('contractAbi', { abi: decoderContract.abi.abiJson })
-        .with('trustedForDelegateCall', false)
+        .with('trustedForDelegateCall', decoderContract.trustedForDelegateCall)
         .build();
 
       networkService.get.mockImplementation(({ url }) => {

--- a/src/routes/contracts/contracts.controller.ts
+++ b/src/routes/contracts/contracts.controller.ts
@@ -5,6 +5,7 @@ import { ContractsService } from '@/routes/contracts/contracts.service';
 import { Contract as ApiContract } from '@/routes/contracts/entities/contract.entity';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
 @ApiTags('contracts')
 @Controller({
@@ -17,7 +18,7 @@ export class ContractsController {
   @ApiOkResponse({ type: ApiContract })
   @Get('chains/:chainId/contracts/:contractAddress')
   async getContract(
-    @Param('chainId') chainId: string,
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('contractAddress', new ValidationPipe(AddressSchema))
     contractAddress: `0x${string}`,
   ): Promise<Contract> {

--- a/src/routes/contracts/contracts.module.ts
+++ b/src/routes/contracts/contracts.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ContractsController } from '@/routes/contracts/contracts.controller';
 import { ContractsService } from '@/routes/contracts/contracts.service';
 import { ContractsRepositoryModule } from '@/domain/contracts/contracts.repository.interface';
+import { ContractMapper } from '@/routes/contracts/mappers/contract.mapper';
 
 @Module({
   imports: [ContractsRepositoryModule],
   controllers: [ContractsController],
-  providers: [ContractsService],
+  providers: [ContractsService, ContractMapper],
 })
 export class ContractsModule {}

--- a/src/routes/contracts/contracts.service.ts
+++ b/src/routes/contracts/contracts.service.ts
@@ -17,6 +17,6 @@ export class ContractsService {
     contractAddress: `0x${string}`;
   }): Promise<Contract> {
     const contract = await this.contractsRepository.getContract(args);
-    return this.contractMapper.mapContract(contract);
+    return this.contractMapper.map(contract);
   }
 }

--- a/src/routes/contracts/contracts.service.ts
+++ b/src/routes/contracts/contracts.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
@@ -12,22 +12,11 @@ export class ContractsService {
     private readonly contractMapper: ContractMapper,
   ) {}
 
-  // async getContract(args: {
-  //   chainId: string;
-  //   contractAddress: `0x${string}`;
-  // }): Promise<Contract> {
-  //   return this.contractsRepository.getContract(args);
-  // }
-
   async getContract(args: {
     chainId: string;
     contractAddress: `0x${string}`;
   }): Promise<Contract> {
-    const { count, results } =
-      await this.contractsRepository.getContracts(args);
-    if (count === 0) {
-      throw new NotFoundException('Error fetching the contract data.');
-    }
-    return this.contractMapper.mapContract(results[0]);
+    const contract = await this.contractsRepository.getContract(args);
+    return this.contractMapper.mapContract(contract);
   }
 }

--- a/src/routes/contracts/contracts.service.ts
+++ b/src/routes/contracts/contracts.service.ts
@@ -1,19 +1,33 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ContractsRepository } from '@/domain/contracts/contracts.repository';
 import { IContractsRepository } from '@/domain/contracts/contracts.repository.interface';
 import { Contract } from '@/domain/contracts/entities/contract.entity';
+import { ContractMapper } from '@/routes/contracts/mappers/contract.mapper';
 
 @Injectable()
 export class ContractsService {
   constructor(
     @Inject(IContractsRepository)
     private readonly contractsRepository: ContractsRepository,
+    private readonly contractMapper: ContractMapper,
   ) {}
+
+  // async getContract(args: {
+  //   chainId: string;
+  //   contractAddress: `0x${string}`;
+  // }): Promise<Contract> {
+  //   return this.contractsRepository.getContract(args);
+  // }
 
   async getContract(args: {
     chainId: string;
     contractAddress: `0x${string}`;
   }): Promise<Contract> {
-    return this.contractsRepository.getContract(args);
+    const { count, results } =
+      await this.contractsRepository.getContracts(args);
+    if (count === 0) {
+      throw new NotFoundException('Error fetching the contract data.');
+    }
+    return this.contractMapper.mapContract(results[0]);
   }
 }

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -1,0 +1,76 @@
+import { fakeJson } from '@/__tests__/faker';
+import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import {
+  abiBuilder,
+  contractBuilder as dataDecodedContractBuilder,
+  projectBuilder,
+} from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
+import { ContractMapper } from '@/routes/contracts/mappers/contract.mapper';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+
+describe('Contract Mapper', () => {
+  let mapper: ContractMapper;
+
+  const address = getAddress(faker.finance.ethereumAddress());
+  const name = faker.word.sample();
+  const displayName = faker.word.words();
+  const logoUri = faker.internet.url({ appendSlash: false });
+  const contractAbi = JSON.parse(fakeJson()) as Record<string, unknown>;
+  const trustedForDelegateCall = false; //faker.datatype.boolean();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mapper = new ContractMapper();
+  });
+
+  it('should return mapped contract', () => {
+    const expected = contractBuilder()
+      .with('address', address)
+      .with('name', name)
+      .with('displayName', displayName)
+      .with('logoUri', logoUri)
+      .with('contractAbi', { abi: [contractAbi] })
+      .with('trustedForDelegateCall', trustedForDelegateCall)
+      .build();
+
+    const contract = dataDecodedContractBuilder()
+      .with('address', address)
+      .with('name', name)
+      .with('displayName', displayName)
+      .with('chainId', faker.number.int() as unknown as string)
+      .with('project', projectBuilder().with('logoFile', logoUri).build())
+      .with('abi', abiBuilder().with('abiJson', [contractAbi]).build())
+      .with('modified', faker.date.past())
+      .build();
+
+    const actual = mapper.mapContract(contract);
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return displayName = "" if its null', () => {
+    const contract = dataDecodedContractBuilder()
+      .with('displayName', null)
+      .build();
+
+    const actual = mapper.mapContract(contract);
+    expect(actual.displayName).toEqual('');
+  });
+
+  it('should return logoUri = null if project is null', () => {
+    const contract = dataDecodedContractBuilder().with('project', null).build();
+
+    const actual = mapper.mapContract(contract);
+    expect(actual.logoUri).toEqual(null);
+  });
+
+  it('should return contractAbi = null if abiJson is null', () => {
+    const contract = dataDecodedContractBuilder()
+      .with('abi', abiBuilder().with('abiJson', null).build())
+      .build();
+
+    const actual = mapper.mapContract(contract);
+    expect(actual.contractAbi).toEqual(null);
+  });
+});

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -14,20 +14,20 @@ describe('Contract Mapper', () => {
   });
 
   it('should return mapped contract', () => {
+    const address = '0xC0cf7C5DbcCBFDb0FAb8509C610dAc8B0Fa006aD';
     const contract = dataDecodedContractBuilder()
-      .with('address', '0xC0cf7C5DbcCBFDb0FAb8509C610dAc8B0Fa006aD')
-      .with('name', 'contract name')
+      .with('address', address)
       .build();
 
     const actual = mapper.map(contract);
     expect(actual).toEqual({
-      address: '0xC0cf7C5DbcCBFDb0FAb8509C610dAc8B0Fa006aD',
+      address: address,
       contractAbi: {
         abi: [expect.any(Object)],
       },
       displayName: expect.any(String),
       logoUri: expect.any(String),
-      name: 'contract name',
+      name: expect.any(String),
       trustedForDelegateCall: expect.any(Boolean),
     });
   });

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -17,7 +17,7 @@ describe('Contract Mapper', () => {
   const displayName = faker.word.words();
   const logoUri = faker.internet.url({ appendSlash: false });
   const contractAbi = JSON.parse(fakeJson()) as Record<string, unknown>;
-  const trustedForDelegateCall = false; //faker.datatype.boolean();
+  const trustedForDelegateCall = faker.datatype.boolean();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -40,9 +40,11 @@ describe('Contract Mapper', () => {
       .with('name', name)
       .with('displayName', displayName)
       .with('chainId', faker.number.int() as unknown as string)
-      .with('project', projectBuilder().with('logoFile', logoUri).build())
+      .with('project', projectBuilder().build())
       .with('abi', abiBuilder().with('abiJson', [contractAbi]).build())
       .with('modified', faker.date.past())
+      .with('trustedForDelegateCall', trustedForDelegateCall)
+      .with('logoUrl', logoUri)
       .build();
 
     const actual = mapper.mapContract(contract);
@@ -58,8 +60,8 @@ describe('Contract Mapper', () => {
     expect(actual.displayName).toEqual('');
   });
 
-  it('should return logoUri = null if project is null', () => {
-    const contract = dataDecodedContractBuilder().with('project', null).build();
+  it('should return logoUri = null if logoUrl is null', () => {
+    const contract = dataDecodedContractBuilder().with('logoUrl', null).build();
 
     const actual = mapper.mapContract(contract);
     expect(actual.logoUri).toEqual(null);

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -1,23 +1,11 @@
-import { fakeJson } from '@/__tests__/faker';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
 import {
   abiBuilder,
   contractBuilder as dataDecodedContractBuilder,
-  projectBuilder,
 } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
 import { ContractMapper } from '@/routes/contracts/mappers/contract.mapper';
-import { faker } from '@faker-js/faker/.';
-import { getAddress } from 'viem';
 
 describe('Contract Mapper', () => {
   let mapper: ContractMapper;
-
-  const address = getAddress(faker.finance.ethereumAddress());
-  const name = faker.word.sample();
-  const displayName = faker.word.words();
-  const logoUri = faker.internet.url({ appendSlash: false });
-  const contractAbi = JSON.parse(fakeJson()) as Record<string, unknown>;
-  const trustedForDelegateCall = faker.datatype.boolean();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -26,29 +14,22 @@ describe('Contract Mapper', () => {
   });
 
   it('should return mapped contract', () => {
-    const expected = contractBuilder()
-      .with('address', address)
-      .with('name', name)
-      .with('displayName', displayName)
-      .with('logoUri', logoUri)
-      .with('contractAbi', { abi: [contractAbi] })
-      .with('trustedForDelegateCall', trustedForDelegateCall)
-      .build();
-
     const contract = dataDecodedContractBuilder()
-      .with('address', address)
-      .with('name', name)
-      .with('displayName', displayName)
-      .with('chainId', faker.number.int() as unknown as string)
-      .with('project', projectBuilder().build())
-      .with('abi', abiBuilder().with('abiJson', [contractAbi]).build())
-      .with('modified', faker.date.past())
-      .with('trustedForDelegateCall', trustedForDelegateCall)
-      .with('logoUrl', logoUri)
+      .with('address', '0xC0cf7C5DbcCBFDb0FAb8509C610dAc8B0Fa006aD')
+      .with('name', 'contract name')
       .build();
 
-    const actual = mapper.mapContract(contract);
-    expect(actual).toEqual(expected);
+    const actual = mapper.map(contract);
+    expect(actual).toEqual({
+      address: '0xC0cf7C5DbcCBFDb0FAb8509C610dAc8B0Fa006aD',
+      contractAbi: {
+        abi: [expect.any(Object)],
+      },
+      displayName: expect.any(String),
+      logoUri: expect.any(String),
+      name: 'contract name',
+      trustedForDelegateCall: expect.any(Boolean),
+    });
   });
 
   it('should return displayName = "" if its null', () => {
@@ -56,14 +37,14 @@ describe('Contract Mapper', () => {
       .with('displayName', null)
       .build();
 
-    const actual = mapper.mapContract(contract);
+    const actual = mapper.map(contract);
     expect(actual.displayName).toEqual('');
   });
 
   it('should return logoUri = null if logoUrl is null', () => {
     const contract = dataDecodedContractBuilder().with('logoUrl', null).build();
 
-    const actual = mapper.mapContract(contract);
+    const actual = mapper.map(contract);
     expect(actual.logoUri).toEqual(null);
   });
 
@@ -72,7 +53,14 @@ describe('Contract Mapper', () => {
       .with('abi', abiBuilder().with('abiJson', null).build())
       .build();
 
-    const actual = mapper.mapContract(contract);
+    const actual = mapper.map(contract);
+    expect(actual.contractAbi).toEqual(null);
+  });
+
+  it('should return contractAbi = null if abi is null', () => {
+    const contract = dataDecodedContractBuilder().with('abi', null).build();
+
+    const actual = mapper.map(contract);
     expect(actual.contractAbi).toEqual(null);
   });
 });

--- a/src/routes/contracts/mappers/contract.mapper.ts
+++ b/src/routes/contracts/mappers/contract.mapper.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { Contract } from '@/domain/contracts/entities/contract.entity';
+import { Contract as DataDecoderContract } from '@/domain/data-decoder/v2/entities/contract.entity';
+
+@Injectable()
+export class ContractMapper {
+  constructor() {}
+
+  mapContract(contract: DataDecoderContract): Contract {
+    const contractAbi = contract.abi.abiJson
+      ? { abi: contract.abi.abiJson }
+      : null;
+    return {
+      address: contract.address,
+      name: contract.name,
+      displayName: contract.displayName ?? '',
+      logoUri: contract.project?.logoFile ?? null,
+      contractAbi: contractAbi,
+      trustedForDelegateCall: false, //TODO fix when the value is available
+    };
+  }
+}

--- a/src/routes/contracts/mappers/contract.mapper.ts
+++ b/src/routes/contracts/mappers/contract.mapper.ts
@@ -15,7 +15,7 @@ export class ContractMapper {
       name: contract.name,
       displayName: contract.displayName ?? '',
       logoUri: contract.logoUrl,
-      contractAbi: contractAbi,
+      contractAbi,
       trustedForDelegateCall: contract.trustedForDelegateCall,
     };
   }

--- a/src/routes/contracts/mappers/contract.mapper.ts
+++ b/src/routes/contracts/mappers/contract.mapper.ts
@@ -14,9 +14,9 @@ export class ContractMapper {
       address: contract.address,
       name: contract.name,
       displayName: contract.displayName ?? '',
-      logoUri: contract.project?.logoFile ?? null,
+      logoUri: contract.logoUrl,
       contractAbi: contractAbi,
-      trustedForDelegateCall: false, //TODO fix when the value is available
+      trustedForDelegateCall: contract.trustedForDelegateCall,
     };
   }
 }

--- a/src/routes/contracts/mappers/contract.mapper.ts
+++ b/src/routes/contracts/mappers/contract.mapper.ts
@@ -4,10 +4,10 @@ import { Contract as DataDecoderContract } from '@/domain/data-decoder/v2/entiti
 
 @Injectable()
 export class ContractMapper {
-  constructor() {}
+  public constructor() {}
 
-  mapContract(contract: DataDecoderContract): Contract {
-    const contractAbi = contract.abi.abiJson
+  public map(contract: DataDecoderContract): Contract {
+    const contractAbi = contract.abi?.abiJson
       ? { abi: contract.abi.abiJson }
       : null;
     return {

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -7,7 +7,7 @@ import { TestAppProvider } from '@/__tests__/test-app.provider';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { safeAppBuilder } from '@/domain/safe-apps/entities/__tests__/safe-app.builder';
 import { Operation } from '@/domain/safe/entities/operation.entity';
@@ -236,6 +236,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const contract = contractBuilder()
       .with('trustedForDelegateCall', false)
       .build();
+    const contractPage = pageBuilder().with('results', [contract]).build();
     const moduleTransactionId = faker.string.uuid();
     const moduleTransaction = moduleTransactionBuilder()
       .with('safe', getAddress(safe.address))
@@ -247,8 +248,8 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${moduleTransactionId}`;
-    const getContractUrl = `${chain.transactionService}/api/v1/contracts/${moduleTransaction.to}`;
-    const getModuleContractUrl = `${chain.transactionService}/api/v1/contracts/${moduleTransaction.module}`;
+    const getContractUrl = `${safeDecoderUrl}/api/v1/contracts/${moduleTransaction.to}`;
+    const getModuleContractUrl = `${safeDecoderUrl}/api/v1/contracts/${moduleTransaction.module}`;
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
@@ -261,9 +262,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getSafeUrl:
           return Promise.resolve({ data: rawify(safe), status: 200 });
         case getContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         case getModuleContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -353,6 +354,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const chain = chainBuilder().with('chainId', chainId).build();
     const safe = safeBuilder().build();
     const contract = contractBuilder().build();
+    const contractPage = pageBuilder().with('results', [contract]).build();
     const transferId = faker.string.uuid();
     const transfer = nativeTokenTransferBuilder()
       .with('transferId', transferId)
@@ -361,8 +363,8 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getTransferUrl = `${chain.transactionService}/api/v1/transfer/${transferId}`;
-    const getFromContractUrl = `${chain.transactionService}/api/v1/contracts/${transfer.from}`;
-    const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${transfer.to}`;
+    const getFromContractUrl = `${safeDecoderUrl}/api/v1/contracts/${transfer.from}`;
+    const getToContractUrl = `${safeDecoderUrl}/api/v1/contracts/${transfer.to}`;
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
@@ -375,9 +377,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getSafeUrl:
           return Promise.resolve({ data: rawify(safe), status: 200 });
         case getFromContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -466,6 +468,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       )
       .build();
     const contract = contractBuilder().build();
+    const contractPage = pageBuilder().with('results', [contract]).build();
     const executionDate = faker.date.recent();
     const safeTxGas = faker.number.int();
     const gasPrice = faker.string.numeric();
@@ -512,7 +515,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}/`;
     const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
-    const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
+    const getToContractUrl = `${safeDecoderUrl}/api/v1/contracts/${tx.to}`;
     const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${tx.to}`;
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
@@ -533,7 +536,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getGasTokenContractUrl:
           return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         case getToTokenUrl:
           return Promise.resolve({ data: rawify(token), status: 200 });
         case getSafeAppsUrl:
@@ -659,6 +662,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       )
       .build();
     const contract = contractBuilder().build();
+    const contractPage = pageBuilder().with('results', [contract]).build();
     const executionDate = faker.date.recent();
     const safeTxGas = faker.number.int();
     const gasPrice = faker.string.numeric();
@@ -706,7 +710,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     }/api/v1/multisig-transactions/${tx.safeTxHash.slice(2)}/`;
     const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
-    const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
+    const getToContractUrl = `${safeDecoderUrl}/api/v1/contracts/${tx.to}`;
     const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${tx.to}`;
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
@@ -727,7 +731,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getGasTokenContractUrl:
           return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         case getToTokenUrl:
           return Promise.resolve({ data: rawify(token), status: 200 });
         case getSafeAppsUrl:
@@ -852,6 +856,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .with('nonce', 5)
       .build();
     const contract = contractBuilder().build();
+    const contractPage = pageBuilder().with('results', [contract]).build();
     const executionDate = faker.date.recent();
     const safeTxGas = faker.number.int();
     const gasPrice = faker.string.numeric();
@@ -897,7 +902,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${tx.safeTxHash}/`;
     const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
-    const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
+    const getToContractUrl = `${safeDecoderUrl}/api/v1/contracts/${tx.to}`;
     networkService.get.mockImplementation(({ url }) => {
       switch (url) {
         case getChainUrl:
@@ -917,7 +922,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getGasTokenContractUrl:
           return Promise.resolve({ data: rawify(gasToken), status: 200 });
         case getToContractUrl:
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         case getSafeAppsUrl:
           return Promise.resolve({
             data: rawify(safeAppsResponse),
@@ -953,7 +958,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             to: {
               value: contract.address,
               name: contract.displayName,
-              logoUri: contract.logoUri,
+              logoUri: contract.logoUrl,
             },
             dataSize: expect.any(String),
             value: expect.any(String),
@@ -967,7 +972,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             to: {
               value: contract.address,
               name: contract.displayName,
-              logoUri: contract.logoUri,
+              logoUri: contract.logoUrl,
             },
             value: tx.value,
             operation: tx.operation,

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -9,7 +9,7 @@ import configuration from '@/config/entities/__tests__/configuration';
 import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
 import {
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
@@ -256,7 +256,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-      const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${safeDecoderUrl}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -391,7 +391,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-      const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${safeDecoderUrl}/api/v1/contracts/`;
       const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/0x7Af3460d552f832fD7E2DE973c628ACeA59B0712`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -475,6 +475,9 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const chain = chainBuilder().build();
     const safeAppsResponse = [safeAppBuilder().build()];
     const contractResponse = contractBuilder().build();
+    const contractPageResponse = pageBuilder()
+      .with('results', [contractResponse])
+      .build();
     const signers = Array.from({ length: 3 }, () => {
       const privateKey = generatePrivateKey();
       return privateKeyToAccount(privateKey);
@@ -518,7 +521,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${domainTransaction.safe}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${domainTransaction.safe}`;
-      const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${safeDecoderUrl}/api/v1/contracts/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chain), status: 200 });
       }
@@ -535,7 +538,10 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         return Promise.resolve({ data: rawify(safe), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
+        return Promise.resolve({
+          data: rawify(contractPageResponse),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -566,7 +572,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
                   to: {
                     value: contractResponse.address,
                     name: contractResponse.displayName,
-                    logoUri: contractResponse.logoUri,
+                    logoUri: contractResponse.logoUrl,
                   },
                   dataSize: '16',
                   value: domainTransaction.value,
@@ -634,7 +640,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
-      const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${safeDecoderUrl}/api/v1/contracts/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chain), status: 200 });
       }

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.spec.ts
@@ -8,7 +8,7 @@ import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { AppModule } from '@/app.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
 import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
@@ -39,6 +39,7 @@ import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
 import { rawify } from '@/validation/entities/raw.entity';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 
 describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -121,6 +122,9 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contractResponse = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPageResponse = pageBuilder()
+        .with('results', [contractResponse])
+        .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -145,10 +149,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
+          `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`
         ) {
           return Promise.resolve({
-            data: rawify(contractResponse),
+            data: rawify(contractPageResponse),
             status: 200,
           });
         }
@@ -219,7 +223,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             to: {
               value: previewTransactionDto.to,
               name: contractResponse.displayName,
-              logoUri: contractResponse.logoUri,
+              logoUri: contractResponse.logoUrl,
             },
             value: previewTransactionDto.value,
             operation: previewTransactionDto.operation,
@@ -259,6 +263,9 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contractResponse = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPageResponse = pageBuilder()
+        .with('results', [contractResponse])
+        .build();
       const tokenResponse = tokenBuilder()
         .with('address', swapTransaction.to)
         .build();
@@ -286,10 +293,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
+          `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`
         ) {
           return Promise.resolve({
-            data: rawify(contractResponse),
+            data: rawify(contractPageResponse),
             status: 200,
           });
         }
@@ -366,7 +373,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             to: {
               value: previewTransactionDto.to,
               name: contractResponse.displayName,
-              logoUri: contractResponse.logoUri,
+              logoUri: contractResponse.logoUrl,
             },
             value: previewTransactionDto.value,
             operation: previewTransactionDto.operation,
@@ -394,6 +401,9 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contractResponse = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPageResponse = pageBuilder()
+        .with('results', [contractResponse])
+        .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -408,10 +418,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
+          `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`
         ) {
           return Promise.resolve({
-            data: rawify(contractResponse),
+            data: rawify(contractPageResponse),
             status: 200,
           });
         }
@@ -454,6 +464,9 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contractResponse = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPageResponse = pageBuilder()
+        .with('results', [contractResponse])
+        .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -478,10 +491,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
+          `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`
         ) {
           return Promise.resolve({
-            data: rawify(contractResponse),
+            data: rawify(contractPageResponse),
             status: 200,
           });
         }
@@ -524,6 +537,9 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contractResponse = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPageResponse = pageBuilder()
+        .with('results', [contractResponse])
+        .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -548,10 +564,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
+          `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`
         ) {
           return Promise.resolve({
-            data: rawify(contractResponse),
+            data: rawify(contractPageResponse),
             status: 200,
           });
         }
@@ -596,6 +612,9 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contractResponse = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPageResponse = pageBuilder()
+        .with('results', [contractResponse])
+        .build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -620,10 +639,10 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`
+          `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`
         ) {
           return Promise.resolve({
-            data: rawify(contractResponse),
+            data: rawify(contractPageResponse),
             status: 200,
           });
         }
@@ -695,6 +714,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contract = contractBuilder()
         .with('address', ComposableCowAddress)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -719,11 +739,8 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         ) {
           return Promise.resolve({ data: rawify(safe), status: 200 });
         }
-        if (
-          url ===
-          `${chain.transactionService}/api/v1/contracts/${contract.address}`
-        ) {
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+        if (url === `${dataDecoderUrl}/api/v1/contracts/${contract.address}`) {
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -797,7 +814,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             to: {
               value: ComposableCowAddress,
               name: contract.displayName,
-              logoUri: contract.logoUri,
+              logoUri: contract.logoUrl,
             },
             value: previewTransactionDto.value,
             operation: previewTransactionDto.operation,
@@ -831,6 +848,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contract = contractBuilder()
         .with('address', previewTransactionDto.to)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
       const tokenResponse = tokenBuilder()
         .with('address', ComposableCowAddress)
         .build();
@@ -858,11 +876,8 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         ) {
           return Promise.resolve({ data: rawify(safe), status: 200 });
         }
-        if (
-          url ===
-          `${chain.transactionService}/api/v1/contracts/${contract.address}`
-        ) {
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+        if (url === `${dataDecoderUrl}/api/v1/contracts/${contract.address}`) {
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         }
         if (
           url ===
@@ -942,7 +957,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
             to: {
               value: previewTransactionDto.to,
               name: contract.displayName,
-              logoUri: contract.logoUri,
+              logoUri: contract.logoUrl,
             },
             value: previewTransactionDto.value,
             operation: previewTransactionDto.operation,
@@ -964,6 +979,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contract = contractBuilder()
         .with('address', ComposableCowAddress)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -988,11 +1004,8 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         ) {
           return Promise.resolve({ data: rawify(safe), status: 200 });
         }
-        if (
-          url ===
-          `${chain.transactionService}/api/v1/contracts/${contract.address}`
-        ) {
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+        if (url === `${dataDecoderUrl}/api/v1/contracts/${contract.address}`) {
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -1026,6 +1039,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contract = contractBuilder()
         .with('address', ComposableCowAddress)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
       networkService.get.mockImplementation(({ url }) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: rawify(chain), status: 200 });
@@ -1050,11 +1064,8 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         ) {
           return Promise.resolve({ data: rawify(safe), status: 200 });
         }
-        if (
-          url ===
-          `${chain.transactionService}/api/v1/contracts/${contract.address}`
-        ) {
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+        if (url === `${dataDecoderUrl}/api/v1/contracts/${contract.address}`) {
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -1088,6 +1099,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
       const contract = contractBuilder()
         .with('address', ComposableCowAddress)
         .build();
+      const contractPage = pageBuilder().with('results', [contract]).build();
       const fullAppData = {
         fullAppData: JSON.stringify({
           appCode:
@@ -1119,11 +1131,8 @@ describe('Preview transaction - CoW Swap - Transactions Controller (Unit)', () =
         ) {
           return Promise.resolve({ data: rawify(safe), status: 200 });
         }
-        if (
-          url ===
-          `${chain.transactionService}/api/v1/contracts/${contract.address}`
-        ) {
-          return Promise.resolve({ data: rawify(contract), status: 200 });
+        if (url === `${dataDecoderUrl}/api/v1/contracts/${contract.address}`) {
+          return Promise.resolve({ data: rawify(contractPage), status: 200 });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -8,7 +8,9 @@ import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { AppModule } from '@/app.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder as contractTokenBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
+import { contractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/data-decoded.builder';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
@@ -123,6 +125,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -152,9 +157,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             default:
@@ -221,7 +226,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               to: {
                 value: contractResponse.address,
                 name: contractResponse.displayName,
-                logoUri: contractResponse.logoUri,
+                logoUri: contractResponse.logoUrl,
               },
               value: previewTransactionDto.value,
               operation: previewTransactionDto.operation,
@@ -264,12 +269,19 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const depositContractResponse = contractBuilder()
           .with('address', depositTransaction.to)
+          .build();
+        const depositContractPageResponse = pageBuilder()
+          .with('results', [depositContractResponse])
           .build();
         const depositTokenResponse = tokenBuilder()
           .with('address', depositTransaction.to)
           .build();
+
         networkService.get.mockImplementation(({ url }) => {
           switch (url) {
             case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -299,14 +311,14 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${depositContractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${depositContractResponse.address}`:
               return Promise.resolve({
-                data: rawify(depositContractResponse),
+                data: rawify(depositContractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${depositTokenResponse.address}`:
@@ -378,7 +390,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               to: {
                 value: contractResponse.address,
                 name: contractResponse.displayName,
-                logoUri: contractResponse.logoUri,
+                logoUri: contractResponse.logoUrl,
               },
               value: previewTransactionDto.value,
               operation: previewTransactionDto.operation,
@@ -403,6 +415,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -419,9 +434,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -469,6 +484,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -486,9 +504,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -537,6 +555,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -554,9 +575,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecodedBuilder}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -603,6 +624,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -620,9 +644,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -670,6 +694,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -687,9 +714,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -738,6 +765,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -764,9 +794,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -815,6 +845,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -841,9 +874,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -903,6 +936,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', deployment.address)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('data', data)
           .with('operation', Operation.CALL)
@@ -932,9 +968,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             default:
@@ -981,7 +1017,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               to: {
                 value: contractResponse.address,
                 name: contractResponse.displayName,
-                logoUri: contractResponse.logoUri,
+                logoUri: contractResponse.logoUrl,
               },
               value: previewTransactionDto.value,
               operation: previewTransactionDto.operation,
@@ -1036,11 +1072,17 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
-        const tokenResponse = contractBuilder()
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
+        const tokenResponse = contractTokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
         const requestValidatorsExiContractResponse = contractBuilder()
           .with('address', deployment.address)
+          .build();
+        const requestValidatorsExiContractPageResponse = pageBuilder()
+          .with('results', [requestValidatorsExiContractResponse])
           .build();
         const requestValidatorsExitTokenResponse = tokenBuilder()
           .with('address', deployment.address)
@@ -1069,14 +1111,14 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${requestValidatorsExiContractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${requestValidatorsExiContractResponse.address}`:
               return Promise.resolve({
-                data: rawify(requestValidatorsExiContractResponse),
+                data: rawify(requestValidatorsExiContractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -1133,7 +1175,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               to: {
                 value: contractResponse.address,
                 name: contractResponse.displayName,
-                logoUri: contractResponse.logoUri,
+                logoUri: contractResponse.logoUrl,
               },
               value: previewTransactionDto.value,
               operation: previewTransactionDto.operation,
@@ -1168,6 +1210,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -1184,9 +1229,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -1243,6 +1288,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -1260,9 +1308,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -1321,6 +1369,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -1338,9 +1389,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -1397,6 +1448,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -1414,9 +1468,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -1473,6 +1527,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', deployment.address)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('data', data)
           .with('operation', Operation.CALL)
@@ -1504,9 +1561,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -1560,6 +1617,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', deployment.address)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('data', data)
           .with('operation', Operation.CALL)
@@ -1591,9 +1651,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -1660,6 +1720,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', deployment.address)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('data', data)
           .with('operation', Operation.CALL)
@@ -1684,9 +1747,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             default:
@@ -1730,7 +1793,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               to: {
                 value: contractResponse.address,
                 name: contractResponse.displayName,
-                logoUri: contractResponse.logoUri,
+                logoUri: contractResponse.logoUrl,
               },
               value: previewTransactionDto.value,
               operation: previewTransactionDto.operation,
@@ -1792,11 +1855,17 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
         const batchWithdrawCLFeeContractResponse = contractBuilder()
           .with('address', batchWithdrawCLFeeTransaction.to)
+          .build();
+        const batchWithdrawCLFeeContractPageResponse = pageBuilder()
+          .with('results', [batchWithdrawCLFeeContractResponse])
           .build();
         const batchWithdrawCLFeeTokenResponse = tokenBuilder()
           .with('address', batchWithdrawCLFeeTransaction.to)
@@ -1820,9 +1889,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${tokenResponse.address}`:
@@ -1830,9 +1899,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(tokenResponse),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${batchWithdrawCLFeeContractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${batchWithdrawCLFeeContractResponse.address}`:
               return Promise.resolve({
-                data: rawify(batchWithdrawCLFeeContractResponse),
+                data: rawify(batchWithdrawCLFeeContractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${batchWithdrawCLFeeTokenResponse.address}`:
@@ -1881,7 +1950,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
               to: {
                 value: contractResponse.address,
                 name: contractResponse.displayName,
-                logoUri: contractResponse.logoUri,
+                logoUri: contractResponse.logoUrl,
               },
               value: previewTransactionDto.value,
               operation: previewTransactionDto.operation,
@@ -1920,6 +1989,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -1936,9 +2008,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -2000,6 +2072,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -2017,9 +2092,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -2082,6 +2157,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -2099,9 +2177,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -2162,6 +2240,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const tokenResponse = tokenBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -2179,9 +2260,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/tokens/${previewTransactionDto.to}`:
@@ -2238,6 +2319,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const contractResponse = contractBuilder()
           .with('address', deployment.address)
           .build();
+        const contractPageResponse = pageBuilder()
+          .with('results', [contractResponse])
+          .build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('data', data)
           .with('operation', Operation.CALL)
@@ -2261,9 +2345,9 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/contracts/${contractResponse.address}`:
+            case `${dataDecoderUrl}/api/v1/contracts/${contractResponse.address}`:
               return Promise.resolve({
-                data: rawify(contractResponse),
+                data: rawify(contractPageResponse),
                 status: 200,
               });
             default:

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -8,7 +8,6 @@ import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module
 import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
 import { AppModule } from '@/app.module';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
-import { contractBuilder } from '@/domain/contracts/entities/__tests__/contract.builder';
 import {
   dataDecodedBuilder,
   dataDecodedParameterBuilder,
@@ -36,6 +35,8 @@ import { TestPostgresDatabaseModuleV2 } from '@/datasources/db/v2/test.postgres-
 import { TestTargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/__tests__/test.targeted-messaging.datasource.module';
 import { TargetedMessagingDatasourceModule } from '@/datasources/targeted-messaging/targeted-messaging.datasource.module';
 import { rawify } from '@/validation/entities/raw.entity';
+import { contractBuilder } from '@/domain/data-decoder/v2/entities/__tests__/contract.builder';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 
 describe('Preview transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -108,10 +109,13 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const chainResponse = chainBuilder().build();
     const dataDecodedResponse = dataDecodedBuilder().build();
     const contractResponse = contractBuilder().build();
+    const contractPageResponse = pageBuilder()
+      .with('results', [contractResponse])
+      .build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
-      const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${dataDecoderUrl}/api/v1/contracts/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -119,7 +123,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
         return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
+        return Promise.resolve({
+          data: rawify(contractPageResponse),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -143,7 +150,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           to: {
             value: contractResponse.address,
             name: contractResponse.displayName,
-            logoUri: contractResponse.logoUri,
+            logoUri: contractResponse.logoUrl,
           },
           dataSize: '16',
           value: previewTransactionDto.value,
@@ -158,7 +165,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           to: {
             value: contractResponse.address,
             name: contractResponse.displayName,
-            logoUri: contractResponse.logoUri,
+            logoUri: contractResponse.logoUrl,
           },
           value: previewTransactionDto.value,
           operation: previewTransactionDto.operation,
@@ -181,7 +188,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
-      const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${dataDecoderUrl}/api/v1/contracts/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -250,7 +257,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
-      const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${dataDecoderUrl}/api/v1/contracts/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -325,10 +332,13 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const contractResponse = contractBuilder()
       .with('trustedForDelegateCall', true)
       .build();
+    const contractPageResponse = pageBuilder()
+      .with('results', [contractResponse])
+      .build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
-      const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      const getContractUrlPattern = `${dataDecoderUrl}/api/v1/contracts/`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: rawify(chainResponse), status: 200 });
       }
@@ -336,7 +346,10 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
         return Promise.resolve({ data: rawify(safeResponse), status: 200 });
       }
       if (url.includes(getContractUrlPattern)) {
-        return Promise.resolve({ data: rawify(contractResponse), status: 200 });
+        return Promise.resolve({
+          data: rawify(contractPageResponse),
+          status: 200,
+        });
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
@@ -360,7 +373,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           to: {
             value: contractResponse.address,
             name: contractResponse.displayName,
-            logoUri: contractResponse.logoUri,
+            logoUri: contractResponse.logoUrl,
           },
           dataSize: '16',
           value: previewTransactionDto.value,
@@ -375,7 +388,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
           to: {
             value: contractResponse.address,
             name: contractResponse.displayName,
-            logoUri: contractResponse.logoUri,
+            logoUri: contractResponse.logoUrl,
           },
           value: previewTransactionDto.value,
           operation: previewTransactionDto.operation,


### PR DESCRIPTION
OCX-53

## Summary
Migrate the `/v1/chains/{chainId}/contracts/{contractAddress}` endpoint to fetch the data from Decoder API Service instead of Transaction Service

## Changes
- Use another method `getContracts` from Decoder API to fetch the contract data
- Add mapper for contract response type as a new method returns a page of contracts