### PR TITLE
fix: Redis client is closed error

### DIFF
--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -177,20 +177,41 @@ export class RedisCacheService
     const forceQuitTimeout = setTimeout(() => {
       this.forceQuit();
     }, this.quitTimeoutInSeconds * 1000);
-    await this.client.quit();
-    clearTimeout(forceQuitTimeout);
+    try {
+      await this.client.quit();
+    } catch {
+      // `quit` throws `ClientClosedError` if the connection is already closed
+      // (e.g. the socket dropped). Fall back to a force close.
+      this.forceQuit();
+    } finally {
+      clearTimeout(forceQuitTimeout);
+    }
   }
 
   /**
    * Forces the closing of the Redis connection associated with this service.
    */
   private forceQuit(): void {
+    // `destroy` throws `ClientClosedError` when the socket is no longer open.
+    // As this runs in a `setTimeout` callback, an uncaught throw here would
+    // crash the process, so guard against it.
+    if (!this.client.isOpen) {
+      return;
+    }
     this.loggingService.warn({
       type: LogType.CacheEvent,
       source: 'RedisCacheService',
       event: 'Forcing Redis connection close',
     });
-    this.client.destroy();
+    try {
+      this.client.destroy();
+    } catch {
+      this.loggingService.error({
+        type: LogType.CacheError,
+        source: 'RedisCacheService',
+        event: 'Error forcing Redis connection close',
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Fix Redis `The client is closed` crash on shutdown

### Problem

Datadog reports an `UnhandledException` crash that terminates the process:

> Process was terminated due to an unhandled exception of type 'Error'. Message: The client is closed

Stack: `RedisSocket.destroy` (`@redis/client/dist/lib/client/socket.js`), `is_crash: true`.
https://app.datadoghq.eu/error-tracking/issue/40248892-165e-11f1-97f1-da7ad0900005

### Root cause

In `src/datasources/cache/redis.cache.service.ts`, `onModuleDestroy` schedules `forceQuit()` via `setTimeout` and then awaits `client.quit()`. `forceQuit()` calls `this.client.destroy()`, which was introduced when the deprecated `disconnect()` was replaced in #2889.

In redis v6, `RedisSocket.destroy()` throws synchronously when the socket is already closed:

```js
destroy() {
    if (!this.#isOpen) {
        throw new errors_1.ClientClosedError(); // "The client is closed"
    }
    ...
}
```

If the connection has already dropped (server unreachable / socket closed) and `quit()` doesn't resolve within the 2s timeout, the timer fires and `destroy()` throws **inside a bare `setTimeout` callback** — an uncaught exception that crashes the process. The previous `await this.client.disconnect()` could not crash this way. `client.quit()` throws the same `ClientClosedError` when the connection is already closed.

### Fix

In `src/datasources/cache/redis.cache.service.ts`:

- `forceQuit()` early-returns when `!this.client.isOpen` (the exact condition `socket.destroy()` guards on) and wraps `destroy()` in try/catch, since an uncaught throw in a timer callback is fatal.
- `onModuleDestroy()` wraps `client.quit()` in try/catch/finally — on failure it falls back to the now-safe `forceQuit()`, and always clears the timeout.

The healthy-shutdown path is unchanged: `quit()` succeeds, the timeout is cleared, and `forceQuit()` never runs.