### PR TITLE
fix: default contract.name to <empty string> if null

### DIFF
--- a/src/domain/data-decoder/v2/entities/contract.entity.spec.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.spec.ts
@@ -255,5 +255,23 @@ describe('Contract', () => {
         },
       ]);
     });
+
+    it('should default name to empty string', () => {
+      const contract = { ...contractBuilder().build(), name: null };
+
+      const result = ContractSchema.safeParse(contract);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe('');
+    });
+
+    it('should default displayName to empty string', () => {
+      const contract = { ...contractBuilder().build(), displayName: null };
+
+      const result = ContractSchema.safeParse(contract);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.displayName).toBe('');
+    });
   });
 });

--- a/src/domain/data-decoder/v2/entities/contract.entity.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.ts
@@ -17,7 +17,7 @@ export const AbiSchema = z.object({
 
 export const ContractSchema = z.object({
   address: AddressSchema,
-  name: z.string(),
+  name: z.string().nullable(),
   displayName: z.string().nullable(),
   chainId: z.number().transform(String),
   project: ProjectSchema.nullable(),

--- a/src/domain/data-decoder/v2/entities/contract.entity.ts
+++ b/src/domain/data-decoder/v2/entities/contract.entity.ts
@@ -17,8 +17,14 @@ export const AbiSchema = z.object({
 
 export const ContractSchema = z.object({
   address: AddressSchema,
-  name: z.string().nullable(),
-  displayName: z.string().nullable(),
+  name: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? ''),
+  displayName: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? ''),
   chainId: z.number().transform(String),
   project: ProjectSchema.nullable(),
   abi: AbiSchema.nullable(),

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -149,7 +149,7 @@ describe('Contracts controller', () => {
         .expect(503);
     });
 
-    it('should not get a validation error if name is null', async () => {
+    it('Should pass validation if name is null', async () => {    
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
       const contractPage = pageBuilder()

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -149,7 +149,7 @@ describe('Contracts controller', () => {
         .expect(503);
     });
 
-    it('Should pass validation if name is null', async () => {    
+    it('Should pass validation if name is null', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
       const contractPage = pageBuilder()
@@ -184,7 +184,7 @@ describe('Contracts controller', () => {
         });
     });
 
-    it('should get a validation error', async () => {
+    it('Should get a validation error', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
       const contractPage = pageBuilder()

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -32,6 +32,13 @@ describe('Contract Mapper', () => {
     });
   });
 
+  it('should return name = "" if its null', () => {
+    const contract = dataDecodedContractBuilder().with('name', null).build();
+
+    const actual = mapper.map(contract);
+    expect(actual.name).toEqual('');
+  });
+
   it('should return displayName = "" if its null', () => {
     const contract = dataDecodedContractBuilder()
       .with('displayName', null)

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -32,22 +32,6 @@ describe('Contract Mapper', () => {
     });
   });
 
-  it('Should return name = "" if it is null', () => {
-    const contract = dataDecodedContractBuilder().with('name', null).build();
-
-    const actual = mapper.map(contract);
-    expect(actual.name).toEqual('');
-  });
-
-  it('should return displayName = "" if its null', () => {
-    const contract = dataDecodedContractBuilder()
-      .with('displayName', null)
-      .build();
-
-    const actual = mapper.map(contract);
-    expect(actual.displayName).toEqual('');
-  });
-
   it('should return logoUri = null if logoUrl is null', () => {
     const contract = dataDecodedContractBuilder().with('logoUrl', null).build();
 

--- a/src/routes/contracts/mappers/contract.mapper.spec.ts
+++ b/src/routes/contracts/mappers/contract.mapper.spec.ts
@@ -32,7 +32,7 @@ describe('Contract Mapper', () => {
     });
   });
 
-  it('should return name = "" if its null', () => {
+  it('Should return name = "" if it is null', () => {
     const contract = dataDecodedContractBuilder().with('name', null).build();
 
     const actual = mapper.map(contract);

--- a/src/routes/contracts/mappers/contract.mapper.ts
+++ b/src/routes/contracts/mappers/contract.mapper.ts
@@ -12,7 +12,7 @@ export class ContractMapper {
       : null;
     return {
       address: contract.address,
-      name: contract.name,
+      name: contract.name ?? '',
       displayName: contract.displayName ?? '',
       logoUri: contract.logoUrl,
       contractAbi,

--- a/src/routes/contracts/mappers/contract.mapper.ts
+++ b/src/routes/contracts/mappers/contract.mapper.ts
@@ -12,8 +12,8 @@ export class ContractMapper {
       : null;
     return {
       address: contract.address,
-      name: contract.name ?? '',
-      displayName: contract.displayName ?? '',
+      name: contract.name,
+      displayName: contract.displayName,
       logoUri: contract.logoUrl,
       contractAbi,
       trustedForDelegateCall: contract.trustedForDelegateCall,


### PR DESCRIPTION
## Summary [OCX-102](https://linear.app/safe-global/issue/OCX-102/accept-namedisplayname-null-for-contracts-response)

## Changes

- Default contract.name to`''` if the decoder service returned `null`