### PR TITLE
fix: Zerion /portfolio 429 storm — fetch-once-per-wallet + shared rate limit

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1584,6 +1584,18 @@
     "required": false
   },
   {
+    "name": "ZERION_RATE_LIMIT_PER_ADDRESS_CALLS_BY_PERIOD",
+    "description": "Maximum Zerion API calls per time period for a single address (per-address sub-budget; 0 disables it)",
+    "defaultValue": 0,
+    "required": false
+  },
+  {
+    "name": "ZERION_RATE_LIMIT_PER_ADDRESS_PERIOD_SECONDS",
+    "description": "Time period for the Zerion per-address rate limit in seconds",
+    "defaultValue": 10,
+    "required": false
+  },
+  {
     "name": "SAFE_CONFIG_CGW_KEY",
     "description": "The service key for CGW internal feature flag fetching",
     "defaultValue": "CGW",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -76,6 +76,8 @@ export default (): ReturnType<typeof configuration> => ({
         ),
         limitPeriodSeconds: faker.number.int({ min: 1, max: 10 }),
         limitCalls: faker.number.int({ min: 1, max: 5 }),
+        perAddressLimitPeriodSeconds: faker.number.int({ min: 1, max: 10 }),
+        perAddressLimitCalls: faker.number.int({ min: 1, max: 5 }),
       },
     },
   },

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -75,9 +75,12 @@ export default (): ReturnType<typeof configuration> => ({
           ]),
         ),
         limitPeriodSeconds: faker.number.int({ min: 1, max: 10 }),
-        limitCalls: faker.number.int({ min: 1, max: 5 }),
+        // High enough that the shared budget stays inert in app-boot tests;
+        // rate-limit specs override these with their own small values.
+        limitCalls: faker.number.int({ min: 1000, max: 100000 }),
         perAddressLimitPeriodSeconds: faker.number.int({ min: 1, max: 10 }),
-        perAddressLimitCalls: faker.number.int({ min: 1, max: 5 }),
+        // Disabled by default (matches the production default).
+        perAddressLimitCalls: 0,
       },
     },
   },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -141,6 +141,16 @@ export default () => ({
           process.env.ZERION_RATE_LIMIT_CALLS_BY_PERIOD ?? `${2}`,
           10,
         ),
+        // Per-address sub-budget (DoS isolation): one hot wallet cannot starve
+        // the shared account budget. Disabled by default (0); opt in per env.
+        perAddressLimitPeriodSeconds: Number.parseInt(
+          process.env.ZERION_RATE_LIMIT_PER_ADDRESS_PERIOD_SECONDS ?? `${10}`,
+          10,
+        ),
+        perAddressLimitCalls: Number.parseInt(
+          process.env.ZERION_RATE_LIMIT_PER_ADDRESS_CALLS_BY_PERIOD ?? `${0}`,
+          10,
+        ),
       },
     },
   },

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -107,4 +107,19 @@ describe('FakeCacheService', () => {
 
     await expect(target.getCounter(key)).resolves.toBe(value + 3);
   });
+
+  it('creates a missing key and increments its value with incrWithTtl', async () => {
+    const key = faker.string.alphanumeric();
+    const ttl = faker.number.int({ min: 1, max: 10 });
+
+    const firstResult = await target.incrWithTtl(key, ttl);
+    expect(firstResult).toEqual(1);
+
+    const results: Array<number> = [];
+    for (let i = 0; i < 5; i++) {
+      results.push(await target.incrWithTtl(key, ttl));
+    }
+
+    expect(results).toEqual([2, 3, 4, 5, 6]);
+  });
 });

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -80,10 +80,12 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
   }
 
   incrWithTtl(cacheKey: string, _ttlSeconds: number): Promise<number> {
-    let currentValue: number = this.cache[cacheKey] as number;
-    currentValue = currentValue ? currentValue + 1 : 1;
-    this.cache[cacheKey] = currentValue;
-    return Promise.resolve(currentValue);
+    const currentValue = (this.cache[cacheKey] as number | undefined) ?? 0;
+    const nextValue = currentValue + 1;
+
+    this.cache[cacheKey] = nextValue;
+
+    return Promise.resolve(nextValue);
   }
 
   setCounter(

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -79,6 +79,13 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
     return Promise.resolve(currentValue);
   }
 
+  incrWithTtl(cacheKey: string, _ttlSeconds: number): Promise<number> {
+    let currentValue: number = this.cache[cacheKey] as number;
+    currentValue = currentValue ? currentValue + 1 : 1;
+    this.cache[cacheKey] = currentValue;
+    return Promise.resolve(currentValue);
+  }
+
   setCounter(
     key: string,
     value: number,

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -24,15 +24,11 @@ export interface ICacheService {
   ): Promise<number>;
 
   /**
-   * Atomically increments a counter and sets its TTL on first creation.
-   *
-   * Unlike {@link increment} (which relies on `EXPIRE … NX`, a Redis 7.0+
-   * feature), this uses a Lua `INCR`+`EXPIRE` script that works on Redis 6 and
-   * 7 alike. Use this for fixed-window rate limiting so the window reliably
-   * resets regardless of the deployed Redis version.
+   * Atomically increments a counter and sets its TTL on first creation, for
+   * fixed-window rate limiting.
    *
    * @param cacheKey - Counter key (not prefixed, matching {@link increment}).
-   * @param ttlSeconds - Window length in seconds, applied on first increment.
+   * @param ttlSeconds - Window length in seconds, applied on the first increment.
    * @returns The counter value after incrementing.
    */
   incrWithTtl(cacheKey: string, ttlSeconds: number): Promise<number>;

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 
 export const CacheService = Symbol('ICacheService');

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -22,6 +22,20 @@ export interface ICacheService {
     expireDeviatePercent?: number,
   ): Promise<number>;
 
+  /**
+   * Atomically increments a counter and sets its TTL on first creation.
+   *
+   * Unlike {@link increment} (which relies on `EXPIRE … NX`, a Redis 7.0+
+   * feature), this uses a Lua `INCR`+`EXPIRE` script that works on Redis 6 and
+   * 7 alike. Use this for fixed-window rate limiting so the window reliably
+   * resets regardless of the deployed Redis version.
+   *
+   * @param cacheKey - Counter key (not prefixed, matching {@link increment}).
+   * @param ttlSeconds - Window length in seconds, applied on first increment.
+   * @returns The counter value after incrementing.
+   */
+  incrWithTtl(cacheKey: string, ttlSeconds: number): Promise<number>;
+
   setCounter(
     key: string,
     value: number,

--- a/src/datasources/cache/redis.cache.service.integration.spec.ts
+++ b/src/datasources/cache/redis.cache.service.integration.spec.ts
@@ -226,6 +226,36 @@ describe('RedisCacheService', () => {
     expect(ttl).toBeLessThanOrEqual(maxExpireTime);
   });
 
+  it('incrWithTtl creates a missing key and sets its TTL on first increment', async () => {
+    const ttlSeconds = faker.number.int({ min: 5, max: maxTtlDeviated });
+    const key = faker.string.alphanumeric();
+
+    const firstResult = await redisCacheService.incrWithTtl(key, ttlSeconds);
+
+    const ttl = await redisClient.ttl(key);
+    expect(firstResult).toEqual(1);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(ttlSeconds);
+  });
+
+  it('incrWithTtl keeps the window TTL stable across subsequent increments', async () => {
+    const ttlSeconds = faker.number.int({ min: 50, max: maxTtlDeviated });
+    const key = faker.string.alphanumeric();
+
+    await redisCacheService.incrWithTtl(key, ttlSeconds);
+    const ttlAfterFirst = await redisClient.ttl(key);
+
+    const results: Array<number> = [];
+    for (let i = 0; i < 4; i++) {
+      // A different TTL here must NOT reset the window once the key exists.
+      results.push(await redisCacheService.incrWithTtl(key, ttlSeconds * 10));
+    }
+    const ttlAfterMore = await redisClient.ttl(key);
+
+    expect(results).toEqual([2, 3, 4, 5]);
+    expect(ttlAfterMore).toBeLessThanOrEqual(ttlAfterFirst);
+  });
+
   it('sets and gets the value of a counter key', async () => {
     const key = faker.string.alphanumeric();
     const value = faker.number.int({ min: 100 });

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -17,6 +17,11 @@ import {
 export class RedisCacheService
   implements ICacheService, ICacheReadiness, OnModuleDestroy
 {
+  // Atomic INCR that sets a TTL only on the key's creation. Uses a plain
+  // EXPIRE (not EXPIRE … NX) so it works on Redis 6 as well as 7.
+  private static readonly INCR_WITH_TTL_LUA =
+    "local c = redis.call('INCR', KEYS[1]); if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end; return c";
+
   private readonly quitTimeoutInSeconds: number = 2;
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultExpirationDeviatePercent: number;
@@ -123,6 +128,23 @@ export class RedisCacheService
     }
     const [incrRes] = await transaction.get(cacheKey).exec();
     return Number(incrRes);
+  }
+
+  /**
+   * Atomic, Redis-version-agnostic fixed-window counter.
+   *
+   * `EXPIRE … NX` (used by {@link increment}) requires Redis 7.0+, so on Redis
+   * 6 that counter never expires and the window never resets. This Lua script
+   * sets the TTL only on the first increment using a plain `EXPIRE`, which
+   * works on both Redis 6 and 7.
+   */
+  async incrWithTtl(cacheKey: string, ttlSeconds: number): Promise<number> {
+    const ttl = this.enforceMaxRedisTTL(ttlSeconds);
+    const result = await this.client.eval(RedisCacheService.INCR_WITH_TTL_LUA, {
+      keys: [cacheKey],
+      arguments: [`${ttl}`],
+    });
+    return Number(result);
   }
 
   async setCounter(

--- a/src/domain/common/entities/log-type.entity.ts
+++ b/src/domain/common/entities/log-type.entity.ts
@@ -30,6 +30,7 @@ export enum LogType {
   NotificationSent = 'NOTIFICATION_SENT',
   NotificationEventProcessed = 'NOTIFICATION_EVENT_PROCESSED',
   NotificationDeliveryQueued = 'NOTIFICATION_DELIVERY_QUEUED',
+  PortfolioDegradedServe = 'PORTFOLIO_DEGRADED_SERVE',
   PortfolioRequestError = 'PORTFOLIO_REQUEST_ERROR',
   RateLimit = 'RATE_LIMIT',
   TxRelayEligibility = 'TX_RELAY_ELIGIBILITY',

--- a/src/modules/balances/balances.module.ts
+++ b/src/modules/balances/balances.module.ts
@@ -21,6 +21,7 @@ import { BalancesController } from '@/modules/balances/routes/balances.controlle
 import { BalancesService } from '@/modules/balances/routes/balances.service';
 import { ChainsModule } from '@/modules/chains/chains.module';
 import { SafeRepositoryModule } from '@/modules/safe/domain/safe.repository.interface';
+import { ZerionModule } from '@/modules/zerion/zerion.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { SafeRepositoryModule } from '@/modules/safe/domain/safe.repository.inte
     TxAuthNetworkModule,
     ChainsModule,
     SafeRepositoryModule,
+    ZerionModule,
   ],
   controllers: [BalancesController],
   providers: [

--- a/src/modules/balances/datasources/zerion-balances-api.service.spec.ts
+++ b/src/modules/balances/datasources/zerion-balances-api.service.spec.ts
@@ -232,4 +232,25 @@ describe('ZerionBalancesApiService', () => {
       expect(mockLoggingService.warn).toHaveBeenCalledWith(message);
     });
   });
+
+  describe('getCollectibles', () => {
+    it('rethrows LimitReachedError (not a wrapped 5xx) when over budget', async () => {
+      const chain = chainBuilder().with('isTestnet', false).build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      mockCacheService.hGet.mockResolvedValue(null);
+      mockZerionRateLimiter.assertWithinBudget.mockRejectedValue(
+        new LimitReachedError(),
+      );
+
+      await expect(
+        service.getCollectibles({ chain, safeAddress }),
+      ).rejects.toThrow(LimitReachedError);
+      expect(mockZerionRateLimiter.assertWithinBudget).toHaveBeenCalledWith({
+        datasource: 'collectibles',
+      });
+      expect(mockNetworkService.get).not.toHaveBeenCalled();
+      // The error must not be re-wrapped by the HTTP error factory.
+      expect(mockHttpErrorFactory.from).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/modules/balances/datasources/zerion-balances-api.service.spec.ts
+++ b/src/modules/balances/datasources/zerion-balances-api.service.spec.ts
@@ -7,12 +7,14 @@ import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import type { ICacheService } from '@/datasources/cache/cache.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { HttpExceptionNoLog } from '@/domain/common/errors/http-exception-no-log.error';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { ZerionBalancesApi } from '@/modules/balances/datasources/zerion-balances-api.service';
 import { balancesProviderBuilder } from '@/modules/chains/domain/entities/__tests__/balances-provider.builder';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import type { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { rawify } from '@/validation/entities/raw.entity';
 
 const mockCacheService = vi.mocked({
@@ -33,6 +35,10 @@ const mockNetworkService = vi.mocked({
 const mockHttpErrorFactory = vi.mocked({
   from: vi.fn(),
 } as MockedObject<HttpErrorFactory>);
+
+const mockZerionRateLimiter = vi.mocked({
+  assertWithinBudget: vi.fn(),
+} as unknown as MockedObject<ZerionRateLimiter>);
 
 describe('ZerionBalancesApiService', () => {
   let service: ZerionBalancesApi;
@@ -87,6 +93,7 @@ describe('ZerionBalancesApiService', () => {
       mockNetworkService,
       fakeConfigurationService,
       mockHttpErrorFactory,
+      mockZerionRateLimiter,
     );
   });
 
@@ -105,6 +112,24 @@ describe('ZerionBalancesApiService', () => {
           fiatCode,
         }),
       ).rejects.toThrow(`Unsupported currency code: ${fiatCode}`);
+    });
+
+    it('should not hit the network and rethrow when over the Zerion budget', async () => {
+      const chain = chainBuilder().with('isTestnet', false).build();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const fiatCode = faker.helpers.arrayElement(supportedFiatCodes);
+      mockCacheService.hGet.mockResolvedValue(null);
+      mockZerionRateLimiter.assertWithinBudget.mockRejectedValue(
+        new LimitReachedError(),
+      );
+
+      await expect(
+        service.getBalances({ chain, safeAddress, fiatCode }),
+      ).rejects.toThrow(LimitReachedError);
+      expect(mockZerionRateLimiter.assertWithinBudget).toHaveBeenCalledWith({
+        datasource: 'balances',
+      });
+      expect(mockNetworkService.get).not.toHaveBeenCalled();
     });
 
     it('should get the chainName from the chain parameter', async () => {

--- a/src/modules/balances/datasources/zerion-balances-api.service.ts
+++ b/src/modules/balances/datasources/zerion-balances-api.service.ts
@@ -45,6 +45,7 @@ import type {
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import type { Collectible } from '@/modules/collectibles/domain/entities/collectible.entity';
 import { ZerionChainsSchema } from '@/modules/portfolio/datasources/entities/zerion-chain.entity';
+import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 export const IZerionBalancesApi = Symbol('IZerionBalancesApi');
@@ -52,15 +53,10 @@ export const IZerionBalancesApi = Symbol('IZerionBalancesApi');
 @Injectable()
 export class ZerionBalancesApi implements IBalancesApi {
   private static readonly COLLECTIBLES_SORTING = '-floor_price';
-  private static readonly RATE_LIMIT_CACHE_KEY_PREFIX = 'zerion';
   private readonly apiKey: string | undefined;
   private readonly baseUri: string;
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly fiatCodes: Array<string>;
-  // Number of seconds for each rate-limit cycle
-  private readonly limitPeriodSeconds: number;
-  // Number of allowed calls on each rate-limit cycle
-  private readonly limitCalls: number;
   // In-memory chain mappings: chainId -> zerion chain name
   private chainMappings: {
     mainnet: Record<string, string>;
@@ -81,6 +77,7 @@ export class ZerionBalancesApi implements IBalancesApi {
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     private readonly httpErrorFactory: HttpErrorFactory,
+    private readonly zerionRateLimiter: ZerionRateLimiter,
   ) {
     this.apiKey = this.configurationService.get<string>(
       'balances.providers.zerion.apiKey',
@@ -94,12 +91,6 @@ export class ZerionBalancesApi implements IBalancesApi {
       );
     this.fiatCodes = this.configurationService.getOrThrow<Array<string>>(
       'balances.providers.zerion.currencies',
-    );
-    this.limitPeriodSeconds = configurationService.getOrThrow(
-      'balances.providers.zerion.limitPeriodSeconds',
-    );
-    this.limitCalls = configurationService.getOrThrow(
-      'balances.providers.zerion.limitCalls',
     );
   }
 
@@ -142,7 +133,9 @@ export class ZerionBalancesApi implements IBalancesApi {
     }
 
     try {
-      await this._checkRateLimit();
+      await this.zerionRateLimiter.assertWithinBudget({
+        datasource: 'balances',
+      });
       const { key, field } = cacheDir;
       this.loggingService.debug({ type: LogType.CacheMiss, key, field });
       const url = `${this.baseUri}/v1/wallets/${args.safeAddress}/positions`;
@@ -202,7 +195,9 @@ export class ZerionBalancesApi implements IBalancesApi {
       return this._buildCollectiblesPage(data.links.next, data.data);
     }
     try {
-      await this._checkRateLimit();
+      await this.zerionRateLimiter.assertWithinBudget({
+        datasource: 'collectibles',
+      });
       const chainName = await this._getChainName(args.chain);
       const url = `${this.baseUri}/v1/wallets/${args.safeAddress}/nft-positions`;
       const pageAfter = this._encodeZerionPageOffset(args.offset);
@@ -492,15 +487,5 @@ export class ZerionBalancesApi implements IBalancesApi {
       );
     }
     return zerionUrl.toString();
-  }
-
-  private async _checkRateLimit(): Promise<void> {
-    const current = await this.cacheService.increment(
-      CacheRouter.getRateLimitCacheKey(
-        ZerionBalancesApi.RATE_LIMIT_CACHE_KEY_PREFIX,
-      ),
-      this.limitPeriodSeconds,
-    );
-    if (current > this.limitCalls) throw new LimitReachedError();
   }
 }

--- a/src/modules/balances/datasources/zerion-balances-api.service.ts
+++ b/src/modules/balances/datasources/zerion-balances-api.service.ts
@@ -226,7 +226,7 @@ export class ZerionBalancesApi implements IBalancesApi {
         zerionCollectibles.data,
       );
     } catch (error) {
-      if (error instanceof ZodError) {
+      if (error instanceof LimitReachedError || error instanceof ZodError) {
         throw error;
       }
       throw this.httpErrorFactory.from(error);

--- a/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.spec.ts
+++ b/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.spec.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { ZodError } from 'zod';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import type { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { ZerionWalletPortfolioApi } from '@/modules/balances/datasources/zerion-wallet-portfolio-api.service';
+import type { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
+
+const mockNetworkService = vi.mocked({
+  get: vi.fn(),
+} as MockedObject<INetworkService>);
+
+const mockCacheService = vi.mocked({
+  hGet: vi.fn(),
+  hSet: vi.fn(),
+} as MockedObject<ICacheService>);
+
+const mockLoggingService = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+const mockHttpErrorFactory = vi.mocked({
+  from: vi.fn(),
+} as MockedObject<HttpErrorFactory>);
+
+const mockZerionRateLimiter = vi.mocked({
+  assertWithinBudget: vi.fn(),
+} as unknown as MockedObject<ZerionRateLimiter>);
+
+const buildPortfolioResponse = (
+  byChain: Record<string, number>,
+): { data: unknown } => ({
+  data: {
+    type: 'portfolio',
+    id: faker.string.uuid(),
+    attributes: {
+      total: { positions: Object.values(byChain).reduce((a, b) => a + b, 0) },
+      positions_distribution_by_chain: byChain,
+    },
+  },
+});
+
+describe('ZerionWalletPortfolioApi', () => {
+  let service: ZerionWalletPortfolioApi;
+  let fakeConfigurationService: FakeConfigurationService;
+  const zerionApiKey = faker.string.sample();
+  const zerionBaseUri = faker.internet.url({ appendSlash: false });
+  const address = getAddress(faker.finance.ethereumAddress());
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'balances.providers.zerion.apiKey',
+      zerionApiKey,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.baseUri',
+      zerionBaseUri,
+    );
+
+    service = new ZerionWalletPortfolioApi(
+      fakeConfigurationService,
+      mockNetworkService,
+      mockHttpErrorFactory,
+      mockCacheService,
+      mockLoggingService,
+      mockZerionRateLimiter,
+    );
+  });
+
+  it('returns the cached portfolio without a network call or budget check', async () => {
+    const cached = buildPortfolioResponse({ ethereum: 100 });
+    mockCacheService.hGet.mockResolvedValue(JSON.stringify(cached));
+
+    const result = await service.getPortfolio({
+      address,
+      currency: 'usd',
+      isTestnet: false,
+    });
+
+    expect(
+      result.data.attributes.positions_distribution_by_chain.ethereum,
+    ).toBe(100);
+    expect(mockZerionRateLimiter.assertWithinBudget).not.toHaveBeenCalled();
+    expect(mockNetworkService.get).not.toHaveBeenCalled();
+  });
+
+  it('fetches, validates, and caches on a cache miss', async () => {
+    const response = buildPortfolioResponse({ ethereum: 42, polygon: 8 });
+    mockCacheService.hGet.mockResolvedValue(null);
+    mockNetworkService.get.mockResolvedValue({ data: response, status: 200 });
+
+    const result = await service.getPortfolio({
+      address,
+      currency: 'usd',
+      isTestnet: false,
+    });
+
+    expect(mockZerionRateLimiter.assertWithinBudget).toHaveBeenCalledWith({
+      datasource: 'wallet_portfolio',
+      address,
+    });
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${zerionBaseUri}/v1/wallets/${address}/portfolio`,
+      networkRequest: {
+        headers: { Authorization: `Basic ${zerionApiKey}` },
+        params: { currency: 'usd', 'filter[positions]': 'no_filter' },
+      },
+    });
+    expect(mockCacheService.hSet).toHaveBeenCalled();
+    expect(result.data.attributes.positions_distribution_by_chain).toEqual({
+      ethereum: 42,
+      polygon: 8,
+    });
+  });
+
+  it('does not hit the network when over budget (degrade upstream)', async () => {
+    mockCacheService.hGet.mockResolvedValue(null);
+    mockZerionRateLimiter.assertWithinBudget.mockRejectedValue(
+      new LimitReachedError(),
+    );
+
+    await expect(
+      service.getPortfolio({ address, currency: 'usd', isTestnet: false }),
+    ).rejects.toThrow(LimitReachedError);
+    expect(mockNetworkService.get).not.toHaveBeenCalled();
+    expect(mockCacheService.hSet).not.toHaveBeenCalled();
+  });
+
+  it('throws ZodError on a malformed fresh 200 (never cached)', async () => {
+    mockCacheService.hGet.mockResolvedValue(null);
+    mockNetworkService.get.mockResolvedValue({
+      data: { data: { type: 'portfolio' } },
+      status: 200,
+    });
+
+    await expect(
+      service.getPortfolio({ address, currency: 'usd', isTestnet: false }),
+    ).rejects.toThrow(ZodError);
+    expect(mockCacheService.hSet).not.toHaveBeenCalled();
+  });
+
+  it('sends the testnet header and trash filter for testnet + trusted', async () => {
+    mockCacheService.hGet.mockResolvedValue(null);
+    mockNetworkService.get.mockResolvedValue({
+      data: buildPortfolioResponse({ ethereum: 1 }),
+      status: 200,
+    });
+
+    await service.getPortfolio({
+      address,
+      currency: 'eur',
+      isTestnet: true,
+      trusted: true,
+    });
+
+    expect(mockNetworkService.get).toHaveBeenCalledWith({
+      url: `${zerionBaseUri}/v1/wallets/${address}/portfolio`,
+      networkRequest: {
+        headers: { Authorization: `Basic ${zerionApiKey}`, 'X-Env': 'testnet' },
+        params: {
+          currency: 'eur',
+          'filter[positions]': 'no_filter',
+          'filter[trash]': 'only_non_trash',
+        },
+      },
+    });
+  });
+
+  it('keys the cache distinctly by testnet and trusted', () => {
+    const mainnet = CacheRouter.getZerionWalletPortfolioCacheDir({
+      address,
+      fiatCode: 'usd',
+      isTestnet: false,
+    });
+    const testnet = CacheRouter.getZerionWalletPortfolioCacheDir({
+      address,
+      fiatCode: 'usd',
+      isTestnet: true,
+    });
+    const trusted = CacheRouter.getZerionWalletPortfolioCacheDir({
+      address,
+      fiatCode: 'usd',
+      trusted: true,
+    });
+
+    expect(mainnet.field).not.toBe(testnet.field);
+    expect(mainnet.field).not.toBe(trusted.field);
+  });
+});

--- a/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.ts
+++ b/src/modules/balances/datasources/zerion-wallet-portfolio-api.service.ts
@@ -23,6 +23,7 @@ import {
   ZerionWalletPortfolioSchema,
 } from '@/modules/balances/datasources/entities/zerion-wallet-portfolio.entity';
 import { getZerionHeaders } from '@/modules/balances/datasources/zerion-api.helpers';
+import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 
 export const IZerionWalletPortfolioApi = Symbol('IZerionWalletPortfolioApi');
 
@@ -59,6 +60,7 @@ export class ZerionWalletPortfolioApi implements IZerionWalletPortfolioApi {
     private readonly httpErrorFactory: HttpErrorFactory,
     @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    private readonly zerionRateLimiter: ZerionRateLimiter,
   ) {
     this.apiKey = this.configurationService.get<string>(
       'balances.providers.zerion.apiKey',
@@ -90,6 +92,14 @@ export class ZerionWalletPortfolioApi implements IZerionWalletPortfolioApi {
     }
 
     this.loggingService.debug({ type: LogType.CacheMiss, key, field });
+
+    // Enforce the shared cross-pod Zerion budget before the network call. Over
+    // budget throws LimitReachedError, which the overview service degrades into
+    // a fallback (it is never surfaced as a client-facing 429).
+    await this.zerionRateLimiter.assertWithinBudget({
+      datasource: 'wallet_portfolio',
+      address: args.address,
+    });
 
     const url = `${this.baseUri}/v1/wallets/${args.address}/portfolio`;
 

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
@@ -14,6 +14,7 @@ import { DataSourceError } from '@/domain/errors/data-source.error';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { ZerionPortfolioApi } from '@/modules/portfolio/datasources/zerion-portfolio-api.service';
 import type { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import type { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 
 describe('ZerionPortfolioApi', () => {
   let service: ZerionPortfolioApi;
@@ -52,6 +53,10 @@ describe('ZerionPortfolioApi', () => {
     getChainIdFromNetwork: vi.fn(),
   } as MockedObject<ZerionChainMappingService>);
 
+  const mockZerionRateLimiter = vi.mocked({
+    assertWithinBudget: vi.fn(),
+  } as unknown as MockedObject<ZerionRateLimiter>);
+
   beforeEach(() => {
     vi.resetAllMocks();
     fakeConfigurationService = new FakeConfigurationService();
@@ -75,6 +80,7 @@ describe('ZerionPortfolioApi', () => {
       mockLoggingService,
       mockCacheService,
       mockChainMappingService,
+      mockZerionRateLimiter,
     );
   });
 

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -35,6 +35,7 @@ import type { Portfolio } from '@/modules/portfolio/domain/entities/portfolio.en
 import type { TokenBalance } from '@/modules/portfolio/domain/entities/token-balance.entity';
 import { IPortfolioApi } from '@/modules/portfolio/interfaces/portfolio-api.interface';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 /**
@@ -69,6 +70,7 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     private readonly loggingService: ILoggingService,
     @Inject(CacheService) readonly _cacheService: ICacheService,
     private readonly zerionChainMappingService: ZerionChainMappingService,
+    private readonly zerionRateLimiter: ZerionRateLimiter,
   ) {
     this.apiKey = this.configurationService.get<string>(
       'balances.providers.zerion.apiKey',
@@ -114,6 +116,13 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     isTestnet?: boolean;
     sync?: boolean;
   }): Promise<Array<ZerionBalance>> {
+    // Enforce the shared Zerion budget before the network call. A
+    // LimitReachedError here propagates as a 429 (not logged as a request
+    // failure); the limiter already records the rate-limit event.
+    await this.zerionRateLimiter.assertWithinBudget({
+      datasource: 'portfolio',
+    });
+
     try {
       const url = `${this.baseUri}/v1/wallets/${args.address}/positions`;
       const params: Record<string, string> = {

--- a/src/modules/positions/datasources/zerion-positions-api.service.spec.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.spec.ts
@@ -19,7 +19,12 @@ import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.b
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import { ZerionPositionsApi } from '@/modules/positions/datasources/zerion-positions-api.service';
 import type { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import type { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { rawify } from '@/validation/entities/raw.entity';
+
+const mockZerionRateLimiter = vi.mocked({
+  assertWithinBudget: vi.fn(),
+} as unknown as MockedObject<ZerionRateLimiter>);
 
 const loggingService = {
   debug: vi.fn(),
@@ -121,6 +126,7 @@ describe('ZerionPositionsApi', () => {
         configurationService as IConfigurationService,
         new HttpErrorFactory(),
         zerionChainMappingService,
+        mockZerionRateLimiter,
       );
     });
 
@@ -266,6 +272,7 @@ describe('ZerionPositionsApi', () => {
         fakeConfigurationService,
         mockHttpErrorFactory,
         mockChainMappingService,
+        mockZerionRateLimiter,
       );
     });
 

--- a/src/modules/positions/datasources/zerion-positions-api.service.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.ts
@@ -41,6 +41,7 @@ import type {
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import type { Position } from '@/modules/positions/domain/entities/position.entity';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 @Injectable()
@@ -58,6 +59,7 @@ export class ZerionPositionsApi implements IPositionsApi {
     private readonly configurationService: IConfigurationService,
     private readonly httpErrorFactory: HttpErrorFactory,
     private readonly zerionChainMappingService: ZerionChainMappingService,
+    private readonly zerionRateLimiter: ZerionRateLimiter,
   ) {
     this.apiKey = this.configurationService.get<string>(
       'balances.providers.zerion.apiKey',
@@ -104,6 +106,9 @@ export class ZerionPositionsApi implements IPositionsApi {
     }
 
     try {
+      await this.zerionRateLimiter.assertWithinBudget({
+        datasource: 'positions',
+      });
       const { key, field } = cacheDir;
       this.loggingService.debug({
         type: LogType.CacheMiss,

--- a/src/modules/safe/routes/v2/__tests__/safes.v2.controller.overview.integration.spec.ts
+++ b/src/modules/safe/routes/v2/__tests__/safes.v2.controller.overview.integration.spec.ts
@@ -309,6 +309,97 @@ describe('Safes V2 Controller Overview', () => {
       );
     });
 
+    it('fetches the wallet portfolio once for a Safe on multiple Zerion chains', async () => {
+      const polygonChain = chainBuilder()
+        .with('chainId', '137')
+        .with('isTestnet', false)
+        .with('balancesProvider', { chainName: 'polygon', enabled: true })
+        .with('features', ['PORTFOLIO_ENDPOINT'])
+        .build();
+      const ethereumChain = chainBuilder()
+        .with('chainId', '1')
+        .with('isTestnet', false)
+        .with('balancesProvider', { chainName: 'ethereum', enabled: true })
+        .with('features', ['PORTFOLIO_ENDPOINT'])
+        .build();
+      const safeInfo = safeBuilder().build();
+
+      const zerionPortfolioResponse = {
+        data: {
+          type: 'portfolio',
+          id: safeInfo.address,
+          attributes: {
+            total: { positions: 7500.0 },
+            positions_distribution_by_chain: {
+              ethereum: 5000.0,
+              polygon: 2500.0,
+            },
+          },
+        },
+      };
+      const queuedTransactions = pageBuilder()
+        .with('results', [])
+        .with('count', 0)
+        .build();
+
+      let portfolioCallCount = 0;
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${polygonChain.chainId}`:
+          case `${safeConfigUrl}/api/v2/chains/CGW/${polygonChain.chainId}`: {
+            return Promise.resolve({ data: rawify(polygonChain), status: 200 });
+          }
+          case `${safeConfigUrl}/api/v1/chains/${ethereumChain.chainId}`:
+          case `${safeConfigUrl}/api/v2/chains/CGW/${ethereumChain.chainId}`: {
+            return Promise.resolve({
+              data: rawify(ethereumChain),
+              status: 200,
+            });
+          }
+          case `${polygonChain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          case `${ethereumChain.transactionService}/api/v1/safes/${safeInfo.address}`: {
+            return Promise.resolve({ data: rawify(safeInfo), status: 200 });
+          }
+          case `${zerionBaseUri}/v1/wallets/${safeInfo.address}/portfolio`: {
+            portfolioCallCount += 1;
+            return Promise.resolve({
+              data: rawify(zerionPortfolioResponse),
+              status: 200,
+            });
+          }
+          case `${polygonChain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`:
+          case `${ethereumChain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`: {
+            return Promise.resolve({
+              data: rawify(queuedTransactions),
+              status: 200,
+            });
+          }
+          default: {
+            return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v2/safes?currency=USD&safes=137:${safeInfo.address},1:${safeInfo.address}`,
+        )
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toHaveLength(2);
+          expect(
+            body.find((o: { chainId: string }) => o.chainId === '137')
+              ?.fiatTotal,
+          ).toBe('2500');
+          expect(
+            body.find((o: { chainId: string }) => o.chainId === '1')?.fiatTotal,
+          ).toBe('5000');
+        });
+
+      // The portfolio is per-wallet: one identity ⇒ exactly one network fetch.
+      expect(portfolioCallCount).toBe(1);
+    });
+
     it('should use Safe balances API when zerionBalancesEnabled is false, even for chains with Zerion chain name', async () => {
       const moduleFixture = await createTestModule({
         config: () => ({

--- a/src/modules/safe/routes/v2/safes.v2.service.spec.ts
+++ b/src/modules/safe/routes/v2/safes.v2.service.spec.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import type { ILoggingService } from '@/logging/logging.interface';
+import type { ZerionWalletPortfolio } from '@/modules/balances/datasources/entities/zerion-wallet-portfolio.entity';
+import type { IZerionWalletPortfolioApi } from '@/modules/balances/datasources/zerion-wallet-portfolio-api.service';
+import type { IBalancesRepository } from '@/modules/balances/domain/balances.repository.interface';
+import { balanceBuilder } from '@/modules/balances/domain/entities/__tests__/balance.builder';
+import type { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
+import { balancesProviderBuilder } from '@/modules/chains/domain/entities/__tests__/balances-provider.builder';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
+import type { IFeatureFlagService } from '@/modules/chains/feature-flags/feature-flag.service.interface';
+import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
+import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+import { SafesV2Service } from '@/modules/safe/routes/v2/safes.v2.service';
+
+const mockSafeRepository = vi.mocked({
+  getSafe: vi.fn(),
+  getTransactionQueue: vi.fn(),
+} as unknown as MockedObject<ISafeRepository>);
+
+const mockChainsRepository = vi.mocked({
+  getChain: vi.fn(),
+} as unknown as MockedObject<IChainsRepository>);
+
+const mockBalancesRepository = vi.mocked({
+  getBalances: vi.fn(),
+} as unknown as MockedObject<IBalancesRepository>);
+
+const mockZerionWalletPortfolioApi = vi.mocked({
+  getPortfolio: vi.fn(),
+} as unknown as MockedObject<IZerionWalletPortfolioApi>);
+
+const mockLoggingService = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+const mockFeatureFlagService = vi.mocked({
+  isFeatureEnabled: vi.fn(),
+} as MockedObject<IFeatureFlagService>);
+
+const buildZerionChain = (
+  chainId: string,
+  chainName: string,
+  isTestnet = false,
+): Chain =>
+  chainBuilder()
+    .with('chainId', chainId)
+    .with('isTestnet', isTestnet)
+    .with(
+      'balancesProvider',
+      balancesProviderBuilder().with('chainName', chainName).build(),
+    )
+    .build();
+
+const buildPortfolio = (
+  byChain: Record<string, number>,
+): ZerionWalletPortfolio => ({
+  data: {
+    type: 'portfolio',
+    id: faker.string.uuid(),
+    attributes: {
+      total: { positions: Object.values(byChain).reduce((a, b) => a + b, 0) },
+      positions_distribution_by_chain: byChain,
+    },
+  },
+});
+
+describe('SafesV2Service', () => {
+  let service: SafesV2Service;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    const fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set('mappings.safe.maxOverviews', 10);
+    fakeConfigurationService.set('features.zerionBalancesEnabled', true);
+
+    service = new SafesV2Service(
+      mockSafeRepository,
+      mockChainsRepository,
+      mockBalancesRepository,
+      mockZerionWalletPortfolioApi,
+      fakeConfigurationService,
+      mockLoggingService,
+      mockFeatureFlagService,
+    );
+
+    mockSafeRepository.getSafe.mockImplementation(({ address }) =>
+      Promise.resolve(safeBuilder().with('address', address).build()),
+    );
+    mockSafeRepository.getTransactionQueue.mockResolvedValue({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+    mockFeatureFlagService.isFeatureEnabled.mockResolvedValue(true);
+  });
+
+  it('fetches one portfolio for a multi-chain wallet and maps distinct per-chain values', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    const chains: Record<string, Chain> = {
+      '1': buildZerionChain('1', 'ethereum'),
+      '137': buildZerionChain('137', 'polygon'),
+    };
+    mockChainsRepository.getChain.mockImplementation((chainId: string) =>
+      Promise.resolve(chains[chainId]),
+    );
+    mockZerionWalletPortfolioApi.getPortfolio.mockResolvedValue(
+      buildPortfolio({ ethereum: 100, polygon: 50 }),
+    );
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [
+        { chainId: '1', address },
+        { chainId: '137', address },
+      ],
+      trusted: false,
+    });
+
+    expect(mockZerionWalletPortfolioApi.getPortfolio).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(2);
+    expect(result.find((o) => o.chainId === '1')?.fiatTotal).toBe('100');
+    expect(result.find((o) => o.chainId === '137')?.fiatTotal).toBe('50');
+    expect(mockBalancesRepository.getBalances).not.toHaveBeenCalled();
+  });
+
+  it('fetches two portfolios for the same address across mainnet and testnet', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    const chains: Record<string, Chain> = {
+      '1': buildZerionChain('1', 'ethereum', false),
+      '11155111': buildZerionChain('11155111', 'sepolia', true),
+    };
+    mockChainsRepository.getChain.mockImplementation((chainId: string) =>
+      Promise.resolve(chains[chainId]),
+    );
+    mockZerionWalletPortfolioApi.getPortfolio.mockResolvedValue(
+      buildPortfolio({ ethereum: 10, sepolia: 5 }),
+    );
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [
+        { chainId: '1', address },
+        { chainId: '11155111', address },
+      ],
+      trusted: false,
+    });
+
+    expect(mockZerionWalletPortfolioApi.getPortfolio).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('uses the portfolio for enabled chains and the balances repo for disabled ones, deduping getChain', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    const enabled = buildZerionChain('1', 'ethereum');
+    const disabled = chainBuilder()
+      .with('chainId', '10')
+      .with('isTestnet', false)
+      .with('balancesProvider', { chainName: null, enabled: false })
+      .build();
+    const chains: Record<string, Chain> = { '1': enabled, '10': disabled };
+    mockChainsRepository.getChain.mockImplementation((chainId: string) =>
+      Promise.resolve(chains[chainId]),
+    );
+    mockZerionWalletPortfolioApi.getPortfolio.mockResolvedValue(
+      buildPortfolio({ ethereum: 100 }),
+    );
+    mockBalancesRepository.getBalances.mockResolvedValue([
+      balanceBuilder().with('fiatBalance', '7').build(),
+    ]);
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [
+        { chainId: '1', address },
+        { chainId: '1', address: getAddress(faker.finance.ethereumAddress()) },
+        { chainId: '10', address },
+      ],
+      trusted: false,
+    });
+
+    // getChain called once per unique chainId (1 and 10), not per entry.
+    expect(mockChainsRepository.getChain).toHaveBeenCalledTimes(2);
+    expect(mockBalancesRepository.getBalances).toHaveBeenCalledTimes(1);
+    expect(result.find((o) => o.chainId === '10')?.fiatTotal).toBe('7');
+    expect(result).toHaveLength(3);
+  });
+
+  it('degrades a failed portfolio to the balances repo without dropping the Safe or fabricating $0', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    mockChainsRepository.getChain.mockResolvedValue(
+      buildZerionChain('1', 'ethereum'),
+    );
+    mockZerionWalletPortfolioApi.getPortfolio.mockRejectedValue(
+      new Error('429 Too Many Requests'),
+    );
+    mockBalancesRepository.getBalances.mockResolvedValue([
+      balanceBuilder().with('fiatBalance', '42').build(),
+      balanceBuilder().with('fiatBalance', '8').build(),
+    ]);
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [{ chainId: '1', address }],
+      trusted: false,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].fiatTotal).toBe('50');
+    expect(mockBalancesRepository.getBalances).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the Safe (never $0) when both the portfolio and the balances repo fail', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    mockChainsRepository.getChain.mockResolvedValue(
+      buildZerionChain('1', 'ethereum'),
+    );
+    mockZerionWalletPortfolioApi.getPortfolio.mockRejectedValue(
+      new Error('429'),
+    );
+    mockBalancesRepository.getBalances.mockRejectedValue(
+      new Error('balances upstream down'),
+    );
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [{ chainId: '1', address }],
+      trusted: false,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('falls back to the balances repo (not $0) for a chain with a null balancesProvider chainName even when the flag is on', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    mockChainsRepository.getChain.mockResolvedValue(
+      chainBuilder()
+        .with('chainId', '1')
+        .with('isTestnet', false)
+        .with('balancesProvider', { chainName: null, enabled: true })
+        .build(),
+    );
+    mockBalancesRepository.getBalances.mockResolvedValue([
+      balanceBuilder().with('fiatBalance', '15').build(),
+    ]);
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [{ chainId: '1', address }],
+      trusted: false,
+    });
+
+    expect(mockZerionWalletPortfolioApi.getPortfolio).not.toHaveBeenCalled();
+    expect(result[0].fiatTotal).toBe('15');
+  });
+
+  it('ignores non-finite token balances in the fallback reducer', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    mockChainsRepository.getChain.mockResolvedValue(
+      chainBuilder()
+        .with('chainId', '1')
+        .with('balancesProvider', { chainName: null, enabled: true })
+        .build(),
+    );
+    mockBalancesRepository.getBalances.mockResolvedValue([
+      balanceBuilder().with('fiatBalance', '20').build(),
+      balanceBuilder().with('fiatBalance', 'not-a-number').build(),
+    ]);
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [{ chainId: '1', address }],
+      trusted: false,
+    });
+
+    expect(result[0].fiatTotal).toBe('20');
+  });
+
+  it('returns a real $0 for an enabled chain absent from the portfolio distribution', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    mockChainsRepository.getChain.mockResolvedValue(
+      buildZerionChain('1', 'ethereum'),
+    );
+    // Wallet holds nothing on ethereum — chain key absent from distribution.
+    mockZerionWalletPortfolioApi.getPortfolio.mockResolvedValue(
+      buildPortfolio({ polygon: 30 }),
+    );
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [{ chainId: '1', address }],
+      trusted: false,
+    });
+
+    expect(result[0].fiatTotal).toBe('0');
+    expect(mockBalancesRepository.getBalances).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/safe/routes/v2/safes.v2.service.spec.ts
+++ b/src/modules/safe/routes/v2/safes.v2.service.spec.ts
@@ -219,6 +219,25 @@ describe('SafesV2Service', () => {
     expect(mockBalancesRepository.getBalances).toHaveBeenCalledTimes(1);
   });
 
+  it('does not fetch the portfolio for a non-Safe address and drops the entry', async () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+    mockChainsRepository.getChain.mockResolvedValue(
+      buildZerionChain('1', 'ethereum'),
+    );
+    // Address is not a Safe — getSafe rejects.
+    mockSafeRepository.getSafe.mockRejectedValue(new Error('Not a Safe'));
+
+    const result = await service.getSafeOverview({
+      currency: 'USD',
+      addresses: [{ chainId: '1', address }],
+      trusted: false,
+    });
+
+    expect(result).toHaveLength(0);
+    // The Safe is validated first, so no Zerion budget is spent on a non-Safe.
+    expect(mockZerionWalletPortfolioApi.getPortfolio).not.toHaveBeenCalled();
+  });
+
   it('drops the Safe (never $0) when both the portfolio and the balances repo fail', async () => {
     const address = getAddress(faker.finance.ethereumAddress());
     mockChainsRepository.getChain.mockResolvedValue(

--- a/src/modules/safe/routes/v2/safes.v2.service.ts
+++ b/src/modules/safe/routes/v2/safes.v2.service.ts
@@ -25,15 +25,6 @@ import { SafeOverview } from '@/modules/safe/routes/entities/safe-overview.entit
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 /**
- * Outcome of fetching one wallet-identity's Zerion portfolio: either the parsed
- * portfolio, or a `degraded` marker meaning the balance must come from the
- * fallback path (never a fabricated `$0`).
- */
-type PortfolioResult =
-  | { status: 'ok'; portfolio: ZerionWalletPortfolio }
-  | { status: 'degraded' };
-
-/**
  * A (chainId, address) entry whose chain and Safe have been resolved up front,
  * so the balance fetch can run without re-validating or risking a wasted
  * external call for a non-Safe address.
@@ -187,19 +178,20 @@ export class SafesV2Service {
     limitedSafes: Caip10Addresses,
   ): Promise<Map<string, Chain | null>> {
     const uniqueChainIds = [...new Set(limitedSafes.map((s) => s.chainId))];
-    const entries = await Promise.all(
-      uniqueChainIds.map(async (chainId): Promise<[string, Chain | null]> => {
-        try {
-          return [chainId, await this.chainsRepository.getChain(chainId)];
-        } catch (error) {
-          this.loggingService.warn(
-            `Error while getting chain ${chainId}: ${asError(error)} `,
-          );
-          return [chainId, null];
-        }
-      }),
+    return new Map(
+      await Promise.all(
+        uniqueChainIds.map(async (chainId): Promise<[string, Chain | null]> => {
+          try {
+            return [chainId, await this.chainsRepository.getChain(chainId)];
+          } catch (error) {
+            this.loggingService.warn(
+              `Error while getting chain ${chainId}: ${asError(error)} `,
+            );
+            return [chainId, null];
+          }
+        }),
+      ),
     );
-    return new Map(entries);
   }
 
   /**
@@ -210,37 +202,38 @@ export class SafesV2Service {
   private async resolveZerionEligibility(
     chainsById: Map<string, Chain | null>,
   ): Promise<Map<string, boolean>> {
-    const entries = await Promise.all(
-      [...chainsById.entries()].map(
-        async ([chainId, chain]): Promise<[string, boolean]> => {
-          if (
-            !(
-              this.zerionBalancesEnabled &&
-              chain &&
-              this.getZerionChainName(chain)
-            )
-          ) {
-            return [chainId, false];
-          }
-          return [chainId, await this.isPortfolioEndpointFeatureEnabled(chain)];
-        },
+    if (!this.zerionBalancesEnabled) {
+      return new Map();
+    }
+    return new Map(
+      await Promise.all(
+        [...chainsById.entries()].map(
+          async ([chainId, chain]): Promise<[string, boolean]> => {
+            if (!(chain && this.getZerionChainName(chain))) {
+              return [chainId, false];
+            }
+            return [
+              chainId,
+              await this.isPortfolioEndpointFeatureEnabled(chain),
+            ];
+          },
+        ),
       ),
     );
-    return new Map(entries);
   }
 
   /**
    * Fetches one portfolio per unique wallet-identity (address, isTestnet,
    * currency, trusted) among the Zerion-enabled entries. A failed fetch is
-   * captured as `degraded` for that identity so every Safe on that wallet
-   * degrades together rather than rejecting.
+   * omitted from the map (and logged), so every Safe on that wallet degrades
+   * together via the fallback rather than rejecting.
    */
   private async fetchPortfoliosOncePerIdentity(args: {
     entries: Array<ResolvedEntry>;
     zerionEnabledById: Map<string, boolean>;
     currency: string;
     trusted: boolean;
-  }): Promise<Map<string, PortfolioResult>> {
+  }): Promise<Map<string, ZerionWalletPortfolio>> {
     const { entries, zerionEnabledById, currency, trusted } = args;
 
     const identities = new Map<
@@ -261,7 +254,7 @@ export class SafesV2Service {
       }
     }
 
-    const results = new Map<string, PortfolioResult>();
+    const results = new Map<string, ZerionWalletPortfolio>();
     await Promise.all(
       [...identities.entries()].map(async ([key, { address, isTestnet }]) => {
         try {
@@ -271,10 +264,9 @@ export class SafesV2Service {
             isTestnet,
             trusted,
           });
-          results.set(key, { status: 'ok', portfolio });
+          results.set(key, portfolio);
         } catch (error) {
           this.logPortfolioFetchError({ address, error });
-          results.set(key, { status: 'degraded' });
         }
       }),
     );
@@ -356,7 +348,7 @@ export class SafesV2Service {
     currency: string;
     trusted: boolean;
     zerionEnabled: boolean;
-    portfoliosByIdentity: Map<string, PortfolioResult>;
+    portfoliosByIdentity: Map<string, ZerionWalletPortfolio>;
   }): Promise<number> {
     const { chain, safeAddress, currency, trusted, zerionEnabled } = args;
 
@@ -375,14 +367,13 @@ export class SafesV2Service {
       currency,
       trusted,
     });
-    const result = args.portfoliosByIdentity.get(key);
+    const portfolio = args.portfoliosByIdentity.get(key);
 
-    if (result?.status === 'ok') {
-      const value = this.extractChainFiatBalance(result.portfolio, chain);
+    if (portfolio) {
+      const value = this.extractChainFiatBalance(portfolio, chain);
       if (value !== null) {
         return value;
       }
-      // Chain has no usable Zerion mapping despite the gate — degrade honestly.
     }
 
     return await this.serveDegradedBalance({

--- a/src/modules/safe/routes/v2/safes.v2.service.ts
+++ b/src/modules/safe/routes/v2/safes.v2.service.ts
@@ -18,6 +18,7 @@ import { IChainsRepository } from '@/modules/chains/domain/chains.repository.int
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import { IFeatureFlagService } from '@/modules/chains/feature-flags/feature-flag.service.interface';
 import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
 import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 import type { Caip10Addresses } from '@/modules/safe/routes/entities/caip-10-addresses.entity';
 import { SafeOverview } from '@/modules/safe/routes/entities/safe-overview.entity';
@@ -31,6 +32,18 @@ import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 type PortfolioResult =
   | { status: 'ok'; portfolio: ZerionWalletPortfolio }
   | { status: 'degraded' };
+
+/**
+ * A (chainId, address) entry whose chain and Safe have been resolved up front,
+ * so the balance fetch can run without re-validating or risking a wasted
+ * external call for a non-Safe address.
+ */
+type ResolvedEntry = {
+  chainId: string;
+  address: Address;
+  chain: Chain;
+  safe: Safe;
+};
 
 @Injectable()
 export class SafesV2Service {
@@ -67,28 +80,25 @@ export class SafesV2Service {
   }): Promise<Array<SafeOverview>> {
     const limitedSafes = args.addresses.slice(0, this.maxOverviews);
 
-    // The Zerion portfolio is per-wallet and contains every chain, so fetch it
-    // once per wallet-identity instead of once per (chainId, address). The
-    // per-chain work below (chain, Safe, queue) stays per entry.
     const chainsById = await this.resolveChains(limitedSafes);
     const zerionEnabledById = await this.resolveZerionEligibility(chainsById);
+
+    // Validate each Safe before any external balance fetch, so a non-Safe or
+    // stale address never spends a Zerion call or consumes the shared budget.
+    const resolvedEntries = await this.resolveSafes(limitedSafes, chainsById);
+
+    // The Zerion portfolio is per-wallet and contains every chain, so fetch it
+    // once per wallet-identity (among validated, Zerion-enabled entries)
+    // instead of once per (chainId, address).
     const portfoliosByIdentity = await this.fetchPortfoliosOncePerIdentity({
-      limitedSafes,
-      chainsById,
+      entries: resolvedEntries,
       zerionEnabledById,
       currency: args.currency,
       trusted: args.trusted,
     });
 
     const settledOverviews = await Promise.allSettled(
-      limitedSafes.map(async ({ chainId, address }) => {
-        const chain = chainsById.get(chainId);
-        if (!chain) {
-          throw new Error(`Chain ${chainId} could not be resolved`);
-        }
-
-        const safe = await this.safeRepository.getSafe({ chainId, address });
-
+      resolvedEntries.map(async ({ chainId, address, chain, safe }) => {
         const [fiatBalance, queue] = await Promise.all([
           this.resolveFiatBalance({
             chain,
@@ -133,6 +143,39 @@ export class SafesV2Service {
     }
 
     return safeOverviews;
+  }
+
+  /**
+   * Resolves and validates the Safe for each entry up front. Entries whose
+   * chain or Safe cannot be resolved are logged and dropped here — before any
+   * Zerion call — so a non-Safe address never consumes the shared budget.
+   */
+  private async resolveSafes(
+    limitedSafes: Caip10Addresses,
+    chainsById: Map<string, Chain | null>,
+  ): Promise<Array<ResolvedEntry>> {
+    const settled = await Promise.allSettled(
+      limitedSafes.map(async ({ chainId, address }): Promise<ResolvedEntry> => {
+        const chain = chainsById.get(chainId);
+        if (!chain) {
+          throw new Error(`Chain ${chainId} could not be resolved`);
+        }
+        const safe = await this.safeRepository.getSafe({ chainId, address });
+        return { chainId, address, chain, safe };
+      }),
+    );
+
+    const resolved: Array<ResolvedEntry> = [];
+    for (const entry of settled) {
+      if (entry.status === 'rejected') {
+        this.loggingService.warn(
+          `Error while getting Safe overview: ${asError(entry.reason)} `,
+        );
+      } else {
+        resolved.push(entry.value);
+      }
+    }
+    return resolved;
   }
 
   /**
@@ -193,22 +236,19 @@ export class SafesV2Service {
    * degrades together rather than rejecting.
    */
   private async fetchPortfoliosOncePerIdentity(args: {
-    limitedSafes: Caip10Addresses;
-    chainsById: Map<string, Chain | null>;
+    entries: Array<ResolvedEntry>;
     zerionEnabledById: Map<string, boolean>;
     currency: string;
     trusted: boolean;
   }): Promise<Map<string, PortfolioResult>> {
-    const { limitedSafes, chainsById, zerionEnabledById, currency, trusted } =
-      args;
+    const { entries, zerionEnabledById, currency, trusted } = args;
 
     const identities = new Map<
       string,
       { address: Address; isTestnet: boolean }
     >();
-    for (const { chainId, address } of limitedSafes) {
-      const chain = chainsById.get(chainId);
-      if (chain && zerionEnabledById.get(chainId)) {
+    for (const { chainId, address, chain } of entries) {
+      if (zerionEnabledById.get(chainId)) {
         const key = this.getPortfolioIdentityKey({
           address,
           isTestnet: chain.isTestnet,

--- a/src/modules/safe/routes/v2/safes.v2.service.ts
+++ b/src/modules/safe/routes/v2/safes.v2.service.ts
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import type { Address } from 'viem';
+import { ZodError } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
+import { LogType } from '@/domain/common/entities/log-type.entity';
 import { getNumberString } from '@/domain/common/utils/utils';
 import {
   type ILoggingService,
   LoggingService,
 } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
+import type { ZerionWalletPortfolio } from '@/modules/balances/datasources/entities/zerion-wallet-portfolio.entity';
 import { IZerionWalletPortfolioApi } from '@/modules/balances/datasources/zerion-wallet-portfolio-api.service';
 import { IBalancesRepository } from '@/modules/balances/domain/balances.repository.interface';
 import { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
@@ -18,6 +22,15 @@ import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface
 import type { Caip10Addresses } from '@/modules/safe/routes/entities/caip-10-addresses.entity';
 import { SafeOverview } from '@/modules/safe/routes/entities/safe-overview.entity';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+
+/**
+ * Outcome of fetching one wallet-identity's Zerion portfolio: either the parsed
+ * portfolio, or a `degraded` marker meaning the balance must come from the
+ * fallback path (never a fabricated `$0`).
+ */
+type PortfolioResult =
+  | { status: 'ok'; portfolio: ZerionWalletPortfolio }
+  | { status: 'degraded' };
 
 @Injectable()
 export class SafesV2Service {
@@ -54,26 +67,38 @@ export class SafesV2Service {
   }): Promise<Array<SafeOverview>> {
     const limitedSafes = args.addresses.slice(0, this.maxOverviews);
 
+    // The Zerion portfolio is per-wallet and contains every chain, so fetch it
+    // once per wallet-identity instead of once per (chainId, address). The
+    // per-chain work below (chain, Safe, queue) stays per entry.
+    const chainsById = await this.resolveChains(limitedSafes);
+    const zerionEnabledById = await this.resolveZerionEligibility(chainsById);
+    const portfoliosByIdentity = await this.fetchPortfoliosOncePerIdentity({
+      limitedSafes,
+      chainsById,
+      zerionEnabledById,
+      currency: args.currency,
+      trusted: args.trusted,
+    });
+
     const settledOverviews = await Promise.allSettled(
       limitedSafes.map(async ({ chainId, address }) => {
-        const chain = await this.chainsRepository.getChain(chainId);
+        const chain = chainsById.get(chainId);
+        if (!chain) {
+          throw new Error(`Chain ${chainId} could not be resolved`);
+        }
 
-        const safe = await this.safeRepository.getSafe({
-          chainId,
-          address,
-        });
+        const safe = await this.safeRepository.getSafe({ chainId, address });
 
         const [fiatBalance, queue] = await Promise.all([
-          this.getFiatBalance({
+          this.resolveFiatBalance({
             chain,
             safeAddress: address,
             currency: args.currency,
             trusted: args.trusted,
+            zerionEnabled: zerionEnabledById.get(chainId) ?? false,
+            portfoliosByIdentity,
           }),
-          this.safeRepository.getTransactionQueue({
-            chainId,
-            safe,
-          }),
+          this.safeRepository.getTransactionQueue({ chainId, safe }),
         ]);
 
         const awaitingConfirmation = args.walletAddress
@@ -110,6 +135,158 @@ export class SafesV2Service {
     return safeOverviews;
   }
 
+  /**
+   * Resolves each unique chainId once (today the chain is fetched per entry).
+   * A chain that fails to resolve maps to null; its Safes are dropped during
+   * the per-entry build (as today), not the whole batch.
+   */
+  private async resolveChains(
+    limitedSafes: Caip10Addresses,
+  ): Promise<Map<string, Chain | null>> {
+    const uniqueChainIds = [...new Set(limitedSafes.map((s) => s.chainId))];
+    const entries = await Promise.all(
+      uniqueChainIds.map(async (chainId): Promise<[string, Chain | null]> => {
+        try {
+          return [chainId, await this.chainsRepository.getChain(chainId)];
+        } catch (error) {
+          this.loggingService.warn(
+            `Error while getting chain ${chainId}: ${asError(error)} `,
+          );
+          return [chainId, null];
+        }
+      }),
+    );
+    return new Map(entries);
+  }
+
+  /**
+   * Determines, per unique chainId, whether the Zerion wallet-portfolio path is
+   * active: Zerion enabled globally, a Zerion chain name exists, and the
+   * PORTFOLIO_ENDPOINT feature flag is on for that chain.
+   */
+  private async resolveZerionEligibility(
+    chainsById: Map<string, Chain | null>,
+  ): Promise<Map<string, boolean>> {
+    const entries = await Promise.all(
+      [...chainsById.entries()].map(
+        async ([chainId, chain]): Promise<[string, boolean]> => {
+          if (
+            !(
+              this.zerionBalancesEnabled &&
+              chain &&
+              this.getZerionChainName(chain)
+            )
+          ) {
+            return [chainId, false];
+          }
+          return [chainId, await this.isPortfolioEndpointFeatureEnabled(chain)];
+        },
+      ),
+    );
+    return new Map(entries);
+  }
+
+  /**
+   * Fetches one portfolio per unique wallet-identity (address, isTestnet,
+   * currency, trusted) among the Zerion-enabled entries. A failed fetch is
+   * captured as `degraded` for that identity so every Safe on that wallet
+   * degrades together rather than rejecting.
+   */
+  private async fetchPortfoliosOncePerIdentity(args: {
+    limitedSafes: Caip10Addresses;
+    chainsById: Map<string, Chain | null>;
+    zerionEnabledById: Map<string, boolean>;
+    currency: string;
+    trusted: boolean;
+  }): Promise<Map<string, PortfolioResult>> {
+    const { limitedSafes, chainsById, zerionEnabledById, currency, trusted } =
+      args;
+
+    const identities = new Map<
+      string,
+      { address: Address; isTestnet: boolean }
+    >();
+    for (const { chainId, address } of limitedSafes) {
+      const chain = chainsById.get(chainId);
+      if (chain && zerionEnabledById.get(chainId)) {
+        const key = this.getPortfolioIdentityKey({
+          address,
+          isTestnet: chain.isTestnet,
+          currency,
+          trusted,
+        });
+        if (!identities.has(key)) {
+          identities.set(key, { address, isTestnet: chain.isTestnet });
+        }
+      }
+    }
+
+    const results = new Map<string, PortfolioResult>();
+    await Promise.all(
+      [...identities.entries()].map(async ([key, { address, isTestnet }]) => {
+        try {
+          const portfolio = await this.zerionWalletPortfolioApi.getPortfolio({
+            address,
+            currency,
+            isTestnet,
+            trusted,
+          });
+          results.set(key, { status: 'ok', portfolio });
+        } catch (error) {
+          this.logPortfolioFetchError({ address, error });
+          results.set(key, { status: 'degraded' });
+        }
+      }),
+    );
+    return results;
+  }
+
+  private getPortfolioIdentityKey(args: {
+    address: Address;
+    isTestnet: boolean;
+    currency: string;
+    trusted: boolean;
+  }): string {
+    return `${args.address}_${args.isTestnet}_${args.currency}_${args.trusted}`;
+  }
+
+  /**
+   * Logs a portfolio fetch failure by type. Schema drift is an error (a
+   * contract break to investigate); rate limiting is expected degradation (the
+   * limiter already records it); everything else is a warning. In all cases the
+   * wallet degrades to the balances-repository path — it is never dropped here.
+   */
+  private logPortfolioFetchError(args: {
+    address: Address;
+    error: unknown;
+  }): void {
+    const { address, error } = args;
+    if (error instanceof ZodError) {
+      this.loggingService.error({
+        type: LogType.PortfolioRequestError,
+        source: 'SafesV2Service',
+        event: 'Portfolio schema drift',
+        safeAddress: address,
+        detail: error.message,
+      });
+    } else if (error instanceof LimitReachedError) {
+      this.loggingService.debug({
+        type: LogType.PortfolioRequestError,
+        source: 'SafesV2Service',
+        event: 'Portfolio over budget',
+        safeAddress: address,
+      });
+    } else {
+      this.loggingService.warn({
+        type: LogType.PortfolioRequestError,
+        source: 'SafesV2Service',
+        event: 'Portfolio request failed',
+        safeAddress: address,
+        detail: asError(error).message,
+      });
+    }
+  }
+
   private async isPortfolioEndpointFeatureEnabled(
     chain: Chain,
   ): Promise<boolean> {
@@ -128,23 +305,23 @@ export class SafesV2Service {
   }
 
   /**
-   * Gets fiat balance using Zerion wallet portfolio API for enabled chains,
-   * falling back to balances repository for other chains.
+   * Resolves the fiat balance for one (chain, Safe). Zerion-enabled chains read
+   * the per-chain slice of the wallet's portfolio; a degraded portfolio (or an
+   * unmappable chain) falls back to the balances repository. Never returns a
+   * fabricated `$0` for an unknown balance.
    */
-  private async getFiatBalance(args: {
+  private async resolveFiatBalance(args: {
     chain: Chain;
     safeAddress: Address;
     currency: string;
     trusted: boolean;
+    zerionEnabled: boolean;
+    portfoliosByIdentity: Map<string, PortfolioResult>;
   }): Promise<number> {
-    const { chain, safeAddress, currency, trusted } = args;
+    const { chain, safeAddress, currency, trusted, zerionEnabled } = args;
 
-    if (
-      this.zerionBalancesEnabled &&
-      this.getZerionChainName(chain) &&
-      (await this.isPortfolioEndpointFeatureEnabled(chain))
-    ) {
-      return this.getFiatBalanceFromZerionPortfolio({
+    if (!zerionEnabled) {
+      return await this.getFiatBalanceFromBalancesRepository({
         chain,
         safeAddress,
         currency,
@@ -152,8 +329,23 @@ export class SafesV2Service {
       });
     }
 
-    // Fall back to v1 logic using balances repository
-    return this.getFiatBalanceFromBalancesRepository({
+    const key = this.getPortfolioIdentityKey({
+      address: safeAddress,
+      isTestnet: chain.isTestnet,
+      currency,
+      trusted,
+    });
+    const result = args.portfoliosByIdentity.get(key);
+
+    if (result?.status === 'ok') {
+      const value = this.extractChainFiatBalance(result.portfolio, chain);
+      if (value !== null) {
+        return value;
+      }
+      // Chain has no usable Zerion mapping despite the gate — degrade honestly.
+    }
+
+    return await this.serveDegradedBalance({
       chain,
       safeAddress,
       currency,
@@ -162,38 +354,57 @@ export class SafesV2Service {
   }
 
   /**
-   * Gets fiat balance from Zerion Wallet Portfolio API.
-   * Uses the /v1/wallets/{address}/portfolio endpoint.
-   * Extracts the per-chain value from the full portfolio response.
+   * Reads the per-chain fiat value from a successful portfolio. A chain missing
+   * from the distribution is a real `0` (the wallet holds nothing there). Only
+   * an unmappable chain name or a non-finite value returns null (degrade).
    */
-  private async getFiatBalanceFromZerionPortfolio(args: {
+  private extractChainFiatBalance(
+    portfolio: ZerionWalletPortfolio,
+    chain: Chain,
+  ): number | null {
+    const zerionChainName = this.getZerionChainName(chain);
+    if (!zerionChainName) {
+      return null;
+    }
+    const value =
+      portfolio.data.attributes.positions_distribution_by_chain[
+        zerionChainName
+      ] ?? 0;
+    return Number.isFinite(value) ? value : null;
+  }
+
+  /**
+   * Serves a balance via the balances-repository fallback when the portfolio is
+   * unavailable. Emits a degraded-serve metric. If the fallback also fails the
+   * error propagates so the Safe is dropped — never shown a fabricated `$0`.
+   */
+  private async serveDegradedBalance(args: {
     chain: Chain;
     safeAddress: Address;
     currency: string;
     trusted: boolean;
   }): Promise<number> {
-    const { chain, safeAddress, currency, trusted } = args;
-
-    const portfolio = await this.zerionWalletPortfolioApi.getPortfolio({
-      address: safeAddress,
-      currency,
-      isTestnet: chain.isTestnet,
-      trusted,
-    });
-
-    const zerionChainName = this.getZerionChainName(chain);
-    if (!zerionChainName) {
-      this.loggingService.warn(
-        `Zerion chain name not found for chainId ${chain.chainId}`,
-      );
-      return 0;
+    try {
+      const value = await this.getFiatBalanceFromBalancesRepository(args);
+      this.loggingService.warn({
+        type: LogType.PortfolioDegradedServe,
+        source: 'SafesV2Service',
+        safeAddress: args.safeAddress,
+        chainId: args.chain.chainId,
+        balanceSource: 'balances_repo',
+      });
+      return value;
+    } catch (error) {
+      this.loggingService.warn({
+        type: LogType.PortfolioDegradedServe,
+        source: 'SafesV2Service',
+        safeAddress: args.safeAddress,
+        chainId: args.chain.chainId,
+        balanceSource: 'unavailable',
+        detail: asError(error).message,
+      });
+      throw error;
     }
-
-    return (
-      portfolio.data.attributes.positions_distribution_by_chain[
-        zerionChainName
-      ] ?? 0
-    );
   }
 
   /**
@@ -224,7 +435,10 @@ export class SafesV2Service {
 
     return balances
       .filter((b) => b.fiatBalance !== null)
-      .reduce((acc, b) => acc + Number(b.fiatBalance), 0);
+      .reduce((acc, b) => {
+        const value = Number(b.fiatBalance);
+        return Number.isFinite(value) ? acc + value : acc;
+      }, 0);
   }
 
   private computeAwaitingConfirmation(args: {

--- a/src/modules/zerion/datasources/zerion-rate-limiter.service.spec.ts
+++ b/src/modules/zerion/datasources/zerion-rate-limiter.service.spec.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
+import { LogType } from '@/domain/common/entities/log-type.entity';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
+
+const mockCacheService = vi.mocked({
+  incrWithTtl: vi.fn(),
+} as MockedObject<ICacheService>);
+
+const mockLoggingService = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+const GLOBAL_KEY = CacheRouter.getRateLimitCacheKey('zerion');
+
+describe('ZerionRateLimiter', () => {
+  let limiter: ZerionRateLimiter;
+  let fakeConfigurationService: FakeConfigurationService;
+  const limitCalls = 9;
+  const limitPeriodSeconds = 1;
+  const perAddressCalls = 3;
+  const perAddressPeriodSeconds = 10;
+  const address = getAddress('0x0000000000000000000000000000000000000001');
+
+  const buildLimiter = (overrides?: {
+    limitCalls?: number;
+    perAddressCalls?: number;
+  }): ZerionRateLimiter => {
+    fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'balances.providers.zerion.limitCalls',
+      overrides?.limitCalls ?? limitCalls,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.limitPeriodSeconds',
+      limitPeriodSeconds,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.perAddressLimitCalls',
+      overrides?.perAddressCalls ?? perAddressCalls,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.perAddressLimitPeriodSeconds',
+      perAddressPeriodSeconds,
+    );
+    return new ZerionRateLimiter(
+      mockCacheService,
+      fakeConfigurationService,
+      mockLoggingService,
+    );
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    limiter = buildLimiter();
+  });
+
+  it('does not throw when within the global budget', async () => {
+    mockCacheService.incrWithTtl.mockResolvedValue(limitCalls);
+
+    await expect(
+      limiter.assertWithinBudget({ datasource: 'balances' }),
+    ).resolves.toBeUndefined();
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+      GLOBAL_KEY,
+      limitPeriodSeconds,
+    );
+  });
+
+  it('throws LimitReachedError when over the global budget', async () => {
+    mockCacheService.incrWithTtl.mockResolvedValue(limitCalls + 1);
+
+    await expect(
+      limiter.assertWithinBudget({ datasource: 'balances' }),
+    ).rejects.toThrow(LimitReachedError);
+    expect(mockLoggingService.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ type: LogType.RateLimit, scope: 'global' }),
+    );
+  });
+
+  it('does not check the per-address budget when no address is provided', async () => {
+    mockCacheService.incrWithTtl.mockResolvedValue(1);
+
+    await limiter.assertWithinBudget({ datasource: 'balances' });
+
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+      GLOBAL_KEY,
+      limitPeriodSeconds,
+    );
+  });
+
+  it('checks the per-address budget before the global budget', async () => {
+    // First increment (per-address) trips the limit.
+    mockCacheService.incrWithTtl.mockResolvedValueOnce(perAddressCalls + 1);
+
+    await expect(
+      limiter.assertWithinBudget({ datasource: 'wallet_portfolio', address }),
+    ).rejects.toThrow(LimitReachedError);
+
+    // Per-address tripped => global budget must NOT be consumed.
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+      CacheRouter.getRateLimitCacheKey(`zerion_${address}`),
+      perAddressPeriodSeconds,
+    );
+    expect(mockLoggingService.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: LogType.RateLimit,
+        scope: 'per_address',
+      }),
+    );
+  });
+
+  it('checks per-address then global when per-address is within budget', async () => {
+    mockCacheService.incrWithTtl
+      .mockResolvedValueOnce(perAddressCalls) // per-address ok
+      .mockResolvedValueOnce(limitCalls); // global ok
+
+    await expect(
+      limiter.assertWithinBudget({ datasource: 'wallet_portfolio', address }),
+    ).resolves.toBeUndefined();
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the per-address tier when its limit is non-positive (disabled)', async () => {
+    limiter = buildLimiter({ perAddressCalls: 0 });
+    mockCacheService.incrWithTtl.mockResolvedValue(1);
+
+    await limiter.assertWithinBudget({
+      datasource: 'wallet_portfolio',
+      address,
+    });
+
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+      GLOBAL_KEY,
+      limitPeriodSeconds,
+    );
+  });
+
+  it('fails open (does not throw) when the cache errors', async () => {
+    mockCacheService.incrWithTtl.mockRejectedValue(new Error('Redis down'));
+
+    await expect(
+      limiter.assertWithinBudget({ datasource: 'balances' }),
+    ).resolves.toBeUndefined();
+    expect(mockLoggingService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed open'),
+    );
+  });
+
+  it('fails open when the counter is non-finite', async () => {
+    mockCacheService.incrWithTtl.mockResolvedValue(Number.NaN);
+
+    await expect(
+      limiter.assertWithinBudget({ datasource: 'balances' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
+++ b/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import type { Address } from 'viem';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
+import { LogType } from '@/domain/common/entities/log-type.entity';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
+
+type RateLimitScope = 'global' | 'per_address';
+
+/**
+ * Cross-pod rate limiter for the shared Zerion API account budget.
+ *
+ * Zerion enforces an account-wide ceiling (~10 RPS), shared by every CGW pod
+ * and every Zerion datasource (balances, positions, wallet portfolio…). This
+ * limiter increments a single Redis fixed-window counter so the cluster stays
+ * under that ceiling, with an optional per-address sub-budget that prevents one
+ * hot wallet from starving the global budget.
+ *
+ * On over-budget it throws {@link LimitReachedError}; callers decide whether to
+ * surface it (a 429) or degrade gracefully. It fails open on Redis errors — a
+ * Redis blip must not block the Zerion path.
+ */
+@Injectable()
+export class ZerionRateLimiter {
+  private static readonly GLOBAL_KEY_PREFIX = 'zerion';
+  private readonly limitCalls: number;
+  private readonly limitPeriodSeconds: number;
+  private readonly perAddressCalls: number;
+  private readonly perAddressPeriodSeconds: number;
+
+  constructor(
+    @Inject(CacheService) private readonly cacheService: ICacheService,
+    @Inject(IConfigurationService)
+    configurationService: IConfigurationService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {
+    this.limitCalls = configurationService.getOrThrow<number>(
+      'balances.providers.zerion.limitCalls',
+    );
+    this.limitPeriodSeconds = configurationService.getOrThrow<number>(
+      'balances.providers.zerion.limitPeriodSeconds',
+    );
+    this.perAddressCalls = configurationService.getOrThrow<number>(
+      'balances.providers.zerion.perAddressLimitCalls',
+    );
+    this.perAddressPeriodSeconds = configurationService.getOrThrow<number>(
+      'balances.providers.zerion.perAddressLimitPeriodSeconds',
+    );
+  }
+
+  /**
+   * Enforces the shared Zerion budget before a network call.
+   *
+   * The per-address sub-budget is checked first so a hot wallet trips its own
+   * limit before consuming any of the global budget. A tier whose configured
+   * limit is non-positive is treated as disabled.
+   *
+   * @param args.datasource - Caller label, used for observability.
+   * @param args.address - When provided, also enforces the per-address budget.
+   * @throws {LimitReachedError} When either budget is exceeded.
+   */
+  async assertWithinBudget(args: {
+    datasource: string;
+    address?: Address;
+  }): Promise<void> {
+    if (args.address && this.perAddressCalls > 0) {
+      const perAddress = await this._increment(
+        CacheRouter.getRateLimitCacheKey(
+          `${ZerionRateLimiter.GLOBAL_KEY_PREFIX}_${args.address}`,
+        ),
+        this.perAddressPeriodSeconds,
+      );
+      if (perAddress !== null && perAddress > this.perAddressCalls) {
+        this._logRateLimited({
+          datasource: args.datasource,
+          scope: 'per_address',
+        });
+        throw new LimitReachedError();
+      }
+    }
+
+    if (this.limitCalls > 0) {
+      const global = await this._increment(
+        CacheRouter.getRateLimitCacheKey(ZerionRateLimiter.GLOBAL_KEY_PREFIX),
+        this.limitPeriodSeconds,
+      );
+      if (global !== null && global > this.limitCalls) {
+        this._logRateLimited({ datasource: args.datasource, scope: 'global' });
+        throw new LimitReachedError();
+      }
+    }
+  }
+
+  /**
+   * Increments a fixed-window counter, failing open (returns null) on a Redis
+   * error or non-finite value so the Zerion path is never blocked by the cache.
+   */
+  private async _increment(
+    key: string,
+    periodSeconds: number,
+  ): Promise<number | null> {
+    try {
+      const count = await this.cacheService.incrWithTtl(key, periodSeconds);
+      return Number.isFinite(count) ? count : null;
+    } catch (error) {
+      this.loggingService.warn(
+        `Zerion rate-limit check failed open: ${asError(error)}`,
+      );
+      return null;
+    }
+  }
+
+  private _logRateLimited(args: {
+    datasource: string;
+    scope: RateLimitScope;
+  }): void {
+    this.loggingService.warn({
+      type: LogType.RateLimit,
+      source: 'ZerionRateLimiter',
+      datasource: args.datasource,
+      scope: args.scope,
+      event: 'Zerion account budget exceeded',
+    });
+  }
+}

--- a/src/modules/zerion/zerion.module.ts
+++ b/src/modules/zerion/zerion.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 
 @Module({
-  providers: [ZerionChainMappingService],
-  exports: [ZerionChainMappingService],
+  providers: [ZerionChainMappingService, ZerionRateLimiter],
+  exports: [ZerionChainMappingService, ZerionRateLimiter],
 })
 export class ZerionModule {}

--- a/src/modules/zerion/zerion.module.ts
+++ b/src/modules/zerion/zerion.module.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
 import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';


### PR DESCRIPTION
## Summary

`GET /v2/safes` (with the per-chain `PORTFOLIO_ENDPOINT` flag on) called Zerion
`GET /v1/wallets/{address}/portfolio` **once per `(chainId, address)` pair**, even though a
portfolio response is **per-wallet and already contains every chain** (`positions_distribution_by_chain`)
and the cache key is address-scoped. A Safe on N chains therefore triggered N identical, unthrottled
calls. With no rate limit, this exceeded Zerion's ~10 RPS account ceiling and produced an ~88% `429`
rate, so multi-chain Safes intermittently dropped out of the overview.

This PR makes two structural fixes plus the honest degradation and observability they require:

- **W1 — fetch once per wallet-identity.** `getSafeOverview` now fetches the portfolio once per
  `(address, isTestnet, currency, trusted)` identity and slices the per-chain value, instead of once
  per chain. `getChain` is deduped per `chainId`. Call count per request drops from O(chains) to
  O(unique wallet-identities).
- **W2 — shared cross-pod rate limit.** A `ZerionRateLimiter` enforces the account-wide budget
  (global + optional per-address sub-budget) via a Redis fixed-window counter, so cluster traffic
  stays under the ceiling and calls **succeed** (warming the existing 10s cache) instead of storming
  `429`s. Every Zerion account consumer — wallet portfolio, balances, positions, and the portfolio
  route — now shares this one budget.
- **Honest degradation.** A failed/over-budget portfolio degrades the wallet to the balances
  repository (a real computed total) — it is **never dropped on a 429** and **never shown a
  fabricated `$0`**. Only a double failure (portfolio *and* balances-repo) drops the Safe.
- **Redis-6-safe counter.** The existing `increment` relied on `EXPIRE … NX` (Redis 7.0+), so on
  Redis 6 the window never resets. A new version-agnostic Lua `INCR`+`EXPIRE` counter (`incrWithTtl`)
  works on both; the existing balances counter is migrated onto it.

## Changes

- `cache.service.interface.ts` / `redis.cache.service.ts` / `fake.cache.service.ts`: add
  `incrWithTtl` (atomic Lua `INCR`+`EXPIRE`, Redis 6/7 safe) + tests.
- `modules/zerion`: new `ZerionRateLimiter` (global + per-address tiers, fail-open on Redis errors)
  exported from `ZerionModule`; `BalancesModule` now imports `ZerionModule`.
- `ZerionBalancesApi` migrated off `increment`; `ZerionPositionsApi`, `ZerionPortfolioApi`, and
  `ZerionWalletPortfolioApi` wired through the shared budget.
- `SafesV2Service.getSafeOverview` restructured (fetch-once-per-identity + dedupe `getChain` +
  honest degradation); new `LogType.PortfolioDegradedServe` for observability.
- New config: `ZERION_RATE_LIMIT_PER_ADDRESS_CALLS_BY_PERIOD` / `_PERIOD_SECONDS` (per-address
  sub-budget, disabled by default).
- New specs: `zerion-rate-limiter.service.spec.ts`, `zerion-wallet-portfolio-api.service.spec.ts`,
  `safes.v2.service.spec.ts`; extended balances, fake-cache, redis-integration, and overview
  integration specs.

> **Config (no code, required for the real ceiling):** code defaults are unchanged and
> safe-by-default. To enforce a hard `<10 RPS` ceiling, set `ZERION_RATE_LIMIT_CALLS_BY_PERIOD` /
> `ZERION_RATE_LIMIT_PERIOD_SECONDS` to a short window (e.g. `period=1, calls≈9`) per environment.

## Affected flows

- `/v2/safes` overview (primary): single-chain unchanged; multi-chain now one portfolio call.
- `/balances`, `/positions`, portfolio route: now share the Zerion budget (can `429` under load;
  previously unbounded).
- Non-Zerion / flag-off chains and empty Safes: unchanged (real `$0` still renders).

## Risks / not checked

- Production Redis 6-vs-7 behaviour: the Lua counter is correct on both; not run against prod Redis.
- Production rate-limit tuning is an ops/env step (defaults are safe placeholders).
- Integration/e2e specs require a live Postgres + Redis and are not in CI; verified here via the unit
  suite (full run green) + analysis of the affected integration assertions.

## Visual summary

```mermaid
flowchart TD
  R["GET /v2/safes — Safe on N chains, P pods"] --> M["getSafeOverview"]
  subgraph Before
    M -.->|"getPortfolio per (chainId,address) — N identical, unthrottled"| Zb["Zerion /portfolio"]
    Zb -.->|"burst > 10 RPS → 429 (88%)"| Drop["throws → Safe dropped"]
  end
  subgraph After
    M -->|"fetch once per (address,isTestnet,currency,trusted)"| RL["ZerionRateLimiter\nglobal + per-address budget"]
    RL -->|"within budget"| Za["Zerion /portfolio (1 call)"]
    Za --> Slice["slice positions_distribution_by_chain → per chain"]
    RL -->|"over budget / failure"| Deg["degrade → balances repo\n(never \$0, never drop)"]
  end
```

## Checklist

- [x] I've added unit tests for the new logic (rate limiter, wallet portfolio datasource, overview service)
- [ ] I've tested the branch on mobile (n/a — backend gateway change)
- [x] I've documented how it affects analytics (new `PortfolioDegradedServe` + `RateLimit{datasource,scope}` logs)
