### PR TITLE
revert: remove lua script

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -107,19 +107,4 @@ describe('FakeCacheService', () => {
 
     await expect(target.getCounter(key)).resolves.toBe(value + 3);
   });
-
-  it('creates a missing key and increments its value with incrWithTtl', async () => {
-    const key = faker.string.alphanumeric();
-    const ttl = faker.number.int({ min: 1, max: 10 });
-
-    const firstResult = await target.incrWithTtl(key, ttl);
-    expect(firstResult).toEqual(1);
-
-    const results: Array<number> = [];
-    for (let i = 0; i < 5; i++) {
-      results.push(await target.incrWithTtl(key, ttl));
-    }
-
-    expect(results).toEqual([2, 3, 4, 5, 6]);
-  });
 });

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -79,15 +79,6 @@ export class FakeCacheService implements ICacheService, ICacheReadiness {
     return Promise.resolve(currentValue);
   }
 
-  incrWithTtl(cacheKey: string, _ttlSeconds: number): Promise<number> {
-    const currentValue = (this.cache[cacheKey] as number | undefined) ?? 0;
-    const nextValue = currentValue + 1;
-
-    this.cache[cacheKey] = nextValue;
-
-    return Promise.resolve(nextValue);
-  }
-
   setCounter(
     key: string,
     value: number,

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -23,16 +23,6 @@ export interface ICacheService {
     expireDeviatePercent?: number,
   ): Promise<number>;
 
-  /**
-   * Atomically increments a counter and sets its TTL on first creation, for
-   * fixed-window rate limiting.
-   *
-   * @param cacheKey - Counter key (not prefixed, matching {@link increment}).
-   * @param ttlSeconds - Window length in seconds, applied on the first increment.
-   * @returns The counter value after incrementing.
-   */
-  incrWithTtl(cacheKey: string, ttlSeconds: number): Promise<number>;
-
   setCounter(
     key: string,
     value: number,

--- a/src/datasources/cache/redis.cache.service.integration.spec.ts
+++ b/src/datasources/cache/redis.cache.service.integration.spec.ts
@@ -226,36 +226,6 @@ describe('RedisCacheService', () => {
     expect(ttl).toBeLessThanOrEqual(maxExpireTime);
   });
 
-  it('incrWithTtl creates a missing key and sets its TTL on first increment', async () => {
-    const ttlSeconds = faker.number.int({ min: 5, max: maxTtlDeviated });
-    const key = faker.string.alphanumeric();
-
-    const firstResult = await redisCacheService.incrWithTtl(key, ttlSeconds);
-
-    const ttl = await redisClient.ttl(key);
-    expect(firstResult).toEqual(1);
-    expect(ttl).toBeGreaterThan(0);
-    expect(ttl).toBeLessThanOrEqual(ttlSeconds);
-  });
-
-  it('incrWithTtl keeps the window TTL stable across subsequent increments', async () => {
-    const ttlSeconds = faker.number.int({ min: 50, max: maxTtlDeviated });
-    const key = faker.string.alphanumeric();
-
-    await redisCacheService.incrWithTtl(key, ttlSeconds);
-    const ttlAfterFirst = await redisClient.ttl(key);
-
-    const results: Array<number> = [];
-    for (let i = 0; i < 4; i++) {
-      // A different TTL here must NOT reset the window once the key exists.
-      results.push(await redisCacheService.incrWithTtl(key, ttlSeconds * 10));
-    }
-    const ttlAfterMore = await redisClient.ttl(key);
-
-    expect(results).toEqual([2, 3, 4, 5]);
-    expect(ttlAfterMore).toBeLessThanOrEqual(ttlAfterFirst);
-  });
-
   it('sets and gets the value of a counter key', async () => {
     const key = faker.string.alphanumeric();
     const value = faker.number.int({ min: 100 });

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -17,11 +17,6 @@ import {
 export class RedisCacheService
   implements ICacheService, ICacheReadiness, OnModuleDestroy
 {
-  // Atomic INCR that sets a TTL only on the key's creation. Uses a plain
-  // EXPIRE (not EXPIRE … NX) so it works on Redis 6 as well as 7.
-  private static readonly INCR_WITH_TTL_LUA =
-    "local c = redis.call('INCR', KEYS[1]); if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end; return c";
-
   private readonly quitTimeoutInSeconds: number = 2;
   private readonly defaultExpirationTimeInSeconds: number;
   private readonly defaultExpirationDeviatePercent: number;
@@ -128,23 +123,6 @@ export class RedisCacheService
     }
     const [incrRes] = await transaction.get(cacheKey).exec();
     return Number(incrRes);
-  }
-
-  /**
-   * Atomic, Redis-version-agnostic fixed-window counter.
-   *
-   * `EXPIRE … NX` (used by {@link increment}) requires Redis 7.0+, so on Redis
-   * 6 that counter never expires and the window never resets. This Lua script
-   * sets the TTL only on the first increment using a plain `EXPIRE`, which
-   * works on both Redis 6 and 7.
-   */
-  async incrWithTtl(cacheKey: string, ttlSeconds: number): Promise<number> {
-    const ttl = this.enforceMaxRedisTTL(ttlSeconds);
-    const result = await this.client.eval(RedisCacheService.INCR_WITH_TTL_LUA, {
-      keys: [cacheKey],
-      arguments: [`${ttl}`],
-    });
-    return Number(result);
   }
 
   async setCounter(

--- a/src/modules/zerion/datasources/zerion-rate-limiter.service.spec.ts
+++ b/src/modules/zerion/datasources/zerion-rate-limiter.service.spec.ts
@@ -11,7 +11,7 @@ import type { ILoggingService } from '@/logging/logging.interface';
 import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 
 const mockCacheService = vi.mocked({
-  incrWithTtl: vi.fn(),
+  increment: vi.fn(),
 } as MockedObject<ICacheService>);
 
 const mockLoggingService = {
@@ -66,19 +66,20 @@ describe('ZerionRateLimiter', () => {
   });
 
   it('does not throw when within the global budget', async () => {
-    mockCacheService.incrWithTtl.mockResolvedValue(limitCalls);
+    mockCacheService.increment.mockResolvedValue(limitCalls);
 
     await expect(
       limiter.assertWithinBudget({ datasource: 'balances' }),
     ).resolves.toBeUndefined();
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+    expect(mockCacheService.increment).toHaveBeenCalledWith(
       GLOBAL_KEY,
       limitPeriodSeconds,
+      0,
     );
   });
 
   it('throws LimitReachedError when over the global budget', async () => {
-    mockCacheService.incrWithTtl.mockResolvedValue(limitCalls + 1);
+    mockCacheService.increment.mockResolvedValue(limitCalls + 1);
 
     await expect(
       limiter.assertWithinBudget({ datasource: 'balances' }),
@@ -89,30 +90,32 @@ describe('ZerionRateLimiter', () => {
   });
 
   it('does not check the per-address budget when no address is provided', async () => {
-    mockCacheService.incrWithTtl.mockResolvedValue(1);
+    mockCacheService.increment.mockResolvedValue(1);
 
     await limiter.assertWithinBudget({ datasource: 'balances' });
 
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+    expect(mockCacheService.increment).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.increment).toHaveBeenCalledWith(
       GLOBAL_KEY,
       limitPeriodSeconds,
+      0,
     );
   });
 
   it('checks the per-address budget before the global budget', async () => {
     // First increment (per-address) trips the limit.
-    mockCacheService.incrWithTtl.mockResolvedValueOnce(perAddressCalls + 1);
+    mockCacheService.increment.mockResolvedValueOnce(perAddressCalls + 1);
 
     await expect(
       limiter.assertWithinBudget({ datasource: 'wallet_portfolio', address }),
     ).rejects.toThrow(LimitReachedError);
 
     // Per-address tripped => global budget must NOT be consumed.
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+    expect(mockCacheService.increment).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.increment).toHaveBeenCalledWith(
       CacheRouter.getRateLimitCacheKey(`zerion_${address}`),
       perAddressPeriodSeconds,
+      0,
     );
     expect(mockLoggingService.warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -123,34 +126,35 @@ describe('ZerionRateLimiter', () => {
   });
 
   it('checks per-address then global when per-address is within budget', async () => {
-    mockCacheService.incrWithTtl
+    mockCacheService.increment
       .mockResolvedValueOnce(perAddressCalls) // per-address ok
       .mockResolvedValueOnce(limitCalls); // global ok
 
     await expect(
       limiter.assertWithinBudget({ datasource: 'wallet_portfolio', address }),
     ).resolves.toBeUndefined();
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(2);
+    expect(mockCacheService.increment).toHaveBeenCalledTimes(2);
   });
 
   it('skips the per-address tier when its limit is non-positive (disabled)', async () => {
     limiter = buildLimiter({ perAddressCalls: 0 });
-    mockCacheService.incrWithTtl.mockResolvedValue(1);
+    mockCacheService.increment.mockResolvedValue(1);
 
     await limiter.assertWithinBudget({
       datasource: 'wallet_portfolio',
       address,
     });
 
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledTimes(1);
-    expect(mockCacheService.incrWithTtl).toHaveBeenCalledWith(
+    expect(mockCacheService.increment).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.increment).toHaveBeenCalledWith(
       GLOBAL_KEY,
       limitPeriodSeconds,
+      0,
     );
   });
 
   it('fails open (does not throw) when the cache errors', async () => {
-    mockCacheService.incrWithTtl.mockRejectedValue(new Error('Redis down'));
+    mockCacheService.increment.mockRejectedValue(new Error('Redis down'));
 
     await expect(
       limiter.assertWithinBudget({ datasource: 'balances' }),
@@ -161,7 +165,7 @@ describe('ZerionRateLimiter', () => {
   });
 
   it('fails open when the counter is non-finite', async () => {
-    mockCacheService.incrWithTtl.mockResolvedValue(Number.NaN);
+    mockCacheService.increment.mockResolvedValue(Number.NaN);
 
     await expect(
       limiter.assertWithinBudget({ datasource: 'balances' }),

--- a/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
+++ b/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
@@ -110,7 +110,7 @@ export class ZerionRateLimiter {
     periodSeconds: number,
   ): Promise<number | null> {
     try {
-      const count = await this.cacheService.incrWithTtl(key, periodSeconds);
+      const count = await this.cacheService.increment(key, periodSeconds, 0);
       return Number.isFinite(count) ? count : null;
     } catch (error) {
       this.loggingService.warn(


### PR DESCRIPTION
## Revert Redis 6-safe Lua counter; use `increment` with `EXPIRE NX`

### Context
Commit 142559ada introduced a Lua-script counter (`incrWithTtl`) on the
assumption that we run Redis 6, where `EXPIRE … NX` is unavailable. We
actually run Redis 7, so the existing `increment` method (which uses
`EXPIRE NX`) already provides a correct fixed-window counter. This PR
removes the Lua script and routes the Zerion rate limiter back through
`increment`.

### Changes
- **src/datasources/cache/redis.cache.service.ts** — remove the
  `INCR_WITH_TTL_LUA` static and the `eval`-based `incrWithTtl()` method.
- **src/datasources/cache/cache.service.interface.ts** — drop `incrWithTtl`
  from `ICacheService`.
- **src/datasources/cache/__tests__/fake.cache.service.ts** — remove the
  fake `incrWithTtl` implementation.
- **src/modules/zerion/datasources/zerion-rate-limiter.service.ts** —
  `_increment` now calls `increment(key, periodSeconds, 0)`. The `0`
  deviate-percent keeps an exact fixed window (no TTL jitter), and
  `EXPIRE NX` sets the TTL only on key creation so later increments don't
  extend the window.
- **Tests** — remove the two `incrWithTtl` Redis integration tests and the
  fake-cache spec test; update the rate-limiter spec to mock/assert
  `increment` (with the `0` third arg).