### PR TITLE
fix: Invalidates notification subscription cache when removing a subscription/device

### DIFF
--- a/src/datasources/db/v2/__tests__/repository.mock.ts
+++ b/src/datasources/db/v2/__tests__/repository.mock.ts
@@ -1,3 +1,4 @@
+import { mockEntityManager } from '@/datasources/db/v2/__tests__/entity-manager.mock';
 import type { ObjectLiteral, Repository } from 'typeorm';
 
 export const mockRepository = {
@@ -12,4 +13,5 @@ export const mockRepository = {
   count: jest.fn(),
   findBy: jest.fn(),
   findOneBy: jest.fn(),
+  manager: mockEntityManager,
 } as jest.MockedObjectDeep<Repository<ObjectLiteral>>;


### PR DESCRIPTION
## Summary
This PR adds cache invalidation for notification subscriptions when a subscription or device is removed.

Previously, removing a subscription or device did not invalidate the associated cache. This could result in stale subscription data being served, leading to inconsistencies in push notifications. This fix explicitly clears the relevant cache entries on removal, ensuring consistency across notification states.

## Changes
- Adds cache invalidation logic to `notificationRepository.deleteDevice`
- Adds cache invalidation logic to `notificationRepository.deleteSubscription`
- Adds new tests