### PR TITLE
fix: Staking rewards fee caching

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -652,8 +652,15 @@ export class CacheRouter {
     return new CacheDir(this.STAKING_DEPLOYMENTS_KEY, cacheType);
   }
 
-  static getStakingRewardsFeeCacheDir(cacheType: 'earn' | 'staking'): CacheDir {
-    return new CacheDir(this.STAKING_REWARDS_FEE_KEY, cacheType);
+  static getStakingRewardsFeeCacheDir(args: {
+    cacheType: 'earn' | 'staking';
+    chainId: string;
+    contract: `0x${string}`;
+  }): CacheDir {
+    return new CacheDir(
+      `${args.chainId}_${this.STAKING_REWARDS_FEE_KEY}_${args.contract}`,
+      args.cacheType,
+    );
   }
 
   static getStakingNetworkStatsCacheDir(

--- a/src/datasources/staking-api/kiln-api.service.spec.ts
+++ b/src/datasources/staking-api/kiln-api.service.spec.ts
@@ -151,6 +151,12 @@ describe('KilnApi', () => {
   });
 
   describe('getRewardsFee', () => {
+    const chainId = faker.string.numeric();
+
+    beforeEach(() => {
+      createTarget(chainId);
+    });
+
     it('should return rewards fee', async () => {
       const contract = getAddress(faker.finance.ethereumAddress());
       const rewardsFee = rewardsFeeBuilder().build();
@@ -166,7 +172,10 @@ describe('KilnApi', () => {
 
       expect(actual).toBe(rewardsFee);
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_rewards_fee', cacheType),
+        cacheDir: new CacheDir(
+          `${chainId}_staking_rewards_fee_${contract}`,
+          cacheType,
+        ),
         url: `${baseUrl}/v1/eth/onchain/v1/fee`,
         networkRequest: {
           headers: {
@@ -202,7 +211,10 @@ describe('KilnApi', () => {
       await expect(target.getRewardsFee(contract)).rejects.toThrow(expected);
 
       expect(dataSource.get).toHaveBeenNthCalledWith(1, {
-        cacheDir: new CacheDir('staking_rewards_fee', cacheType),
+        cacheDir: new CacheDir(
+          `${chainId}_staking_rewards_fee_${contract}`,
+          cacheType,
+        ),
         url: getRewardsFeeUrl,
         networkRequest: {
           headers: {

--- a/src/datasources/staking-api/kiln-api.service.ts
+++ b/src/datasources/staking-api/kiln-api.service.ts
@@ -79,7 +79,11 @@ export class KilnApi implements IStakingApi {
   // Therefore, this data will live in cache until [stakingExpirationTimeInSeconds]
   async getRewardsFee(contract: `0x${string}`): Promise<Raw<RewardsFee>> {
     const url = `${this.baseUrl}/v1/eth/onchain/v1/fee`;
-    const cacheDir = CacheRouter.getStakingRewardsFeeCacheDir(this.cacheType);
+    const cacheDir = CacheRouter.getStakingRewardsFeeCacheDir({
+      cacheType: this.cacheType,
+      chainId: this.chainId,
+      contract,
+    });
     return await this.get<{
       data: RewardsFee;
     }>({


### PR DESCRIPTION
## Summary
Updates the staking rewards fee caching mechanism to generate unique cache keys for each combination of chain ID and contract address, preventing cache collisions between different chains and contracts.

Resolves [COR-333](https://linear.app/safe-global/issue/COR-333/incorrect-caching-of-rewards-fee)

## Changes
Changes cache key format from the static key `staking_rewards_fee` to: 

```{chainId}_staking_rewards_fee_{contract}```