### PR TITLE
Fix/decodingDiamondAddress

### DIFF
--- a/src/domain/bridge/bridge.repository.ts
+++ b/src/domain/bridge/bridge.repository.ts
@@ -20,12 +20,13 @@ export class BridgeRepository implements IBridgeRepository {
     const result = await api.getChains();
     const { chains } = BridgeChainPageSchema.parse(result);
     const chain = chains.find((chain) => {
-      return chain.id === chainId;
+      return chain.id === chainId && chain.diamondAddress;
     });
 
-    if (!chain) {
+    if (!chain || !chain.diamondAddress) {
       throw new NotFoundException(`Chain not found. chainId=${chainId}`);
     }
+
     return chain.diamondAddress;
   }
 

--- a/src/domain/bridge/entities/bridge-chain.entity.spec.ts
+++ b/src/domain/bridge/entities/bridge-chain.entity.spec.ts
@@ -35,4 +35,40 @@ describe('BridgeChainSchema', () => {
       getAddress(nonChecksummedAddress),
     );
   });
+
+  it('should allow diamondAddress to be undefined', () => {
+    const bridgeChain = bridgeChainBuilder()
+      .with('diamondAddress', undefined)
+      .build();
+
+    const result = BridgeChainSchema.safeParse(bridgeChain);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.diamondAddress).toBeUndefined();
+  });
+
+  it('should allow diamondAddress to be omitted', () => {
+    const bridgeChain = {
+      id: faker.string.numeric(),
+    };
+
+    const result = BridgeChainSchema.safeParse(bridgeChain);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.diamondAddress).toBeUndefined();
+  });
+
+  it('should reject invalid diamondAddress format', () => {
+    const invalidAddress = 'invalid-address';
+    const bridgeChain = bridgeChainBuilder()
+      .with('diamondAddress', invalidAddress as `0x${string}`)
+      .build();
+
+    const result = BridgeChainSchema.safeParse(bridgeChain);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Invalid address');
+    }
+  });
 });

--- a/src/domain/bridge/entities/bridge-chain.entity.ts
+++ b/src/domain/bridge/entities/bridge-chain.entity.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 export const BridgeChainSchema = z.object({
   id: z.coerce.string(),
-  diamondAddress: AddressSchema,
+  diamondAddress: AddressSchema.optional(),
 });
 
 export type BridgeChain = z.infer<typeof BridgeChainSchema>;


### PR DESCRIPTION
## Summary

This pull request updates the logic related to the diamondAddress field:
- diamondAddress is now optional: The decoding logic has been adjusted to gracefully handle cases where this field may be missing or null.
- Filtering logic added: Further downstream, objects with a null diamondAddress are now filtered out to ensure clean and valid data processing.

### Why

Some data entries do not include a diamondAddress, and the system should not break when these are encountered. This change ensures we only work with entries containing valid addresses.

## Changes
- Modified the decoding logic to treat `diamondAddress` as an optional field.
- Added a filtering step after decoding Ensures downstream components only operate on valid, non-null `diamondAddress`.
- Added new unit tests to cover edge cases when the `diamondAddress` is nullish.