### PR TITLE
feat: Remove signature management cache every hour, reduce event cache clear time to 30 seconds

### DIFF
--- a/src/domain/common/entities/safe-signature.ts
+++ b/src/domain/common/entities/safe-signature.ts
@@ -10,6 +10,7 @@ import {
   V_HEX_LENGTH,
 } from '@/domain/common/utils/signatures';
 import { ADDRESS_LENGTH, HEX_PREFIX_LENGTH } from '@/routes/common/constants';
+import { Cron, CronExpression } from '@nestjs/schedule';
 
 const ETH_SIGN_V_OFFSET = 4;
 
@@ -95,6 +96,15 @@ export class SafeSignature {
       return this.signature + this.hash;
     },
   );
+
+  @Cron(CronExpression.EVERY_HOUR, {
+    disabled: process.env.NODE_ENV === 'test',
+  })
+  public clearSignatureMemo(): void {
+    if (this._owner.cache.clear) {
+      this._owner.cache.clear();
+    }
+  }
 }
 
 function recoverAddress(args: {

--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -168,7 +168,7 @@ export class EventCacheHelper {
    * Logs the number of unsupported chain events for each chain and clears the store.
    * This function is public just for testing purposes.
    */
-  @Cron(CronExpression.EVERY_MINUTE, {
+  @Cron(CronExpression.EVERY_30_SECONDS, {
     disabled: process.env.NODE_ENV === 'test',
   })
   public async logUnsupportedEvents(): Promise<void> {
@@ -189,7 +189,7 @@ export class EventCacheHelper {
     this.unsupportedChains = [];
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, {
+  @Cron(CronExpression.EVERY_30_SECONDS, {
     disabled: process.env.NODE_ENV === 'test',
   })
   public clearSupportedChainsMemo(): void {


### PR DESCRIPTION
## Summary
This PR addresses a memory leak issue where the service's memory usage gradually increases. The root cause is unbounded memoization caches that accumulate entries without proper cleanup, leading to continuous memory growth in long-running instances.

## Changes
- Add hourly cleanup for SafeSignature cache: Clear the memoized signature owner cache every hour to prevent unbounded growth from cryptographic signature processing.
- Reduce EventCacheHelper cache cleanup interval: Change memoization cache clearing from every minute to every 30 seconds to reduce peak memory usage during high event processing periods.