### PR TITLE
docs: add db docker to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ yarn generate-abis
 
 ## Running the app
 
-1. Start Redis instance. By default, it will start on port `6379` of `localhost`.
+1. Start the Redis and DB (PostgreSQL) instances. By default, Redis will start on port `6379` of `localhost`, DB on port `5432`.
 
 ```shell
-docker compose up -d redis
+docker compose up -d redis db
 ```
 
 2. Start the Safe Client Gateway


### PR DESCRIPTION
## Summary

Adds command and documentation to start the DB instance to the README.

## Changes
