### PR TITLE
fix: coalesce concurrent Zerion wallet portfolio fetches

### DIFF
--- a/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.spec.ts
+++ b/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.spec.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import type { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import type { ZerionWalletPortfolio } from '@/modules/balances/datasources/entities/zerion-wallet-portfolio.entity';
+import { ZerionWalletPortfolioApi } from '@/modules/balances/datasources/zerion-wallet-portfolio-api.service';
+
+describe('ZerionWalletPortfolioApi', () => {
+  let service: ZerionWalletPortfolioApi;
+  let fakeConfigurationService: FakeConfigurationService;
+
+  const zerionApiKey = faker.string.sample();
+  const zerionBaseUri = faker.internet.url({ appendSlash: false });
+
+  const mockNetworkService = vi.mocked({
+    get: vi.fn(),
+  } as MockedObject<INetworkService>);
+
+  const mockHttpErrorFactory = vi.mocked({
+    from: vi.fn(),
+  } as MockedObject<HttpErrorFactory>);
+
+  const mockCacheService = vi.mocked({
+    hGet: vi.fn(),
+    hSet: vi.fn(),
+  } as MockedObject<ICacheService>);
+
+  const mockLoggingService = vi.mocked({
+    debug: vi.fn(),
+  } as MockedObject<ILoggingService>);
+
+  const portfolio = (): ZerionWalletPortfolio => ({
+    data: {
+      type: 'portfolio',
+      id: faker.string.uuid(),
+      attributes: {
+        total: { positions: faker.number.float() },
+        positions_distribution_by_chain: { ethereum: faker.number.float() },
+      },
+    },
+  });
+
+  const args = (): {
+    address: `0x${string}`;
+    currency: string;
+    isTestnet: boolean;
+  } => ({
+    address: getAddress(faker.finance.ethereumAddress()),
+    currency: 'USD',
+    isTestnet: false,
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'balances.providers.zerion.apiKey',
+      zerionApiKey,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.baseUri',
+      zerionBaseUri,
+    );
+
+    service = new ZerionWalletPortfolioApi(
+      fakeConfigurationService as IConfigurationService,
+      mockNetworkService,
+      mockHttpErrorFactory,
+      mockCacheService,
+      mockLoggingService,
+    );
+  });
+
+  it('returns the cached portfolio without calling the network', async () => {
+    const data = portfolio();
+    mockCacheService.hGet.mockResolvedValue(JSON.stringify(data));
+
+    const result = await service.getPortfolio(args());
+
+    expect(result).toStrictEqual(data);
+    expect(mockNetworkService.get).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches the portfolio on a cache miss', async () => {
+    const data = portfolio();
+    mockCacheService.hGet.mockResolvedValue(null);
+    mockNetworkService.get.mockResolvedValue({ status: 200, data } as never);
+
+    const result = await service.getPortfolio(args());
+
+    expect(result).toStrictEqual(data);
+    expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.hSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent identical fetches on a cold cache into one request', async () => {
+    const data = portfolio();
+    mockCacheService.hGet.mockResolvedValue(null);
+    let resolveGet: (value: unknown) => void = () => {};
+    mockNetworkService.get.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }) as never,
+    );
+    const sharedArgs = args();
+
+    const [first, second] = [
+      service.getPortfolio(sharedArgs),
+      service.getPortfolio(sharedArgs),
+    ];
+    resolveGet({ status: 200, data });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult).toStrictEqual(data);
+    expect(secondResult).toStrictEqual(data);
+    expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the in-flight entry when the fetch rejects so the next caller retries', async () => {
+    const data = portfolio();
+    mockCacheService.hGet.mockResolvedValue(null);
+    mockHttpErrorFactory.from.mockReturnValue(new Error('Zerion error'));
+    mockNetworkService.get
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ status: 200, data } as never);
+    const sharedArgs = args();
+
+    await expect(service.getPortfolio(sharedArgs)).rejects.toThrow();
+    const result = await service.getPortfolio(sharedArgs);
+
+    expect(result).toStrictEqual(data);
+    expect(mockNetworkService.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.ts
+++ b/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.ts
@@ -50,6 +50,13 @@ export class ZerionWalletPortfolioApi implements IZerionWalletPortfolioApi {
   private static readonly CACHE_TTL_SECONDS = 10;
   private readonly apiKey: string | undefined;
   private readonly baseUri: string;
+  // Coalesces concurrent identical fetches (per instance): while one request for
+  // a given cache key is in flight, others await the same promise instead of
+  // issuing duplicate Zerion calls. Prevents cache-miss/expiry stampedes.
+  private readonly inFlightRequests = new Map<
+    string,
+    Promise<ZerionWalletPortfolio>
+  >();
 
   constructor(
     @Inject(IConfigurationService)
@@ -91,6 +98,30 @@ export class ZerionWalletPortfolioApi implements IZerionWalletPortfolioApi {
 
     this.loggingService.debug({ type: LogType.CacheMiss, key, field });
 
+    // Coalesce: if an identical fetch is already running, await it instead of
+    // issuing a duplicate Zerion request.
+    const inFlightKey = `${key}:${field}`;
+    const existing = this.inFlightRequests.get(inFlightKey);
+    if (existing) {
+      return existing;
+    }
+
+    const request = this.fetchAndCachePortfolio(args, cacheDir).finally(() => {
+      this.inFlightRequests.delete(inFlightKey);
+    });
+    this.inFlightRequests.set(inFlightKey, request);
+    return request;
+  }
+
+  private async fetchAndCachePortfolio(
+    args: {
+      address: Address;
+      currency: string;
+      isTestnet: boolean;
+      trusted?: boolean;
+    },
+    cacheDir: ReturnType<typeof CacheRouter.getZerionWalletPortfolioCacheDir>,
+  ): Promise<ZerionWalletPortfolio> {
     const url = `${this.baseUri}/v1/wallets/${args.address}/portfolio`;
 
     const params: Record<string, string> = {


### PR DESCRIPTION
## Summary

- The `/v2/safes` overview fetches the Zerion wallet portfolio per `(address, currency, trusted, testnet)`. A **multichain Safe** is requested once per chain, **concurrently**, and the cache key omits chainId — so all chain branches miss the shared cache before any write lands and each fires an **identical** Zerion call. Frontend polling/spam compounds this across requests, producing bursts of duplicate calls that hit Zerion rate limits (**429**).
- Adds a per-instance **in-flight promise map** in `ZerionWalletPortfolioApi` (mirroring `TenderlySimulationApi`'s `blockGasLimitCache` precedent): concurrent identical fetches share a single Zerion request; the entry is evicted on settle so the next caller refetches. The 10s Redis cache still handles sequential repeats.

## Why coalescing (not request-scoped dedupe)

Datasource-level coalescing collapses **both** the intra-request chain fan-out *and* cross-request concurrent spam (per pod), so it subsumes a request-scoped dedupe in `getSafeOverview`. The Redis cache can't catch the burst because the duplicate calls are concurrent (all miss before any write).

## Tests

New `zerion-wallet-portfolio-api.service.spec.ts`: cache hit, cache-miss fetch+cache, concurrent-coalescing (one network call for two concurrent identical fetches), and eviction-on-reject (next caller retries).

## Related

- Complementary to the configurable-TTL PR (tuning knob); this is the root-cause fix for the duplicate concurrent calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)