### PR TITLE
fix: turn off Redis connect notification

### DIFF
--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -40,6 +40,11 @@ async function redisClientFactory(
     username: redisUser,
     password: redisPass,
     disableOfflineQueue: redisDisableOfflineQueue,
+    // As of redis v6 the default RESP protocol is 3, which flips `maintNotifications`
+    // to 'auto' and makes the client send `CLIENT MAINT_NOTIFICATIONS ON` on
+    // connect. Our standard (non-Enterprise) Redis does not support that
+    // subcommand and replies with `ERR unknown subcommand 'MAINT_NOTIFICATIONS'`.
+    maintNotifications: 'disabled',
   });
   client.on('error', (err) =>
     loggingService.error({


### PR DESCRIPTION
## Summary

resolves issue: [ERR unknown subcommand 'MAINT_NOTIFICATIONS'. Try CLIENT HELP.](https://app.datadoghq.eu/error-tracking/issue/f73da902-6b07-11f1-96bd-da7ad0900005) 

## Changes
PR [#3151](https://github.com/redis/node-redis) bumped redis 5.12.1 → 6.0.0 on 2026-06-18 — the exact day the error first appeared.
redis v6 changed DEFAULT_RESP from 2 → 3.
In `EnterpriseMaintenanceManager.setupDefaultMaintOptions`, when `maintNotifications` is unset it defaults to 'auto' if RESP is 3, else 'disabled'. So RESP3 flipped the default from disabled to 'auto'.
With 'auto', the client sends `CLIENT MAINT_NOTIFICATIONS ON …` on every connect (a Redis Enterprise feature). Our standard managed Redis doesn't know that subcommand and replies with an error, which the socket decoder re-emits as a client 'error'.
It's non-fatal ('auto' swallows the handshake failure and keeps the connection), but it's pure error-tracking noise.
