### PR TITLE
Feat/notification delete all subscriptions

### DIFF
--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder.ts
@@ -1,0 +1,21 @@
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { DeleteAllSubscriptionsDto } from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
+import type { UUID } from 'crypto';
+
+export function deleteAllSubscriptionsDtoBuilder(): DeleteAllSubscriptionsDto {
+  return {
+    subscriptions: Array.from(
+      {
+        length: faker.number.int({ min: 1, max: 5 }),
+      },
+      () => {
+        return {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        };
+      },
+    ),
+  };
+}

--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
@@ -1,0 +1,205 @@
+import { DeleteAllSubscriptionsDtoSchema } from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
+import { deleteAllSubscriptionsDtoBuilder } from '@/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder';
+import { faker } from '@faker-js/faker';
+import type { UUID } from 'crypto';
+import { getAddress } from 'viem';
+
+describe('DeleteAllSubscriptionsDtoSchema', () => {
+  it('should validate a valid DeleteAllSubscriptionsDto', () => {
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder();
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not allow an empty array', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each([
+    ['chainId' as const, 'string'],
+    ['deviceUuid' as const, 'string'],
+    ['safeAddress' as const, 'string'],
+  ])('should require %s for each subscription', (key, expected) => {
+    const subscriptions = [
+      {
+        chainId: faker.string.numeric(),
+        deviceUuid: faker.string.uuid() as UUID,
+        safeAddress: getAddress(faker.finance.ethereumAddress()),
+      },
+    ];
+    delete subscriptions[0][key];
+
+    const deleteAllSubscriptionsDto = {
+      subscriptions,
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected,
+        message: 'Required',
+        path: ['subscriptions', 0, key],
+        received: 'undefined',
+      },
+    ]);
+  });
+
+  it('should not allow non-UUID values for deviceUuid', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: 'not-a-uuid' as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_string',
+        message: 'Invalid UUID',
+        path: ['subscriptions', 0, 'deviceUuid'],
+        validation: 'uuid',
+      },
+    ]);
+  });
+
+  it('should checksum safeAddress', () => {
+    const nonChecksummedAddress = faker.finance.ethereumAddress().toLowerCase();
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: nonChecksummedAddress as `0x${string}`,
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success && result.data.subscriptions[0].safeAddress).toBe(
+      getAddress(nonChecksummedAddress),
+    );
+  });
+
+  it('should not allow non-hex address values for safeAddress', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: 'not-an-address' as `0x${string}`,
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid address',
+        path: ['subscriptions', 0, 'safeAddress'],
+      },
+    ]);
+  });
+
+  it('should validate multiple subscriptions', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail validation when chainId is not a string', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: 123 as unknown as string, // number instead of string
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Expected string, received number',
+        path: ['subscriptions', 0, 'chainId'],
+        received: 'number',
+      },
+    ]);
+  });
+
+  it('should fail validation when chainId is not a valid numeric string', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.alpha(), // non-numeric string
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid base-10 numeric string',
+        path: ['subscriptions', 0, 'chainId'],
+      },
+    ]);
+  });
+});

--- a/src/domain/notifications/v2/entities/__tests__/notification.repository.mock.ts
+++ b/src/domain/notifications/v2/entities/__tests__/notification.repository.mock.ts
@@ -7,5 +7,6 @@ export const MockNotificationRepositoryV2: jest.MockedObjectDeep<INotificationsR
     getSafeSubscription: jest.fn(),
     getSubscribersBySafe: jest.fn(),
     deleteSubscription: jest.fn(),
+    deleteAllSubscriptions: jest.fn(),
     deleteDevice: jest.fn(),
   };

--- a/src/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
+++ b/src/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
@@ -1,0 +1,20 @@
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { UuidSchema } from '@/validation/entities/schemas/uuid.schema';
+import { z } from 'zod';
+
+export const DeleteAllSubscriptionsDtoSchema = z.object({
+  subscriptions: z
+    .array(
+      z.object({
+        chainId: NumericStringSchema,
+        deviceUuid: UuidSchema,
+        safeAddress: AddressSchema,
+      }),
+    )
+    .min(1, 'At least one subscription is required'),
+});
+
+export type DeleteAllSubscriptionsDto = z.infer<
+  typeof DeleteAllSubscriptionsDtoSchema
+>;

--- a/src/domain/notifications/v2/notifications.repository.interface.ts
+++ b/src/domain/notifications/v2/notifications.repository.interface.ts
@@ -38,6 +38,14 @@ export interface INotificationsRepositoryV2 {
     }>
   >;
 
+  deleteAllSubscriptions(args: {
+    subscriptions: Array<{
+      chainId: string;
+      deviceUuid: UUID;
+      safeAddress: `0x${string}`;
+    }>;
+  }): Promise<void>;
+
   deleteSubscription(args: {
     deviceUuid: UUID;
     chainId: string;

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -425,6 +425,46 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
     });
   }
 
+  public async deleteAllSubscriptions(args: {
+    subscriptions: Array<{
+      chainId: string;
+      deviceUuid: UUID;
+      safeAddress: `0x${string}`;
+    }>;
+  }): Promise<void> {
+    const notificationsSubscriptionsRepository =
+      await this.postgresDatabaseService.getRepository<NotificationSubscription>(
+        NotificationSubscription,
+      );
+    const subscriptionsQueryFilter = args.subscriptions.map((subscription) => ({
+      chain_id: subscription.chainId,
+      safe_address: subscription.safeAddress,
+      push_notification_device: {
+        device_uuid: subscription.deviceUuid,
+      },
+    }));
+    const subscriptions = await notificationsSubscriptionsRepository.find({
+      where: subscriptionsQueryFilter,
+    });
+
+    if (!subscriptions.length) {
+      throw new NotFoundException('No Subscription Found!');
+    }
+
+    await notificationsSubscriptionsRepository.remove(subscriptions);
+    for (const subscription of subscriptions) {
+      await this.removeGetSubscribersBySafeCache({
+        entityManager: notificationsSubscriptionsRepository.manager,
+        safes: [
+          {
+            chainId: subscription.chain_id,
+            address: subscription.safe_address,
+          },
+        ],
+      });
+    }
+  }
+
   public async deleteDevice(deviceUuid: UUID): Promise<void> {
     const notificationsDeviceRepository =
       await this.postgresDatabaseService.getRepository<NotificationDevice>(

--- a/src/routes/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
+++ b/src/routes/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { DeleteAllSubscriptionsDto as DomainDeleteAllSubscriptionsDto } from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
+
+export class DeleteAllSubscriptionItemDto {
+  @ApiProperty()
+  chainId!: string;
+
+  @ApiProperty()
+  deviceUuid!: UUID;
+
+  @ApiProperty()
+  safeAddress!: `0x${string}`;
+}
+
+export class DeleteAllSubscriptionsDto
+  implements DomainDeleteAllSubscriptionsDto
+{
+  @ApiProperty({
+    isArray: true,
+    type: DeleteAllSubscriptionItemDto,
+    minItems: 1,
+    description: 'At least one subscription is required',
+  })
+  subscriptions!: Array<DeleteAllSubscriptionItemDto>;
+}

--- a/src/routes/notifications/v2/notifications.controller.spec.ts
+++ b/src/routes/notifications/v2/notifications.controller.spec.ts
@@ -21,6 +21,7 @@ import { safeBuilder } from '@/domain/safe/entities/__tests__/safe.builder';
 import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
 import { RequestScopedLoggingModule } from '@/logging/logging.module';
 import { upsertSubscriptionsDtoBuilder } from '@/routes/notifications/v2/entities/__tests__/upsert-subscriptions.dto.builder';
+import { deleteAllSubscriptionsDtoBuilder } from '@/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder';
 import type { Chain } from '@/routes/chains/entities/chain.entity';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
@@ -48,6 +49,7 @@ import { AddressBooksDatasourceModule } from '@/datasources/accounts/address-boo
 import { rawify } from '@/validation/entities/raw.entity';
 import { NotificationsRepositoryV2Module } from '@/domain/notifications/v2/notifications.repository.module';
 import { TestNotificationsRepositoryV2Module } from '@/domain/notifications/v2/test.notification.repository.module';
+import type { DeleteAllSubscriptionsDto } from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
 
 describe('Notifications Controller V2 (Unit)', () => {
   let app: INestApplication<Server>;
@@ -998,6 +1000,144 @@ describe('Notifications Controller V2 (Unit)', () => {
           message: 'Not Found',
           statusCode: 404,
         });
+    });
+  });
+
+  describe('DELETE /v2/notifications/subscriptions', () => {
+    it('Should delete all subscriptions successfully', async () => {
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder();
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect(200);
+
+      expect(
+        notificationsRepository.deleteAllSubscriptions,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        notificationsRepository.deleteAllSubscriptions,
+      ).toHaveBeenNthCalledWith(1, {
+        subscriptions: deleteAllSubscriptionsDto.subscriptions,
+      });
+    });
+
+    it('should handle empty subscriptions array', async () => {
+      const deleteAllSubscriptionsDto: DeleteAllSubscriptionsDto = {
+        subscriptions: [],
+      };
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect(422);
+
+      expect(
+        notificationsRepository.deleteAllSubscriptions,
+      ).toHaveBeenCalledTimes(0);
+    });
+
+    it('should return 422 if chainId is invalid', async () => {
+      const baseDto = deleteAllSubscriptionsDtoBuilder();
+      const deleteAllSubscriptionsDto = {
+        subscriptions: [
+          {
+            ...baseDto.subscriptions[0],
+            chainId: faker.string.alpha(),
+          },
+        ],
+      };
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'Invalid base-10 numeric string',
+          path: ['subscriptions', 0, 'chainId'],
+        });
+    });
+
+    it('should return 422 if deviceUuid is invalid', async () => {
+      const baseDto = deleteAllSubscriptionsDtoBuilder();
+      const deleteAllSubscriptionsDto = {
+        subscriptions: [
+          {
+            ...baseDto.subscriptions[0],
+            deviceUuid: faker.string.alphanumeric(),
+          },
+        ],
+      };
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect({
+          statusCode: 422,
+          validation: 'uuid',
+          code: 'invalid_string',
+          message: 'Invalid UUID',
+          path: ['subscriptions', 0, 'deviceUuid'],
+        });
+    });
+
+    it('should return 422 if safeAddress is invalid', async () => {
+      const baseDto = deleteAllSubscriptionsDtoBuilder();
+      const deleteAllSubscriptionsDto = {
+        subscriptions: [
+          {
+            ...baseDto.subscriptions[0],
+            safeAddress: faker.string.alphanumeric(),
+          },
+        ],
+      };
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'Invalid address',
+          path: ['subscriptions', 0, 'safeAddress'],
+        });
+    });
+
+    it('should return 422 if required fields are missing', async () => {
+      const deleteAllSubscriptionsDto = {
+        subscriptions: [
+          {
+            chainId: faker.string.numeric(),
+          },
+        ],
+      };
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect(422);
+    });
+
+    it('should forward datasource errors', async () => {
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder();
+      const error = new NotFoundException();
+      notificationsRepository.deleteAllSubscriptions.mockRejectedValue(error);
+
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send(deleteAllSubscriptionsDto)
+        .expect({
+          message: 'Not Found',
+          statusCode: 404,
+        });
+    });
+
+    it('should handle invalid JSON in request body', async () => {
+      await request(app.getHttpServer())
+        .delete('/v2/notifications/subscriptions')
+        .send('invalid json')
+        .expect(422);
     });
   });
 

--- a/src/routes/notifications/v2/notifications.controller.ts
+++ b/src/routes/notifications/v2/notifications.controller.ts
@@ -21,6 +21,10 @@ import { ApiTags } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { OptionalAuthGuard } from '@/routes/auth/guards/optional-auth.guard';
 import { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
+import {
+  DeleteAllSubscriptionsDto,
+  DeleteAllSubscriptionsDtoSchema,
+} from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
 
 @ApiTags('notifications')
 @Controller({ path: '', version: '2' })
@@ -71,6 +75,16 @@ export class NotificationsControllerV2 {
       chainId,
       safeAddress,
     });
+  }
+
+  @Delete('notifications/subscriptions')
+  deleteAllSubscriptions(
+    @Body(new ValidationPipe(DeleteAllSubscriptionsDtoSchema))
+    deleteAllSubscriptionsDto: DeleteAllSubscriptionsDto,
+  ): Promise<void> {
+    return this.notificationsService.deleteAllSubscriptions(
+      deleteAllSubscriptionsDto,
+    );
   }
 
   @Delete('chains/:chainId/notifications/devices/:deviceUuid')

--- a/src/routes/notifications/v2/notifications.controller.ts
+++ b/src/routes/notifications/v2/notifications.controller.ts
@@ -21,10 +21,8 @@ import { ApiTags } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { OptionalAuthGuard } from '@/routes/auth/guards/optional-auth.guard';
 import { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
-import {
-  DeleteAllSubscriptionsDto,
-  DeleteAllSubscriptionsDtoSchema,
-} from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
+import { DeleteAllSubscriptionsDtoSchema } from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
+import { DeleteAllSubscriptionsDto } from '@/routes/notifications/v2/entities/delete-all-subscriptions.dto.entity';
 
 @ApiTags('notifications')
 @Controller({ path: '', version: '2' })

--- a/src/routes/notifications/v2/notifications.service.ts
+++ b/src/routes/notifications/v2/notifications.service.ts
@@ -38,6 +38,16 @@ export class NotificationsServiceV2 {
     await this.notificationsRepository.deleteSubscription(args);
   }
 
+  async deleteAllSubscriptions(args: {
+    subscriptions: Array<{
+      chainId: string;
+      deviceUuid: UUID;
+      safeAddress: `0x${string}`;
+    }>;
+  }): Promise<void> {
+    await this.notificationsRepository.deleteAllSubscriptions(args);
+  }
+
   async deleteDevice(deviceUuid: UUID): Promise<void> {
     await this.notificationsRepository.deleteDevice(deviceUuid);
   }


### PR DESCRIPTION
## Summary
This PR introduces a new method, `deleteAllSubscriptions`, to the `NotificationsRepositoryV2` class. The goal of this addition is to allow bulk deletion of notification subscriptions based on given criteria and to delete all the subscription of a device regardless of it's signer. It enhances the flexibility of the notification system by allowing developers to efficiently remove multiple subscriptions that match certain conditions.

## Changes
- Enables deletion of `Safe` subscriptions of a device regardless of its signer address.
- Enables deletion of multiple notification subscriptions in a single call.
- Ensures related cached notification data is purged or refreshed after deletion to prevent stale data access.