### PR TITLE
feat: Add origin and nonce fields

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -1114,11 +1114,13 @@ export class CacheRouter {
     operation: number;
     gasToken: Address;
     threshold: number;
+    nonce: string;
+    origin?: string;
     fiatCode?: string;
   }): CacheDir {
     const hash = crypto.createHash('sha256');
     hash.update(
-      `${args.to}_${args.value}_${args.data}_${args.operation}_${args.gasToken}_${args.threshold}_${args.fiatCode ?? 'USD'}`,
+      `${args.to}_${args.value}_${args.data}_${args.operation}_${args.gasToken}_${args.threshold}_${args.nonce}_${args.origin ?? 'NATIVE'}_${args.fiatCode ?? 'USD'}`,
     );
     return new CacheDir(
       CacheRouter.getRelayFeePreviewCacheKey(args),

--- a/src/datasources/fee-service-api/fee-service-api.service.spec.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.spec.ts
@@ -15,6 +15,7 @@ import {
   txDataResponseBuilder,
   txFeesResponseBuilder,
 } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
+import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import { PriceSource } from '@/modules/fees/domain/entities/price-source.entity';
 import { feePreviewTransactionDtoBuilder } from '@/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder';
 import { rawify } from '@/validation/entities/raw.entity';
@@ -180,10 +181,29 @@ describe('FeeServiceApi', () => {
           key: expect.stringContaining('relay_fee_preview'),
         }),
         url: `${baseUri}/v1/chains/${chainId}/safes/${safeAddress}/transactions/relay-fees`,
-        data: request,
+        data: { ...request, origin: request.origin ?? Origin.NATIVE },
         notFoundExpireTimeSeconds: 30,
         expireTimeSeconds: 60,
       });
+    });
+
+    it('should default origin to NATIVE when omitted', async () => {
+      const requestWithoutOrigin = feePreviewTransactionDtoBuilder()
+        .with('origin', undefined)
+        .build();
+      mockDataSource.post.mockResolvedValueOnce(rawify(mockFeeResponse));
+
+      await target.getRelayFees({
+        chainId,
+        safeAddress,
+        request: requestWithoutOrigin,
+      });
+
+      expect(mockDataSource.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { ...requestWithoutOrigin, origin: Origin.NATIVE },
+        }),
+      );
     });
 
     it('should forward errors from dataSource', async () => {

--- a/src/datasources/fee-service-api/fee-service-api.service.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.ts
@@ -11,6 +11,7 @@ import {
 } from '@/datasources/network/network.service.interface';
 import type { IFeeServiceApi } from '@/domain/interfaces/fee-service-api.interface';
 import type { CanRelayResponse } from '@/modules/fees/domain/entities/can-relay-response.entity';
+import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import { CanRelayResponseSchema } from '@/modules/fees/domain/entities/schemas/can-relay-response.schema';
 import { TxFeesResponseSchema } from '@/modules/fees/domain/entities/schemas/tx-fees-response.schema';
 import type { TxFeesRequest } from '@/modules/fees/domain/entities/tx-fees-request.entity';
@@ -78,6 +79,8 @@ export class FeeServiceApi implements IFeeServiceApi {
       operation: args.request.operation,
       gasToken: args.request.gasToken,
       threshold: args.request.numberSignatures,
+      nonce: args.request.nonce,
+      origin: args.request.origin,
       fiatCode: args.request.fiatCode,
     });
     const url = `${this.relayFeeConfiguration.baseUri}/v1/chains/${args.chainId}/safes/${args.safeAddress}/transactions/relay-fees`;
@@ -86,7 +89,13 @@ export class FeeServiceApi implements IFeeServiceApi {
       const data = await this.dataSource.post<TxFeesResponse>({
         cacheDir,
         url,
-        data: args.request,
+        // The fee service persists a quote keyed by `nonce` (required) and
+        // `origin` (defaults to NATIVE when omitted). This persisted quote is
+        // what `/can-relay` later checks against, so both must be sent here.
+        data: {
+          ...args.request,
+          origin: args.request.origin ?? Origin.NATIVE,
+        },
         notFoundExpireTimeSeconds: this.notFoundExpireTimeSeconds,
         expireTimeSeconds: this.relayFeeConfiguration.feePreviewTtlSeconds,
       });

--- a/src/modules/fees/domain/entities/origin.entity.ts
+++ b/src/modules/fees/domain/entities/origin.entity.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+export enum Origin {
+  SAFE_APP = 'SAFE_APP',
+  WALLET_CONNECT = 'WALLET_CONNECT',
+  TX_BUILDER = 'TX_BUILDER',
+  NATIVE = 'NATIVE',
+}

--- a/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-request.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-request.schema.spec.ts
@@ -12,12 +12,32 @@ describe('TxFeesRequestSchema', () => {
       data: '0x',
       operation: 0,
       numberSignatures: 2,
+      nonce: '42',
       gasToken: getAddress(zeroAddress),
     };
 
     const result = TxFeesRequestSchema.safeParse(request);
 
     expect(result.success).toBe(true);
+  });
+
+  it('should require nonce', () => {
+    const request = {
+      to: getAddress(faker.finance.ethereumAddress()),
+      value: '0',
+      data: '0x',
+      operation: 0,
+      numberSignatures: 1,
+      gasToken: getAddress(zeroAddress),
+    };
+
+    const result = TxFeesRequestSchema.safeParse(request);
+
+    expect(!result.success && result.error.issues).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: ['nonce'] }),
+      ]),
+    );
   });
 
   it('should not allow an invalid address for to', () => {

--- a/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-request.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-request.schema.spec.ts
@@ -34,9 +34,7 @@ describe('TxFeesRequestSchema', () => {
     const result = TxFeesRequestSchema.safeParse(request);
 
     expect(!result.success && result.error.issues).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ path: ['nonce'] }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ path: ['nonce'] })]),
     );
   });
 

--- a/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-request.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-request.schema.spec.ts
@@ -38,6 +38,29 @@ describe('TxFeesRequestSchema', () => {
     );
   });
 
+  it.each([
+    ['hex', '0x12'],
+    ['negative', '-12'],
+    ['decimal', '1.5'],
+    ['non-numeric', 'abc'],
+  ])('should reject a %s nonce', (_label, nonce) => {
+    const request = {
+      to: getAddress(faker.finance.ethereumAddress()),
+      value: '0',
+      data: '0x',
+      operation: 0,
+      numberSignatures: 1,
+      nonce,
+      gasToken: getAddress(zeroAddress),
+    };
+
+    const result = TxFeesRequestSchema.safeParse(request);
+
+    expect(!result.success && result.error.issues).toStrictEqual(
+      expect.arrayContaining([expect.objectContaining({ path: ['nonce'] })]),
+    );
+  });
+
   it('should not allow an invalid address for to', () => {
     const request = {
       to: 'not-an-address',

--- a/src/modules/fees/domain/entities/schemas/tx-fees-request.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/tx-fees-request.schema.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
+import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import { Operation } from '@/modules/safe/domain/entities/operation.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
@@ -11,6 +12,8 @@ export const TxFeesRequestSchema = z.object({
   data: HexSchema,
   operation: z.enum(Operation),
   numberSignatures: z.number().int().min(1),
+  nonce: NumericStringSchema,
   gasToken: AddressSchema,
+  origin: z.enum(Origin).optional(),
   fiatCode: z.string().optional(),
 });

--- a/src/modules/fees/domain/entities/schemas/tx-fees-request.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/tx-fees-request.schema.ts
@@ -4,6 +4,7 @@ import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import { Operation } from '@/modules/safe/domain/entities/operation.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { NonNegativeNumericStringSchema } from '@/validation/entities/schemas/non-negative-numeric-string.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
 export const TxFeesRequestSchema = z.object({
@@ -12,7 +13,7 @@ export const TxFeesRequestSchema = z.object({
   data: HexSchema,
   operation: z.enum(Operation),
   numberSignatures: z.number().int().min(1),
-  nonce: NumericStringSchema,
+  nonce: NonNegativeNumericStringSchema,
   gasToken: AddressSchema,
   origin: z.enum(Origin).optional(),
   fiatCode: z.string().optional(),

--- a/src/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder.ts
+++ b/src/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import { getAddress, zeroAddress } from 'viem';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
+import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import type { FeePreviewTransactionDto } from '@/modules/fees/routes/entities/fee-preview-transaction.dto.entity';
 import { Operation } from '@/modules/safe/domain/entities/operation.entity';
 
@@ -19,5 +20,7 @@ export function feePreviewTransactionDtoBuilder(): IBuilder<FeePreviewTransactio
     )
     .with('operation', Operation.CALL)
     .with('gasToken', getAddress(zeroAddress))
-    .with('numberSignatures', faker.number.int({ min: 1, max: 10 }));
+    .with('numberSignatures', faker.number.int({ min: 1, max: 10 }))
+    .with('nonce', faker.string.numeric())
+    .with('origin', faker.helpers.enumValue(Origin));
 }

--- a/src/modules/fees/routes/entities/fee-preview-transaction.dto.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-transaction.dto.entity.ts
@@ -2,6 +2,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import type { Address, Hex } from 'viem';
 import type { z } from 'zod';
+import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import type { FeePreviewTransactionDtoSchema } from '@/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema';
 import { Operation } from '@/modules/safe/domain/entities/operation.entity';
 
@@ -38,6 +39,20 @@ export class FeePreviewTransactionDto
   numberSignatures: number;
 
   @ApiProperty({
+    description: 'Safe nonce the transaction will use (uint256 string)',
+    example: '42',
+  })
+  nonce: string;
+
+  @ApiProperty({
+    enum: Origin,
+    enumName: 'Origin',
+    description: 'Transaction origin. Defaults to NATIVE when omitted.',
+    required: false,
+  })
+  origin?: Origin;
+
+  @ApiProperty({
     description:
       'Fiat currency code for relay cost conversion (e.g. EUR, GBP). Defaults to USD.',
     example: 'EUR',
@@ -52,6 +67,8 @@ export class FeePreviewTransactionDto
     this.operation = dto.operation;
     this.gasToken = dto.gasToken;
     this.numberSignatures = dto.numberSignatures;
+    this.nonce = dto.nonce;
+    this.origin = dto.origin;
     this.fiatCode = dto.fiatCode;
   }
 }

--- a/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
+++ b/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
@@ -4,12 +4,12 @@ import { z } from 'zod';
 import { TransactionBaseSchema } from '@/domain/common/schemas/transaction-base.schema';
 import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { NonNegativeNumericStringSchema } from '@/validation/entities/schemas/non-negative-numeric-string.schema';
 
 export const FeePreviewTransactionDtoSchema = TransactionBaseSchema.extend({
   gasToken: AddressSchema,
   numberSignatures: z.number().int().min(1),
-  nonce: NumericStringSchema,
+  nonce: NonNegativeNumericStringSchema,
   origin: z.enum(Origin).optional(),
   fiatCode: z.string().optional(),
 });

--- a/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
+++ b/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
@@ -2,10 +2,14 @@
 
 import { z } from 'zod';
 import { TransactionBaseSchema } from '@/domain/common/schemas/transaction-base.schema';
+import { Origin } from '@/modules/fees/domain/entities/origin.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
 export const FeePreviewTransactionDtoSchema = TransactionBaseSchema.extend({
   gasToken: AddressSchema,
   numberSignatures: z.number().int().min(1),
+  nonce: NumericStringSchema,
+  origin: z.enum(Origin).optional(),
   fiatCode: z.string().optional(),
 });

--- a/src/validation/entities/schemas/non-negative-numeric-string.schema.ts
+++ b/src/validation/entities/schemas/non-negative-numeric-string.schema.ts
@@ -8,12 +8,6 @@ import { z } from 'zod';
  * values (hex, decimals, negatives, non-numeric) are rejected by the gateway
  * with a consistent 422 before the request reaches the fee service.
  */
-function isNonNegativeIntegerString(value: unknown): boolean {
-  return typeof value === 'string' && /^\d+$/.test(value);
-}
-
 export const NonNegativeNumericStringSchema = z
   .string()
-  .refine(isNonNegativeIntegerString, {
-    error: 'Invalid non-negative integer string',
-  });
+  .regex(/^\d+$/, { error: 'Invalid non-negative integer string' });

--- a/src/validation/entities/schemas/non-negative-numeric-string.schema.ts
+++ b/src/validation/entities/schemas/non-negative-numeric-string.schema.ts
@@ -12,9 +12,8 @@ function isNonNegativeIntegerString(value: unknown): boolean {
   return typeof value === 'string' && /^\d+$/.test(value);
 }
 
-export const NonNegativeNumericStringSchema = z.string().refine(
-  isNonNegativeIntegerString,
-  {
+export const NonNegativeNumericStringSchema = z
+  .string()
+  .refine(isNonNegativeIntegerString, {
     error: 'Invalid non-negative integer string',
-  },
-);
+  });

--- a/src/validation/entities/schemas/non-negative-numeric-string.schema.ts
+++ b/src/validation/entities/schemas/non-negative-numeric-string.schema.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+/**
+ * Validates a base-10 integer string that is non-negative (>= 0).
+ *
+ * Mirrors the fee service's `IsNonNegativeBigInt` validation so that invalid
+ * values (hex, decimals, negatives, non-numeric) are rejected by the gateway
+ * with a consistent 422 before the request reaches the fee service.
+ */
+function isNonNegativeIntegerString(value: unknown): boolean {
+  return typeof value === 'string' && /^\d+$/.test(value);
+}
+
+export const NonNegativeNumericStringSchema = z.string().refine(
+  isNonNegativeIntegerString,
+  {
+    error: 'Invalid non-negative integer string',
+  },
+);


### PR DESCRIPTION
## Summary

This pull request introduces required support for the `nonce` and optional `origin` fields in fee preview transaction requests

## Changes

### Fee Preview API and Data Handling

* Added `nonce` (required) and `origin` (optional, defaults to `NATIVE` if omitted) to `FeePreviewTransactionDto`, its schema, and related builders, ensuring these fields are present throughout the fee preview flow. [[1]](diffhunk://#diff-07b5fa50d7b3b14567f64a80dc6e48f3b1db53fa800ad56e85fe3234338cd4e1R41-R54) [[2]](diffhunk://#diff-07b5fa50d7b3b14567f64a80dc6e48f3b1db53fa800ad56e85fe3234338cd4e1R70-R71) [[3]](diffhunk://#diff-574d3e249a3b8712d397c191357da72a1cb7943ba397d63344056d860c0a2e20R5-R13) [[4]](diffhunk://#diff-206f486a37687ea4b5878a96f828118793b9bfbb5a9f2a519d673c6a31d9f44fL22-R25)
* Updated `FeeServiceApi` and `CacheRouter` to include `nonce` and `origin` in cache keys and API requests, and to always send `origin` (defaulting to `NATIVE` when not provided) to the fee service. [[1]](diffhunk://#diff-ec67d65e60cdb04348dcf7b9d05e7c02597ed04647614e8204f1a05a0da0f028R82-R83) [[2]](diffhunk://#diff-ec67d65e60cdb04348dcf7b9d05e7c02597ed04647614e8204f1a05a0da0f028L89-R98) [[3]](diffhunk://#diff-2f034c50accbebd11015c4039a26b7bd8349f330a0d53f19c6856c2a33411799R1117-R1123)

### Validation and Type Safety

* Updated `TxFeesRequestSchema` to require `nonce` and accept optional `origin`, with corresponding tests to enforce validation. [[1]](diffhunk://#diff-c9f7f30a6bda75b8741b32dd798e1e44f4d5854feec6d789d198ddd4938f9477R15-R17) [[2]](diffhunk://#diff-2af877318d94afac57709ed2c515262c055acba8669511676443e3697c83c7bfR15) [[3]](diffhunk://#diff-2af877318d94afac57709ed2c515262c055acba8669511676443e3697c83c7bfR24-R42)
* Introduced the `Origin` enum to standardize allowed values for transaction origin.

### Testing

* Enhanced tests to verify that `origin` defaults to `NATIVE` when omitted and that `nonce` is required. [[1]](diffhunk://#diff-bcb488d2889c4bdc2ec6a8e3a4f2612055f5d77ab26ff843bb965bc45e88e97fL183-R208) [[2]](diffhunk://#diff-2af877318d94afac57709ed2c515262c055acba8669511676443e3697c83c7bfR24-R42)

These changes ensure that fee preview requests are uniquely and accurately identified, and that the API contract is explicit and validated end-to-end.