### PR TITLE
feat(users): per-user email encryption with blind index

### DIFF
--- a/migrations/1781600000000-user-email-field-encryption.ts
+++ b/migrations/1781600000000-user-email-field-encryption.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Prepares users.email for deterministic field-level encryption.
+ *
+ * - Widens `email` to `text` to hold ciphertext.
+ * - Drops the lowercase CHECK constraint: ciphertext is not lowercase. The
+ *   lowercase invariant is preserved by EmailAddressSchema (`.toLowerCase()`)
+ *   before values reach the database.
+ *
+ * The unique partial index `idx_users_email` is intentionally kept: deterministic
+ * encryption maps identical emails to identical ciphertext, so uniqueness and
+ * equality lookups continue to work. Postgres rebuilds the index automatically
+ * when the column type changes.
+ */
+export class UserEmailFieldEncryption1781600000000
+  implements MigrationInterface
+{
+  name = 'UserEmailFieldEncryption1781600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP CONSTRAINT "users_email_lowercase_check"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "email" TYPE text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Narrowing back will fail if encrypted values remain (they exceed the old
+    // length and are not lowercase) — encryption must be backfilled-out first.
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "email" TYPE character varying(255)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD CONSTRAINT "users_email_lowercase_check" CHECK ("email" IS NULL OR "email" = lower("email"))`,
+    );
+  }
+}

--- a/migrations/1781800000000-user-email-encryption.ts
+++ b/migrations/1781800000000-user-email-encryption.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Prepares users.email for per-user encryption with a blind index.
+ *
+ * - Adds `encrypted_data_key`: the KMS-wrapped per-user data key that encrypts
+ *   the email value.
+ * - Adds `email_index`: an app-wide HMAC blind index over the normalised email,
+ *   so uniqueness and equality lookups keep working now that the value is
+ *   encrypted non-deterministically.
+ * - Replaces the unique index on `email` with one on `email_index` (a
+ *   non-deterministic value cannot be unique).
+ */
+export class UserEmailEncryption1781800000000 implements MigrationInterface {
+  name = 'UserEmailEncryption1781800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "encrypted_data_key" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "email_index" text`,
+    );
+    await queryRunner.query(`DROP INDEX "idx_users_email"`);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "idx_users_email_index" ON "users" ("email_index") WHERE "email_index" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_users_email_index"`);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "idx_users_email" ON "users" ("email") WHERE "email" IS NOT NULL`,
+    );
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "email_index"`);
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "encrypted_data_key"`,
+    );
+  }
+}

--- a/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
@@ -140,6 +140,7 @@ describe('SpaceAuditRepository', () => {
       postgresDatabaseService,
       walletsRepository,
       spaceAuditRepository,
+      createMockPerEntityFieldCrypto(),
     );
     membersRepository = new MembersRepository(
       postgresDatabaseService,

--- a/src/modules/users/datasources/entities/users.entity.db.ts
+++ b/src/modules/users/datasources/entities/users.entity.db.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import {
-  Check,
   Column,
   Entity,
   Index,
@@ -17,10 +16,8 @@ import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db
 import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
 
 @Entity('users')
-@Check(
-  'users_email_lowercase_check',
-  '"email" IS NULL OR "email" = lower("email")',
-)
+// The lowercase CHECK constraint cannot apply to ciphertext; lowercasing is
+// enforced by EmailAddressSchema before the value reaches the database.
 export class User implements DomainUser {
   @PrimaryGeneratedColumn({ primaryKeyConstraintName: 'PK_id' })
   id!: number;
@@ -45,17 +42,38 @@ export class User implements DomainUser {
   })
   extUserId!: string | null;
 
-  @Index('idx_users_email', {
-    unique: true,
-    where: '"email" IS NOT NULL',
-  })
+  // Encrypted under the per-user data key (non-deterministic, authenticated).
+  // Lookups and uniqueness use `emailIndex` (a blind index) instead, since the
+  // ciphertext is no longer stable. Encryption is performed in UsersRepository.
   @Column({
     name: 'email',
-    type: 'varchar',
-    length: 255,
+    type: 'text',
     nullable: true,
   })
   email!: EmailAddress | null;
+
+  // App-wide HMAC blind index over the normalised email. Deterministic, so it
+  // backs the unique constraint and equality lookups while the value above stays
+  // non-deterministic.
+  @Index('idx_users_email_index', {
+    unique: true,
+    where: '"email_index" IS NOT NULL',
+  })
+  @Column({
+    name: 'email_index',
+    type: 'text',
+    nullable: true,
+  })
+  emailIndex?: string | null;
+
+  // KMS-wrapped per-user data key (`kdk:v1:<base64>`) that encrypts this user's
+  // email. Populated by the repository when an email is set.
+  @Column({
+    name: 'encrypted_data_key',
+    type: 'text',
+    nullable: true,
+  })
+  encryptedDataKey?: string | null;
 
   @OneToMany(
     () => Wallet,

--- a/src/modules/users/domain/members/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members/members.repository.integration.spec.ts
@@ -138,6 +138,7 @@ describe('MembersRepository', () => {
         postgresDatabaseService,
         walletsRepo,
         createMockSpaceAuditRepository(),
+        createMockPerEntityFieldCrypto(),
       ),
       new SpacesRepository(
         postgresDatabaseService,

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -10,6 +10,7 @@ import configuration from '@/config/entities/__tests__/configuration';
 import { postgresConfig } from '@/config/entities/postgres.config';
 import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { createMockPerEntityFieldCrypto } from '@/datasources/encryption/__tests__/per-entity-field-crypto.mock';
 import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { ILoggingService } from '@/logging/logging.interface';
@@ -107,6 +108,7 @@ describe('UsersRepository', () => {
       postgresDatabaseService,
       new WalletsRepository(postgresDatabaseService),
       createMockSpaceAuditRepository(),
+      createMockPerEntityFieldCrypto(),
     );
   });
 

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -6,6 +6,7 @@ import { QueryFailedError } from 'typeorm';
 import { getAddress } from 'viem';
 import type { Mock, MockedObject } from 'vitest';
 import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { PerEntityFieldCrypto } from '@/datasources/encryption/per-entity-field-crypto';
 import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { User as DbUser } from '@/modules/users/datasources/entities/users.entity.db';
 import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-email-already-in-use.error';
@@ -23,6 +24,15 @@ function uniqueConstraintError(constraint: string): QueryFailedError {
 
 describe('UsersRepository', () => {
   const walletsRepository = {} as MockedObject<IWalletsRepository>;
+  // Passthrough crypto (disabled-like): blind index null, values unchanged, so
+  // existing plaintext assertions hold. Per-user encryption + blind-index
+  // lookups are covered by integration tests.
+  const fieldCrypto = {
+    encryptFields: vi.fn(),
+    decryptFields: vi.fn(),
+    isEncrypted: vi.fn(),
+    blindIndex: vi.fn(),
+  } as unknown as MockedObject<PerEntityFieldCrypto>;
 
   let postgresDatabaseService: MockedObject<PostgresDatabaseService>;
   let userRepository: {
@@ -61,10 +71,23 @@ describe('UsersRepository', () => {
       transaction: vi.fn(),
     } as MockedObject<PostgresDatabaseService>;
 
+    fieldCrypto.encryptFields.mockImplementation((_context, key, fields) =>
+      Promise.resolve({
+        encryptedDataKey: key ?? null,
+        values: fields.map((field) => field.value),
+      }),
+    );
+    fieldCrypto.decryptFields.mockImplementation((_context, _key, fields) =>
+      Promise.resolve(fields.map((field) => field.value)),
+    );
+    fieldCrypto.isEncrypted.mockReturnValue(false);
+    fieldCrypto.blindIndex.mockReturnValue(null);
+
     target = new UsersRepository(
       postgresDatabaseService,
       walletsRepository,
       createMockSpaceAuditRepository(),
+      fieldCrypto,
     );
   });
 
@@ -207,7 +230,7 @@ describe('UsersRepository', () => {
       const extUserId = faker.string.uuid();
       userRepository.findOne.mockResolvedValue(null);
       postgresDatabaseService.transaction.mockRejectedValue(
-        uniqueConstraintError('idx_users_email'),
+        uniqueConstraintError('idx_users_email_index'),
       );
 
       await expect(
@@ -304,7 +327,7 @@ describe('UsersRepository', () => {
       });
       userRepository.update.mockResolvedValue({ affected: 0 });
       postgresDatabaseService.transaction.mockRejectedValue(
-        uniqueConstraintError('idx_users_email'),
+        uniqueConstraintError('idx_users_email_index'),
       );
 
       await expect(
@@ -323,7 +346,7 @@ describe('UsersRepository', () => {
       await expect(target.findEmailById(userId)).resolves.toBe(email);
       expect(userRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        select: { email: true },
+        select: { id: true, email: true, encryptedDataKey: true },
       });
     });
 

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -10,6 +10,8 @@ import type { FindOptionsRelations, FindOptionsWhere } from 'typeorm';
 import { EntityManager, In, IsNull } from 'typeorm';
 import type { Address } from 'viem';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { FieldEncryptionAad } from '@/datasources/encryption/field-encryption.constants';
+import { PerEntityFieldCrypto } from '@/datasources/encryption/per-entity-field-crypto';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
@@ -33,7 +35,29 @@ export class UsersRepository implements IUsersRepository {
     private readonly walletsRepository: IWalletsRepository,
     @Inject(ISpaceAuditRepository)
     private readonly spaceAuditRepository: ISpaceAuditRepository,
+    private readonly fieldCrypto: PerEntityFieldCrypto,
   ) {}
+
+  /**
+   * Decrypts loaded users' `email` under their per-user key (one KMS unwrap per
+   * user, since each user has its own key). Skipped when the value is not
+   * ciphertext (disabled / legacy plaintext).
+   */
+  private async decryptUserEmails(users: Array<DbUser>): Promise<void> {
+    for (const user of users) {
+      if (
+        typeof user.email === 'string' &&
+        this.fieldCrypto.isEncrypted(user.email)
+      ) {
+        const [plaintext] = await this.fieldCrypto.decryptFields(
+          { userId: String(user.id) },
+          user.encryptedDataKey,
+          [{ value: user.email, aad: FieldEncryptionAad.USER_EMAIL }],
+        );
+        user.email = plaintext as EmailAddress;
+      }
+    }
+  }
 
   public async findOneOrFail(
     where: Array<FindOptionsWhere<DbUser>> | FindOptionsWhere<DbUser>,
@@ -47,6 +71,7 @@ export class UsersRepository implements IUsersRepository {
       throw new NotFoundException('User not found.');
     }
 
+    await this.decryptUserEmails([user]);
     return user;
   }
 
@@ -56,7 +81,9 @@ export class UsersRepository implements IUsersRepository {
   ): Promise<Array<DbUser>> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
-    return userRepository.find({ where, relations });
+    const users = await userRepository.find({ where, relations });
+    await this.decryptUserEmails(users);
+    return users;
   }
 
   public async createWithWallet(args: {
@@ -90,13 +117,38 @@ export class UsersRepository implements IUsersRepository {
     entityManager: EntityManager,
     options?: { extUserId?: string; email?: EmailAddress },
   ): Promise<User['id']> {
+    const email = options?.email;
+    // When enabled, the blind index enforces uniqueness at insert (the email
+    // value is set once the id is known, below); when disabled, the plaintext
+    // email is stored directly.
+    const emailIndex = email ? this.fieldCrypto.blindIndex(email) : null;
+    let emailColumns: { emailIndex?: string; email?: EmailAddress } = {};
+    if (emailIndex) {
+      emailColumns = { emailIndex };
+    } else if (email) {
+      emailColumns = { email };
+    }
+
     const userInsertResult = await entityManager.insert(DbUser, {
       status,
       ...(options?.extUserId && { extUserId: options.extUserId }),
-      ...(options?.email && { email: options.email }),
+      ...emailColumns,
     });
+    const userId = userInsertResult.identifiers[0].id;
 
-    return userInsertResult.identifiers[0].id;
+    if (email && emailIndex) {
+      const { encryptedDataKey, values } = await this.fieldCrypto.encryptFields(
+        { userId: String(userId) },
+        undefined,
+        [{ value: email, aad: FieldEncryptionAad.USER_EMAIL }],
+      );
+      await entityManager.update(DbUser, userId, {
+        email: values[0] as EmailAddress,
+        encryptedDataKey,
+      });
+    }
+
+    return userId;
   }
 
   public async getWithWallets(authPayload: AuthPayload): Promise<{
@@ -281,18 +333,39 @@ export class UsersRepository implements IUsersRepository {
     const upsertThenSelect = async (
       manager: EntityManager,
     ): Promise<User['id']> => {
+      const emailIndex = this.fieldCrypto.blindIndex(email);
+
       await manager
         .createQueryBuilder()
         .insert()
         .into(DbUser)
-        .values({ status: 'PENDING', email })
+        .values({
+          status: 'PENDING',
+          ...(emailIndex ? { emailIndex } : { email }),
+        })
         .orIgnore()
         .execute();
 
+      // Look up by blind index when enabled, by plaintext value when disabled.
       const user = await manager.findOneOrFail(DbUser, {
-        where: { email },
-        select: { id: true },
+        where: emailIndex ? { emailIndex } : { email },
+        select: { id: true, email: true, encryptedDataKey: true },
       });
+
+      // Newly inserted under encryption: the value column is still null, so set
+      // the encrypted email and the per-user key now that the id is known.
+      if (emailIndex && !user.email) {
+        const { encryptedDataKey, values } =
+          await this.fieldCrypto.encryptFields(
+            { userId: String(user.id) },
+            undefined,
+            [{ value: email, aad: FieldEncryptionAad.USER_EMAIL }],
+          );
+        await manager.update(DbUser, user.id, {
+          email: values[0] as EmailAddress,
+          encryptedDataKey,
+        });
+      }
       return user.id;
     };
 
@@ -356,7 +429,7 @@ export class UsersRepository implements IUsersRepository {
         }
         return this.reconcileEmail(raced, email);
       }
-      if (this.isUniqueConstraintViolation(error, 'idx_users_email')) {
+      if (this.isUniqueConstraintViolation(error, 'idx_users_email_index')) {
         throw new UserEmailAlreadyInUseError();
       }
       throw error;
@@ -377,8 +450,9 @@ export class UsersRepository implements IUsersRepository {
   ): Promise<User['id'] | null> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
+    const emailIndex = this.fieldCrypto.blindIndex(email);
     const candidate = await userRepository.findOne({
-      where: { email },
+      where: emailIndex ? { emailIndex } : { email },
       select: { id: true, status: true, extUserId: true },
     });
 
@@ -400,13 +474,13 @@ export class UsersRepository implements IUsersRepository {
 
   private async findByExtUserId(
     extUserId: string,
-  ): Promise<Pick<DbUser, 'id' | 'email'> | null> {
+  ): Promise<Pick<DbUser, 'id' | 'email' | 'encryptedDataKey'> | null> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
 
     return userRepository.findOne({
       where: { extUserId },
-      select: { id: true, email: true },
+      select: { id: true, email: true, encryptedDataKey: true },
     });
   }
 
@@ -416,11 +490,17 @@ export class UsersRepository implements IUsersRepository {
    * conflicting one.
    */
   private async reconcileEmail(
-    user: Pick<DbUser, 'id' | 'email'>,
+    user: Pick<DbUser, 'id' | 'email' | 'encryptedDataKey'>,
     email: EmailAddress,
   ): Promise<User['id']> {
     if (user.email) {
-      if (user.email !== email) {
+      // Stored email is ciphertext under the per-user key; compare plaintext.
+      const [storedEmail] = await this.fieldCrypto.decryptFields(
+        { userId: String(user.id) },
+        user.encryptedDataKey,
+        [{ value: user.email, aad: FieldEncryptionAad.USER_EMAIL }],
+      );
+      if (storedEmail !== email) {
         throw new UnauthorizedException(
           'Email does not match the registered email for this account',
         );
@@ -440,16 +520,33 @@ export class UsersRepository implements IUsersRepository {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
 
+    const emailIndex = this.fieldCrypto.blindIndex(email);
+    let emailValue: string = email;
+    let encryptedDataKey: string | null = null;
+    if (emailIndex) {
+      const encrypted = await this.fieldCrypto.encryptFields(
+        { userId: String(userId) },
+        undefined,
+        [{ value: email, aad: FieldEncryptionAad.USER_EMAIL }],
+      );
+      emailValue = encrypted.values[0];
+      encryptedDataKey = encrypted.encryptedDataKey;
+    }
+
     try {
       await userRepository
         .createQueryBuilder()
         .update(DbUser)
-        .set({ email })
+        .set({
+          email: emailValue as EmailAddress,
+          ...(emailIndex && { emailIndex }),
+          ...(encryptedDataKey && { encryptedDataKey }),
+        })
         .where('id = :userId', { userId })
         .andWhere('email IS NULL')
         .execute();
     } catch (error) {
-      if (this.isUniqueConstraintViolation(error, 'idx_users_email')) {
+      if (this.isUniqueConstraintViolation(error, 'idx_users_email_index')) {
         throw new UserEmailAlreadyInUseError();
       }
       throw error;
@@ -463,11 +560,15 @@ export class UsersRepository implements IUsersRepository {
       await this.postgresDatabaseService.getRepository(DbUser);
     const user = await userRepository.findOne({
       where: { id: userId },
-      select: { email: true },
+      select: { id: true, email: true, encryptedDataKey: true },
     });
 
-    // /me omits absent email fields, so normalize null/missing rows to undefined.
-    return user?.email ?? undefined;
+    if (!user?.email) {
+      // /me omits absent email fields, so normalize null/missing to undefined.
+      return undefined;
+    }
+    await this.decryptUserEmails([user]);
+    return user.email;
   }
 
   public async findEmailsByIds(
@@ -478,8 +579,10 @@ export class UsersRepository implements IUsersRepository {
       await this.postgresDatabaseService.getRepository(DbUser);
     const users = await userRepository.find({
       where: { id: In(userIds) },
-      select: { id: true, email: true },
+      select: { id: true, email: true, encryptedDataKey: true },
     });
+
+    await this.decryptUserEmails(users);
 
     return new Map(
       users.flatMap(


### PR DESCRIPTION
## Summary
  Encrypts `users.email` under a per-user data key and adds an HMAC blind index so uniqueness and equality lookups keep working. Independent of the per-space work (different key, different table); depends only on the foundation PR.

  ## Changes
  - Migration: widen `email` to `text`, add `users.encrypted_data_key` and a unique `users.email_index`, drop the old unique index on `email`.
  - `User` entity: per-user key + `email_index` columns; email transformer removed.
  - `UsersRepository`: encrypt the email value under a per-user DEK on create/persist (user-id-bound context); compute the blind index for storage; route every `where:{email}` lookup through the blind index; decrypt email on read. Unique-constraint handling retargeted to
  `idx_users_email_index`.
  - Unit spec updated.
  
  ⚠️  Rollout: while encryption is disabled, `email_index` is null and email uniqueness isn't enforced — enable encryption + run the backfill promptly after this lands (or keep the old index during the transition).
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)