### PR TITLE
fix: invoke forceQuit callback in Redis connection timeout

### DIFF
--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -171,7 +171,7 @@ export class RedisCacheService
       event: 'Closing Redis connection',
     });
     const forceQuitTimeout = setTimeout(() => {
-      this.forceQuit.bind(this);
+      this.forceQuit();
     }, this.quitTimeoutInSeconds * 1000);
     await this.client.quit();
     clearTimeout(forceQuitTimeout);


### PR DESCRIPTION
## Summary

Fixes a critical bug where the `forceQuit()` callback was not being invoked during Redis connection shutdown timeout.

## Problem

In `RedisCacheService.onModuleDestroy()`, the timeout callback was using `this.forceQuit.bind(this)` but not actually calling the bound function. This meant that if the graceful `quit()` operation took longer than the timeout period, the force quit would never execute, potentially leaving Redis connections open.

```typescript
// Before (incorrect)
setTimeout(() => {
  this.forceQuit.bind(this);  // Returns bound function but doesn't call it
}, this.quitTimeoutInSeconds * 1000);

// After (correct)
setTimeout(() => {
  this.forceQuit();  // Actually invokes the function
}, this.quitTimeoutInSeconds * 1000);
```

## Impact

- **Severity**: Critical
- **Risk**: Connection pool exhaustion over time as connections accumulate without proper cleanup
- **Affected**: Module shutdown/restart scenarios where Redis is unresponsive

## Changes

- Changed line 174 in `src/datasources/cache/redis.cache.service.ts` from `this.forceQuit.bind(this);` to `this.forceQuit();`

## Test plan

- [x] Code review: verify the timeout callback now invokes the function
- [ ] Manual testing: simulate Redis unresponsiveness during shutdown and verify force quit executes
- [ ] Monitor connection pool metrics in staging after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)