### PR TITLE
feat: add datasource for export api

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -73,6 +73,7 @@ export class CacheRouter {
   private static readonly ZERION_BALANCES_KEY = 'zerion_balances';
   private static readonly ZERION_COLLECTIBLES_KEY = 'zerion_collectibles';
   private static readonly ORM_QUERY_CACHE_KEY = 'orm_query_cache';
+  private static readonly TRANSACTIONS_EXPORT_KEY = 'transactions_export';
 
   static getAuthNonceCacheKey(nonce: string): string {
     return `${CacheRouter.AUTH_NONCE_KEY}_${nonce}`;
@@ -802,6 +803,27 @@ export class CacheRouter {
 
   static getOutreachFileProcessorCacheDir(): CacheDir {
     return new CacheDir(CacheRouter.getOutreachFileProcessorCacheKey(), '');
+  }
+
+  static getTransactionsExportCacheKey(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+  }): string {
+    return `${args.chainId}_${CacheRouter.TRANSACTIONS_EXPORT_KEY}_${args.safeAddress}`;
+  }
+
+  static getTransactionsExportCacheDir(args: {
+    chainId: string;
+    safeAddress: `0x${string}`;
+    executionDateGte: string;
+    executionDateLte: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getTransactionsExportCacheKey(args),
+      `${args.executionDateGte}_${args.executionDateLte}_${args.limit}_${args.offset}`,
+    );
   }
 
   /**

--- a/src/modules/csv-export/v1/__tests__/transaction-export.builder.ts
+++ b/src/modules/csv-export/v1/__tests__/transaction-export.builder.ts
@@ -1,0 +1,31 @@
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { Hex } from 'viem';
+import { Builder } from '@/__tests__/builder';
+import type { IBuilder } from '@/__tests__/builder';
+import type { TransactionExport } from '@/modules/csv-export/v1/transaction-export.entity';
+
+export function transactionExportBuilder(): IBuilder<TransactionExport> {
+  return new Builder<TransactionExport>()
+    .with('safe', getAddress(faker.finance.ethereumAddress()))
+    .with('from', getAddress(faker.finance.ethereumAddress()))
+    .with('to', getAddress(faker.finance.ethereumAddress()))
+    .with('amount', faker.number.int({ min: 1, max: 1000 }).toString())
+    .with(
+      'assetType',
+      faker.helpers.arrayElement(['native', 'erc20', 'erc721']),
+    ) //todo maybe it should just be a random string
+    .with('assetAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('assetSymbol', faker.finance.currencyCode())
+    .with('assetDecimals', faker.number.int({ min: 0, max: 18 }))
+    .with('proposerAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('proposedAt', faker.date.recent())
+    .with('executorAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('executedAt', faker.date.recent())
+    .with('note', faker.lorem.sentence())
+    .with('transactionHash', faker.string.hexadecimal({ length: 64 }) as Hex)
+    .with('safeTxHash', faker.string.hexadecimal({ length: 64 }) as Hex)
+    .with('method', faker.lorem.word())
+    .with('contractAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('isExecuted', faker.datatype.boolean());
+}

--- a/src/modules/csv-export/v1/export-api.interface.ts
+++ b/src/modules/csv-export/v1/export-api.interface.ts
@@ -1,0 +1,15 @@
+import type { Page } from '@/domain/entities/page.entity';
+import type { TransactionExport } from '@/modules/csv-export/v1/transaction-export.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
+
+export const IExportApi = Symbol('IExportApi');
+
+export interface IExportApi {
+  export(args: {
+    safeAddress: `0x${string}`;
+    executionDateGte: string; //todo Date?
+    executionDateLte: string; //todo Date?
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<TransactionExport>>>;
+}

--- a/src/modules/csv-export/v1/export-api.manager.interface.ts
+++ b/src/modules/csv-export/v1/export-api.manager.interface.ts
@@ -1,0 +1,22 @@
+import type { IApiManager } from '@/domain/interfaces/api.manager.interface';
+import type { IExportApi } from '@/modules/csv-export/v1/export-api.interface';
+import { Module } from '@nestjs/common';
+import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data.source.module';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
+import { ExportApiManager } from '@/modules/csv-export/v1/export-api.manager';
+
+export const IExportApiManager = Symbol('IExportApiManager');
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface IExportApiManager extends IApiManager<IExportApi> {}
+
+@Module({
+  imports: [CacheFirstDataSourceModule, ConfigApiModule],
+  providers: [
+    { provide: IExportApiManager, useClass: ExportApiManager },
+    HttpErrorFactory,
+  ],
+  exports: [IExportApiManager],
+})
+export class ExportApiManagerModule {}

--- a/src/modules/csv-export/v1/export-api.manager.spec.ts
+++ b/src/modules/csv-export/v1/export-api.manager.spec.ts
@@ -1,0 +1,92 @@
+import { faker } from '@faker-js/faker';
+import { ExportApiManager } from './export-api.manager';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import type { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
+import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import { rawify } from '@/validation/entities/raw.entity';
+import { getAddress } from 'viem';
+
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+const mockConfigApi = jest.mocked({
+  getChain: jest.fn(),
+} as jest.MockedObjectDeep<IConfigApi>);
+
+const mockDataSource = jest.mocked({
+  get: jest.fn(),
+} as jest.MockedObjectDeep<CacheFirstDataSource>);
+
+const mockHttpErrorFactory = {} as jest.MockedObjectDeep<HttpErrorFactory>;
+
+describe('ExportApiManager', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  const txServiceUrl = faker.internet.url({ appendSlash: false });
+  const vpcTxServiceUrl = faker.internet.url({ appendSlash: false });
+
+  it.each([
+    [true, vpcTxServiceUrl],
+    [false, txServiceUrl],
+  ])('uses vpc url %s', async (useVpcUrl, expectedUrl) => {
+    const chain = chainBuilder()
+      .with('transactionService', txServiceUrl)
+      .with('vpcTransactionService', vpcTxServiceUrl)
+      .build();
+
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'safeTransaction.useVpcUrl') return useVpcUrl;
+      if (key === 'expirationTimeInSeconds.default') return faker.number.int();
+      if (key === 'expirationTimeInSeconds.notFound.default')
+        return faker.number.int();
+      throw new Error(`Unexpected key: ${key}`);
+    });
+
+    mockConfigApi.getChain.mockResolvedValue(rawify(chain));
+
+    const manager = new ExportApiManager(
+      mockConfigurationService,
+      mockConfigApi,
+      mockDataSource,
+      mockHttpErrorFactory,
+    );
+
+    const exportApi = await manager.getApi(chain.chainId);
+    mockDataSource.get.mockResolvedValue(rawify({}));
+
+    const args = {
+      safeAddress: getAddress(faker.finance.ethereumAddress()),
+      executionDateGte: faker.date.past().toISOString(),
+      executionDateLte: faker.date.recent().toISOString(),
+    };
+    await exportApi.export(args);
+
+    expect(mockDataSource.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `${expectedUrl}/api/v1/safes/${args.safeAddress}/export`,
+      }),
+    );
+  });
+
+  it('caches api instances', async () => {
+    const chain = chainBuilder().build();
+    mockConfigurationService.getOrThrow.mockReturnValue(false);
+    mockConfigApi.getChain.mockResolvedValue(rawify(chain));
+
+    const manager = new ExportApiManager(
+      mockConfigurationService,
+      mockConfigApi,
+      mockDataSource,
+      mockHttpErrorFactory,
+    );
+
+    const exportApi1 = await manager.getApi(chain.chainId);
+    const exportApi2 = await manager.getApi(chain.chainId);
+
+    expect(exportApi1).toBe(exportApi2);
+  });
+});

--- a/src/modules/csv-export/v1/export-api.manager.ts
+++ b/src/modules/csv-export/v1/export-api.manager.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { ChainSchema } from '@/domain/chains/entities/schemas/chain.schema';
+import { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import type { IExportApi } from './export-api.interface';
+import { ExportApi } from './export-api.service';
+import { IExportApiManager } from '@/modules/csv-export/v1/export-api.manager.interface';
+
+@Injectable()
+export class ExportApiManager implements IExportApiManager {
+  private readonly exportApiMap: Record<string, ExportApi> = {};
+  private readonly useVpcUrl: boolean;
+
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(IConfigApi) private readonly configApi: IConfigApi,
+    private readonly dataSource: CacheFirstDataSource,
+    private readonly httpErrorFactory: HttpErrorFactory,
+  ) {
+    this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
+      'safeTransaction.useVpcUrl',
+    );
+  }
+
+  async getApi(chainId: string): Promise<IExportApi> {
+    const api = this.exportApiMap[chainId];
+    if (api) return api;
+
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
+    const baseUrl = this.useVpcUrl
+      ? chain.vpcTransactionService
+      : chain.transactionService;
+    this.exportApiMap[chainId] = new ExportApi(
+      chainId,
+      baseUrl,
+      this.dataSource,
+      this.configurationService,
+      this.httpErrorFactory,
+    );
+    return this.exportApiMap[chainId];
+  }
+
+  destroyApi(chainId: string): void {
+    if (this.exportApiMap[chainId]) {
+      delete this.exportApiMap[chainId];
+    }
+  }
+}

--- a/src/modules/csv-export/v1/export-api.module.ts
+++ b/src/modules/csv-export/v1/export-api.module.ts
@@ -1,0 +1,12 @@
+import { CacheFirstDataSourceModule } from '@/datasources/cache/cache.first.data.source.module';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { IExportApi } from '@/modules/csv-export/v1/export-api.interface';
+import { ExportApi } from '@/modules/csv-export/v1/export-api.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [CacheFirstDataSourceModule],
+  providers: [HttpErrorFactory, { provide: IExportApi, useClass: ExportApi }],
+  exports: [IExportApi],
+})
+export class ExportApiModule {}

--- a/src/modules/csv-export/v1/export-api.service.spec.ts
+++ b/src/modules/csv-export/v1/export-api.service.spec.ts
@@ -1,0 +1,150 @@
+import { faker } from '@faker-js/faker';
+import { ExportApi } from './export-api.service';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import { rawify } from '@/validation/entities/raw.entity';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import { transactionExportBuilder } from '@/modules/csv-export/v1/__tests__/transaction-export.builder';
+import { getAddress } from 'viem';
+import { DataSourceError } from '@/domain/errors/data-source.error';
+
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+const mockCacheFirstDataSource = jest.mocked({
+  get: jest.fn(),
+  post: jest.fn(),
+} as jest.MockedObjectDeep<CacheFirstDataSource>);
+
+describe('ExportApi', () => {
+  const chainId = faker.string.numeric();
+  const baseUrl = faker.internet.url({ appendSlash: false });
+  const defaultExpiration = faker.number.int();
+  const defaultNotFoundExpiration = faker.number.int();
+  let service: ExportApi;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'expirationTimeInSeconds.default') return defaultExpiration;
+      if (key === 'expirationTimeInSeconds.notFound.default')
+        return defaultNotFoundExpiration;
+      throw new Error(`Unexpected key: ${key}`);
+    });
+    const httpErrorFactory = new HttpErrorFactory();
+
+    service = new ExportApi(
+      chainId,
+      baseUrl,
+      mockCacheFirstDataSource,
+      mockConfigurationService,
+      httpErrorFactory,
+    );
+  });
+
+  describe('export', () => {
+    it('should return export data', async () => {
+      const txnExport = transactionExportBuilder().build();
+      const page = pageBuilder().with('results', [txnExport]).build();
+
+      const executionDateGte = faker.date.past().toISOString();
+      const executionDateLte = faker.date.recent().toISOString();
+      const limit = faker.number.int({ min: 1, max: 100 });
+      const offset = faker.number.int({ min: 0, max: 10 });
+
+      const exportUrl = `${baseUrl}/api/v1/safes/${txnExport.safe}/export`;
+      mockCacheFirstDataSource.get.mockImplementation(({ url }) => {
+        if (exportUrl === url) {
+          return Promise.resolve(rawify(page));
+        }
+        throw new Error('Unexpected URL');
+      });
+
+      const actual = await service.export({
+        safeAddress: txnExport.safe,
+        executionDateGte,
+        executionDateLte,
+        limit,
+        offset,
+      });
+
+      expect(actual).toStrictEqual(page);
+      expect(mockCacheFirstDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
+        cacheDir: {
+          key: `${chainId}_transactions_export_${txnExport.safe}`,
+          field: `${executionDateGte}_${executionDateLte}_${limit}_${offset}`,
+        },
+        url: exportUrl,
+        networkRequest: {
+          params: {
+            execution_date__gte: executionDateGte,
+            execution_date__lte: executionDateLte,
+            limit: limit,
+            offset: offset,
+          },
+        },
+        expireTimeSeconds: defaultExpiration,
+        notFoundExpireTimeSeconds: defaultNotFoundExpiration,
+      });
+    });
+
+    it('should forward an error', async () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const executionDateGte = faker.date.past().toISOString();
+      const executionDateLte = faker.date.recent().toISOString();
+
+      const errorMessage = faker.word.words();
+      const statusCode = faker.internet.httpStatusCode({
+        types: ['clientError', 'serverError'],
+      });
+
+      const exportUrl = `${baseUrl}/api/v1/safes/${safeAddress}/export`;
+      mockCacheFirstDataSource.get.mockImplementation(({ url }) => {
+        if (exportUrl === url) {
+          return Promise.reject(
+            new NetworkResponseError(
+              new URL(exportUrl),
+              {
+                status: statusCode,
+              } as Response,
+              new Error(errorMessage),
+            ),
+          );
+        }
+        throw new Error('Unexpected URL');
+      });
+
+      await expect(
+        service.export({
+          safeAddress,
+          executionDateGte,
+          executionDateLte,
+        }),
+      ).rejects.toThrow(new DataSourceError(errorMessage, statusCode));
+
+      expect(mockCacheFirstDataSource.get).toHaveBeenCalledTimes(1);
+      expect(mockCacheFirstDataSource.get).toHaveBeenCalledWith({
+        cacheDir: {
+          key: `${chainId}_transactions_export_${safeAddress}`,
+          field: `${executionDateGte}_${executionDateLte}_undefined_undefined`,
+        },
+        url: exportUrl,
+        networkRequest: {
+          params: {
+            execution_date__gte: executionDateGte,
+            execution_date__lte: executionDateLte,
+            limit: undefined,
+            offset: undefined,
+          },
+        },
+        expireTimeSeconds: defaultExpiration,
+        notFoundExpireTimeSeconds: defaultNotFoundExpiration,
+      });
+    });
+  });
+});

--- a/src/modules/csv-export/v1/export-api.service.ts
+++ b/src/modules/csv-export/v1/export-api.service.ts
@@ -1,0 +1,64 @@
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { Page } from '@/domain/entities/page.entity';
+import { IExportApi } from '@/modules/csv-export/v1/export-api.interface';
+import { TransactionExport } from '@/modules/csv-export/v1/transaction-export.entity';
+import { Raw } from '@/validation/entities/raw.entity';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ExportApi implements IExportApi {
+  private readonly defaultExpirationTimeInSeconds: number;
+  private readonly defaultNotFoundExpirationTimeSeconds: number;
+
+  constructor(
+    private readonly chainId: string,
+    private readonly baseUrl: string,
+    private readonly dataSource: CacheFirstDataSource,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    private readonly httpErrorFactory: HttpErrorFactory,
+  ) {
+    this.defaultExpirationTimeInSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.default',
+      );
+    this.defaultNotFoundExpirationTimeSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.notFound.default',
+      );
+  }
+
+  async export(args: {
+    safeAddress: `0x${string}`;
+    executionDateGte: string;
+    executionDateLte: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<TransactionExport>>> {
+    try {
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/export`;
+      return await this.dataSource.get<Page<TransactionExport>>({
+        cacheDir: CacheRouter.getTransactionsExportCacheDir({
+          ...args,
+          chainId: this.chainId,
+        }),
+        url,
+        networkRequest: {
+          params: {
+            execution_date__gte: args.executionDateGte,
+            execution_date__lte: args.executionDateLte,
+            limit: args.limit,
+            offset: args.offset,
+          },
+        },
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+}

--- a/src/modules/csv-export/v1/transaction-export.entity.ts
+++ b/src/modules/csv-export/v1/transaction-export.entity.ts
@@ -1,0 +1,32 @@
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { z } from 'zod';
+
+export const TransactionExportSchema = z.object({
+  safe: AddressSchema,
+  from: AddressSchema,
+  to: AddressSchema,
+  amount: NumericStringSchema,
+  assetType: z.string(), //z.enum(['native', 'erc20', 'erc721']),
+  assetAddress: AddressSchema,
+  assetSymbol: z.string(),
+  assetDecimals: z.number(),
+  proposerAddress: AddressSchema,
+  proposedAt: z.coerce.date(),
+  executorAddress: AddressSchema,
+  executedAt: z.coerce.date(),
+  note: z.string(),
+  transactionHash: HexSchema,
+  safeTxHash: HexSchema,
+  method: z.string(),
+  contractAddress: AddressSchema,
+  isExecuted: z.boolean(),
+});
+
+export const TransactionExportPageSchema = buildPageSchema(
+  TransactionExportSchema,
+);
+
+export type TransactionExport = z.infer<typeof TransactionExportSchema>;


### PR DESCRIPTION
## Summary
[OCX-90](https://linear.app/safe-global/issue/OCX-90/create-a-new-export-datasource-in-cgw-client-gateway-for-transaction)

Adds a new Datasource for /export endpoint (transaction service)

## Changes
