### PR TITLE
fix: revert hoodi chain changes in contracts caching

### DIFF
--- a/src/datasources/data-decoder-api/data-decoder-api.service.spec.ts
+++ b/src/datasources/data-decoder-api/data-decoder-api.service.spec.ts
@@ -42,6 +42,9 @@ describe('DataDecoderApi', () => {
       if (key === 'expirationTimeInSeconds.default') {
         return expireTimeSeconds;
       }
+      if (key === 'expirationTimeInSeconds.hoodi') {
+        return expireTimeSeconds;
+      }
       throw new Error('Unexpected key');
     });
     const httpErrorFactory = new HttpErrorFactory();


### PR DESCRIPTION
## Summary reverts part of changes from [PR](https://github.com/safe-global/safe-client-gateway/pull/2684)

## Changes

Reverts [07d8bf2](https://github.com/safe-global/safe-client-gateway/pull/2684/commits/07d8bf20a9b3b90ad8bb6c5a642fa477f3d91dd3)
