### PR TITLE
fix: update swagger type for operation - it can be only 0 and 1

### DIFF
--- a/src/routes/data-decode/entities/data-decoded.entity.ts
+++ b/src/routes/data-decode/entities/data-decoded.entity.ts
@@ -23,7 +23,11 @@ class BaseDataDecoded implements DomainBaseDataDecoded {
 }
 
 class MultiSend implements DomainMultiSend {
-  @ApiProperty({ enum: Operation })
+  @ApiProperty({
+    enum: Operation,
+    enumName: 'Operation',
+    description: 'Operation type: 0 for CALL, 1 for DELEGATE',
+  })
   operation!: Operation;
 
   @ApiProperty()

--- a/src/routes/estimations/entities/get-estimation.dto.entity.ts
+++ b/src/routes/estimations/entities/get-estimation.dto.entity.ts
@@ -10,6 +10,10 @@ export class GetEstimationDto implements DomainGetEstimationDto {
   value!: string;
   @ApiPropertyOptional({ type: String, nullable: true })
   data!: Hex | null;
-  @ApiProperty()
+  @ApiProperty({
+    enum: Operation,
+    enumName: 'Operation',
+    description: 'Operation type: 0 for CALL, 1 for DELEGATE',
+  })
   operation!: Operation;
 }

--- a/src/routes/transactions/entities/preview-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/preview-transaction.dto.entity.ts
@@ -13,6 +13,10 @@ export class PreviewTransactionDto
   data!: Hex | null;
   @ApiProperty()
   value!: string;
-  @ApiProperty()
+  @ApiProperty({
+    enum: Operation,
+    enumName: 'Operation',
+    description: 'Operation type: 0 for CALL, 1 for DELEGATE',
+  })
   operation!: Operation;
 }

--- a/src/routes/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/propose-transaction.dto.entity.ts
@@ -12,7 +12,11 @@ export class ProposeTransactionDto implements DomainProposeTransactionDto {
   data!: Hex | null;
   @ApiProperty()
   nonce!: string;
-  @ApiProperty()
+  @ApiProperty({
+    enum: Operation,
+    enumName: 'Operation',
+    description: 'Operation type: 0 for CALL, 1 for DELEGATE',
+  })
   operation!: Operation;
   @ApiProperty()
   safeTxGas!: string;

--- a/src/routes/transactions/entities/transaction-data.entity.ts
+++ b/src/routes/transactions/entities/transaction-data.entity.ts
@@ -24,7 +24,11 @@ export class TransactionData {
   to: AddressInfo;
   @ApiPropertyOptional({ type: String, nullable: true })
   value: string | null;
-  @ApiProperty()
+  @ApiProperty({
+    enum: Operation,
+    enumName: 'Operation',
+    description: 'Operation type: 0 for CALL, 1 for DELEGATE',
+  })
   operation: Operation;
   @ApiPropertyOptional({ type: Boolean, nullable: true })
   trustedDelegateCallTarget: boolean | null;

--- a/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
+++ b/src/routes/transactions/entities/txs-multisig-transaction.entity.ts
@@ -16,7 +16,11 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
   value: string;
   @ApiProperty()
   data: Hex | null;
-  @ApiProperty()
+  @ApiProperty({
+    enum: Operation,
+    enumName: 'Operation',
+    description: 'Operation type: 0 for CALL, 1 for DELEGATE',
+  })
   operation: Operation;
   @ApiProperty()
   gasToken: Address | null;


### PR DESCRIPTION
## Summary
The swagger type outputs "operation:number", where in reality operation can only be 0 = call and 1 = delegate.

## Changes
Ads the necessary swagger apiProperty to specify the operation type