### PR TITLE
refactor: extract UsersRepositoryModule

### DIFF
--- a/src/modules/auth/oidc/oidc-auth.module.ts
+++ b/src/modules/auth/oidc/oidc-auth.module.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { AuthRepositoryModule } from '@/modules/auth/domain/auth-repository.module';
 import { Auth0Module } from '@/modules/auth/oidc/auth0/auth0.module';
 import { OidcAuthController } from '@/modules/auth/oidc/routes/oidc-auth.controller';
 import { OidcAuthService } from '@/modules/auth/oidc/routes/oidc-auth.service';
-import { UsersModule } from '@/modules/users/users.module';
+import { UsersRepositoryModule } from '@/modules/users/domain/users-repository.module';
 
 @Module({
-  imports: [AuthRepositoryModule, Auth0Module, forwardRef(() => UsersModule)],
+  imports: [AuthRepositoryModule, Auth0Module, UsersRepositoryModule],
   providers: [OidcAuthService],
   controllers: [OidcAuthController],
 })

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -26,6 +26,7 @@ import {
 import { TestEmailApiModule } from '@/modules/email/pushwoosh/__tests__/test.email-api.module';
 import { EmailModule } from '@/modules/email/pushwoosh/pushwoosh-email.module';
 import { TestUsersModule } from '@/modules/users/__tests__/test.users.module';
+import { UsersRepositoryModule } from '@/modules/users/domain/users-repository.module';
 import { UsersModule } from '@/modules/users/users.module';
 import { rawify } from '@/validation/entities/raw.entity';
 
@@ -82,8 +83,15 @@ describe('OidcAuthController', () => {
           originalModule: EmailModule,
           testModule: TestEmailApiModule,
         },
+        // Both modules are overridden with the same TestUsersModule: it mocks
+        // IUsersRepository, which UsersRepositoryModule exports (consumed by
+        // OidcAuthService) and which UsersModule re-exports.
         {
           originalModule: UsersModule,
+          testModule: TestUsersModule,
+        },
+        {
+          originalModule: UsersRepositoryModule,
           testModule: TestUsersModule,
         },
       ],

--- a/src/modules/users/domain/users-repository.module.ts
+++ b/src/modules/users/domain/users-repository.module.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { SpaceAuditModule } from '@/modules/spaces/domain/audit/space-audit.module';
+import { Member } from '@/modules/users/datasources/entities/member.entity.db';
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import { UsersRepository } from '@/modules/users/domain/users.repository';
+import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import { WalletsModule } from '@/modules/wallets/wallets.module';
+
+/**
+ * Standalone module for {@link IUsersRepository} so that {@link OidcAuthModule}
+ * can consume it without importing the full {@link UsersModule} (which also
+ * registers {@link UsersController} and forward-imports {@link AuthModule} and
+ * {@link SpacesModule}). Mirrors the {@link AuthRepositoryModule} pattern.
+ *
+ * {@link IMembersRepository} is intentionally NOT provided here: its
+ * implementation depends on `ISpacesRepository`, which would re-introduce the
+ * `SpacesModule` coupling this extraction is meant to remove. It remains in
+ * {@link UsersModule}.
+ */
+@Module({
+  imports: [
+    PostgresDatabaseModuleV2,
+    TypeOrmModule.forFeature([User, Member, Wallet]),
+    WalletsModule,
+    SpaceAuditModule,
+  ],
+  providers: [{ provide: IUsersRepository, useClass: UsersRepository }],
+  exports: [IUsersRepository],
+})
+export class UsersRepositoryModule {}

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -10,18 +10,16 @@ import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
 import { MembersRepository } from '@/modules/users/domain/members/members.repository';
 import { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
-import { UsersRepository } from '@/modules/users/domain/users.repository';
-import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { UsersRepositoryModule } from '@/modules/users/domain/users-repository.module';
 import { UsersController } from '@/modules/users/routes/users.controller';
 import { UsersService } from '@/modules/users/routes/users.service';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
-import { WalletsModule } from '@/modules/wallets/wallets.module';
 
 @Module({
   imports: [
+    UsersRepositoryModule,
     PostgresDatabaseModuleV2,
     TypeOrmModule.forFeature([User, Member, Wallet]),
-    WalletsModule,
     forwardRef(() => AuthModule),
     SiweModule,
     forwardRef(() => SpacesModule),
@@ -29,16 +27,12 @@ import { WalletsModule } from '@/modules/wallets/wallets.module';
   ],
   providers: [
     {
-      provide: IUsersRepository,
-      useClass: UsersRepository,
-    },
-    {
       provide: IMembersRepository,
       useClass: MembersRepository,
     },
     UsersService,
   ],
   controllers: [UsersController],
-  exports: [IUsersRepository, IMembersRepository],
+  exports: [UsersRepositoryModule, IMembersRepository],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Summary [WA-1819](https://linear.app/safe-global/issue/WA-1819/tech-debt-extract-usersrepositorymodule-to-decouple-oidcauthmodule)
`OidcAuthModule` imported `UsersModule` just to get `IUsersRepository`. But `UsersModule` also registers `UsersController` and forward-imports `AuthModule` and `SpacesModule`, so enabling `FF_OIDC_AUTH=true` pulled in the entire users/auth/spaces dependency tree regardless of those features' own flags. This breaks the principle of independent feature-flag rollout.

This mirrors the existing `AuthRepositoryModule` extraction done for the same reason (shared `IAuthRepository` between SiWe and OIDC auth).

## Changes

- **New `src/modules/users/domain/users-repository.module.ts`** — standalone module providing and exporting `IUsersRepository`, importing only what `UsersRepository` actually needs (`PostgresDatabaseModuleV2`, `WalletsModule`, `SpaceAuditModule`, TypeORM entities).
- **`src/modules/auth/oidc/oidc-auth.module.ts`** — imports `UsersRepositoryModule` instead of `forwardRef(() => UsersModule)`. The `forwardRef` is no longer needed since `UsersRepositoryModule` has no back-edge to `OidcAuthModule`.
- **`src/modules/users/users.module.ts`** — imports and re-exports `UsersRepositoryModule` so existing consumers resolve `IUsersRepository` unchanged. Drops the now-redundant local `IUsersRepository` provider and the unused `WalletsModule` import.
- **`src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts`** — adds a `UsersRepositoryModule → TestUsersModule` override (with explanatory comment) so `OidcAuthService` receives the mock repository.

## Notes

`IMembersRepository` was deliberately left in `UsersModule`, not moved into `UsersRepositoryModule`. Its implementation depends on `ISpacesRepository`, so moving it would reintroduce the `SpacesModule` coupling this change removes. `OidcAuthService` only needs `IUsersRepository`, which has no such dependency.
