### PR TITLE
refactor(address-book): Update name validation to use dynamic max length constant

### DIFF
--- a/migrations/1755621780124-addressBookItemLength.ts
+++ b/migrations/1755621780124-addressBookItemLength.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddressBookItemLength1755621780124 implements MigrationInterface {
+  name = 'AddressBookItemLength1755621780124';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "space_address_book_items" ALTER COLUMN "name" TYPE character varying(50)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "space_address_book_items" ALTER COLUMN "name" TYPE character varying(30)`,
+    );
+  }
+}

--- a/src/domain/accounts/address-books/entities/address-book.entity.spec.ts
+++ b/src/domain/accounts/address-books/entities/address-book.entity.spec.ts
@@ -1,7 +1,9 @@
 import { addressBookBuilder } from '@/domain/accounts/address-books/entities/__tests__/address-book.builder';
-import { AddressBookSchema } from '@/domain/accounts/address-books/entities/address-book.entity';
+import {
+  ADDRESS_BOOK_NAME_MAX_LENGTH,
+  AddressBookSchema,
+} from '@/domain/accounts/address-books/entities/address-book.entity';
 import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
-import { NAME_MAX_LENGTH } from '@/domain/common/entities/name.schema';
 import { faker } from '@faker-js/faker/.';
 import { getAddress } from 'viem';
 
@@ -129,7 +131,7 @@ describe('AddressBookSchema', () => {
 
   it('should not verify an AddressBookItem with a longer name', () => {
     const addressBook = addressBookBuilder().build();
-    addressBook.data[0].name = 'e'.repeat(NAME_MAX_LENGTH + 1);
+    addressBook.data[0].name = 'e'.repeat(ADDRESS_BOOK_NAME_MAX_LENGTH + 1);
 
     const result = AddressBookSchema.safeParse(addressBook);
 
@@ -138,8 +140,8 @@ describe('AddressBookSchema', () => {
         code: 'too_big',
         exact: false,
         inclusive: true,
-        message: `Names must be at most ${NAME_MAX_LENGTH} characters long`,
-        maximum: NAME_MAX_LENGTH,
+        message: `Names must be at most ${ADDRESS_BOOK_NAME_MAX_LENGTH} characters long`,
+        maximum: ADDRESS_BOOK_NAME_MAX_LENGTH,
         path: ['data', 0, 'name'],
         type: 'string',
       },

--- a/src/domain/accounts/address-books/entities/address-book.entity.ts
+++ b/src/domain/accounts/address-books/entities/address-book.entity.ts
@@ -1,13 +1,15 @@
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import { AccountSchema } from '@/domain/accounts/entities/account.entity';
-import { NameSchema } from '@/domain/common/entities/name.schema';
+import { makeNameSchema } from '@/domain/common/entities/name.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { z } from 'zod';
+
+export const ADDRESS_BOOK_NAME_MAX_LENGTH = 50;
 
 export const AddressBookItemSchema = z.object({
   // TODO: add limitation to the id according to MAX_ADDRESS_BOOK_ITEMS
   id: z.number().int().gte(1),
-  name: NameSchema,
+  name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),
   address: AddressSchema,
 });
 

--- a/src/domain/common/entities/name.schema.spec.ts
+++ b/src/domain/common/entities/name.schema.spec.ts
@@ -1,4 +1,7 @@
-import { NameSchema } from '@/domain/common/entities/name.schema';
+import {
+  makeNameSchema,
+  NameSchema,
+} from '@/domain/common/entities/name.schema';
 import { faker } from '@faker-js/faker/.';
 import { ZodError } from 'zod';
 
@@ -102,5 +105,257 @@ describe('NameSchema', () => {
         },
       ]),
     );
+  });
+});
+
+describe('makeNameSchema', () => {
+  describe('with default parameters', () => {
+    it('should create a schema with default min/max lengths', () => {
+      const schema = makeNameSchema();
+      const validName = 'ValidName123';
+
+      const result = schema.safeParse(validName);
+
+      expect(result.success && result.data).toBe(validName);
+    });
+
+    it('should behave the same as NameSchema', () => {
+      const schema = makeNameSchema();
+      const testName = 'Test_Name.123';
+
+      const defaultResult = schema.safeParse(testName);
+      const namedResult = NameSchema.safeParse(testName);
+
+      expect(defaultResult.success).toBe(namedResult.success);
+      if (defaultResult.success && namedResult.success) {
+        expect(defaultResult.data).toBe(namedResult.data);
+      }
+    });
+  });
+
+  describe('with custom minLength', () => {
+    it('should enforce custom minimum length', () => {
+      const schema = makeNameSchema({ minLength: 5 });
+      const shortName = 'abc';
+
+      const result = schema.safeParse(shortName);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'too_small',
+            minimum: 5,
+            type: 'string',
+            inclusive: true,
+            exact: false,
+            message: 'Names must be at least 5 characters long',
+            path: [],
+          },
+        ]),
+      );
+    });
+
+    it('should accept names that meet custom minimum length', () => {
+      const schema = makeNameSchema({ minLength: 5 });
+      const validName = 'abcde'; // exactly 5 characters
+
+      const result = schema.safeParse(validName);
+
+      expect(result.success && result.data).toBe(validName);
+    });
+
+    it('should accept names longer than custom minimum length', () => {
+      const schema = makeNameSchema({ minLength: 10 });
+      const validName = 'ThisIsALongName'; // 15 characters
+
+      const result = schema.safeParse(validName);
+
+      expect(result.success && result.data).toBe(validName);
+    });
+  });
+
+  describe('with custom maxLength', () => {
+    it('should enforce custom maximum length', () => {
+      const schema = makeNameSchema({ maxLength: 10 });
+      const longName = 'ThisIsAVeryLongName'; // 18 characters
+
+      const result = schema.safeParse(longName);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'too_big',
+            maximum: 10,
+            type: 'string',
+            inclusive: true,
+            exact: false,
+            message: 'Names must be at most 10 characters long',
+            path: [],
+          },
+        ]),
+      );
+    });
+
+    it('should accept names that meet custom maximum length', () => {
+      const schema = makeNameSchema({ maxLength: 10 });
+      const validName = 'ValidName1'; // exactly 10 characters
+
+      const result = schema.safeParse(validName);
+
+      expect(result.success && result.data).toBe(validName);
+    });
+
+    it('should accept names shorter than custom maximum length', () => {
+      const schema = makeNameSchema({ maxLength: 50 });
+      const validName = 'Short'; // 5 characters
+
+      const result = schema.safeParse(validName);
+
+      expect(result.success && result.data).toBe(validName);
+    });
+  });
+
+  describe('with both custom minLength and maxLength', () => {
+    it('should enforce both custom minimum and maximum lengths', () => {
+      const schema = makeNameSchema({ minLength: 5, maxLength: 15 });
+
+      // Test below minimum
+      const tooShort = 'a'.repeat(3);
+      const shortResult = schema.safeParse(tooShort);
+      expect(shortResult.success).toBe(false);
+
+      // Test above maximum
+      const tooLong = 'a'.repeat(34);
+      const longResult = schema.safeParse(tooLong);
+      expect(longResult.success).toBe(false);
+
+      // Test within range
+      const validName = 'a'.repeat(9);
+      const validResult = schema.safeParse(validName);
+      expect(validResult.success && validResult.data).toBe(validName);
+    });
+
+    it('should validate edge cases for custom lengths', () => {
+      const schema = makeNameSchema({ minLength: 8, maxLength: 12 });
+
+      // Test exactly minimum length
+      const minLength = 'a'.repeat(8);
+      const minResult = schema.safeParse(minLength);
+      expect(minResult.success && minResult.data).toBe(minLength);
+
+      // Test exactly maximum length
+      const maxLength = 'a'.repeat(12);
+      const maxResult = schema.safeParse(maxLength);
+      expect(maxResult.success && maxResult.data).toBe(maxLength);
+    });
+  });
+
+  describe('regex validation with custom lengths', () => {
+    it('should still enforce regex rules with custom lengths', () => {
+      const schema = makeNameSchema({ minLength: 5, maxLength: 50 });
+      const invalidName = 'Valid@Name'; // contains invalid character
+
+      const result = schema.safeParse(invalidName);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toStrictEqual(
+          new ZodError([
+            {
+              validation: 'regex',
+              code: 'invalid_string',
+              message:
+                'Names must start with a letter or number and can contain alphanumeric characters, spaces, periods, underscores, or hyphens',
+              path: [],
+            },
+          ]),
+        );
+      }
+    });
+
+    it('should accept valid characters with custom lengths', () => {
+      const schema = makeNameSchema({ minLength: 3, maxLength: 50 });
+      const validNames = [
+        'Simple123',
+        'With Spaces',
+        'With.Periods',
+        'With_Underscores',
+        'With-Hyphens',
+        'Mixed_Types.And-Spaces 123',
+      ];
+
+      validNames.forEach((name) => {
+        const result = schema.safeParse(name);
+        expect(result.success && result.data).toBe(name);
+      });
+    });
+  });
+
+  describe('string trimming with custom lengths', () => {
+    it('should trim whitespace before validation', () => {
+      const schema = makeNameSchema({ minLength: 5, maxLength: 15 });
+      const nameWithSpaces = '  ValidName  ';
+      const expectedTrimmed = 'ValidName';
+
+      const result = schema.safeParse(nameWithSpaces);
+
+      expect(result.success && result.data).toBe(expectedTrimmed);
+    });
+
+    it('should validate length after trimming', () => {
+      const schema = makeNameSchema({ minLength: 5, maxLength: 10 });
+      const nameWithSpaces = '  abc  '; // 3 characters after trimming
+
+      const result = schema.safeParse(nameWithSpaces);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'too_small',
+            minimum: 5,
+            type: 'string',
+            inclusive: true,
+            exact: false,
+            message: 'Names must be at least 5 characters long',
+            path: [],
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('edge cases and error scenarios', () => {
+    it('should handle zero length', () => {
+      const schemaZeroMin = makeNameSchema({ minLength: 0 });
+      const emptyString = '';
+
+      const result = schemaZeroMin.safeParse(emptyString);
+
+      // Should still fail on regex (empty string doesn't match the pattern)
+      expect(result.success).toBe(false);
+    });
+
+    it('should handle non-string input with custom lengths', () => {
+      const schema = makeNameSchema({ minLength: 5, maxLength: 50 });
+      const numberInput = 12345;
+
+      const result = schema.safeParse(numberInput);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toStrictEqual(
+        new ZodError([
+          {
+            code: 'invalid_type',
+            expected: 'string',
+            received: 'number',
+            path: [],
+            message: 'Expected string, received number',
+          },
+        ]),
+      );
+    });
   });
 });

--- a/src/domain/common/entities/name.schema.ts
+++ b/src/domain/common/entities/name.schema.ts
@@ -3,16 +3,23 @@ import { z } from 'zod';
 export const NAME_MIN_LENGTH = 3;
 export const NAME_MAX_LENGTH = 30;
 
-export const NameSchema = z
-  .string()
-  .trim()
-  .min(NAME_MIN_LENGTH, {
-    message: `Names must be at least ${NAME_MIN_LENGTH} characters long`,
-  })
-  .max(NAME_MAX_LENGTH, {
-    message: `Names must be at most ${NAME_MAX_LENGTH} characters long`,
-  })
-  .regex(/^[a-zA-Z0-9]+(?:[ ._-][a-zA-Z0-9]+)*$/, {
-    message:
-      'Names must start with a letter or number and can contain alphanumeric characters, spaces, periods, underscores, or hyphens',
-  });
+export const makeNameSchema = (args?: {
+  minLength?: number;
+  maxLength?: number;
+}): z.ZodString => {
+  return z
+    .string()
+    .trim()
+    .min(args?.minLength ?? NAME_MIN_LENGTH, {
+      message: `Names must be at least ${args?.minLength ?? NAME_MIN_LENGTH} characters long`,
+    })
+    .max(args?.maxLength ?? NAME_MAX_LENGTH, {
+      message: `Names must be at most ${args?.maxLength ?? NAME_MAX_LENGTH} characters long`,
+    })
+    .regex(/^[a-zA-Z0-9]+(?:[ ._-][a-zA-Z0-9]+)*$/, {
+      message:
+        'Names must start with a letter or number and can contain alphanumeric characters, spaces, periods, underscores, or hyphens',
+    });
+};
+
+export const NameSchema = makeNameSchema();

--- a/src/domain/spaces/address-books/entities/address-book-item.db.entity.ts
+++ b/src/domain/spaces/address-books/entities/address-book-item.db.entity.ts
@@ -2,8 +2,9 @@ import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
 import type { Space } from '@/domain/spaces/entities/space.entity';
 import { SpaceSchema } from '@/domain/spaces/entities/space.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { NameSchema } from '@/domain/common/entities/name.schema';
+import { makeNameSchema } from '@/domain/common/entities/name.schema';
 import { z } from 'zod';
+import { ADDRESS_BOOK_NAME_MAX_LENGTH } from '@/domain/accounts/address-books/entities/address-book.entity';
 
 // We need explicitly define ZodType due to recursion
 export const AddressBookDbItemSchema: z.ZodType<
@@ -19,7 +20,7 @@ export const AddressBookDbItemSchema: z.ZodType<
   space: z.lazy(() => SpaceSchema),
   chainIds: z.array(z.string()),
   address: AddressSchema as z.ZodType<`0x${string}`>,
-  name: NameSchema,
+  name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),
   createdBy: AddressSchema as z.ZodType<`0x${string}`>,
   lastUpdatedBy: AddressSchema as z.ZodType<`0x${string}`>,
 });

--- a/src/domain/spaces/address-books/entities/address-book-item.entity.ts
+++ b/src/domain/spaces/address-books/entities/address-book-item.entity.ts
@@ -1,12 +1,13 @@
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { NameSchema } from '@/domain/common/entities/name.schema';
+import { makeNameSchema } from '@/domain/common/entities/name.schema';
 import { z } from 'zod';
+import { ADDRESS_BOOK_NAME_MAX_LENGTH } from '@/domain/accounts/address-books/entities/address-book.entity';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const AddressBookItemSchema = z.object({
   chainIds: z.array(z.string()),
   address: AddressSchema,
-  name: NameSchema,
+  name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),
 });
 
 export type AddressBookItem = z.infer<typeof AddressBookItemSchema>;


### PR DESCRIPTION
## Summary

fixes https://linear.app/safe-global/issue/COR-489/spaces-back-end-and-front-end-have-diff-validation-for-the-name-field

This PR refactors `NameSchema` to support a dynamic max length. Instead of being tied to a single hardcoded limit, the schema can now be configured with different maximum lengths depending on context.


## Changes
- Extracted the common name validation logic into a base schema.
- Introduced a factory function to generate a `NameSchema` with a configurable max length.
- Updated existing `NameSchema` in the `AddressBookItemSchema` entity to use the new dynamic version with a different max length, `ADDRESS_BOOK_NAME_MAX_LENGTH`.
- update database to respect the new maxLength on the name field