### PR TITLE
fix(positions): remove position value aggregation

### DIFF
--- a/src/domain/common/utils/utils.ts
+++ b/src/domain/common/utils/utils.ts
@@ -2,9 +2,9 @@ import { createHash } from 'crypto';
 import type { BinaryLike } from 'crypto';
 import type { Address } from 'viem';
 
-// We use the maximum value in order to preserve all decimals
+// We use a high value to preserve decimals (max allowed is 20)
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-const MAX_MAXIMUM_FRACTION_DIGITS = 100;
+const MAX_MAXIMUM_FRACTION_DIGITS = 20;
 
 const formatter = new Intl.NumberFormat('en-US', {
   // Prevent scientific notation

--- a/src/routes/positions/positions.service.ts
+++ b/src/routes/positions/positions.service.ts
@@ -65,10 +65,12 @@ export class PositionsService {
     const positionGroups = Object.entries(nameGroups).map(([name, group]) =>
       this._mapPositionGroup(name, group),
     );
-    const fiatTotal = positionGroups.reduce(
-      (acc, group) => acc + this._sumFiatBalances(group.items),
-      0,
-    );
+    // Calculate fiat total from all individual positions
+    const fiatTotal = positions.reduce((sum, position) => {
+      const fiatBalance = Number(position.fiatBalance) || 0;
+      const sign = position.position_type === PositionType.loan ? -1 : 1;
+      return sum + sign * fiatBalance;
+    }, 0);
     return {
       protocol,
       protocol_metadata: positions[0].application_metadata,
@@ -87,41 +89,23 @@ export class PositionsService {
     name: string,
     positions: Array<PositionEntry>,
   ): PositionGroup {
-    return { name, items: this._aggregateByType(positions) };
-  }
-
-  private _aggregateByType(positions: Array<PositionEntry>): Array<Position> {
-    const typeGroups = groupBy(
-      positions,
-      (position) => position.position_type ?? PositionType.unknown,
-    );
-    return Object.values(typeGroups).map((group) =>
-      this._mapAggregatedPosition(group),
-    );
-  }
-
-  private _mapAggregatedPosition(group: Array<PositionEntry>): Position {
-    const [first] = group;
-    const balance = group.reduce((sum, item) => sum + Number(item.balance), 0);
-    const fiatBalance = group.reduce(
-      (sum, item) => sum + Number(item.fiatBalance),
-      0,
-    );
-    return {
-      position_type: first.position_type,
-      tokenInfo: first.tokenInfo,
-      balance: getNumberString(balance),
-      fiatBalance: getNumberString(fiatBalance),
-      fiatBalance24hChange: first.fiatBalance24hChange,
-      fiatConversion: first.fiatConversion,
-    };
+    const items = positions.map((position) => ({
+      position_type: position.position_type,
+      tokenInfo: position.tokenInfo,
+      balance: position.balance,
+      fiatBalance: position.fiatBalance,
+      fiatBalance24hChange: position.fiatBalance24hChange,
+      fiatConversion: position.fiatConversion,
+    }));
+    return { name, items };
   }
 
   private _sumFiatBalances(items: Array<Position>): number {
     return items.reduce((sum, item) => {
       // Loans = Debt and need to be subtracted from the total fiat balance of a protocol
+      const fiatBalance = Number(item.fiatBalance) || 0;
       const sign = item.position_type === PositionType.loan ? -1 : 1;
-      return sum + sign * Number(item.fiatBalance);
+      return sum + sign * fiatBalance;
     }, 0);
   }
 


### PR DESCRIPTION
## Summary

We noticed multiple inconsistencies and decided to simplify the logic and just display positions 1-to-1, like in the Zerion API.

## Changes

* removes the aggregation of single positions per protocol
* reworks sum of fiat value
