### PR TITLE
feat: add signerAddress prop to DELETE subscriptions endpoint

### DIFF
--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder.ts
@@ -17,12 +17,7 @@ export function deleteAllSubscriptionsDtoBuilder(): IBuilder<DeleteAllSubscripti
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
-          ...(faker.datatype.boolean() && {
-            signerAddress: faker.helpers.arrayElement([
-              getAddress(faker.finance.ethereumAddress()),
-              null,
-            ]),
-          }),
+          // signerAddress is undefined by default - use .with() to add it on demand
         };
       },
     ),

--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder.ts
@@ -17,6 +17,12 @@ export function deleteAllSubscriptionsDtoBuilder(): IBuilder<DeleteAllSubscripti
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
+          ...(faker.datatype.boolean() && {
+            signerAddress: faker.helpers.arrayElement([
+              getAddress(faker.finance.ethereumAddress()),
+              null,
+            ]),
+          }),
         };
       },
     ),

--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
@@ -203,4 +203,146 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
       },
     ]);
   });
+
+  it('should validate signerAddress when provided', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          signerAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate when signerAddress is not provided', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should checksum signerAddress when provided', () => {
+    const nonChecksummedAddress = faker.finance.ethereumAddress().toLowerCase();
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          signerAddress: nonChecksummedAddress as `0x${string}`,
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success && result.data.subscriptions[0].signerAddress).toBe(
+      getAddress(nonChecksummedAddress),
+    );
+  });
+
+  it('should not allow non-hex address values for signerAddress', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          signerAddress: 'not-an-address' as `0x${string}`,
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(!result.success && result.error.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'Invalid address',
+        path: ['subscriptions', 0, 'signerAddress'],
+      },
+    ]);
+  });
+
+  it('should validate when signerAddress is explicitly set to null', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          signerAddress: null,
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.subscriptions[0].signerAddress).toBe(
+      null,
+    );
+  });
+
+  it('should validate mixed signerAddress values in array', () => {
+    const deleteAllSubscriptionsDto = {
+      subscriptions: [
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          // signerAddress omitted (undefined)
+        },
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          signerAddress: null,
+        },
+        {
+          chainId: faker.string.numeric(),
+          deviceUuid: faker.string.uuid() as UUID,
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          signerAddress: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    };
+
+    const result = DeleteAllSubscriptionsDtoSchema.safeParse(
+      deleteAllSubscriptionsDto,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.subscriptions[0].signerAddress).toBeUndefined();
+      expect(result.data.subscriptions[1].signerAddress).toBe(null);
+      expect(result.data.subscriptions[2].signerAddress).toBeDefined();
+    }
+  });
 });

--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
@@ -240,7 +240,9 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.success && result.data.subscriptions[0].signerAddress).toBeUndefined();
+    expect(
+      result.success && result.data.subscriptions[0].signerAddress,
+    ).toBeUndefined();
   });
 
   it('should checksum signerAddress when provided', () => {

--- a/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
+++ b/src/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.entity.spec.ts
@@ -205,16 +205,16 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
   });
 
   it('should validate signerAddress when provided', () => {
-    const deleteAllSubscriptionsDto = {
-      subscriptions: [
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+      .with('subscriptions', [
         {
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
           signerAddress: getAddress(faker.finance.ethereumAddress()),
         },
-      ],
-    };
+      ])
+      .build();
 
     const result = DeleteAllSubscriptionsDtoSchema.safeParse(
       deleteAllSubscriptionsDto,
@@ -223,36 +223,38 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should validate when signerAddress is not provided', () => {
-    const deleteAllSubscriptionsDto = {
-      subscriptions: [
+  it('should validate when signerAddress is omitted (undefined)', () => {
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+      .with('subscriptions', [
         {
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
+          // signerAddress intentionally omitted
         },
-      ],
-    };
+      ])
+      .build();
 
     const result = DeleteAllSubscriptionsDtoSchema.safeParse(
       deleteAllSubscriptionsDto,
     );
 
     expect(result.success).toBe(true);
+    expect(result.success && result.data.subscriptions[0].signerAddress).toBeUndefined();
   });
 
   it('should checksum signerAddress when provided', () => {
     const nonChecksummedAddress = faker.finance.ethereumAddress().toLowerCase();
-    const deleteAllSubscriptionsDto = {
-      subscriptions: [
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+      .with('subscriptions', [
         {
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
           signerAddress: nonChecksummedAddress as `0x${string}`,
         },
-      ],
-    };
+      ])
+      .build();
 
     const result = DeleteAllSubscriptionsDtoSchema.safeParse(
       deleteAllSubscriptionsDto,
@@ -264,16 +266,16 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
   });
 
   it('should not allow non-hex address values for signerAddress', () => {
-    const deleteAllSubscriptionsDto = {
-      subscriptions: [
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+      .with('subscriptions', [
         {
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
           signerAddress: 'not-an-address' as `0x${string}`,
         },
-      ],
-    };
+      ])
+      .build();
 
     const result = DeleteAllSubscriptionsDtoSchema.safeParse(
       deleteAllSubscriptionsDto,
@@ -289,16 +291,16 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
   });
 
   it('should validate when signerAddress is explicitly set to null', () => {
-    const deleteAllSubscriptionsDto = {
-      subscriptions: [
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+      .with('subscriptions', [
         {
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
           safeAddress: getAddress(faker.finance.ethereumAddress()),
           signerAddress: null,
         },
-      ],
-    };
+      ])
+      .build();
 
     const result = DeleteAllSubscriptionsDtoSchema.safeParse(
       deleteAllSubscriptionsDto,
@@ -311,8 +313,8 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
   });
 
   it('should validate mixed signerAddress values in array', () => {
-    const deleteAllSubscriptionsDto = {
-      subscriptions: [
+    const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+      .with('subscriptions', [
         {
           chainId: faker.string.numeric(),
           deviceUuid: faker.string.uuid() as UUID,
@@ -331,8 +333,8 @@ describe('DeleteAllSubscriptionsDtoSchema', () => {
           safeAddress: getAddress(faker.finance.ethereumAddress()),
           signerAddress: getAddress(faker.finance.ethereumAddress()),
         },
-      ],
-    };
+      ])
+      .build();
 
     const result = DeleteAllSubscriptionsDtoSchema.safeParse(
       deleteAllSubscriptionsDto,

--- a/src/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
+++ b/src/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
@@ -10,6 +10,7 @@ export const DeleteAllSubscriptionsDtoSchema = z.object({
         chainId: NumericStringSchema,
         deviceUuid: UuidSchema,
         safeAddress: AddressSchema,
+        signerAddress: AddressSchema.nullable().optional(),
       }),
     )
     .min(1, 'At least one subscription is required'),

--- a/src/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
+++ b/src/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
@@ -10,7 +10,7 @@ export const DeleteAllSubscriptionsDtoSchema = z.object({
         chainId: NumericStringSchema,
         deviceUuid: UuidSchema,
         safeAddress: AddressSchema,
-        signerAddress: AddressSchema.nullable().optional(),
+        signerAddress: AddressSchema.nullish(),
       }),
     )
     .min(1, 'At least one subscription is required'),

--- a/src/domain/notifications/v2/notifications.repository.integration.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.integration.spec.ts
@@ -1187,5 +1187,254 @@ describe('NotificationsRepositoryV2', () => {
       expect(firstSubscription).toHaveLength(0);
       expect(secondSubscription).toHaveLength(1);
     });
+
+    it('Should delete subscriptions with specific signerAddress when provided', async () => {
+      const signerAddress = getAddress(faker.finance.ethereumAddress());
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayload = new AuthPayload(authPayloadDto);
+      const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+
+      const notificationSubscriptionRepository = dataSource.getRepository(
+        NotificationSubscription,
+      );
+
+      // Manually update a subscription to have a signerAddress
+      const subscriptions = await notificationSubscriptionRepository.find({
+        where: {
+          chain_id: upsertSubscriptionsDto.safes[0].chainId,
+          safe_address: upsertSubscriptionsDto.safes[0].address,
+          push_notification_device: {
+            device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          },
+        },
+      });
+
+      expect(subscriptions).toHaveLength(1);
+
+      // Update the subscription to have a signerAddress
+      await notificationSubscriptionRepository.update(subscriptions[0].id, {
+        signer_address: signerAddress,
+      });
+
+      const deleteAllSubscriptionsDto = [
+        {
+          chainId: upsertSubscriptionsDto.safes[0].chainId,
+          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          safeAddress: upsertSubscriptionsDto.safes[0].address,
+          signerAddress,
+        },
+      ];
+
+      await notificationsRepositoryService.deleteAllSubscriptions({
+        subscriptions: deleteAllSubscriptionsDto,
+      });
+
+      const remainingSubscriptions =
+        await notificationSubscriptionRepository.find({
+          where: {
+            chain_id: upsertSubscriptionsDto.safes[0].chainId,
+            safe_address: upsertSubscriptionsDto.safes[0].address,
+            push_notification_device: {
+              device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            },
+            signer_address: signerAddress,
+          },
+        });
+
+      expect(remainingSubscriptions).toHaveLength(0);
+    });
+
+    it('Should not delete subscriptions with different signerAddress when signerAddress is specified', async () => {
+      const signerAddress1 = getAddress(faker.finance.ethereumAddress());
+      const signerAddress2 = getAddress(faker.finance.ethereumAddress());
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayload = new AuthPayload(authPayloadDto);
+      const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+
+      const notificationSubscriptionRepository = dataSource.getRepository(
+        NotificationSubscription,
+      );
+
+      // Manually update a subscription to have signerAddress1
+      const subscriptions = await notificationSubscriptionRepository.find({
+        where: {
+          chain_id: upsertSubscriptionsDto.safes[0].chainId,
+          safe_address: upsertSubscriptionsDto.safes[0].address,
+          push_notification_device: {
+            device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          },
+        },
+      });
+
+      expect(subscriptions).toHaveLength(1);
+
+      // Update the subscription to have signerAddress1
+      await notificationSubscriptionRepository.update(subscriptions[0].id, {
+        signer_address: signerAddress1,
+      });
+
+      const deleteAllSubscriptionsDto = [
+        {
+          chainId: upsertSubscriptionsDto.safes[0].chainId,
+          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          safeAddress: upsertSubscriptionsDto.safes[0].address,
+          signerAddress: signerAddress2, // Different signer address
+        },
+      ];
+
+      const result = notificationsRepositoryService.deleteAllSubscriptions({
+        subscriptions: deleteAllSubscriptionsDto,
+      });
+
+      // Should throw NotFoundException since no subscription matches the different signerAddress
+      await expect(result).rejects.toThrow(
+        new NotFoundException('No Subscription Found!'),
+      );
+
+      // The subscription with signerAddress1 should still exist
+      const remainingSubscriptions =
+        await notificationSubscriptionRepository.find({
+          where: {
+            chain_id: upsertSubscriptionsDto.safes[0].chainId,
+            safe_address: upsertSubscriptionsDto.safes[0].address,
+            push_notification_device: {
+              device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            },
+            signer_address: signerAddress1,
+          },
+        });
+
+      expect(remainingSubscriptions).toHaveLength(1);
+    });
+
+    it('Should delete subscriptions with null signerAddress when explicitly set to null', async () => {
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayload = new AuthPayload(authPayloadDto);
+      const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+
+      const notificationSubscriptionRepository = dataSource.getRepository(
+        NotificationSubscription,
+      );
+
+      // Find and update a subscription to have null signerAddress
+      const subscriptions = await notificationSubscriptionRepository.find({
+        where: {
+          chain_id: upsertSubscriptionsDto.safes[0].chainId,
+          safe_address: upsertSubscriptionsDto.safes[0].address,
+          push_notification_device: {
+            device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          },
+        },
+      });
+
+      expect(subscriptions).toHaveLength(1);
+
+      // Ensure the subscription has null signerAddress (it should by default)
+      expect(subscriptions[0].signer_address).toBe(null);
+
+      const deleteAllSubscriptionsDto = [
+        {
+          chainId: upsertSubscriptionsDto.safes[0].chainId,
+          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          safeAddress: upsertSubscriptionsDto.safes[0].address,
+          signerAddress: null, // Explicitly set to null
+        },
+      ];
+
+      await notificationsRepositoryService.deleteAllSubscriptions({
+        subscriptions: deleteAllSubscriptionsDto,
+      });
+
+      const remainingSubscriptions =
+        await notificationSubscriptionRepository.find({
+          where: {
+            chain_id: upsertSubscriptionsDto.safes[0].chainId,
+            safe_address: upsertSubscriptionsDto.safes[0].address,
+            push_notification_device: {
+              device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            },
+          },
+        });
+
+      expect(remainingSubscriptions).toHaveLength(0);
+    });
+
+    it('Should not delete subscriptions with null signerAddress when filtering by specific address', async () => {
+      const specificSignerAddress = getAddress(faker.finance.ethereumAddress());
+      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayload = new AuthPayload(authPayloadDto);
+      const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
+
+      await notificationsRepositoryService.upsertSubscriptions({
+        authPayload,
+        upsertSubscriptionsDto,
+      });
+
+      const notificationSubscriptionRepository = dataSource.getRepository(
+        NotificationSubscription,
+      );
+
+      // Verify the subscription has null signerAddress
+      const subscriptions = await notificationSubscriptionRepository.find({
+        where: {
+          chain_id: upsertSubscriptionsDto.safes[0].chainId,
+          safe_address: upsertSubscriptionsDto.safes[0].address,
+          push_notification_device: {
+            device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          },
+        },
+      });
+
+      expect(subscriptions).toHaveLength(1);
+      expect(subscriptions[0].signer_address).toBe(null);
+
+      const deleteAllSubscriptionsDto = [
+        {
+          chainId: upsertSubscriptionsDto.safes[0].chainId,
+          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+          safeAddress: upsertSubscriptionsDto.safes[0].address,
+          signerAddress: specificSignerAddress, // Specific address, not null
+        },
+      ];
+
+      const result = notificationsRepositoryService.deleteAllSubscriptions({
+        subscriptions: deleteAllSubscriptionsDto,
+      });
+
+      // Should throw NotFoundException since subscription has null signer_address, not the specific address
+      await expect(result).rejects.toThrow(
+        new NotFoundException('No Subscription Found!'),
+      );
+
+      // The subscription with null signerAddress should still exist
+      const remainingSubscriptions =
+        await notificationSubscriptionRepository.find({
+          where: {
+            chain_id: upsertSubscriptionsDto.safes[0].chainId,
+            safe_address: upsertSubscriptionsDto.safes[0].address,
+            push_notification_device: {
+              device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            },
+          },
+        });
+
+      expect(remainingSubscriptions).toHaveLength(1);
+      expect(remainingSubscriptions[0].signer_address).toBe(null);
+    });
   });
 });

--- a/src/domain/notifications/v2/notifications.repository.integration.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.integration.spec.ts
@@ -22,6 +22,7 @@ import type { ConfigService } from '@nestjs/config';
 import { NotFoundException } from '@nestjs/common';
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import { getAddress } from 'viem';
+import { deleteAllSubscriptionsDtoBuilder } from '@/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder';
 
 describe('NotificationsRepositoryV2', () => {
   const mockLoggingService = {
@@ -1221,14 +1222,16 @@ describe('NotificationsRepositoryV2', () => {
         signer_address: signerAddress,
       });
 
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: upsertSubscriptionsDto.safes[0].chainId,
-          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
-          safeAddress: upsertSubscriptionsDto.safes[0].address,
-          signerAddress,
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: upsertSubscriptionsDto.safes[0].chainId,
+            deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            safeAddress: upsertSubscriptionsDto.safes[0].address,
+            signerAddress,
+          },
+        ])
+        .build().subscriptions;
 
       await notificationsRepositoryService.deleteAllSubscriptions({
         subscriptions: deleteAllSubscriptionsDto,
@@ -1283,14 +1286,16 @@ describe('NotificationsRepositoryV2', () => {
         signer_address: signerAddress1,
       });
 
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: upsertSubscriptionsDto.safes[0].chainId,
-          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
-          safeAddress: upsertSubscriptionsDto.safes[0].address,
-          signerAddress: signerAddress2, // Different signer address
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: upsertSubscriptionsDto.safes[0].chainId,
+            deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            safeAddress: upsertSubscriptionsDto.safes[0].address,
+            signerAddress: signerAddress2, // Different signer address
+          },
+        ])
+        .build().subscriptions;
 
       const result = notificationsRepositoryService.deleteAllSubscriptions({
         subscriptions: deleteAllSubscriptionsDto,
@@ -1347,14 +1352,16 @@ describe('NotificationsRepositoryV2', () => {
       // Ensure the subscription has null signerAddress (it should by default)
       expect(subscriptions[0].signer_address).toBe(null);
 
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: upsertSubscriptionsDto.safes[0].chainId,
-          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
-          safeAddress: upsertSubscriptionsDto.safes[0].address,
-          signerAddress: null, // Explicitly set to null
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: upsertSubscriptionsDto.safes[0].chainId,
+            deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            safeAddress: upsertSubscriptionsDto.safes[0].address,
+            signerAddress: null, // Explicitly set to null
+          },
+        ])
+        .build().subscriptions;
 
       await notificationsRepositoryService.deleteAllSubscriptions({
         subscriptions: deleteAllSubscriptionsDto,
@@ -1403,14 +1410,16 @@ describe('NotificationsRepositoryV2', () => {
       expect(subscriptions).toHaveLength(1);
       expect(subscriptions[0].signer_address).toBe(null);
 
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: upsertSubscriptionsDto.safes[0].chainId,
-          deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
-          safeAddress: upsertSubscriptionsDto.safes[0].address,
-          signerAddress: specificSignerAddress, // Specific address, not null
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: upsertSubscriptionsDto.safes[0].chainId,
+            deviceUuid: upsertSubscriptionsDto.deviceUuid as UUID,
+            safeAddress: upsertSubscriptionsDto.safes[0].address,
+            signerAddress: specificSignerAddress, // Specific address, not null
+          },
+        ])
+        .build().subscriptions;
 
       const result = notificationsRepositoryService.deleteAllSubscriptions({
         subscriptions: deleteAllSubscriptionsDto,

--- a/src/domain/notifications/v2/notifications.repository.integration.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.integration.spec.ts
@@ -1191,7 +1191,9 @@ describe('NotificationsRepositoryV2', () => {
 
     it('Should delete subscriptions with specific signerAddress when provided', async () => {
       const signerAddress = getAddress(faker.finance.ethereumAddress());
-      const authPayloadDto = authPayloadDtoBuilder().build();
+      const authPayloadDto = authPayloadDtoBuilder()
+        .with('signer_address', signerAddress)
+        .build();
       const authPayload = new AuthPayload(authPayloadDto);
       const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
 
@@ -1203,24 +1205,6 @@ describe('NotificationsRepositoryV2', () => {
       const notificationSubscriptionRepository = dataSource.getRepository(
         NotificationSubscription,
       );
-
-      // Manually update a subscription to have a signerAddress
-      const subscriptions = await notificationSubscriptionRepository.find({
-        where: {
-          chain_id: upsertSubscriptionsDto.safes[0].chainId,
-          safe_address: upsertSubscriptionsDto.safes[0].address,
-          push_notification_device: {
-            device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
-          },
-        },
-      });
-
-      expect(subscriptions).toHaveLength(1);
-
-      // Update the subscription to have a signerAddress
-      await notificationSubscriptionRepository.update(subscriptions[0].id, {
-        signer_address: signerAddress,
-      });
 
       const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
         .with('subscriptions', [

--- a/src/domain/notifications/v2/notifications.repository.integration.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.integration.spec.ts
@@ -1323,8 +1323,7 @@ describe('NotificationsRepositoryV2', () => {
     });
 
     it('Should delete subscriptions with null signerAddress when explicitly set to null', async () => {
-      const authPayloadDto = authPayloadDtoBuilder().build();
-      const authPayload = new AuthPayload(authPayloadDto);
+      const authPayload = new AuthPayload();
       const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
 
       await notificationsRepositoryService.upsertSubscriptions({
@@ -1383,8 +1382,7 @@ describe('NotificationsRepositoryV2', () => {
 
     it('Should not delete subscriptions with null signerAddress when filtering by specific address', async () => {
       const specificSignerAddress = getAddress(faker.finance.ethereumAddress());
-      const authPayloadDto = authPayloadDtoBuilder().build();
-      const authPayload = new AuthPayload(authPayloadDto);
+      const authPayload = new AuthPayload();
       const upsertSubscriptionsDto = upsertSubscriptionsDtoBuilder().build();
 
       await notificationsRepositoryService.upsertSubscriptions({

--- a/src/domain/notifications/v2/notifications.repository.interface.ts
+++ b/src/domain/notifications/v2/notifications.repository.interface.ts
@@ -43,6 +43,7 @@ export interface INotificationsRepositoryV2 {
       chainId: string;
       deviceUuid: UUID;
       safeAddress: `0x${string}`;
+      signerAddress?: `0x${string}` | null;
     }>;
   }): Promise<void>;
 

--- a/src/domain/notifications/v2/notifications.repository.spec.ts
+++ b/src/domain/notifications/v2/notifications.repository.spec.ts
@@ -18,6 +18,7 @@ import { mockPostgresDatabaseService } from '@/datasources/db/v2/__tests__/postg
 import { mockRepository } from '@/datasources/db/v2/__tests__/repository.mock';
 import { getAddress } from 'viem';
 import { IsNull } from 'typeorm';
+import { deleteAllSubscriptionsDtoBuilder } from '@/domain/notifications/v2/entities/__tests__/delete-all-subscriptions.dto.builder';
 import type { ConfigService } from '@nestjs/config';
 
 describe('NotificationsRepositoryV2', () => {
@@ -649,14 +650,16 @@ describe('NotificationsRepositoryV2', () => {
 
     it('Should include signerAddress in where conditions when provided', async () => {
       const signerAddress = getAddress(faker.finance.ethereumAddress());
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: faker.string.numeric(),
-          deviceUuid: faker.string.uuid() as UUID,
-          safeAddress: getAddress(faker.finance.ethereumAddress()),
-          signerAddress,
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: faker.string.numeric(),
+            deviceUuid: faker.string.uuid() as UUID,
+            safeAddress: getAddress(faker.finance.ethereumAddress()),
+            signerAddress,
+          },
+        ])
+        .build().subscriptions;
 
       const mockSubscriptions = [notificationSubscriptionBuilder().build()];
       notificationSubscriptionsRepository.find.mockResolvedValue(
@@ -687,13 +690,15 @@ describe('NotificationsRepositoryV2', () => {
     });
 
     it('Should not include signerAddress in where conditions when not provided', async () => {
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: faker.string.numeric(),
-          deviceUuid: faker.string.uuid() as UUID,
-          safeAddress: getAddress(faker.finance.ethereumAddress()),
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: faker.string.numeric(),
+            deviceUuid: faker.string.uuid() as UUID,
+            safeAddress: getAddress(faker.finance.ethereumAddress()),
+          },
+        ])
+        .build().subscriptions;
 
       const mockSubscriptions = [notificationSubscriptionBuilder().build()];
       notificationSubscriptionsRepository.find.mockResolvedValue(
@@ -723,14 +728,16 @@ describe('NotificationsRepositoryV2', () => {
     });
 
     it('Should include signer_address: null in where conditions when signerAddress is explicitly null', async () => {
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: faker.string.numeric(),
-          deviceUuid: faker.string.uuid() as UUID,
-          safeAddress: getAddress(faker.finance.ethereumAddress()),
-          signerAddress: null,
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: faker.string.numeric(),
+            deviceUuid: faker.string.uuid() as UUID,
+            safeAddress: getAddress(faker.finance.ethereumAddress()),
+            signerAddress: null,
+          },
+        ])
+        .build().subscriptions;
 
       const mockSubscriptions = [notificationSubscriptionBuilder().build()];
       notificationSubscriptionsRepository.find.mockResolvedValue(
@@ -762,26 +769,28 @@ describe('NotificationsRepositoryV2', () => {
 
     it('Should handle mixed signerAddress values in single request', async () => {
       const signerAddress = getAddress(faker.finance.ethereumAddress());
-      const deleteAllSubscriptionsDto = [
-        {
-          chainId: faker.string.numeric(),
-          deviceUuid: faker.string.uuid() as UUID,
-          safeAddress: getAddress(faker.finance.ethereumAddress()),
-          // signerAddress omitted (undefined)
-        },
-        {
-          chainId: faker.string.numeric(),
-          deviceUuid: faker.string.uuid() as UUID,
-          safeAddress: getAddress(faker.finance.ethereumAddress()),
-          signerAddress: null,
-        },
-        {
-          chainId: faker.string.numeric(),
-          deviceUuid: faker.string.uuid() as UUID,
-          safeAddress: getAddress(faker.finance.ethereumAddress()),
-          signerAddress,
-        },
-      ];
+      const deleteAllSubscriptionsDto = deleteAllSubscriptionsDtoBuilder()
+        .with('subscriptions', [
+          {
+            chainId: faker.string.numeric(),
+            deviceUuid: faker.string.uuid() as UUID,
+            safeAddress: getAddress(faker.finance.ethereumAddress()),
+            // signerAddress omitted (undefined)
+          },
+          {
+            chainId: faker.string.numeric(),
+            deviceUuid: faker.string.uuid() as UUID,
+            safeAddress: getAddress(faker.finance.ethereumAddress()),
+            signerAddress: null,
+          },
+          {
+            chainId: faker.string.numeric(),
+            deviceUuid: faker.string.uuid() as UUID,
+            safeAddress: getAddress(faker.finance.ethereumAddress()),
+            signerAddress,
+          },
+        ])
+        .build().subscriptions;
 
       const mockSubscriptions = [notificationSubscriptionBuilder().build()];
       notificationSubscriptionsRepository.find.mockResolvedValue(

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -447,22 +447,15 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
       };
 
       // Handle signerAddress: undefined (omitted) vs null (explicit) vs string (specific address)
-      if (subscription.signerAddress === undefined) {
-        // Omitted: no signer filtering
-        return baseCondition;
-      } else if (subscription.signerAddress === null) {
-        // Explicit null: filter for records with signer_address = null
-        return {
-          ...baseCondition,
-          signer_address: IsNull(),
-        };
-      } else {
-        // Specific address: filter for records with that signer_address
-        return {
-          ...baseCondition,
-          signer_address: subscription.signerAddress,
-        };
-      }
+      return subscription.signerAddress === undefined
+        ? baseCondition
+        : {
+            ...baseCondition,
+            signer_address:
+              subscription.signerAddress === null
+                ? IsNull()
+                : subscription.signerAddress,
+          };
     });
     const subscriptions = await notificationsSubscriptionsRepository.find({
       where: whereConditions,

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -16,7 +16,7 @@ import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { NotificationSubscription } from '@/datasources/notifications/entities/notification-subscription.entity.db';
 import { NotificationDevice } from '@/datasources/notifications/entities/notification-devices.entity.db';
 import { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
-import { EntityManager, In } from 'typeorm';
+import { EntityManager, In, IsNull } from 'typeorm';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { NotificationSubscriptionNotificationType } from '@/datasources/notifications/entities/notification-subscription-notification-type.entity.db';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -430,19 +430,40 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
       chainId: string;
       deviceUuid: UUID;
       safeAddress: `0x${string}`;
+      signerAddress?: `0x${string}` | null;
     }>;
   }): Promise<void> {
     const notificationsSubscriptionsRepository =
       await this.postgresDatabaseService.getRepository<NotificationSubscription>(
         NotificationSubscription,
       );
-    const whereConditions = args.subscriptions.map((subscription) => ({
-      chain_id: subscription.chainId,
-      safe_address: subscription.safeAddress,
-      push_notification_device: {
-        device_uuid: subscription.deviceUuid,
-      },
-    }));
+    const whereConditions = args.subscriptions.map((subscription) => {
+      const baseCondition = {
+        chain_id: subscription.chainId,
+        safe_address: subscription.safeAddress,
+        push_notification_device: {
+          device_uuid: subscription.deviceUuid,
+        },
+      };
+
+      // Handle signerAddress: undefined (omitted) vs null (explicit) vs string (specific address)
+      if (subscription.signerAddress === undefined) {
+        // Omitted: no signer filtering
+        return baseCondition;
+      } else if (subscription.signerAddress === null) {
+        // Explicit null: filter for records with signer_address = null
+        return {
+          ...baseCondition,
+          signer_address: IsNull(),
+        };
+      } else {
+        // Specific address: filter for records with that signer_address
+        return {
+          ...baseCondition,
+          signer_address: subscription.signerAddress,
+        };
+      }
+    });
     const subscriptions = await notificationsSubscriptionsRepository.find({
       where: whereConditions,
     });

--- a/src/routes/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
+++ b/src/routes/notifications/v2/entities/delete-all-subscriptions.dto.entity.ts
@@ -11,6 +11,19 @@ export class DeleteAllSubscriptionItemDto {
 
   @ApiProperty()
   public readonly safeAddress!: `0x${string}`;
+
+  @ApiProperty({
+    type: 'string',
+    required: false,
+    nullable: true,
+    description:
+      'Optional signer address filter:\n' +
+      '• Omitted (undefined): Deletes subscriptions regardless of signer address\n' +
+      '• null: Deletes only subscriptions with no signer address\n' +
+      '• Valid address: Deletes only subscriptions with that specific signer address',
+    example: '0x1234567890123456789012345678901234567890',
+  })
+  public readonly signerAddress?: `0x${string}` | null;
 }
 
 export class DeleteAllSubscriptionsDto


### PR DESCRIPTION
## Summary
Resolves https://linear.app/safe-global/issue/COR-336/expose-signeraddress-to-the-delete-subscriptions-endpoint

adds a signerAddress prop to the delete subscriptions endpoint. This allows us to delete just a single signerAddress.

With this change the endpoint behaves as follows
- no signer address provided -> drop everything row related to the safeAddress and deviceId
- signerAddress provided -> drop only the rows that match the signerAddress and safeAddress and deviceId
- signerAddress set to null -> drop only the rows where signerAddress is NULL and SafeAddress and DeviceId match

