### PR TITLE
chores: update MAX_MAXIMUM_FRACTION_DIGITS

### DIFF
--- a/src/domain/common/utils/utils.ts
+++ b/src/domain/common/utils/utils.ts
@@ -4,7 +4,7 @@ import type { Address } from 'viem';
 
 // We use the maximum value in order to preserve all decimals
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-const MAX_MAXIMUM_FRACTION_DIGITS = 100;
+const MAX_MAXIMUM_FRACTION_DIGITS = 20;
 
 const formatter = new Intl.NumberFormat('en-US', {
   // Prevent scientific notation


### PR DESCRIPTION
## Summary

resolves an error occurring in runtime:
```
const formatter = new Intl.NumberFormat('en-US', {
                  ^

RangeError: maximumFractionDigits value is out of range.
```

This showed up in other PRs, which could take more time to merge, so I extracted this change to be discussed separately.

## Changes

updates maximumFractionDigits to 20.