### PR TITLE
feat(positions): protect positions/portfolio endpoint with CaptchaGuard

### DIFF
--- a/src/modules/portfolio/portfolio.module.ts
+++ b/src/modules/portfolio/portfolio.module.ts
@@ -11,10 +11,11 @@ import { PortfolioController } from '@/modules/portfolio/v1/portfolio.controller
 import { PortfolioRouteMapper } from '@/modules/portfolio/v1/portfolio.mapper';
 import { PortfolioApiService } from '@/modules/portfolio/v1/portfolio.service';
 import { ZerionModule } from '@/modules/zerion/zerion.module';
+import { CaptchaModule } from '@/routes/captcha/captcha.module';
 import { ChainsModule } from '../chains/chains.module';
 
 @Module({
-  imports: [ChainsModule, ZerionModule],
+  imports: [ChainsModule, ZerionModule, CaptchaModule],
   controllers: [PortfolioController],
   providers: [
     HttpErrorFactory,

--- a/src/modules/portfolio/v1/portfolio.controller.integration.spec.ts
+++ b/src/modules/portfolio/v1/portfolio.controller.integration.spec.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('PortfolioController (Integration)', () => {
+  let app: INestApplication<Server>;
+  let zerionBaseUri: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+
+  describe('CaptchaGuard', () => {
+    const turnstileUrl =
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    const captchaSecretKey = faker.string.alphanumeric(32);
+
+    beforeEach(async () => {
+      jest.resetAllMocks();
+
+      const baseConfig = configuration();
+      const customConfig = (): ReturnType<typeof configuration> => ({
+        ...baseConfig,
+        captcha: { enabled: true, secretKey: captchaSecretKey },
+      });
+      const moduleFixture = await createTestModule({ config: customConfig });
+      const configurationService = moduleFixture.get<IConfigurationService>(
+        IConfigurationService,
+      );
+      zerionBaseUri = configurationService.getOrThrow(
+        'balances.providers.zerion.baseUri',
+      );
+      networkService = moduleFixture.get(NetworkService);
+
+      app = await new TestAppProvider().provide(moduleFixture);
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('returns 401 when the captcha token header is missing', async () => {
+      const address = faker.finance.ethereumAddress();
+
+      await request(app.getHttpServer())
+        .get(`/v1/portfolio/${address}`)
+        .expect(401);
+
+      // Downstream services must not be reached when the guard rejects.
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when the captcha token is invalid', async () => {
+      const address = faker.finance.ethereumAddress();
+      const token = faker.string.alphanumeric();
+
+      networkService.post.mockImplementation(({ url }) => {
+        if (url === turnstileUrl) {
+          return Promise.resolve({
+            data: rawify({ success: false }),
+            status: 200,
+          });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/portfolio/${address}`)
+        .set('x-captcha-token', token)
+        .expect(401);
+
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+
+    it('lets the request through when the captcha token is valid', async () => {
+      const address = faker.finance.ethereumAddress();
+      const token = faker.string.alphanumeric();
+
+      networkService.post.mockImplementation(({ url }) => {
+        if (url === turnstileUrl) {
+          return Promise.resolve({
+            data: rawify({ success: true }),
+            status: 200,
+          });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      networkService.get.mockImplementation(({ url }: { url: string }) => {
+        if (url.startsWith(`${zerionBaseUri}/v1/wallets/`)) {
+          return Promise.resolve({
+            data: rawify({ data: [] }),
+            status: 200,
+          });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/portfolio/${address}`)
+        .set('x-captcha-token', token)
+        .expect(200);
+
+      // Captcha verification was performed, and downstream call was reached.
+      expect(networkService.post).toHaveBeenCalledWith(
+        expect.objectContaining({ url: turnstileUrl }),
+      );
+    });
+  });
+});

--- a/src/modules/portfolio/v1/portfolio.controller.ts
+++ b/src/modules/portfolio/v1/portfolio.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   Param,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiOkResponse,
@@ -19,6 +20,7 @@ import type { GetPortfolioDto } from '@/modules/portfolio/v1/entities/get-portfo
 import { Portfolio } from '@/modules/portfolio/v1/entities/portfolio.entity';
 import { GetPortfolioDtoSchema } from '@/modules/portfolio/v1/entities/schemas/get-portfolio.dto.schema';
 import { PortfolioApiService } from '@/modules/portfolio/v1/portfolio.service';
+import { CaptchaGuard } from '@/routes/captcha/guards/captcha.guard';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
@@ -83,6 +85,7 @@ export class PortfolioController {
   })
   @ApiOkResponse({ type: Portfolio })
   @Get('/portfolio/:address')
+  @UseGuards(CaptchaGuard)
   public getPortfolio(
     @Param('address', new ValidationPipe(AddressSchema))
     address: Address,

--- a/src/modules/positions/positions.module.ts
+++ b/src/modules/positions/positions.module.ts
@@ -10,9 +10,15 @@ import { IPositionsRepository } from '@/modules/positions/domain/positions.repos
 import { PositionsController } from '@/modules/positions/routes/positions.controller';
 import { PositionsService } from '@/modules/positions/routes/positions.service';
 import { ZerionModule } from '@/modules/zerion/zerion.module';
+import { CaptchaModule } from '@/routes/captcha/captcha.module';
 
 @Module({
-  imports: [CacheFirstDataSourceModule, ChainsModule, ZerionModule],
+  imports: [
+    CacheFirstDataSourceModule,
+    ChainsModule,
+    ZerionModule,
+    CaptchaModule,
+  ],
   controllers: [PositionsController],
   providers: [
     HttpErrorFactory,

--- a/src/modules/positions/routes/positions.controller.integration.spec.ts
+++ b/src/modules/positions/routes/positions.controller.integration.spec.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { getAddress } from 'viem';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import type { NetworkRequest } from '@/datasources/network/entities/network.request.entity';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('PositionsController (Integration)', () => {
+  let app: INestApplication<Server>;
+  let safeConfigUrl: string;
+  let zerionBaseUri: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+
+  describe('CaptchaGuard', () => {
+    const turnstileUrl =
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    const captchaSecretKey = faker.string.alphanumeric(32);
+
+    beforeEach(async () => {
+      jest.resetAllMocks();
+
+      const baseConfig = configuration();
+      const customConfig = (): ReturnType<typeof configuration> => ({
+        ...baseConfig,
+        features: {
+          ...baseConfig.features,
+          zerionPositions: true,
+        },
+        captcha: { enabled: true, secretKey: captchaSecretKey },
+      });
+      const moduleFixture = await createTestModule({ config: customConfig });
+      const configurationService = moduleFixture.get<IConfigurationService>(
+        IConfigurationService,
+      );
+      safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+      zerionBaseUri = configurationService.getOrThrow(
+        'balances.providers.zerion.baseUri',
+      );
+      networkService = moduleFixture.get(NetworkService);
+
+      app = await new TestAppProvider().provide(moduleFixture);
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('returns 401 when the captcha token header is missing', async () => {
+      const chainId = faker.string.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const fiatCode = 'USD';
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/positions/${fiatCode}`)
+        .expect(401);
+
+      // Downstream services must not be reached when the guard rejects.
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when the captcha token is invalid', async () => {
+      const chainId = faker.string.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const fiatCode = 'USD';
+      const token = faker.string.alphanumeric();
+
+      networkService.post.mockImplementation(({ url }) => {
+        if (url === turnstileUrl) {
+          return Promise.resolve({
+            data: rawify({ success: false }),
+            status: 200,
+          });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/positions/${fiatCode}`)
+        .set('x-captcha-token', token)
+        .expect(401);
+
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+
+    it('lets the request through when the captcha token is valid', async () => {
+      const chainId = faker.string.numeric();
+      const safeAddress = faker.finance.ethereumAddress();
+      const fiatCode = 'USD';
+      const token = faker.string.alphanumeric();
+      const chain = chainBuilder().with('chainId', chainId).build();
+
+      networkService.post.mockImplementation(({ url }) => {
+        if (url === turnstileUrl) {
+          return Promise.resolve({
+            data: rawify({ success: true }),
+            status: 200,
+          });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      networkService.get.mockImplementation(
+        ({ url }: { url: string; networkRequest?: NetworkRequest }) => {
+          if (url === `${safeConfigUrl}/api/v1/chains/${chainId}`) {
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          }
+          if (
+            url ===
+            `${zerionBaseUri}/v1/wallets/${getAddress(safeAddress)}/positions`
+          ) {
+            return Promise.resolve({
+              data: rawify({ data: [] }),
+              status: 200,
+            });
+          }
+          return Promise.reject(`No matching rule for url: ${url}`);
+        },
+      );
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chainId}/safes/${safeAddress}/positions/${fiatCode}`)
+        .set('x-captcha-token', token)
+        .expect(200)
+        .expect([]);
+
+      // Captcha verification was performed, and downstream call was reached.
+      expect(networkService.post).toHaveBeenCalledWith(
+        expect.objectContaining({ url: turnstileUrl }),
+      );
+    });
+  });
+});

--- a/src/modules/positions/routes/positions.controller.ts
+++ b/src/modules/positions/routes/positions.controller.ts
@@ -12,9 +12,9 @@ import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { Protocol } from '@/modules/positions/routes/entities/protocol.entity';
 import { PositionsService } from '@/modules/positions/routes/positions.service';
+import { CaptchaGuard } from '@/routes/captcha/guards/captcha.guard';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
-import { CaptchaGuard } from '@/routes/captcha/guards/captcha.guard';
 
 @ApiTags('positions')
 @Controller({

--- a/src/modules/positions/routes/positions.controller.ts
+++ b/src/modules/positions/routes/positions.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   ParseBoolPipe,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import type { Address } from 'viem';
@@ -13,6 +14,7 @@ import { Protocol } from '@/modules/positions/routes/entities/protocol.entity';
 import { PositionsService } from '@/modules/positions/routes/positions.service';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import { CaptchaGuard } from '@/routes/captcha/guards/captcha.guard';
 
 @ApiTags('positions')
 @Controller({
@@ -40,6 +42,7 @@ export class PositionsController {
     example: false,
   })
   @Get('chains/:chainId/safes/:safeAddress/positions/:fiatCode')
+  @UseGuards(CaptchaGuard)
   getPositions(
     @Param('chainId') chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))


### PR DESCRIPTION
## Summary

Apply the existing `CaptchaGuard` to the positions/portfolio endpoint so it requires a valid Cloudflare Turnstile token (when CAPTCHA is enabled in config), matching the protection already applied to `GET /v{2,3}/owners/:ownerAddress/safes`. When `captcha.enabled` is `false` (the default), the guard is a no-op and behavior is unchanged.

## Changes

- `src/modules/positions/routes/positions.controller.ts` — decorate `getPositions` (`GET /v1/chains/:chainId/safes/:safeAddress/positions/:fiatCode`) with `@UseGuards(CaptchaGuard)`.
- `src/modules/positions/positions.module.ts` — import `CaptchaModule` so the
    guard's dependencies (`CaptchaService`) are resolvable.
- `src/modules/positions/routes/positions.controller.integration.spec.ts` — new integration spec exercising the guard end-to-end:
  - 401 when the `x-captcha-token` header is missing (no downstream call made)
  - 401 when Turnstile verification returns `success: false`
  - 200 when verification succeeds and the request reaches the Zerion data source (mocked to return an empty list)
  - src/modules/portfolio/portfolio.module.ts — import CaptchaModule.
  - src/modules/portfolio/v1/portfolio.controller.ts:85 — @UseGuards(CaptchaGuard) on GET /v1/portfolio/:address (DELETE is just a cache clear, left unguarded to match positions' GET-only scope).
  - src/modules/portfolio/v1/portfolio.controller.integration.spec.ts — new integration spec covering missing token (401), invalid token (401), and valid token (200, captcha verified) — 3/3 pass; biome and tsc clean; existing unit suite (10/10) still green.

The existing unit tests in `positions.controller.spec.ts` continue to pass — they instantiate the controller directly and bypass guards by design.

## Test plan

- [x] `yarn test:unit src/modules/positions/routes/positions.controller.spec.ts`
- [x] `yarn test:integration src/modules/positions/routes/positions.controller.integration.spec.ts`
- [x] `yarn format` / `biome lint` clean on changed files