### PR TITLE
feat: add a MultiSendTransactionInfo type

### DIFF
--- a/src/routes/transactions/entities/base-transaction.entity.ts
+++ b/src/routes/transactions/entities/base-transaction.entity.ts
@@ -1,6 +1,9 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import { CreationTransactionInfo } from '@/routes/transactions/entities/creation-transaction-info.entity';
-import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import { 
+  CustomTransactionInfo,
+  MultiSendTransactionInfo,
+} from '@/routes/transactions/entities/custom-transaction.entity';
 import { SettingsChangeTransaction } from '@/routes/transactions/entities/settings-change-transaction.entity';
 import { NativeStakingDepositTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-deposit-info.entity';
 import { NativeStakingValidatorsExitTransactionInfo } from '@/routes/transactions/entities/staking/native-staking-validators-exit-info.entity';
@@ -23,6 +26,7 @@ import {
   TransactionInfo,
   CreationTransactionInfo,
   CustomTransactionInfo,
+  MultiSendTransactionInfo,
   SettingsChangeTransaction,
   TransferTransactionInfo,
   BridgeAndSwapTransactionInfo,
@@ -41,6 +45,7 @@ export class BaseTransaction {
     oneOf: [
       { $ref: getSchemaPath(CreationTransactionInfo) },
       { $ref: getSchemaPath(CustomTransactionInfo) },
+      { $ref: getSchemaPath(MultiSendTransactionInfo) },
       { $ref: getSchemaPath(SettingsChangeTransaction) },
       { $ref: getSchemaPath(TransferTransactionInfo) },
       { $ref: getSchemaPath(SwapOrderTransactionInfo) },

--- a/src/routes/transactions/entities/custom-transaction.entity.ts
+++ b/src/routes/transactions/entities/custom-transaction.entity.ts
@@ -18,15 +18,12 @@ export class CustomTransactionInfo extends TransactionInfo {
   isCancellation: boolean;
   @ApiPropertyOptional({ type: String, nullable: true })
   methodName: string | null;
-  @ApiPropertyOptional({ type: Number, nullable: true })
-  actionCount: number | null;
 
   constructor(
     to: AddressInfo,
     dataSize: string,
     value: string | null,
     methodName: string | null,
-    actionCount: number | null,
     isCancellation: boolean,
     humanDescription: string | null,
   ) {
@@ -35,6 +32,39 @@ export class CustomTransactionInfo extends TransactionInfo {
     this.dataSize = dataSize;
     this.value = value;
     this.methodName = methodName;
+    this.isCancellation = isCancellation;
+  }
+}
+
+export class MultiSendTransactionInfo extends TransactionInfo {
+  @ApiProperty({ enum: [TransactionInfoType.Custom] })
+  override type = TransactionInfoType.Custom;
+  @ApiProperty()
+  to: AddressInfo;
+  @ApiProperty()
+  dataSize: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  value: string | null;
+  @ApiProperty()
+  isCancellation: boolean;
+  @ApiProperty({ enum: ['multiSend'] })
+  methodName: 'multiSend'; // Always 'multiSend' for this type
+  @ApiProperty({ type: Number })
+  actionCount: number; // Always present and meaningful for MultiSend
+
+  constructor(
+    to: AddressInfo,
+    dataSize: string,
+    value: string | null,
+    actionCount: number,
+    isCancellation: boolean,
+    humanDescription: string | null,
+  ) {
+    super(TransactionInfoType.Custom, humanDescription);
+    this.to = to;
+    this.dataSize = dataSize;
+    this.value = value;
+    this.methodName = 'multiSend';
     this.actionCount = actionCount;
     this.isCancellation = isCancellation;
   }

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
@@ -8,7 +8,10 @@ import {
 import type { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 import { NULL_ADDRESS } from '@/routes/common/constants';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
-import { CustomTransactionInfo } from '@/routes/transactions/entities/custom-transaction.entity';
+import {
+  CustomTransactionInfo,
+  MultiSendTransactionInfo,
+} from '@/routes/transactions/entities/custom-transaction.entity';
 import { CustomTransactionMapper } from '@/routes/transactions/mappers/common/custom-transaction.mapper';
 import { getAddress } from 'viem';
 
@@ -24,7 +27,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     mapper = new CustomTransactionMapper(addressInfoHelper);
   });
 
-  it('should build a CustomTransactionInfo with null actionCount', async () => {
+  it('should build a CustomTransactionInfo for non-multiSend transactions', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const dataSize = faker.number.int();
@@ -46,7 +49,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       dataSize: dataSize.toString(),
       value: transaction.value,
       methodName: dataDecoded.method,
-      actionCount: null,
       isCancellation: false,
     });
   });
@@ -75,12 +77,11 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       dataSize: dataSize.toString(),
       value: transaction.value,
       methodName: dataDecoded.method,
-      actionCount: null,
       isCancellation: false,
     });
   });
 
-  it('should build a multiSend CustomTransactionInfo with null actionCount', async () => {
+  it('should build a MultiSendTransactionInfo with default actionCount when parameters are missing', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = 'multiSend';
@@ -97,18 +98,18 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       dataDecoded,
     );
 
-    expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
+    expect(customTransaction).toBeInstanceOf(MultiSendTransactionInfo);
     expect(customTransaction).toMatchObject({
       to: toAddress,
       dataSize: dataSize.toString(),
       value: transaction.value,
-      methodName: method,
-      actionCount: null,
+      methodName: 'multiSend',
+      actionCount: 0,
       isCancellation: false,
     });
   });
 
-  it('should build a multiSend CustomTransactionInfo with actionCount', async () => {
+  it('should build a MultiSendTransactionInfo with correct actionCount', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = 'multiSend';
@@ -141,12 +142,12 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       dataDecoded,
     );
 
-    expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
+    expect(customTransaction).toBeInstanceOf(MultiSendTransactionInfo);
     expect(customTransaction).toMatchObject({
       to: toAddress,
       dataSize: dataSize.toString(),
       value: transaction.value,
-      methodName: method,
+      methodName: 'multiSend',
       actionCount: 3,
       isCancellation: false,
     });
@@ -186,7 +187,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
       dataSize: dataSize.toString(),
       value,
       methodName: method,
-      actionCount: null,
       isCancellation: true,
     });
   });


### PR DESCRIPTION
## Summary
We've always only returned a `CustomTransactionInfo` type, but we also have a "special" multiSend type. That is a type that has actionCount when the methodName is "MultiSend". We used to manually type this, but I think that it is better to have it here as a custom tx type doesn't have actionCount

## Changes
