### PR TITLE
Feat(Positions): Filter out dust positions from Zerion data

### DIFF
--- a/src/routes/positions/positions.service.spec.ts
+++ b/src/routes/positions/positions.service.spec.ts
@@ -9,7 +9,7 @@ import type { Chain } from '@/domain/chains/entities/chain.entity';
 import type { Address } from 'viem';
 
 jest.mock('@/domain/common/utils/utils', () => ({
-  getNumberString: (value: number) => value.toString(),
+  getNumberString: (value: number): string => value.toString(),
 }));
 
 const positionsRepoMock = jest.mocked({

--- a/src/routes/positions/positions.service.spec.ts
+++ b/src/routes/positions/positions.service.spec.ts
@@ -8,10 +8,6 @@ import { NULL_ADDRESS } from '@/routes/common/constants';
 import type { Chain } from '@/domain/chains/entities/chain.entity';
 import type { Address } from 'viem';
 
-jest.mock('@/domain/common/utils/utils', () => ({
-  getNumberString: (value: number): string => value.toString(),
-}));
-
 const positionsRepoMock = jest.mocked({
   getPositions: jest.fn(),
 } as jest.MockedObjectDeep<IPositionsRepository>);

--- a/src/routes/positions/positions.service.ts
+++ b/src/routes/positions/positions.service.ts
@@ -155,6 +155,8 @@ export class PositionsService {
 
   private _isDust(position: PositionEntry): boolean {
     const fiatBalance = Number(position.fiatBalance);
-    return Number.isNaN(fiatBalance) || Math.abs(fiatBalance) < DUST_THRESHOLD_USD;
+    return (
+      Number.isNaN(fiatBalance) || Math.abs(fiatBalance) < DUST_THRESHOLD_USD
+    );
   }
 }

--- a/src/routes/positions/positions.service.ts
+++ b/src/routes/positions/positions.service.ts
@@ -155,9 +155,6 @@ export class PositionsService {
 
   private _isDust(position: PositionEntry): boolean {
     const fiatBalance = Number(position.fiatBalance);
-    if (Number.isNaN(fiatBalance)) {
-      return true;
-    }
-    return Math.abs(fiatBalance) < DUST_THRESHOLD_USD;
+    return Number.isNaN(fiatBalance) || Math.abs(fiatBalance) < DUST_THRESHOLD_USD;
   }
 }

--- a/src/routes/positions/positions.service.ts
+++ b/src/routes/positions/positions.service.ts
@@ -50,9 +50,9 @@ export class PositionsService {
 
     const protocolGroups = this._groupByProtocol(positions);
 
-    return Object.entries(protocolGroups).map(([protocol, positions]) =>
-      this._mapProtocol(protocol, positions),
-    );
+    return Object.entries(protocolGroups)
+      .map(([protocol, positions]) => this._mapProtocol(protocol, positions))
+      .filter((protocol): protocol is Protocol => protocol !== null);
   }
 
   private _groupByProtocol(
@@ -61,23 +61,33 @@ export class PositionsService {
     return groupBy(positions, (position) => position.protocol ?? 'unknown');
   }
 
+  private static readonly DUST_THRESHOLD_USD = 0.01;
+
   private _mapProtocol(
     protocol: string,
     positions: Array<PositionEntry>,
-  ): Protocol {
-    const nameGroups = this._groupByName(positions);
+  ): Protocol | null {
+    const filteredPositions = positions.filter(
+      (position) => !this._isDust(position),
+    );
+
+    if (!filteredPositions.length) {
+      return null;
+    }
+
+    const nameGroups = this._groupByName(filteredPositions);
     const positionGroups = Object.entries(nameGroups).map(([name, group]) =>
       this._mapPositionGroup(name, group),
     );
     // Calculate fiat total from all individual positions
-    const fiatTotal = positions.reduce((sum, position) => {
+    const fiatTotal = filteredPositions.reduce((sum, position) => {
       const fiatBalance = Number(position.fiatBalance) || 0;
       const sign = position.position_type === PositionType.loan ? -1 : 1;
       return sum + sign * fiatBalance;
     }, 0);
     return {
       protocol,
-      protocol_metadata: positions[0].application_metadata,
+      protocol_metadata: filteredPositions[0].application_metadata,
       fiatTotal: getNumberString(fiatTotal),
       items: positionGroups,
     };
@@ -141,5 +151,13 @@ export class PositionsService {
       position_type: position.position_type,
       application_metadata: position.application_metadata,
     };
+  }
+
+  private _isDust(position: PositionEntry): boolean {
+    const fiatBalance = Number(position.fiatBalance);
+    if (Number.isNaN(fiatBalance)) {
+      return true;
+    }
+    return Math.abs(fiatBalance) < PositionsService.DUST_THRESHOLD_USD;
   }
 }

--- a/src/routes/positions/positions.service.ts
+++ b/src/routes/positions/positions.service.ts
@@ -14,6 +14,8 @@ import { z } from 'zod';
 import { PositionType } from '@/domain/positions/entities/position-type.entity';
 import type { Address } from 'viem';
 
+const DUST_THRESHOLD_USD = 0.01;
+
 interface PositionEntry extends Position {
   protocol: string | null;
   name: string;
@@ -60,8 +62,6 @@ export class PositionsService {
   ): Record<string, Array<PositionEntry>> {
     return groupBy(positions, (position) => position.protocol ?? 'unknown');
   }
-
-  private static readonly DUST_THRESHOLD_USD = 0.01;
 
   private _mapProtocol(
     protocol: string,
@@ -158,6 +158,6 @@ export class PositionsService {
     if (Number.isNaN(fiatBalance)) {
       return true;
     }
-    return Math.abs(fiatBalance) < PositionsService.DUST_THRESHOLD_USD;
+    return Math.abs(fiatBalance) < DUST_THRESHOLD_USD;
   }
 }


### PR DESCRIPTION
Part of https://linear.app/safe-global/issue/GRO-72/correct-portfolio-view-at-safe-specifically-avoid-double-accounting

## Summary
- filter Zerion-derived positions below $0.01 before grouping and drop empty protocols
- add helper to detect dust positions and reuse filtered data for protocol totals
- extend positions service tests to cover dust filtering and mock number formatting

## Testing
- yarn test src/routes/positions/positions.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_68d4f9a04390832fb84977f12cd1004e