### PR TITLE
fix: Improve error handling and add await for async mapping in transaction-info.mapper

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -131,7 +131,7 @@ export class MultisigTransactionInfoMapper {
         if (error instanceof NotFoundException) {
           this.loggingService.warn(error);
         } else {
-          throw error;
+          this.loggingService.error(error);
         }
       }
     }
@@ -275,7 +275,7 @@ export class MultisigTransactionInfoMapper {
     }
 
     try {
-      return this.bridgeTransactionMapper.mapSwap({
+      return await this.bridgeTransactionMapper.mapSwap({
         data: transaction.data,
         executionDate: args.transaction.executionDate,
         chainId: args.chainId,


### PR DESCRIPTION
## Summary
This PR resolves an issue where transaction history was being blocked due to decoding errors in `Bridge/Swap` operations. Instead of throwing an exception that halts the process, the error is now logged to allow the flow to continue gracefully. Additionally, the `mapSwap` method call has been updated with the `await` keyword to ensure proper asynchronous handling, which helps in capturing and managing errors effectively.

## Changes
- Updated error handling to log errors as critical instead of throwing them directly which breaks the transaction flow.
- Added 'await' keyword to the mapSwap method call to ensure proper asynchronous execution and error handling.