### PR TITLE
feat: rate limit space invite and invite renewal endpoints

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1434,6 +1434,42 @@
     "required": false
   },
   {
+    "name": "SPACES_INVITATION_RATE_LIMIT_MAX",
+    "description": "Maximum invited users (initial invites plus renewals) per Space per time window",
+    "defaultValue": 200,
+    "required": false
+  },
+  {
+    "name": "SPACES_INVITATION_RATE_LIMIT_WINDOW_SECONDS",
+    "description": "Time window in seconds for the per-Space invitation rate limit",
+    "defaultValue": 600,
+    "required": false
+  },
+  {
+    "name": "SPACES_INVITATION_RECIPIENT_RATE_LIMIT_MAX",
+    "description": "Maximum invite emails sent to a single recipient address per time window",
+    "defaultValue": 5,
+    "required": false
+  },
+  {
+    "name": "SPACES_INVITATION_RECIPIENT_RATE_LIMIT_WINDOW_SECONDS",
+    "description": "Time window in seconds for the per-recipient invite email limit",
+    "defaultValue": 86400,
+    "required": false
+  },
+  {
+    "name": "SPACES_INVITATION_EMAILS_ALERT_THRESHOLD",
+    "description": "Invite emails per time window above which a warning is logged (no blocking)",
+    "defaultValue": 1000,
+    "required": false
+  },
+  {
+    "name": "SPACES_INVITATION_EMAILS_ALERT_WINDOW_SECONDS",
+    "description": "Time window in seconds for the global invite email alert threshold",
+    "defaultValue": 3600,
+    "required": false
+  },
+  {
     "name": "SPACES_MAX_ADDRESS_BOOK_ITEMS_PER_SPACE",
     "description": "Maximum address book entries per Space",
     "defaultValue": 500,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -460,6 +460,20 @@ export default (): ReturnType<typeof configuration> => ({
         max: faker.number.int({ min: 100, max: 200 }),
         windowSeconds: faker.number.int({ min: 100, max: 200 }),
       },
+      invitation: {
+        space: {
+          max: faker.number.int({ min: 100, max: 200 }),
+          windowSeconds: faker.number.int({ min: 100, max: 200 }),
+        },
+        recipient: {
+          max: faker.number.int({ min: 100, max: 200 }),
+          windowSeconds: faker.number.int({ min: 100, max: 200 }),
+        },
+        emailsAlert: {
+          threshold: faker.number.int({ min: 1000, max: 2000 }),
+          windowSeconds: faker.number.int({ min: 100, max: 200 }),
+        },
+      },
     },
   },
   staking: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -813,6 +813,40 @@ export default () => ({
           10,
         ),
       },
+      invitation: {
+        space: {
+          max: Number.parseInt(
+            process.env.SPACES_INVITATION_RATE_LIMIT_MAX ?? `${200}`,
+            10,
+          ),
+          windowSeconds: Number.parseInt(
+            process.env.SPACES_INVITATION_RATE_LIMIT_WINDOW_SECONDS ?? `${600}`,
+            10,
+          ),
+        },
+        recipient: {
+          max: Number.parseInt(
+            process.env.SPACES_INVITATION_RECIPIENT_RATE_LIMIT_MAX ?? `${5}`,
+            10,
+          ),
+          windowSeconds: Number.parseInt(
+            process.env.SPACES_INVITATION_RECIPIENT_RATE_LIMIT_WINDOW_SECONDS ??
+              `${24 * 60 * 60}`,
+            10,
+          ),
+        },
+        emailsAlert: {
+          threshold: Number.parseInt(
+            process.env.SPACES_INVITATION_EMAILS_ALERT_THRESHOLD ?? `${1000}`,
+            10,
+          ),
+          windowSeconds: Number.parseInt(
+            process.env.SPACES_INVITATION_EMAILS_ALERT_WINDOW_SECONDS ??
+              `${60 * 60}`,
+            10,
+          ),
+        },
+      },
     },
   },
   staking: {

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
@@ -85,6 +86,19 @@ describe('FakeCacheService', () => {
       const result = await target.increment(key, undefined);
       expect(result).toEqual(initialValue + i);
     }
+  });
+
+  it('increments the value of a key by an arbitrary amount', async () => {
+    const key = faker.string.alphanumeric();
+    const firstAmount = faker.number.int({ min: 1, max: 100 });
+    const secondAmount = faker.number.int({ min: 1, max: 100 });
+
+    await expect(
+      target.incrementBy(key, firstAmount, undefined),
+    ).resolves.toEqual(firstAmount);
+    await expect(
+      target.incrementBy(key, secondAmount, undefined),
+    ).resolves.toEqual(firstAmount + secondAmount);
   });
 
   it('sets and gets the value of a counter key', async () => {

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -73,10 +73,17 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
     cacheKey: string,
     _expireTimeSeconds: number | undefined,
   ): Promise<number> {
-    let currentValue: number = this.cache[cacheKey] as number;
-    currentValue = currentValue ? currentValue + 1 : 1;
-    this.cache[cacheKey] = currentValue;
-    return Promise.resolve(currentValue);
+    return this.incrementBy(cacheKey, 1, _expireTimeSeconds);
+  }
+
+  incrementBy(
+    cacheKey: string,
+    amount: number,
+    _expireTimeSeconds: number | undefined,
+  ): Promise<number> {
+    const currentValue: number = (this.cache[cacheKey] as number) ?? 0;
+    this.cache[cacheKey] = currentValue + amount;
+    return Promise.resolve(currentValue + amount);
   }
 
   setCounter(

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
 export const CacheService = Symbol('ICacheService');
@@ -18,6 +19,13 @@ export interface ICacheService {
 
   increment(
     cacheKey: string,
+    expireTimeSeconds: number | undefined,
+    expireDeviatePercent?: number,
+  ): Promise<number>;
+
+  incrementBy(
+    cacheKey: string,
+    amount: number,
     expireTimeSeconds: number | undefined,
     expireDeviatePercent?: number,
   ): Promise<number>;

--- a/src/datasources/cache/redis.cache.service.integration.spec.ts
+++ b/src/datasources/cache/redis.cache.service.integration.spec.ts
@@ -224,6 +224,34 @@ describe('RedisCacheService', () => {
     expect(ttl).toBeLessThanOrEqual(maxExpireTime);
   });
 
+  it('increments the value of a key by an arbitrary amount', async () => {
+    const expireTime = faker.number.int({ min: 1, max: maxTtlDeviated });
+    const maxExpireTime = offsetByPercentage(
+      expireTime,
+      defaultExpirationDeviatePercent,
+    );
+    const key = faker.string.alphanumeric();
+    const firstAmount = faker.number.int({ min: 1, max: 100 });
+    const secondAmount = faker.number.int({ min: 1, max: 100 });
+
+    const firstResult = await redisCacheService.incrementBy(
+      key,
+      firstAmount,
+      expireTime,
+    );
+    const secondResult = await redisCacheService.incrementBy(
+      key,
+      secondAmount,
+      undefined,
+    );
+
+    const ttl = await redisClient.ttl(key);
+    expect(firstResult).toEqual(firstAmount);
+    expect(secondResult).toEqual(firstAmount + secondAmount);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(maxExpireTime);
+  });
+
   it('sets and gets the value of a counter key', async () => {
     const key = faker.string.alphanumeric();
     const value = faker.number.int({ min: 100 });

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -110,7 +110,21 @@ export class RedisCacheService
     expireTimeSeconds: number | undefined,
     expireDeviatePercent?: number,
   ): Promise<number> {
-    const transaction = this.client.multi().incr(cacheKey);
+    return await this.incrementBy(
+      cacheKey,
+      1,
+      expireTimeSeconds,
+      expireDeviatePercent,
+    );
+  }
+
+  async incrementBy(
+    cacheKey: string,
+    amount: number,
+    expireTimeSeconds: number | undefined,
+    expireDeviatePercent?: number,
+  ): Promise<number> {
+    const transaction = this.client.multi().incrBy(cacheKey, amount);
     if (expireTimeSeconds !== undefined && expireTimeSeconds > 0) {
       const expirationTime = this.enforceMaxRedisTTL(
         deviateRandomlyByPercentage(

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -7,6 +7,9 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import type { ILoggingService } from '@/logging/logging.interface';
 import {
   oidcAuthPayloadDtoBuilder,
   siweAuthPayloadDtoBuilder,
@@ -28,6 +31,8 @@ import { fakeUuid } from '@/validation/entities/schemas/__tests__/uuid.builder';
 
 const MAX_INVITES = 10;
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const SPACE_RATE_LIMIT_MAX = 15;
+const SPACE_RATE_LIMIT_WINDOW_SECONDS = 600;
 
 const membersRepositoryMock = {
   findActiveAdmin: jest.fn(),
@@ -46,8 +51,13 @@ const spaceInviteEmailServiceMock = {
   enqueueRenewalEmail: jest.fn(),
 } as jest.MockedObjectDeep<SpaceInviteEmailService>;
 
+const loggingServiceMock = {
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
 describe('MembersService', () => {
   let service: MembersService;
+  let fakeCacheService: FakeCacheService;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -57,14 +67,21 @@ describe('MembersService', () => {
           return MAX_INVITES;
         case 'spaces.invite.ttlMs':
           return INVITE_TTL_MS;
+        case 'spaces.rateLimit.invitation.space.max':
+          return SPACE_RATE_LIMIT_MAX;
+        case 'spaces.rateLimit.invitation.space.windowSeconds':
+          return SPACE_RATE_LIMIT_WINDOW_SECONDS;
         default:
           throw new Error(`Unexpected config key: ${key}`);
       }
     });
+    fakeCacheService = new FakeCacheService();
     service = new MembersService(
       membersRepositoryMock,
       configurationServiceMock,
       spaceInviteEmailServiceMock,
+      fakeCacheService,
+      loggingServiceMock,
     );
   });
 
@@ -288,9 +305,92 @@ describe('MembersService', () => {
         spaceInviteEmailServiceMock.enqueueInviteEmails,
       ).toHaveBeenCalledWith({ users: inviteUsersDto.users, spaceId });
     });
+
+    it('should throw 429 when the Space invitee budget is exceeded', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const users = Array.from({ length: 8 }, () =>
+        emailInviteUserDtoBuilder().build(),
+      );
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.inviteUsers.mockResolvedValue([]);
+
+      // First batch of 8 fits the budget of 15, the second one exceeds it.
+      await expect(
+        service.inviteUser({ authPayload, spaceId, inviteUsersDto: { users } }),
+      ).resolves.toEqual([]);
+      await expect(
+        service.inviteUser({ authPayload, spaceId, inviteUsersDto: { users } }),
+      ).rejects.toThrow('Rate limit reached');
+
+      expect(membersRepositoryMock.inviteUsers).toHaveBeenCalledTimes(1);
+      expect(
+        spaceInviteEmailServiceMock.enqueueInviteEmails,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep separate invitee budgets per Space', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const users = Array.from({ length: 8 }, () =>
+        emailInviteUserDtoBuilder().build(),
+      );
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.inviteUsers.mockResolvedValue([]);
+
+      await expect(
+        service.inviteUser({
+          authPayload,
+          spaceId: 1,
+          inviteUsersDto: { users },
+        }),
+      ).resolves.toEqual([]);
+      await expect(
+        service.inviteUser({
+          authPayload,
+          spaceId: 2,
+          inviteUsersDto: { users },
+        }),
+      ).resolves.toEqual([]);
+
+      expect(membersRepositoryMock.inviteUsers).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('renewInvite', () => {
+    it('should throw 429 when the Space invitee budget is exhausted', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      await fakeCacheService.setCounter(
+        CacheRouter.getRateLimitCacheKey(`spaces_invitation_${spaceId}`),
+        SPACE_RATE_LIMIT_MAX,
+        SPACE_RATE_LIMIT_WINDOW_SECONDS,
+      );
+
+      await expect(
+        service.renewInvite({ authPayload, spaceId, userId }),
+      ).rejects.toThrow('Rate limit reached');
+
+      expect(membersRepositoryMock.findOneOrFail).not.toHaveBeenCalled();
+      expect(membersRepositoryMock.renewInvite).not.toHaveBeenCalled();
+      expect(
+        spaceInviteEmailServiceMock.enqueueRenewalEmail,
+      ).not.toHaveBeenCalled();
+    });
+
     it('should throw ForbiddenException when the caller is not an active admin', async () => {
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
       const spaceId = faker.number.int({ min: 1 });

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -1,6 +1,22 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ConflictException, ForbiddenException, Inject } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Inject,
+} from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { LogType } from '@/domain/common/entities/log-type.entity';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
@@ -20,6 +36,7 @@ import { IMembersRepository } from '@/modules/users/domain/members.repository.in
 export class MembersService {
   private readonly maxInvites: number;
   private readonly inviteTtlMs: number;
+  private readonly spaceRateLimit: { max: number; windowSeconds: number };
 
   public constructor(
     @Inject(IMembersRepository)
@@ -27,12 +44,24 @@ export class MembersService {
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     private readonly spaceInviteEmailService: SpaceInviteEmailService,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
   ) {
     this.maxInvites =
       this.configurationService.getOrThrow<number>('spaces.maxInvites');
     this.inviteTtlMs = this.configurationService.getOrThrow<number>(
       'spaces.invite.ttlMs',
     );
+    this.spaceRateLimit = {
+      max: this.configurationService.getOrThrow<number>(
+        'spaces.rateLimit.invitation.space.max',
+      ),
+      windowSeconds: this.configurationService.getOrThrow<number>(
+        'spaces.rateLimit.invitation.space.windowSeconds',
+      ),
+    };
   }
 
   /**
@@ -54,6 +83,10 @@ export class MembersService {
     if (args.inviteUsersDto.users.length > this.maxInvites) {
       throw new ConflictException('Too many invites.');
     }
+    await this.assertSpaceInviteBudget({
+      spaceId: args.spaceId,
+      inviteeCount: args.inviteUsersDto.users.length,
+    });
     const invitations = await this.membersRepository.inviteUsers({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
@@ -78,6 +111,10 @@ export class MembersService {
     await this.assertActiveAdmin({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
+    });
+    await this.assertSpaceInviteBudget({
+      spaceId: args.spaceId,
+      inviteeCount: 1,
     });
     const { id, user, name, status, role, invitedBy, space } =
       await this.membersRepository.findOneOrFail(
@@ -242,6 +279,39 @@ export class MembersService {
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
+  }
+
+  /**
+   * Caps how many users can be invited (initial invites and renewals
+   * combined) per Space within a time window. Counting invitees instead of
+   * requests bounds the actual invitation volume, and keying on the Space
+   * makes the budget shared across all of its admins.
+   *
+   * @param args.spaceId - Space the invitations belong to.
+   * @param args.inviteeCount - Number of users this request invites.
+   */
+  private async assertSpaceInviteBudget(args: {
+    spaceId: Space['id'];
+    inviteeCount: number;
+  }): Promise<void> {
+    const count = await this.cacheService.incrementBy(
+      CacheRouter.getRateLimitCacheKey(`spaces_invitation_${args.spaceId}`),
+      args.inviteeCount,
+      this.spaceRateLimit.windowSeconds,
+    );
+    if (count > this.spaceRateLimit.max) {
+      this.loggingService.warn({
+        type: LogType.RateLimit,
+        spaceId: args.spaceId,
+        maxInvitees: this.spaceRateLimit.max,
+        windowSeconds: this.spaceRateLimit.windowSeconds,
+        currentCount: count,
+      });
+      throw new HttpException(
+        'Rate limit reached',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
   }
 
   private async assertActiveAdmin(args: {

--- a/src/modules/spaces/routes/space-invite-email.service.spec.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.spec.ts
@@ -2,6 +2,9 @@
 
 import { faker } from '@faker-js/faker';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import { LogType } from '@/domain/common/entities/log-type.entity';
 import { nameBuilder } from '@/domain/common/entities/name.builder';
 import type { ILoggingService } from '@/logging/logging.interface';
 import type { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.service';
@@ -16,6 +19,10 @@ import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-
 
 const BASE_URI = 'https://app.safe.global';
 const INVITE_URL = 'https://app.safe.global/welcome/spaces';
+const RECIPIENT_RATE_LIMIT_MAX = 2;
+const RECIPIENT_RATE_LIMIT_WINDOW_SECONDS = 24 * 60 * 60;
+const EMAILS_ALERT_THRESHOLD = 10;
+const EMAILS_ALERT_WINDOW_SECONDS = 60 * 60;
 
 const configurationServiceMock = {
   getOrThrow: jest.fn(),
@@ -36,6 +43,7 @@ const sesEmailQueueServiceMock = {
 describe('SpaceInviteEmailService', () => {
   let service: SpaceInviteEmailService;
   let workspaceName: string;
+  let fakeCacheService: FakeCacheService;
 
   const buildService = (
     queue?: SesEmailQueueService,
@@ -44,17 +52,29 @@ describe('SpaceInviteEmailService', () => {
       configurationServiceMock,
       spacesRepositoryMock,
       loggingServiceMock,
+      fakeCacheService,
       queue,
     );
 
   beforeEach(() => {
     jest.resetAllMocks();
     configurationServiceMock.getOrThrow.mockImplementation((key: string) => {
-      if (key === 'safeWebApp.baseUri') {
-        return BASE_URI;
+      switch (key) {
+        case 'safeWebApp.baseUri':
+          return BASE_URI;
+        case 'spaces.rateLimit.invitation.recipient.max':
+          return RECIPIENT_RATE_LIMIT_MAX;
+        case 'spaces.rateLimit.invitation.recipient.windowSeconds':
+          return RECIPIENT_RATE_LIMIT_WINDOW_SECONDS;
+        case 'spaces.rateLimit.invitation.emailsAlert.threshold':
+          return EMAILS_ALERT_THRESHOLD;
+        case 'spaces.rateLimit.invitation.emailsAlert.windowSeconds':
+          return EMAILS_ALERT_WINDOW_SECONDS;
+        default:
+          throw new Error(`Unexpected config key: ${key}`);
       }
-      throw new Error(`Unexpected config key: ${key}`);
     });
+    fakeCacheService = new FakeCacheService();
     workspaceName = nameBuilder();
     spacesRepositoryMock.findOneOrFail.mockResolvedValue(
       spaceBuilder().with('name', workspaceName).build(),
@@ -207,6 +227,92 @@ describe('SpaceInviteEmailService', () => {
 
       expect(loggingServiceMock.warn).toHaveBeenCalledWith(
         'Error while enqueueing space invite email: Redis connection refused',
+      );
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('should suppress emails to a recipient above the per-recipient limit while sending to others', async () => {
+      const spaceId = faker.number.int({ min: 1 });
+      const limitedInvite = emailInviteUserDtoBuilder().build();
+      const otherInvite = emailInviteUserDtoBuilder().build();
+      sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+
+      // RECIPIENT_RATE_LIMIT_MAX = 2: the first two emails to the same
+      // address exhaust its budget, the third one is suppressed.
+      await service.enqueueInviteEmails({ users: [limitedInvite], spaceId });
+      await service.enqueueInviteEmails({ users: [limitedInvite], spaceId });
+      await service.enqueueInviteEmails({
+        users: [limitedInvite, otherInvite],
+        spaceId,
+      });
+
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledTimes(3);
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenLastCalledWith(
+        expect.objectContaining({ to: otherInvite.email }),
+      );
+      expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: LogType.RateLimit,
+          spaceId,
+          maxEmails: RECIPIENT_RATE_LIMIT_MAX,
+        }),
+      );
+    });
+
+    it('should count renewal emails against the recipient budget', async () => {
+      const spaceId = faker.number.int({ min: 1 });
+      const name = nameBuilder();
+      const email = fakeEmailAddress();
+      sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledTimes(
+        RECIPIENT_RATE_LIMIT_MAX,
+      );
+    });
+
+    it('should not leak the recipient address in the rate limit log', async () => {
+      const spaceId = faker.number.int({ min: 1 });
+      const name = nameBuilder();
+      const email = fakeEmailAddress();
+      sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+
+      const rateLimitLogs = loggingServiceMock.warn.mock.calls.filter(
+        ([log]) =>
+          typeof log === 'object' &&
+          (log as { type: string }).type === LogType.RateLimit,
+      );
+      expect(rateLimitLogs).toHaveLength(1);
+      expect(JSON.stringify(rateLimitLogs[0])).not.toContain(email);
+    });
+
+    it('should log a warning above the global alert threshold without blocking', async () => {
+      const spaceId = faker.number.int({ min: 1 });
+      const invite = emailInviteUserDtoBuilder().build();
+      sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+      await fakeCacheService.setCounter(
+        CacheRouter.getRateLimitCacheKey('spaces_invitation_emails_global'),
+        EMAILS_ALERT_THRESHOLD,
+        EMAILS_ALERT_WINDOW_SECONDS,
+      );
+
+      await service.enqueueInviteEmails({ users: [invite], spaceId });
+
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledTimes(1);
+      expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: LogType.RateLimit,
+          alertThreshold: EMAILS_ALERT_THRESHOLD,
+          currentCount: EMAILS_ALERT_THRESHOLD + 1,
+        }),
       );
     });
   });

--- a/src/modules/spaces/routes/space-invite-email.service.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.ts
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import { createHash } from 'node:crypto';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { LogType } from '@/domain/common/entities/log-type.entity';
 import {
   type ILoggingService,
   LoggingService,
@@ -33,6 +40,8 @@ interface InviteEmailRecipient {
 @Injectable()
 export class SpaceInviteEmailService {
   private readonly inviteUrl: string;
+  private readonly recipientRateLimit: { max: number; windowSeconds: number };
+  private readonly emailsAlert: { threshold: number; windowSeconds: number };
 
   constructor(
     @Inject(IConfigurationService)
@@ -41,12 +50,30 @@ export class SpaceInviteEmailService {
     private readonly spacesRepository: ISpacesRepository,
     @Inject(LoggingService)
     private readonly loggingService: ILoggingService,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
     @Optional()
     private readonly sesEmailQueueService?: SesEmailQueueService,
   ) {
     const baseUri =
       this.configurationService.getOrThrow<string>('safeWebApp.baseUri');
     this.inviteUrl = new URL(SPACE_INVITE_PATH, baseUri).toString();
+    this.recipientRateLimit = {
+      max: this.configurationService.getOrThrow<number>(
+        'spaces.rateLimit.invitation.recipient.max',
+      ),
+      windowSeconds: this.configurationService.getOrThrow<number>(
+        'spaces.rateLimit.invitation.recipient.windowSeconds',
+      ),
+    };
+    this.emailsAlert = {
+      threshold: this.configurationService.getOrThrow<number>(
+        'spaces.rateLimit.invitation.emailsAlert.threshold',
+      ),
+      windowSeconds: this.configurationService.getOrThrow<number>(
+        'spaces.rateLimit.invitation.emailsAlert.windowSeconds',
+      ),
+    };
   }
 
   /**
@@ -101,6 +128,15 @@ export class SpaceInviteEmailService {
     }
 
     try {
+      const allowedRecipients = await this.filterRateLimitedRecipients({
+        recipients,
+        spaceId,
+      });
+      if (!allowedRecipients.length) {
+        return;
+      }
+      await this.trackGlobalEmailVolume(allowedRecipients.length);
+
       const { name: workspaceName } = await this.spacesRepository.findOneOrFail(
         {
           where: { id: spaceId },
@@ -108,7 +144,7 @@ export class SpaceInviteEmailService {
         },
       );
 
-      const jobs = recipients.map((recipient) => {
+      const jobs = allowedRecipients.map((recipient) => {
         const templateArgs = {
           name: recipient.name,
           email: recipient.email,
@@ -133,5 +169,77 @@ export class SpaceInviteEmailService {
         `Error while enqueueing space invite email: ${asError(error).message}`,
       );
     }
+  }
+
+  /**
+   * Drops recipients whose address has already received the maximum number
+   * of invite emails within the window, across all Spaces and inviters.
+   * Suppressed emails are logged but no error is surfaced: the invitation
+   * itself remains valid and visible in the app, and callers must not be
+   * able to probe how often an arbitrary address has been invited.
+   *
+   * @param args.recipients - Candidate email recipients.
+   * @param args.spaceId - Space the invitations belong to.
+   * @returns The recipients still within their email budget.
+   */
+  private async filterRateLimitedRecipients(args: {
+    recipients: Array<InviteEmailRecipient>;
+    spaceId: Space['id'];
+  }): Promise<Array<InviteEmailRecipient>> {
+    const allowedRecipients: Array<InviteEmailRecipient> = [];
+    for (const recipient of args.recipients) {
+      const recipientHash = this.hashRecipientEmail(recipient.email);
+      const count = await this.cacheService.increment(
+        CacheRouter.getRateLimitCacheKey(
+          `spaces_invitation_recipient_${recipientHash}`,
+        ),
+        this.recipientRateLimit.windowSeconds,
+      );
+      if (count > this.recipientRateLimit.max) {
+        this.loggingService.warn({
+          type: LogType.RateLimit,
+          spaceId: args.spaceId,
+          recipientHash,
+          maxEmails: this.recipientRateLimit.max,
+          windowSeconds: this.recipientRateLimit.windowSeconds,
+          currentCount: count,
+        });
+      } else {
+        allowedRecipients.push(recipient);
+      }
+    }
+    return allowedRecipients;
+  }
+
+  /**
+   * Counts invite emails across the whole service and logs a warning once
+   * the volume exceeds the alert threshold. Deliberately never blocks:
+   * enforcement is alerting plus the kill switch, so a legitimate spike
+   * cannot disable invite emails system-wide.
+   *
+   * @param emailCount - Number of emails about to be enqueued.
+   */
+  private async trackGlobalEmailVolume(emailCount: number): Promise<void> {
+    const total = await this.cacheService.incrementBy(
+      CacheRouter.getRateLimitCacheKey('spaces_invitation_emails_global'),
+      emailCount,
+      this.emailsAlert.windowSeconds,
+    );
+    if (total > this.emailsAlert.threshold) {
+      this.loggingService.warn({
+        type: LogType.RateLimit,
+        alertThreshold: this.emailsAlert.threshold,
+        windowSeconds: this.emailsAlert.windowSeconds,
+        currentCount: total,
+      });
+    }
+  }
+
+  /**
+   * Cache keys end up in logs and monitoring, so recipient addresses are
+   * hashed before being used as a key to avoid spreading PII.
+   */
+  private hashRecipientEmail(email: EmailAddress): string {
+    return createHash('sha256').update(email.toLowerCase()).digest('hex');
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the per-IP, request-counting rate limit on space invites with volume-based limits: the unit is now invited users (not HTTP requests), so the limit can no longer be multiplied by batching up to `maxInvites` users per request.
- Per-Space invitee budget (default 200 per 10 min, `429` when exceeded), enforced in `MembersService` for both initial invites (counting `users.length`) and renewals (counting 1). Keying on the Space instead of the IP avoids corporate-NAT collisions and makes minting extra admins inside a Space pointless, since all of its admins share one budget.
- Per-recipient email cap (default 5 per 24 h) in `SpaceInviteEmailService`: invite and renewal emails to one address are suppressed beyond the cap (invitation stays valid and visible in-app; no error is surfaced so callers cannot probe how often an address has been invited). Recipient addresses are sha256-hashed before use in cache keys/logs.
- Global invite email counter (default 1,000 per hour) that only logs a warning above the threshold — alerting plus the existing kill switch are the enforcement, so a legitimate spike cannot block invite emails system-wide.
- Adds `ICacheService.incrementBy` (Redis `INCRBY`) to support counting more than one unit per operation.
- Removes `SpacesInvitationRateLimitGuard` and its e2e bypass; the per-IP guard pattern remains on the space-creation surface where it fits.
- Config under `spaces.rateLimit.invitation` via `SPACES_INVITATION_RATE_LIMIT_MAX/_WINDOW_SECONDS`, `SPACES_INVITATION_RECIPIENT_RATE_LIMIT_MAX/_WINDOW_SECONDS` and `SPACES_INVITATION_EMAILS_ALERT_THRESHOLD/_WINDOW_SECONDS`, documented in `.env.sample.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)