### PR TITLE
feat(staking): Add Kiln rewards fee endpoint + update `deployments` response

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -50,6 +50,7 @@ export class CacheRouter {
   private static readonly STAKING_DEFI_MORPHO_EXTRA_REWARDS_KEY =
     'staking_defi_morpho_extra_rewards';
   private static readonly STAKING_DEPLOYMENTS_KEY = 'staking_deployments';
+  private static readonly STAKING_REWARDS_FEE_KEY = 'staking_rewards_fee';
   private static readonly STAKING_NETWORK_STATS_KEY = 'staking_network_stats';
   private static readonly STAKING_POOLED_STAKING_STATS_KEY =
     'staking_pooled_staking_stats';
@@ -649,6 +650,10 @@ export class CacheRouter {
     cacheType: 'earn' | 'staking',
   ): CacheDir {
     return new CacheDir(this.STAKING_DEPLOYMENTS_KEY, cacheType);
+  }
+
+  static getStakingRewardsFeeCacheDir(cacheType: 'earn' | 'staking'): CacheDir {
+    return new CacheDir(this.STAKING_REWARDS_FEE_KEY, cacheType);
   }
 
   static getStakingNetworkStatsCacheDir(

--- a/src/datasources/staking-api/entities/__tests__/deployment.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/deployment.entity.builder.ts
@@ -21,6 +21,5 @@ export function deploymentBuilder(): IBuilder<Deployment> {
     .with('chain_id', faker.number.int())
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('status', faker.helpers.arrayElement(DeploymentStatuses))
-    .with('product_fee', faker.string.numeric())
     .with('external_links', { deposit_url: faker.internet.url() });
 }

--- a/src/datasources/staking-api/entities/__tests__/deployment.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/deployment.entity.spec.ts
@@ -74,45 +74,6 @@ describe('DeploymentSchema', () => {
     );
   });
 
-  it('should allow numeric string product_fee values', () => {
-    const deployment = deploymentBuilder()
-      .with('product_fee', faker.string.numeric())
-      .build();
-
-    const result = DeploymentSchema.safeParse(deployment);
-
-    expect(result.success && result.data.product_fee).toBe(
-      deployment.product_fee,
-    );
-  });
-
-  it('should not allow numeric product_fee values', () => {
-    const deployment = deploymentBuilder()
-      .with('product_fee', faker.number.float() as unknown as string)
-      .build();
-
-    const result = DeploymentSchema.safeParse(deployment);
-
-    expect(!result.success && result.error.issues.length).toBe(1);
-    expect(!result.success && result.error.issues[0]).toStrictEqual({
-      code: 'invalid_type',
-      expected: 'string',
-      message: 'Expected string, received number',
-      path: ['product_fee'],
-      received: 'number',
-    });
-  });
-
-  it.each(['product_fee' as const, 'external_links' as const])(
-    'should default %s to null',
-    (key) => {
-      const deployment = deploymentBuilder().build();
-      delete deployment[key];
-      const result = DeploymentSchema.safeParse(deployment);
-      expect(result.success && result.data[key]).toBe(null);
-    },
-  );
-
   it('should default external_links.deposit_url to null', () => {
     const deployment = deploymentBuilder().build();
     // @ts-expect-error - inferred type does not allow undefined

--- a/src/datasources/staking-api/entities/__tests__/deployment.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/deployment.entity.spec.ts
@@ -74,6 +74,14 @@ describe('DeploymentSchema', () => {
     );
   });
 
+  it('should default external_links to null', () => {
+    const deployment = deploymentBuilder().build();
+    // @ts-expect-error - inferred type does not allow undefined
+    delete deployment.external_links;
+    const result = DeploymentSchema.safeParse(deployment);
+    expect(result.success && result.data.external_links).toBe(null);
+  });
+
   it('should default external_links.deposit_url to null', () => {
     const deployment = deploymentBuilder().build();
     // @ts-expect-error - inferred type does not allow undefined

--- a/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder.ts
+++ b/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder.ts
@@ -1,0 +1,8 @@
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import type { RewardsFee } from '@/datasources/staking-api/entities/rewards-fee.entity';
+import { faker } from '@faker-js/faker';
+
+export function rewardsFeeBuilder(): IBuilder<RewardsFee> {
+  return new Builder<RewardsFee>().with('fee', faker.number.float());
+}

--- a/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
@@ -9,9 +9,7 @@ describe('RewardsFeeSchema', () => {
     const result = RewardsFeeSchema.safeParse(rewardsFee);
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toStrictEqual(rewardsFee);
-    }
+    expect(result.data).toStrictEqual(rewardsFee);
   });
 
   it('should validate a RewardsFee object with null fee', () => {
@@ -20,9 +18,7 @@ describe('RewardsFeeSchema', () => {
     const result = RewardsFeeSchema.safeParse(rewardsFee);
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toStrictEqual(rewardsFee);
-    }
+    expect(result.data).toStrictEqual(rewardsFee);
   });
 
   it('should validate a RewardsFee object with undefined fee and default to null', () => {
@@ -31,9 +27,7 @@ describe('RewardsFeeSchema', () => {
     const result = RewardsFeeSchema.safeParse(rewardsFeeWithoutFee);
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.fee).toBe(null);
-    }
+    expect(result.data?.fee).toBe(null);
   });
 
   it.each([
@@ -49,15 +43,13 @@ describe('RewardsFeeSchema', () => {
       const result = RewardsFeeSchema.safeParse(rewardsFee);
 
       expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0]).toStrictEqual({
-          code: 'invalid_type',
-          expected: 'number',
-          message: `Expected number, received ${type}`,
-          path: ['fee'],
-          received: type,
-        });
-      }
+      expect(result.error?.issues[0]).toStrictEqual({
+        code: 'invalid_type',
+        expected: 'number',
+        message: `Expected number, received ${type}`,
+        path: ['fee'],
+        received: type,
+      });
     },
   );
 
@@ -71,18 +63,14 @@ describe('RewardsFeeSchema', () => {
     const result = RewardsFeeSchema.safeParse({ fee });
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toStrictEqual(rewardsFee);
-    }
+    expect(result.data).toStrictEqual(rewardsFee);
   });
 
   it('should validate an empty object and default fee to null', () => {
     const result = RewardsFeeSchema.safeParse({});
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.fee).toBe(null);
-    }
+    expect(result.data?.fee).toBe(null);
   });
 
   it('should validate a RewardsFee object with extra properties and strip them', () => {
@@ -94,10 +82,8 @@ describe('RewardsFeeSchema', () => {
     const result = RewardsFeeSchema.safeParse(rewardsFee);
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toStrictEqual({
-        fee: rewardsFee.fee,
-      });
-    }
+    expect(result.data).toStrictEqual({
+      fee: rewardsFee.fee,
+    });
   });
 });

--- a/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
@@ -1,0 +1,103 @@
+import { rewardsFeeBuilder } from '@/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder';
+import { RewardsFeeSchema } from '@/datasources/staking-api/entities/rewards-fee.entity';
+import { faker } from '@faker-js/faker';
+
+describe('RewardsFeeSchema', () => {
+  it('should validate a RewardsFee object with a number fee', () => {
+    const rewardsFee = rewardsFeeBuilder().build();
+
+    const result = RewardsFeeSchema.safeParse(rewardsFee);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toStrictEqual(rewardsFee);
+    }
+  });
+
+  it('should validate a RewardsFee object with null fee', () => {
+    const rewardsFee = { fee: null };
+
+    const result = RewardsFeeSchema.safeParse(rewardsFee);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toStrictEqual(rewardsFee);
+    }
+  });
+
+  it('should validate a RewardsFee object with undefined fee and default to null', () => {
+    const rewardsFeeWithoutFee = {};
+
+    const result = RewardsFeeSchema.safeParse(rewardsFeeWithoutFee);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fee).toBe(null);
+    }
+  });
+
+  it.each([
+    ['string', faker.string.numeric() as unknown as number],
+    ['boolean', faker.datatype.boolean() as unknown as number],
+    ['object', {} as unknown as number],
+    ['array', [] as unknown as number],
+  ])(
+    'should not validate a RewardsFee object with %s fee',
+    (type, invalidFee) => {
+      const rewardsFee = { fee: invalidFee };
+
+      const result = RewardsFeeSchema.safeParse(rewardsFee);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]).toStrictEqual({
+          code: 'invalid_type',
+          expected: 'number',
+          message: `Expected number, received ${type}`,
+          path: ['fee'],
+          received: type,
+        });
+      }
+    },
+  );
+
+  it.each([
+    ['zero', 0],
+    ['negative', -0.1],
+    ['very large', 999999.999],
+  ])('should validate a RewardsFee object with %s fee', (description, fee) => {
+    const rewardsFee = { fee };
+
+    const result = RewardsFeeSchema.safeParse({ fee });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toStrictEqual(rewardsFee);
+    }
+  });
+
+  it('should validate an empty object and default fee to null', () => {
+    const result = RewardsFeeSchema.safeParse({});
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fee).toBe(null);
+    }
+  });
+
+  it('should validate a RewardsFee object with extra properties and strip them', () => {
+    const rewardsFee = {
+      fee: faker.number.float(),
+      extraProperty: 'should not be here',
+    };
+
+    const result = RewardsFeeSchema.safeParse(rewardsFee);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toStrictEqual({
+        fee: rewardsFee.fee,
+      });
+    }
+  });
+});

--- a/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
@@ -14,8 +14,10 @@ describe('RewardsFeeSchema', () => {
 
     const result = RewardsFeeSchema.safeParse(rewardsFee);
 
-    expect(result.success).toBe(true);
-    expect(result.data).toStrictEqual(rewardsFee);
+    expect(result).toStrictEqual({
+      success: true,
+      data: rewardsFee,
+    });
   });
 
   it.each([
@@ -23,8 +25,11 @@ describe('RewardsFeeSchema', () => {
     ['empty object', {}],
   ])('should validate an %s and default fee to 0', (_, rewardsFee) => {
     const result = RewardsFeeSchema.safeParse(rewardsFee);
-    expect(result.success).toBe(true);
-    expect(result.data?.fee).toBe(0);
+
+    expect(result).toStrictEqual({
+      success: true,
+      data: { fee: 0 },
+    });
   });
 
   it.each([
@@ -58,9 +63,9 @@ describe('RewardsFeeSchema', () => {
 
     const result = RewardsFeeSchema.safeParse(rewardsFee);
 
-    expect(result.success).toBe(true);
-    expect(result.data).toStrictEqual({
-      fee: rewardsFee.fee,
+    expect(result).toStrictEqual({
+      success: true,
+      data: { fee: rewardsFee.fee },
     });
   });
 });

--- a/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
@@ -3,8 +3,14 @@ import { RewardsFeeSchema } from '@/datasources/staking-api/entities/rewards-fee
 import { faker } from '@faker-js/faker';
 
 describe('RewardsFeeSchema', () => {
-  it('should validate a RewardsFee object with a number fee', () => {
-    const rewardsFee = rewardsFeeBuilder().build();
+  it.each([
+    ['number', faker.number.float()],
+    ['null', null],
+    ['zero', 0],
+    ['negative', -0.1],
+    ['very large', 999999.999],
+  ])('should validate a RewardsFee object with a %s fee value', (_, fee) => {
+    const rewardsFee = rewardsFeeBuilder().with('fee', fee).build();
 
     const result = RewardsFeeSchema.safeParse(rewardsFee);
 
@@ -15,7 +21,7 @@ describe('RewardsFeeSchema', () => {
   it.each([
     ['undefined fee', { fee: undefined }],
     ['empty object', {}],
-  ])('should validate an %s and default to 0', (_, rewardsFee) => {
+  ])('should validate an %s and default fee to 0', (_, rewardsFee) => {
     const result = RewardsFeeSchema.safeParse(rewardsFee);
     expect(result.success).toBe(true);
     expect(result.data?.fee).toBe(0);
@@ -23,12 +29,11 @@ describe('RewardsFeeSchema', () => {
 
   it.each([
     ['string', faker.string.numeric()],
-    ['null', null],
     ['boolean', faker.datatype.boolean()],
     ['object', {}],
     ['array', []],
   ])(
-    'should not validate a RewardsFee object with %s fee',
+    'should not validate a RewardsFee object with a %s fee value',
     (type, invalidFee) => {
       const rewardsFee = { fee: invalidFee };
 
@@ -44,19 +49,6 @@ describe('RewardsFeeSchema', () => {
       });
     },
   );
-
-  it.each([
-    ['zero', 0],
-    ['negative', -0.1],
-    ['very large', 999999.999],
-  ])('should validate a RewardsFee object with %s fee', (_, fee) => {
-    const rewardsFee = { fee };
-
-    const result = RewardsFeeSchema.safeParse({ fee });
-
-    expect(result.success).toBe(true);
-    expect(result.data).toStrictEqual(rewardsFee);
-  });
 
   it('should validate a RewardsFee object with extra properties and strip them', () => {
     const rewardsFee = {

--- a/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
+++ b/src/datasources/staking-api/entities/__tests__/rewards-fee.entity.spec.ts
@@ -12,29 +12,21 @@ describe('RewardsFeeSchema', () => {
     expect(result.data).toStrictEqual(rewardsFee);
   });
 
-  it('should validate a RewardsFee object with null fee', () => {
-    const rewardsFee = { fee: null };
-
+  it.each([
+    ['undefined fee', { fee: undefined }],
+    ['empty object', {}],
+  ])('should validate an %s and default to 0', (_, rewardsFee) => {
     const result = RewardsFeeSchema.safeParse(rewardsFee);
-
     expect(result.success).toBe(true);
-    expect(result.data).toStrictEqual(rewardsFee);
-  });
-
-  it('should validate a RewardsFee object with undefined fee and default to null', () => {
-    const rewardsFeeWithoutFee = {};
-
-    const result = RewardsFeeSchema.safeParse(rewardsFeeWithoutFee);
-
-    expect(result.success).toBe(true);
-    expect(result.data?.fee).toBe(null);
+    expect(result.data?.fee).toBe(0);
   });
 
   it.each([
-    ['string', faker.string.numeric() as unknown as number],
-    ['boolean', faker.datatype.boolean() as unknown as number],
-    ['object', {} as unknown as number],
-    ['array', [] as unknown as number],
+    ['string', faker.string.numeric()],
+    ['null', null],
+    ['boolean', faker.datatype.boolean()],
+    ['object', {}],
+    ['array', []],
   ])(
     'should not validate a RewardsFee object with %s fee',
     (type, invalidFee) => {
@@ -57,20 +49,13 @@ describe('RewardsFeeSchema', () => {
     ['zero', 0],
     ['negative', -0.1],
     ['very large', 999999.999],
-  ])('should validate a RewardsFee object with %s fee', (description, fee) => {
+  ])('should validate a RewardsFee object with %s fee', (_, fee) => {
     const rewardsFee = { fee };
 
     const result = RewardsFeeSchema.safeParse({ fee });
 
     expect(result.success).toBe(true);
     expect(result.data).toStrictEqual(rewardsFee);
-  });
-
-  it('should validate an empty object and default fee to null', () => {
-    const result = RewardsFeeSchema.safeParse({});
-
-    expect(result.success).toBe(true);
-    expect(result.data?.fee).toBe(null);
   });
 
   it('should validate a RewardsFee object with extra properties and strip them', () => {

--- a/src/datasources/staking-api/entities/deployment.entity.ts
+++ b/src/datasources/staking-api/entities/deployment.entity.ts
@@ -1,5 +1,4 @@
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { z } from 'zod';
 
 export const DeploymentProductTypes = ['defi', 'pooling', 'dedicated'] as const;
@@ -35,7 +34,6 @@ export const DeploymentSchema = z.object({
   chain_id: z.number(),
   address: AddressSchema,
   status: z.enum([...DeploymentStatuses, 'unknown']).catch('unknown'),
-  product_fee: NumericStringSchema.nullish().default(null),
   external_links: DeploymentExternalLinksSchema.nullish().default(null),
 });
 

--- a/src/datasources/staking-api/entities/rewards-fee.entity.ts
+++ b/src/datasources/staking-api/entities/rewards-fee.entity.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const RewardsFeeSchema = z.object({
+  fee: z.number().nullish().default(null),
+});
+
+export type RewardsFee = z.infer<typeof RewardsFeeSchema>;

--- a/src/datasources/staking-api/entities/rewards-fee.entity.ts
+++ b/src/datasources/staking-api/entities/rewards-fee.entity.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const RewardsFeeSchema = z.object({
-  fee: z.number().nullish().default(null),
+  fee: z.number().default(0),
 });
 
 export type RewardsFee = z.infer<typeof RewardsFeeSchema>;

--- a/src/datasources/staking-api/entities/rewards-fee.entity.ts
+++ b/src/datasources/staking-api/entities/rewards-fee.entity.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const RewardsFeeSchema = z.object({
-  fee: z.number().default(0),
+  fee: z.number().nullish().default(0),
 });
 
 export type RewardsFee = z.infer<typeof RewardsFeeSchema>;

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -165,7 +165,6 @@ describe('KilnApi', () => {
       const actual = await target.getRewardsFee(contract);
 
       expect(actual).toBe(rewardsFee);
-      expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir('staking_rewards_fee', cacheType),
         url: `${baseUrl}/v1/eth/onchain/v1/fee`,
@@ -202,7 +201,6 @@ describe('KilnApi', () => {
 
       await expect(target.getRewardsFee(contract)).rejects.toThrow(expected);
 
-      expect(dataSource.get).toHaveBeenCalledTimes(1);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
         cacheDir: new CacheDir('staking_rewards_fee', cacheType),
         url: getRewardsFeeUrl,

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -13,6 +13,7 @@ import type {
 import type { Deployment } from '@/datasources/staking-api/entities/deployment.entity';
 import type { NetworkStats } from '@/datasources/staking-api/entities/network-stats.entity';
 import type { PooledStakingStats } from '@/datasources/staking-api/entities/pooled-staking-stats.entity';
+import type { RewardsFee } from '@/datasources/staking-api/entities/rewards-fee.entity';
 import type { Stake } from '@/datasources/staking-api/entities/stake.entity';
 import type { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
 import type { IStakingApi } from '@/domain/interfaces/staking-api.interface';
@@ -67,6 +68,29 @@ export class KilnApi implements IStakingApi {
       networkRequest: {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
+        },
+      },
+      notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+      expireTimeSeconds: this.stakingExpirationTimeInSeconds,
+    });
+  }
+
+  // Important: there is no hook which invalidates this endpoint,
+  // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
+  async getRewardsFee(contract: `0x${string}`): Promise<Raw<RewardsFee>> {
+    const url = `${this.baseUrl}/v1/eth/onchain/v1/fee`;
+    const cacheDir = CacheRouter.getStakingRewardsFeeCacheDir(this.cacheType);
+    return await this.get<{
+      data: RewardsFee;
+    }>({
+      cacheDir,
+      url,
+      networkRequest: {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        params: {
+          integration: contract,
         },
       },
       notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,

--- a/src/domain/earn/earn.repository.ts
+++ b/src/domain/earn/earn.repository.ts
@@ -37,10 +37,6 @@ import {
   DefiMorphoExtraReward,
   DefiMorphoExtraRewardsSchema,
 } from '@/datasources/staking-api/entities/defi-morpho-extra-reward.entity';
-import {
-  RewardsFee,
-  RewardsFeeSchema,
-} from '@/datasources/staking-api/entities/rewards-fee.entity';
 
 // TODO: Deduplicate code with StakingRepository
 
@@ -70,15 +66,6 @@ export class EarnRepository implements IStakingRepository {
       throw new Error('Deployment not found');
     }
     return deployment;
-  }
-
-  public async getRewardsFee(args: {
-    chainId: string;
-    address: `0x${string}`;
-  }): Promise<RewardsFee> {
-    const earnApi = await this.earnApiFactory.getApi(args.chainId);
-    const rewardsFee = await earnApi.getRewardsFee(args.address);
-    return RewardsFeeSchema.parse(rewardsFee);
   }
 
   private async getDeployments(chainId: string): Promise<Array<Deployment>> {

--- a/src/domain/earn/earn.repository.ts
+++ b/src/domain/earn/earn.repository.ts
@@ -37,6 +37,10 @@ import {
   DefiMorphoExtraReward,
   DefiMorphoExtraRewardsSchema,
 } from '@/datasources/staking-api/entities/defi-morpho-extra-reward.entity';
+import {
+  RewardsFee,
+  RewardsFeeSchema,
+} from '@/datasources/staking-api/entities/rewards-fee.entity';
 
 // TODO: Deduplicate code with StakingRepository
 
@@ -66,6 +70,15 @@ export class EarnRepository implements IStakingRepository {
       throw new Error('Deployment not found');
     }
     return deployment;
+  }
+
+  public async getRewardsFee(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<RewardsFee> {
+    const earnApi = await this.earnApiFactory.getApi(args.chainId);
+    const rewardsFee = await earnApi.getRewardsFee(args.address);
+    return RewardsFeeSchema.parse(rewardsFee);
   }
 
   private async getDeployments(chainId: string): Promise<Array<Deployment>> {

--- a/src/domain/hooks/helpers/event-cache.helper.ts
+++ b/src/domain/hooks/helpers/event-cache.helper.ts
@@ -12,7 +12,7 @@ import { IDelegatesV2Repository } from '@/domain/delegate/v2/delegates.v2.reposi
 import { IMessagesRepository } from '@/domain/messages/messages.repository.interface';
 import { ISafeAppsRepository } from '@/domain/safe-apps/safe-apps.repository.interface';
 import { ISafeRepository } from '@/domain/safe/safe.repository.interface';
-import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
+import { IStakingRepositoryWithRewardsFee } from '@/domain/staking/staking.repository.interface';
 import { ITransactionsRepository } from '@/domain/transactions/transactions.repository.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import {
@@ -51,8 +51,8 @@ export class EventCacheHelper {
     private readonly safeAppsRepository: ISafeAppsRepository,
     @Inject(ISafeRepository)
     private readonly safeRepository: ISafeRepository,
-    @Inject(IStakingRepository)
-    private readonly stakingRepository: IStakingRepository,
+    @Inject(IStakingRepositoryWithRewardsFee)
+    private readonly stakingRepository: IStakingRepositoryWithRewardsFee,
     @Inject(EarnRepository)
     private readonly earnRepository: EarnRepository,
     @Inject(ITransactionsRepository)

--- a/src/domain/interfaces/staking-api.interface.ts
+++ b/src/domain/interfaces/staking-api.interface.ts
@@ -8,11 +8,14 @@ import type { TransactionStatus } from '@/datasources/staking-api/entities/trans
 import type { Raw } from '@/validation/entities/raw.entity';
 import type { DefiVaultStake } from '@/datasources/staking-api/entities/defi-vault-stake.entity';
 import type { DefiMorphoExtraReward } from '@/datasources/staking-api/entities/defi-morpho-extra-reward.entity';
+import type { RewardsFee } from '@/datasources/staking-api/entities/rewards-fee.entity';
 
 export const IStakingApi = Symbol('IStakingApi');
 
 export interface IStakingApi {
   getDeployments(): Promise<Raw<Array<Deployment>>>;
+
+  getRewardsFee(contract: `0x${string}`): Promise<Raw<RewardsFee>>;
 
   getNetworkStats(): Promise<Raw<NetworkStats>>;
 

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -10,6 +10,9 @@ import type { DefiMorphoExtraReward } from '@/datasources/staking-api/entities/d
 import type { RewardsFee } from '@/datasources/staking-api/entities/rewards-fee.entity';
 
 export const IStakingRepository = Symbol('IStakingRepository');
+export const IStakingRepositoryWithRewardsFee = Symbol(
+  'IStakingRepositoryWithRewardsFee',
+);
 
 export interface IStakingRepository {
   getDeployment(args: {
@@ -67,7 +70,3 @@ export interface IStakingRepositoryWithRewardsFee extends IStakingRepository {
     address: `0x${string}`;
   }): Promise<RewardsFee>;
 }
-
-export const IStakingRepositoryWithRewardsFee = Symbol(
-  'IStakingRepositoryWithRewardsFee',
-);

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -17,7 +17,7 @@ export interface IStakingRepository {
     address: `0x${string}`;
   }): Promise<Deployment>;
 
-  getRewardsFee(args: {
+  getRewardsFee?(args: {
     chainId: string;
     address: `0x${string}`;
   }): Promise<RewardsFee>;

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -7,6 +7,7 @@ import type { Stake } from '@/datasources/staking-api/entities/stake.entity';
 import type { TransactionStatus } from '@/datasources/staking-api/entities/transaction-status.entity';
 import type { DefiVaultStake } from '@/datasources/staking-api/entities/defi-vault-stake.entity';
 import type { DefiMorphoExtraReward } from '@/datasources/staking-api/entities/defi-morpho-extra-reward.entity';
+import type { RewardsFee } from '@/datasources/staking-api/entities/rewards-fee.entity';
 
 export const IStakingRepository = Symbol('IStakingRepository');
 
@@ -15,6 +16,11 @@ export interface IStakingRepository {
     chainId: string;
     address: `0x${string}`;
   }): Promise<Deployment>;
+
+  getRewardsFee(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<RewardsFee>;
 
   getNetworkStats(chainId: string): Promise<NetworkStats>;
 

--- a/src/domain/staking/staking.repository.interface.ts
+++ b/src/domain/staking/staking.repository.interface.ts
@@ -17,11 +17,6 @@ export interface IStakingRepository {
     address: `0x${string}`;
   }): Promise<Deployment>;
 
-  getRewardsFee?(args: {
-    chainId: string;
-    address: `0x${string}`;
-  }): Promise<RewardsFee>;
-
   getNetworkStats(chainId: string): Promise<NetworkStats>;
 
   getDedicatedStakingStats(chainId: string): Promise<DedicatedStakingStats>;
@@ -65,3 +60,14 @@ export interface IStakingRepository {
 
   clearApi(chainId: string): void;
 }
+
+export interface IStakingRepositoryWithRewardsFee extends IStakingRepository {
+  getRewardsFee(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<RewardsFee>;
+}
+
+export const IStakingRepositoryWithRewardsFee = Symbol(
+  'IStakingRepositoryWithRewardsFee',
+);

--- a/src/domain/staking/staking.repository.module.ts
+++ b/src/domain/staking/staking.repository.module.ts
@@ -1,16 +1,16 @@
 import { StakingApiModule } from '@/datasources/staking-api/staking-api.module';
 import { StakingRepository } from '@/domain/staking/staking.repository';
-import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
+import { IStakingRepositoryWithRewardsFee } from '@/domain/staking/staking.repository.interface';
 import { Module } from '@nestjs/common';
 
 @Module({
   imports: [StakingApiModule],
   providers: [
     {
-      provide: IStakingRepository,
+      provide: IStakingRepositoryWithRewardsFee,
       useClass: StakingRepository,
     },
   ],
-  exports: [IStakingRepository],
+  exports: [IStakingRepositoryWithRewardsFee],
 })
 export class StakingRepositoryModule {}

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -7,7 +7,7 @@ import {
   PooledStakingStats,
   PooledStakingStatsSchema,
 } from '@/datasources/staking-api/entities/pooled-staking-stats.entity';
-import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
+import { IStakingRepositoryWithRewardsFee } from '@/domain/staking/staking.repository.interface';
 import { Inject, Injectable } from '@nestjs/common';
 import {
   DedicatedStakingStats,
@@ -45,7 +45,7 @@ import {
 // TODO: Deduplicate code with EarnRepository
 
 @Injectable()
-export class StakingRepository implements IStakingRepository {
+export class StakingRepository implements IStakingRepositoryWithRewardsFee {
   constructor(
     @Inject(IStakingApiManager)
     private readonly stakingApiFactory: IStakingApiManager,

--- a/src/domain/staking/staking.repository.ts
+++ b/src/domain/staking/staking.repository.ts
@@ -37,6 +37,10 @@ import {
   DefiMorphoExtraReward,
   DefiMorphoExtraRewardsSchema,
 } from '@/datasources/staking-api/entities/defi-morpho-extra-reward.entity';
+import {
+  RewardsFee,
+  RewardsFeeSchema,
+} from '@/datasources/staking-api/entities/rewards-fee.entity';
 
 // TODO: Deduplicate code with EarnRepository
 
@@ -62,6 +66,15 @@ export class StakingRepository implements IStakingRepository {
       throw new Error('Deployment not found');
     }
     return deployment;
+  }
+
+  public async getRewardsFee(args: {
+    chainId: string;
+    address: `0x${string}`;
+  }): Promise<RewardsFee> {
+    const stakingApi = await this.stakingApiFactory.getApi(args.chainId);
+    const rewardsFee = await stakingApi.getRewardsFee(args.address);
+    return RewardsFeeSchema.parse(rewardsFee);
   }
 
   private async getDeployments(chainId: string): Promise<Array<Deployment>> {

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -172,7 +172,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds * 1_000,
-              fee: +rewardsFee.fee!,
+              fee: rewardsFee.fee,
               monthlyNrr,
               annualNrr,
               value,
@@ -341,7 +341,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds * 1_000,
-              fee: +rewardsFee.fee!,
+              fee: rewardsFee.fee,
               monthlyNrr,
               annualNrr,
               value,

--- a/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction-kiln.transactions.controller.spec.ts
@@ -36,6 +36,7 @@ import {
 } from '@/domain/contracts/__tests__/encoders/multi-send-encoder.builder';
 import { rawify } from '@/validation/entities/raw.entity';
 import { createTestModule } from '@/__tests__/testing-module';
+import { rewardsFeeBuilder } from '@/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder';
 
 describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
   let app: INestApplication<Server>;
@@ -72,8 +73,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
         const networkStats = networkStatsBuilder().build();
         // Transaction being proposed (no stakes exists)
@@ -112,6 +113,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify({ data: networkStats }),
                 status: 200,
               });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
+                status: 200,
+              });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
                 data: rawify({ data: stakes }),
@@ -140,7 +146,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
 
         const annualNrr =
           dedicatedStakingStats.gross_apy.last_30d *
-          (1 - Number(deployment.product_fee));
+          (1 - Number(rewardsFee.fee));
         const monthlyNrr = annualNrr / 12;
         const expectedAnnualReward = (annualNrr / 100) * Number(value);
         const expectedMonthlyReward = expectedAnnualReward / 12;
@@ -166,7 +172,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds * 1_000,
-              fee: +deployment.product_fee!,
+              fee: +rewardsFee.fee!,
               monthlyNrr,
               annualNrr,
               value,
@@ -207,8 +213,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const data = depositEncoder().encode();
         const value = getNumberString(64 * 10 ** 18 + 1);
         const depositTransaction = {
@@ -266,6 +272,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 data: rawify({ data: networkStats }),
                 status: 200,
               });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
+                status: 200,
+              });
             case `${stakingApiUrl}/v1/eth/stakes`:
               return Promise.resolve({
                 data: rawify({ data: stakes }),
@@ -304,7 +315,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
 
         const annualNrr =
           dedicatedStakingStats.gross_apy.last_30d *
-          (1 - Number(deployment.product_fee));
+          (1 - Number(rewardsFee.fee));
         const monthlyNrr = annualNrr / 12;
         const expectedAnnualReward = (annualNrr / 100) * Number(value);
         const expectedMonthlyReward = expectedAnnualReward / 12;
@@ -330,7 +341,7 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
                 networkStats.estimated_exit_time_seconds * 1_000,
               estimatedWithdrawalTime:
                 networkStats.estimated_withdrawal_time_seconds * 1_000,
-              fee: +deployment.product_fee!,
+              fee: +rewardsFee.fee!,
               monthlyNrr,
               annualNrr,
               value,
@@ -435,8 +446,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'defi')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const data = depositEncoder().encode();
         const value = getNumberString(64 * 10 ** 18 + 1);
@@ -462,6 +473,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -506,8 +522,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
           .with('chain_id', +chain.chainId)
           .with('chain', 'unknown')
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const data = depositEncoder().encode();
         const value = getNumberString(64 * 10 ** 18 + 1);
@@ -533,6 +549,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -576,8 +597,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const data = depositEncoder().encode();
         const value = getNumberString(64 * 10 ** 18 + 1);
@@ -602,6 +623,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -645,8 +671,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', null)
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const data = depositEncoder().encode();
         const value = getNumberString(64 * 10 ** 18 + 1);
@@ -672,6 +698,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -715,8 +746,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const networkStats = networkStatsBuilder().build();
         const safe = safeBuilder().build();
         const data = depositEncoder().encode();
@@ -752,6 +783,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.resolve({
                 data: rawify({ data: networkStats }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -795,8 +831,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
         const safe = safeBuilder().build();
         const data = depositEncoder().encode();
@@ -833,6 +869,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/eth/network-stats`:
               return Promise.reject({
                 status: 500,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
+                status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
               return Promise.resolve({
@@ -876,8 +917,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const networkStats = networkStatsBuilder().build();
         const validators = [
@@ -916,6 +957,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
@@ -998,8 +1044,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const networkStats = networkStatsBuilder().build();
         const validators = [
@@ -1059,6 +1105,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
@@ -1248,8 +1299,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'defi')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const contractResponse = contractBuilder()
           .with('address', previewTransactionDto.to)
           .build();
@@ -1266,6 +1317,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -1324,8 +1380,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
           .with('chain_id', +chain.chainId)
           .with('chain', 'unknown')
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('to', deployment.address)
           .with('data', data)
@@ -1347,6 +1403,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -1404,8 +1465,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const previewTransactionDto = previewTransactionDtoBuilder()
           .with('data', data)
           .with('operation', Operation.CALL)
@@ -1426,6 +1487,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -1468,8 +1534,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
@@ -1510,6 +1576,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
@@ -1561,8 +1632,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const networkStats = networkStatsBuilder().build();
         const validators = [
@@ -1600,6 +1671,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/network-stats`:
@@ -1653,8 +1729,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
@@ -1700,6 +1776,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
@@ -1774,8 +1855,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
@@ -1842,6 +1923,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:
@@ -2009,8 +2095,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'defi')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
             length: KilnDecoder.KilnPublicKeyLength,
@@ -2050,6 +2136,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -2094,8 +2185,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
           .with('chain_id', +chain.chainId)
           .with('chain', 'unknown')
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
             length: KilnDecoder.KilnPublicKeyLength,
@@ -2135,6 +2226,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -2178,8 +2274,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
             length: KilnDecoder.KilnPublicKeyLength,
@@ -2218,6 +2314,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${chain.transactionService}/api/v1/safes/${safe.address}`:
@@ -2260,8 +2361,8 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
         const deployment = deploymentBuilder()
           .with('chain_id', +chain.chainId)
           .with('product_type', 'dedicated')
-          .with('product_fee', faker.number.float().toString())
           .build();
+        const rewardsFee = rewardsFeeBuilder().build();
         const safe = safeBuilder().build();
         const validators = [
           faker.string.hexadecimal({
@@ -2299,6 +2400,11 @@ describe('Preview transaction - Kiln - Transactions Controller (Unit)', () => {
             case `${stakingApiUrl}/v1/deployments`:
               return Promise.resolve({
                 data: rawify({ data: [deployment] }),
+                status: 200,
+              });
+            case `${stakingApiUrl}/v1/eth/onchain/v1/fee`:
+              return Promise.resolve({
+                data: rawify({ data: rewardsFee }),
                 status: 200,
               });
             case `${stakingApiUrl}/v1/eth/stakes`:

--- a/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@/datasources/staking-api/entities/__tests__/dedicated-staking-stats.entity.builder';
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
 import { networkStatsBuilder } from '@/datasources/staking-api/entities/__tests__/network-stats.entity.builder';
+import { rewardsFeeBuilder } from '@/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder';
 import { stakeBuilder } from '@/datasources/staking-api/entities/__tests__/stake.entity.builder';
 import {
   transactionStatusBuilder,
@@ -34,6 +35,7 @@ import { concat, getAddress } from 'viem';
 
 const mockStakingRepository = jest.mocked({
   getDeployment: jest.fn(),
+  getRewardsFee: jest.fn(),
   getDedicatedStakingStats: jest.fn(),
   getNetworkStats: jest.fn(),
   getStakes: jest.fn(),
@@ -96,14 +98,14 @@ describe('NativeStakingMapper', () => {
   describe('mapDepositInfo', () => {
     it('should map a proposed native staking deposit info', async () => {
       const chain = chainBuilder().build();
-      const productFee = '0.5';
+      const productFee = 0.5;
       const deployment = deploymentBuilder()
         .with('product_type', 'dedicated')
-        .with('product_fee', productFee)
         .build();
       const networkStats = networkStatsBuilder()
         .with('eth_price_usd', 10_000)
         .build();
+      const rewardsFee = rewardsFeeBuilder().with('fee', productFee).build();
       const dedicatedStakingStats = dedicatedStakingStatsBuilder()
         .with(
           'gross_apy',
@@ -113,6 +115,7 @@ describe('NativeStakingMapper', () => {
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
       mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getRewardsFee.mockResolvedValue(rewardsFee);
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );
@@ -156,14 +159,14 @@ describe('NativeStakingMapper', () => {
 
     it('should map a queued native staking deposit info', async () => {
       const chain = chainBuilder().build();
-      const productFee = '0.5';
+      const productFee = 0.5;
       const deployment = deploymentBuilder()
         .with('product_type', 'dedicated')
-        .with('product_fee', productFee)
         .build();
       const networkStats = networkStatsBuilder()
         .with('eth_price_usd', 10_000)
         .build();
+      const rewardsFee = rewardsFeeBuilder().with('fee', productFee).build();
       const dedicatedStakingStats = dedicatedStakingStatsBuilder()
         .with(
           'gross_apy',
@@ -173,6 +176,7 @@ describe('NativeStakingMapper', () => {
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
       mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getRewardsFee.mockResolvedValue(rewardsFee);
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );
@@ -217,14 +221,14 @@ describe('NativeStakingMapper', () => {
 
     it('should map a native staking deposit info', async () => {
       const chain = chainBuilder().build();
-      const productFee = '0.5';
+      const productFee = 0.5;
       const deployment = deploymentBuilder()
         .with('product_type', 'dedicated')
-        .with('product_fee', productFee)
         .build();
       const networkStats = networkStatsBuilder()
         .with('eth_price_usd', 10_000)
         .build();
+      const rewardsFee = rewardsFeeBuilder().with('fee', productFee).build();
       const dedicatedStakingStats = dedicatedStakingStatsBuilder()
         .with(
           'gross_apy',
@@ -258,6 +262,7 @@ describe('NativeStakingMapper', () => {
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
       mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getRewardsFee.mockResolvedValue(rewardsFee);
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );
@@ -310,9 +315,12 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder().build();
       const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
+      const rewardsFee = rewardsFeeBuilder().build();
+
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
       mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getRewardsFee.mockResolvedValue(rewardsFee);
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );
@@ -335,10 +343,12 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder().build();
       const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
+      const rewardsFee = rewardsFeeBuilder().build();
 
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
       mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getRewardsFee.mockResolvedValue(rewardsFee);
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );
@@ -361,10 +371,12 @@ describe('NativeStakingMapper', () => {
         .build();
       const networkStats = networkStatsBuilder().build();
       const dedicatedStakingStats = dedicatedStakingStatsBuilder().build();
+      const rewardsFee = rewardsFeeBuilder().build();
 
       mockChainsRepository.getChain.mockResolvedValue(chain);
       mockStakingRepository.getDeployment.mockResolvedValue(deployment);
       mockStakingRepository.getNetworkStats.mockResolvedValue(networkStats);
+      mockStakingRepository.getRewardsFee.mockResolvedValue(rewardsFee);
       mockStakingRepository.getDedicatedStakingStats.mockResolvedValue(
         dedicatedStakingStats,
       );

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -82,10 +82,9 @@ export class NativeStakingMapper {
         Math.pow(10, chain.nativeCurrency.decimals) /
         NativeStakingMapper.ETH_ETHERS_PER_VALIDATOR,
     );
-    const fee = rewardsFee.fee ?? 0;
     // NRR = GRR * (1 - service_fees)
     // Kiln also uses last_30d field, with product_fee
-    const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);
+    const nrr = nativeStakingStats.gross_apy.last_30d * (1 - rewardsFee.fee);
     const expectedAnnualReward = (nrr / 100) * value;
     const expectedMonthlyReward = expectedAnnualReward / 12;
     const expectedFiatAnnualReward =
@@ -99,7 +98,7 @@ export class NativeStakingMapper {
       estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
       estimatedWithdrawalTime:
         networkStats.estimated_withdrawal_time_seconds * 1_000,
-      fee,
+      fee: rewardsFee.fee,
       monthlyNrr: nrr / 12,
       annualNrr: nrr,
       value: getNumberString(value),

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -52,9 +52,13 @@ export class NativeStakingMapper {
     value: string | null;
     txHash: `0x${string}` | null;
   }): Promise<NativeStakingDepositTransactionInfo> {
-    const [chain, deployment] = await Promise.all([
+    const [chain, deployment, rewardsFee] = await Promise.all([
       this.chainsRepository.getChain(args.chainId),
       this.stakingRepository.getDeployment({
+        chainId: args.chainId,
+        address: args.to,
+      }),
+      this.stakingRepository.getRewardsFee({
         chainId: args.chainId,
         address: args.to,
       }),
@@ -78,7 +82,7 @@ export class NativeStakingMapper {
         Math.pow(10, chain.nativeCurrency.decimals) /
         NativeStakingMapper.ETH_ETHERS_PER_VALIDATOR,
     );
-    const fee = deployment.product_fee ? Number(deployment.product_fee) : 0;
+    const fee = rewardsFee.fee ? Number(rewardsFee.fee) : 0;
     // NRR = GRR * (1 - service_fees)
     // Kiln also uses last_30d field, with product_fee
     const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -6,7 +6,7 @@ import {
 } from '@/domain/chains/chains.repository.interface';
 import { getNumberString } from '@/domain/common/utils/utils';
 import { KilnDecoder } from '@/domain/staking/contracts/decoders/kiln-decoder.helper';
-import { IStakingRepository } from '@/domain/staking/staking.repository.interface';
+import { IStakingRepositoryWithRewardsFee } from '@/domain/staking/staking.repository.interface';
 import { StakingRepositoryModule } from '@/domain/staking/staking.repository.module';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { NULL_ADDRESS } from '@/routes/common/constants';
@@ -26,8 +26,8 @@ export class NativeStakingMapper {
   private static readonly ETH_ETHERS_PER_VALIDATOR = 32;
 
   constructor(
-    @Inject(IStakingRepository)
-    private readonly stakingRepository: IStakingRepository,
+    @Inject(IStakingRepositoryWithRewardsFee)
+    private readonly stakingRepository: IStakingRepositoryWithRewardsFee,
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
     private readonly kilnDecoder: KilnDecoder,
@@ -58,7 +58,7 @@ export class NativeStakingMapper {
         chainId: args.chainId,
         address: args.to,
       }),
-      this.stakingRepository?.getRewardsFee?.({
+      this.stakingRepository.getRewardsFee({
         chainId: args.chainId,
         address: args.to,
       }),
@@ -82,7 +82,7 @@ export class NativeStakingMapper {
         Math.pow(10, chain.nativeCurrency.decimals) /
         NativeStakingMapper.ETH_ETHERS_PER_VALIDATOR,
     );
-    const fee = rewardsFee?.fee ?? 0;
+    const fee = rewardsFee.fee ?? 0;
     // NRR = GRR * (1 - service_fees)
     // Kiln also uses last_30d field, with product_fee
     const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -58,7 +58,7 @@ export class NativeStakingMapper {
         chainId: args.chainId,
         address: args.to,
       }),
-      this.stakingRepository.getRewardsFee({
+      this.stakingRepository?.getRewardsFee?.({
         chainId: args.chainId,
         address: args.to,
       }),
@@ -82,9 +82,10 @@ export class NativeStakingMapper {
         Math.pow(10, chain.nativeCurrency.decimals) /
         NativeStakingMapper.ETH_ETHERS_PER_VALIDATOR,
     );
+    const fee = rewardsFee?.fee ?? 0;
     // NRR = GRR * (1 - service_fees)
     // Kiln also uses last_30d field, with product_fee
-    const nrr = nativeStakingStats.gross_apy.last_30d * (1 - rewardsFee.fee);
+    const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);
     const expectedAnnualReward = (nrr / 100) * value;
     const expectedMonthlyReward = expectedAnnualReward / 12;
     const expectedFiatAnnualReward =
@@ -98,7 +99,7 @@ export class NativeStakingMapper {
       estimatedExitTime: networkStats.estimated_exit_time_seconds * 1_000,
       estimatedWithdrawalTime:
         networkStats.estimated_withdrawal_time_seconds * 1_000,
-      fee: rewardsFee.fee,
+      fee,
       monthlyNrr: nrr / 12,
       annualNrr: nrr,
       value: getNumberString(value),

--- a/src/routes/transactions/mappers/common/native-staking.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-staking.mapper.ts
@@ -82,7 +82,7 @@ export class NativeStakingMapper {
         Math.pow(10, chain.nativeCurrency.decimals) /
         NativeStakingMapper.ETH_ETHERS_PER_VALIDATOR,
     );
-    const fee = rewardsFee.fee ? Number(rewardsFee.fee) : 0;
+    const fee = rewardsFee.fee ?? 0;
     // NRR = GRR * (1 - service_fees)
     // Kiln also uses last_30d field, with product_fee
     const nrr = nativeStakingStats.gross_apy.last_30d * (1 - fee);

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
@@ -5,7 +5,6 @@ import {
   defiVaultStatsBuilder,
 } from '@/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder';
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
-import { rewardsFeeBuilder } from '@/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import type { EarnRepository } from '@/domain/earn/earn.repository';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
@@ -23,7 +22,6 @@ const mockEarnRepository = jest.mocked({
   getDefiVaultStats: jest.fn(),
   getDefiVaultStake: jest.fn(),
   getDefiMorphoExtraRewards: jest.fn(),
-  getRewardsFee: jest.fn(),
 } as jest.MockedObjectDeep<EarnRepository>);
 
 const mockTokenRepository = {
@@ -387,10 +385,8 @@ describe('VaultTransactionMapper', () => {
           Number(faker.string.numeric({ exclude: [chain.chainId] })),
         )
         .build();
-      const rewardsFee = rewardsFeeBuilder().build();
 
       mockEarnRepository.getDeployment.mockResolvedValue(deployment);
-      mockEarnRepository.getRewardsFee.mockResolvedValue(rewardsFee);
 
       await expect(
         target.mapRedeemInfo({

--- a/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/vault-transaction.mapper.spec.ts
@@ -5,6 +5,7 @@ import {
   defiVaultStatsBuilder,
 } from '@/datasources/staking-api/entities/__tests__/defi-vault-stats.entity.builder';
 import { deploymentBuilder } from '@/datasources/staking-api/entities/__tests__/deployment.entity.builder';
+import { rewardsFeeBuilder } from '@/datasources/staking-api/entities/__tests__/rewards-fee.entity.builder';
 import { chainBuilder } from '@/domain/chains/entities/__tests__/chain.builder';
 import type { EarnRepository } from '@/domain/earn/earn.repository';
 import { tokenBuilder } from '@/domain/tokens/__tests__/token.builder';
@@ -22,6 +23,7 @@ const mockEarnRepository = jest.mocked({
   getDefiVaultStats: jest.fn(),
   getDefiVaultStake: jest.fn(),
   getDefiMorphoExtraRewards: jest.fn(),
+  getRewardsFee: jest.fn(),
 } as jest.MockedObjectDeep<EarnRepository>);
 
 const mockTokenRepository = {
@@ -379,14 +381,16 @@ describe('VaultTransactionMapper', () => {
       const assets = faker.number.int();
       const deployment = deploymentBuilder()
         .with('product_type', 'defi')
-        .with('product_fee', '0.1')
         .with('status', 'active')
         .with(
           'chain_id',
           Number(faker.string.numeric({ exclude: [chain.chainId] })),
         )
         .build();
+      const rewardsFee = rewardsFeeBuilder().build();
+
       mockEarnRepository.getDeployment.mockResolvedValue(deployment);
+      mockEarnRepository.getRewardsFee.mockResolvedValue(rewardsFee);
 
       await expect(
         target.mapRedeemInfo({


### PR DESCRIPTION
## Summary
Introduces a new rewards fee endpoint to the Kiln API integration with comprehensive testing. Replaces deprecated `product_fee` field with dedicated rewards fee.

Solves [EN-150](https://linear.app/safe-global/issue/EN-150/updating-kiln-deployment-endpoint-response)

## Changes

### ✨ Features
- **RewardsFee entity**: `RewardsFee` with Zod schema validation
- **Kiln API integration**: `getRewardsFee` method in `KilnApi` service
- **Repository layer**: Added to `StakingRepository` and `EarnRepository`
- 
### API integration
- **Endpoint**: `/v1/eth/onchain/v1/fee`
- **Caching**: `staking_rewards_fee` cache directory
- **Auth**: Bearer token authentication
- **Params**: `integration` contract address

### ⚠️ Breaking changes
- `product_fee` field removed from `DeploymentSchema`
- `NativeStakingMapper` uses `rewardsFee` instead of `product_fee`