### PR TITLE
feat: implement billing service webhook receiver authentication service

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -138,6 +138,18 @@
     "required": false
   },
   {
+    "name": "BILLING_WEBHOOK_JWT_PUBLIC_KEY",
+    "description": "ES256 (EC P-256) public key (PEM) used to verify incoming billing-service webhook JWT tokens",
+    "defaultValue": null,
+    "required": false
+  },
+  {
+    "name": "BILLING_WEBHOOK_JWT_ISSUER",
+    "description": "The CGW's own identifier — checked as both the issuer (iss) and audience (aud) of billing-service webhook tokens",
+    "defaultValue": "safe-client-gateway",
+    "required": false
+  },
+  {
     "name": "AUTH0_CLIENT_SECRET",
     "description": "Client secret for the Auth0 regular web application",
     "defaultValue": null,
@@ -652,6 +664,12 @@
     "description": "Enable authentication feature (OPTIONAL)",
     "defaultValue": true,
     "required": true
+  },
+  {
+    "name": "FF_BILLING_WEBHOOK",
+    "description": "Enable the billing-service webhook receiver endpoint and its JWT auth guard (requires BILLING_WEBHOOK_JWT_PUBLIC_KEY)",
+    "defaultValue": false,
+    "required": false
   },
   {
     "name": "FF_CONFIG_HOOKS_DEBUG_LOGS",

--- a/.env.sample.json
+++ b/.env.sample.json
@@ -150,6 +150,12 @@
     "required": false
   },
   {
+    "name": "BILLING_WEBHOOK_JWT_KMS_KEY_ID",
+    "description": "Optional. Asymmetric KMS key id/ARN (ECC_NIST_P256) used by the token-generation CLI to sign via KMS instead of a local private key; unused by the running app",
+    "defaultValue": null,
+    "required": false
+  },
+  {
     "name": "AUTH0_CLIENT_SECRET",
     "description": "Client secret for the Auth0 regular web application",
     "defaultValue": null,

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
 COPY --chown=node:node scripts/generate-abis.js ./scripts/generate-abis.js
+# Compiled by `yarn build` into dist/scripts/ so the image can mint billing
+# webhook tokens as a one-off workload (see src/modules/billing/README.md).
+COPY --chown=node:node scripts/generate-token.ts ./scripts/generate-token.ts
 COPY --chown=node:node assets ./assets
 COPY --chown=node:node migrations ./migrations
 COPY --chown=node:node src ./src

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It provides UI-oriented mappings and data structures for easier integration with
 
 - [Client Gateway OpenAPI specification](https://safe-client.safe.global/api)
 - [Deploying the service](https://github.com/safe-global/safe-infrastructure)
+- [Billing webhook authentication & token generation](./src/modules/billing/README.md)
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "env:validate:silent": "ts-node scripts/validate-env-json.ts --silent",
     "env:generate": "ts-node scripts/generate-env.ts",
     "env:generate:force": "ts-node scripts/generate-env.ts --force",
-    "env:generate:update": "ts-node scripts/generate-env.ts --update"
+    "env:generate:update": "ts-node scripts/generate-env.ts --update",
+    "generate-token": "ts-node -r tsconfig-paths/register scripts/generate-token.ts"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "3.1076.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "cache-manager": "7.2.8",
     "cookie-parser": "1.4.7",
     "csv-stringify": "^6.8.0",
+    "ecdsa-sig-formatter": "1.0.11",
     "jose": "6.2.3",
     "jsonwebtoken": "9.0.3",
     "lodash": "4.18.1",

--- a/scripts/generate-token.ts
+++ b/scripts/generate-token.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+// biome-ignore-all lint/suspicious/noConsole: CLI script — console is the intended output.
+
+/**
+ * Mints the long-lived ES256 service-to-service token that the billing service
+ * presents on each webhook call to the CGW (`Authorization: Bearer <token>`).
+ *
+ * The CGW is the receiver that issues the credential it later verifies: this
+ * script signs with the CGW's private key, and the running app verifies
+ * incoming tokens with the matching public key (BILLING_WEBHOOK_JWT_PUBLIC_KEY).
+ * The private key lives only here, never in the running app's config.
+ *
+ * Usage:
+ *   BILLING_WEBHOOK_JWT_PRIVATE_KEY="$(cat ec-priv.pem)" \
+ *     yarn generate-token --sub billing-service --expires-in 1825
+ *
+ * Environment:
+ *   BILLING_WEBHOOK_JWT_PRIVATE_KEY  ES256 (EC P-256) private key in PEM (required)
+ *   BILLING_WEBHOOK_JWT_ISSUER       the CGW identifier, used as iss and aud
+ *                                    (default: safe-client-gateway)
+ *
+ * The issuer is resolved from the app config, so it matches what the webhook
+ * guard verifies against.
+ *
+ * See src/modules/billing/README.md for the full usage and provisioning guide.
+ */
+import configuration from '@/config/entities/configuration';
+import {
+  BillingAuthService,
+  DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
+} from '@/modules/billing/domain/billing-auth.service';
+
+const DEFAULT_EXPIRES_IN_DAYS = 5 * 365; // ~5 years, long-lived service credential
+
+/**
+ * Reads a `--flag value` style argument from process.argv.
+ */
+function getArg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1 || index === process.argv.length - 1) {
+    return undefined;
+  }
+  return process.argv[index + 1];
+}
+
+function fail(message: string): never {
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+}
+
+function main(): void {
+  const privateKey = process.env.BILLING_WEBHOOK_JWT_PRIVATE_KEY?.replace(
+    /\\n/g,
+    '\n',
+  );
+  if (!privateKey) {
+    fail(
+      'BILLING_WEBHOOK_JWT_PRIVATE_KEY environment variable is not defined (ES256 EC P-256 private key, PEM).',
+    );
+  }
+
+  // Resolve the issuer the same way the verifying app does (env or default),
+  // so a minted token always matches what the guard verifies.
+  const { issuer } = configuration().billing.webhook;
+  const subject = getArg('sub') ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
+
+  const expiresInArg = getArg('expires-in');
+  const expiresInDays = expiresInArg
+    ? Number.parseInt(expiresInArg, 10)
+    : DEFAULT_EXPIRES_IN_DAYS;
+  if (!Number.isFinite(expiresInDays) || expiresInDays <= 0) {
+    fail(
+      `Invalid --expires-in value: ${expiresInArg}. Must be a positive number of days.`,
+    );
+  }
+
+  let token: string;
+  try {
+    token = BillingAuthService.mint({
+      privateKey,
+      issuer,
+      subject,
+      expiresInDays,
+    });
+  } catch (error) {
+    fail(
+      `Failed to mint token: ${error instanceof Error ? error.message : 'unknown error'}`,
+    );
+  }
+
+  console.log('\n✓ Generated billing-service webhook token:');
+  console.log(`\n${token}`);
+  console.log(`\n• Subject (sub): ${subject}`);
+  console.log(`• Issuer & Audience (iss/aud): ${issuer}`);
+  console.log(`• Algorithm: ES256`);
+  console.log(`• Expires in: ${expiresInDays} days`);
+}
+
+main();

--- a/scripts/generate-token.ts
+++ b/scripts/generate-token.ts
@@ -15,7 +15,8 @@
  *     key). The private key never leaves KMS. Also prints the public key PEM to
  *     configure the verifier. Requires AWS_REGION + credentials (AWS_WEB_IDENTITY_TOKEN_FILE).
  *   - **Local PEM** — set BILLING_WEBHOOK_JWT_PRIVATE_KEY (ES256 EC P-256 PEM).
- *     For dev/CI only; rejected when CGW_ENV=production (KMS is required there).
+ *     For dev/CI only; rejected when CGW_ENV is production or staging (KMS is
+ *     required there).
  *
  * Usage:
  *   # local key
@@ -31,16 +32,26 @@ import { createPublicKey } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import configuration from '@/config/entities/configuration';
 import { AwsKmsSignerService } from '@/datasources/kms/aws-kms-signer.service';
-import {
-  BillingAuthService,
-  DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
-} from '@/modules/billing/domain/billing-auth.service';
+import { DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT } from '@/modules/billing/domain/billing-auth.constants';
+import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
 
 const DEFAULT_EXPIRES_IN_DAYS = 5 * 365; // ~5 years, long-lived service credential
 
 // Service identifiers only — keeps the `sub`/`service_name` claims clean and
 // avoids control/escape characters reaching the terminal or the token.
 const SUBJECT_PATTERN = /^[a-zA-Z0-9._-]{1,128}$/;
+
+type ClaimsArgs = {
+  issuer: string;
+  subject: string;
+  expiresInDays: number;
+};
+
+type MintResult = {
+  token: string;
+  /** Only set for KMS mode, where the caller can't derive it from local env. */
+  publicKeyPem?: string;
+};
 
 function fail(message: string): never {
   console.error(`ERROR: ${message}`);
@@ -65,19 +76,17 @@ function parseCliArgs(): { sub?: string; expiresIn?: string } {
   }
 }
 
-async function main(): Promise<void> {
-  const { sub, expiresIn } = parseCliArgs();
-
-  const config = configuration();
-  const { issuer, kms } = config.billing.webhook;
-
+function resolveSubject(sub?: string): string {
   const subject = sub ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
   if (!SUBJECT_PATTERN.test(subject)) {
     fail(
       `Invalid --sub value: ${JSON.stringify(subject)}. Allowed: letters, digits, '.', '_', '-' (max 128 chars).`,
     );
   }
+  return subject;
+}
 
+function resolveExpiresInDays(expiresIn?: string): number {
   const expiresInDays = expiresIn
     ? Number.parseInt(expiresIn, 10)
     : DEFAULT_EXPIRES_IN_DAYS;
@@ -86,73 +95,110 @@ async function main(): Promise<void> {
       `Invalid --expires-in value: ${JSON.stringify(expiresIn)}. Must be a positive number of days.`,
     );
   }
+  return expiresInDays;
+}
 
-  const claimsArgs = { issuer, subject, expiresInDays };
+/** KMS signing mode — the private key never leaves KMS. */
+async function mintViaKms(
+  kms: { keyId: string; webIdentityTokenFile?: string },
+  claimsArgs: ClaimsArgs,
+): Promise<MintResult> {
+  const signer = new AwsKmsSignerService({
+    keyId: kms.keyId,
+    webIdentityTokenFile: kms.webIdentityTokenFile,
+  });
+  const token = await BillingAuthService.mintViaSigner(claimsArgs, (input) =>
+    signer.sign(input),
+  );
+  // Return the matching public key so ops can set BILLING_WEBHOOK_JWT_PUBLIC_KEY.
+  const spkiDer = await signer.getPublicKey();
+  const publicKeyPem = createPublicKey({
+    key: spkiDer,
+    format: 'der',
+    type: 'spki',
+  })
+    .export({ format: 'pem', type: 'spki' })
+    .toString();
+  return { token, publicKeyPem };
+}
 
-  let token: string;
-  let publicKeyPem: string | undefined;
+/** Local PEM signing mode — dev/CI only; deployed environments must sign via KMS. */
+function mintViaLocalKey(claimsArgs: ClaimsArgs): MintResult {
+  // Mirrors the RootConfigurationSchema guard, which rejects
+  // BILLING_WEBHOOK_JWT_PRIVATE_KEY in these environments at app startup.
+  const isDeployedEnv = ['production', 'staging'].includes(
+    process.env.CGW_ENV ?? '',
+  );
+  if (isDeployedEnv) {
+    fail(
+      'Production and staging require KMS signing: set BILLING_WEBHOOK_JWT_KMS_KEY_ID. Minting with a local BILLING_WEBHOOK_JWT_PRIVATE_KEY is not allowed in these environments.',
+    );
+  }
+  const privateKey = process.env.BILLING_WEBHOOK_JWT_PRIVATE_KEY?.replace(
+    /\\n/g,
+    '\n',
+  );
+  if (!privateKey) {
+    fail(
+      'No signing key configured. Set BILLING_WEBHOOK_JWT_KMS_KEY_ID to sign via KMS, or BILLING_WEBHOOK_JWT_PRIVATE_KEY (ES256 EC P-256 private key, PEM) to sign locally.',
+    );
+  }
+  return { token: BillingAuthService.mint({ privateKey, ...claimsArgs }) };
+}
 
+function printResult(args: {
+  result: MintResult;
+  claimsArgs: ClaimsArgs;
+  signedVia: string;
+}): void {
+  const { result, claimsArgs, signedVia } = args;
+  console.log(`
+✓ Generated billing-service webhook token:
+
+${result.token}
+
+• Subject (sub): ${claimsArgs.subject}
+• Issuer & Audience (iss/aud): ${claimsArgs.issuer}
+• Algorithm: ES256
+• Signed via: ${signedVia}
+• Expires in: ${claimsArgs.expiresInDays} days`);
+
+  if (result.publicKeyPem) {
+    console.log(`
+Configure the verifier with this public key (BILLING_WEBHOOK_JWT_PUBLIC_KEY):
+
+${result.publicKeyPem}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const { sub, expiresIn } = parseCliArgs();
+
+  const config = configuration();
+  const { issuer, kms } = config.billing.webhook;
+
+  const claimsArgs: ClaimsArgs = {
+    issuer,
+    subject: resolveSubject(sub),
+    expiresInDays: resolveExpiresInDays(expiresIn),
+  };
+
+  let result: MintResult;
   try {
-    if (kms.keyId) {
-      // KMS signing mode — the private key never leaves KMS.
-      const signer = new AwsKmsSignerService({
-        keyId: kms.keyId,
-        webIdentityTokenFile: kms.webIdentityTokenFile,
-      });
-      token = await BillingAuthService.mintViaSigner(claimsArgs, (input) =>
-        signer.sign(input),
-      );
-      // Print the matching public key so ops can set BILLING_WEBHOOK_JWT_PUBLIC_KEY.
-      const spkiDer = await signer.getPublicKey();
-      publicKeyPem = createPublicKey({
-        key: spkiDer,
-        format: 'der',
-        type: 'spki',
-      })
-        .export({ format: 'pem', type: 'spki' })
-        .toString();
-    } else {
-      // Local PEM signing mode — dev/CI only; production must sign via KMS.
-      if (config.application.isProduction) {
-        fail(
-          'Production requires KMS signing: set BILLING_WEBHOOK_JWT_KMS_KEY_ID. Minting with a local BILLING_WEBHOOK_JWT_PRIVATE_KEY is not allowed in production.',
-        );
-      }
-      const privateKey = process.env.BILLING_WEBHOOK_JWT_PRIVATE_KEY?.replace(
-        /\\n/g,
-        '\n',
-      );
-      if (!privateKey) {
-        fail(
-          'No signing key configured. Set BILLING_WEBHOOK_JWT_KMS_KEY_ID to sign via KMS, or BILLING_WEBHOOK_JWT_PRIVATE_KEY (ES256 EC P-256 private key, PEM) to sign locally.',
-        );
-      }
-      token = BillingAuthService.mint({ privateKey, ...claimsArgs });
-    }
+    result = kms.keyId
+      ? await mintViaKms({ ...kms, keyId: kms.keyId }, claimsArgs)
+      : mintViaLocalKey(claimsArgs);
   } catch (error) {
     fail(
       `Failed to mint token: ${error instanceof Error ? error.message : 'unknown error'}`,
     );
   }
 
-  const signedVia = kms.keyId ? `KMS (${kms.keyId})` : 'local private key';
-  console.log(`
-✓ Generated billing-service webhook token:
-
-${token}
-
-• Subject (sub): ${subject}
-• Issuer & Audience (iss/aud): ${issuer}
-• Algorithm: ES256
-• Signed via: ${signedVia}
-• Expires in: ${expiresInDays} days`);
-
-  if (publicKeyPem) {
-    console.log(`
-Configure the verifier with this public key (BILLING_WEBHOOK_JWT_PUBLIC_KEY):
-
-${publicKeyPem}`);
-  }
+  printResult({
+    result,
+    claimsArgs,
+    signedVia: kms.keyId ? `KMS (${kms.keyId})` : 'local private key',
+  });
 }
 
 main().catch((error) => {

--- a/scripts/generate-token.ts
+++ b/scripts/generate-token.ts
@@ -24,6 +24,7 @@
  *
  * See src/modules/billing/README.md for the full usage and provisioning guide.
  */
+import { parseArgs } from 'node:util';
 import configuration from '@/config/entities/configuration';
 import {
   BillingAuthService,
@@ -32,20 +33,31 @@ import {
 
 const DEFAULT_EXPIRES_IN_DAYS = 5 * 365; // ~5 years, long-lived service credential
 
-/**
- * Reads a `--flag value` style argument from process.argv.
- */
-function getArg(name: string): string | undefined {
-  const index = process.argv.indexOf(`--${name}`);
-  if (index === -1 || index === process.argv.length - 1) {
-    return undefined;
-  }
-  return process.argv[index + 1];
-}
+// Service identifiers only — keeps the `sub`/`service_name` claims clean and
+// avoids control/escape characters reaching the terminal or the token.
+const SUBJECT_PATTERN = /^[a-zA-Z0-9._-]{1,128}$/;
 
 function fail(message: string): never {
   console.error(`ERROR: ${message}`);
   process.exit(1);
+}
+
+/**
+ * Parses `--sub <value>` and `--expires-in <days>` (also accepts `--flag=value`).
+ * Strict: an unknown flag fails, so a typo'd argument can't quietly mint a token with the wrong values.
+ */
+function parseCliArgs(): { sub?: string; expiresIn?: string } {
+  try {
+    const { values } = parseArgs({
+      options: {
+        sub: { type: 'string' },
+        'expires-in': { type: 'string' },
+      },
+    });
+    return { sub: values.sub, expiresIn: values['expires-in'] };
+  } catch (error) {
+    fail(error instanceof Error ? error.message : 'Invalid arguments');
+  }
 }
 
 function main(): void {
@@ -58,19 +70,23 @@ function main(): void {
       'BILLING_WEBHOOK_JWT_PRIVATE_KEY environment variable is not defined (ES256 EC P-256 private key, PEM).',
     );
   }
+  const { sub, expiresIn } = parseCliArgs();
 
-  // Resolve the issuer the same way the verifying app does (env or default),
-  // so a minted token always matches what the guard verifies.
   const { issuer } = configuration().billing.webhook;
-  const subject = getArg('sub') ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
+  const subject = sub ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
 
-  const expiresInArg = getArg('expires-in');
-  const expiresInDays = expiresInArg
-    ? Number.parseInt(expiresInArg, 10)
+  if (!SUBJECT_PATTERN.test(subject)) {
+    fail(
+      `Invalid --sub value: ${JSON.stringify(subject)}. Allowed: letters, digits, '.', '_', '-' (max 128 chars).`,
+    );
+  }
+
+  const expiresInDays = expiresIn
+    ? Number.parseInt(expiresIn, 10)
     : DEFAULT_EXPIRES_IN_DAYS;
   if (!Number.isFinite(expiresInDays) || expiresInDays <= 0) {
     fail(
-      `Invalid --expires-in value: ${expiresInArg}. Must be a positive number of days.`,
+      `Invalid --expires-in value: ${JSON.stringify(expiresIn)}. Must be a positive number of days.`,
     );
   }
 
@@ -88,12 +104,15 @@ function main(): void {
     );
   }
 
-  console.log('\n✓ Generated billing-service webhook token:');
-  console.log(`\n${token}`);
-  console.log(`\n• Subject (sub): ${subject}`);
-  console.log(`• Issuer & Audience (iss/aud): ${issuer}`);
-  console.log(`• Algorithm: ES256`);
-  console.log(`• Expires in: ${expiresInDays} days`);
+  console.log(`
+✓ Generated billing-service webhook token:
+
+${token}
+
+• Subject (sub): ${subject}
+• Issuer & Audience (iss/aud): ${issuer}
+• Algorithm: ES256
+• Expires in: ${expiresInDays} days`);
 }
 
 main();

--- a/scripts/generate-token.ts
+++ b/scripts/generate-token.ts
@@ -5,27 +5,32 @@
  * Mints the long-lived ES256 service-to-service token that the billing service
  * presents on each webhook call to the CGW (`Authorization: Bearer <token>`).
  *
- * The CGW is the receiver that issues the credential it later verifies: this
- * script signs with the CGW's private key, and the running app verifies
- * incoming tokens with the matching public key (BILLING_WEBHOOK_JWT_PUBLIC_KEY).
- * The private key lives only here, never in the running app's config.
+ * The CGW is the receiver that issues the credential it later verifies. The
+ * running app verifies incoming tokens offline with the matching public key
+ * (BILLING_WEBHOOK_JWT_PUBLIC_KEY); it never signs.
+ *
+ * Two signing modes (the issuer is resolved from app config either way, so a
+ * minted token always matches what the guard verifies):
+ *   - **KMS** — set BILLING_WEBHOOK_JWT_KMS_KEY_ID (asymmetric ECC_NIST_P256
+ *     key). The private key never leaves KMS. Also prints the public key PEM to
+ *     configure the verifier. Requires AWS_REGION + credentials (AWS_WEB_IDENTITY_TOKEN_FILE).
+ *   - **Local PEM** — set BILLING_WEBHOOK_JWT_PRIVATE_KEY (ES256 EC P-256 PEM).
+ *     For dev/CI only; rejected when CGW_ENV=production (KMS is required there).
  *
  * Usage:
+ *   # local key
  *   BILLING_WEBHOOK_JWT_PRIVATE_KEY="$(cat ec-priv.pem)" \
  *     yarn generate-token --sub billing-service --expires-in 1825
- *
- * Environment:
- *   BILLING_WEBHOOK_JWT_PRIVATE_KEY  ES256 (EC P-256) private key in PEM (required)
- *   BILLING_WEBHOOK_JWT_ISSUER       the CGW identifier, used as iss and aud
- *                                    (default: safe-client-gateway)
- *
- * The issuer is resolved from the app config, so it matches what the webhook
- * guard verifies against.
+ *   # KMS
+ *   BILLING_WEBHOOK_JWT_KMS_KEY_ID=<arn> \
+ *     yarn generate-token --sub billing-service
  *
  * See src/modules/billing/README.md for the full usage and provisioning guide.
  */
+import { createPublicKey } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import configuration from '@/config/entities/configuration';
+import { AwsKmsSignerService } from '@/datasources/kms/aws-kms-signer.service';
 import {
   BillingAuthService,
   DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
@@ -60,21 +65,13 @@ function parseCliArgs(): { sub?: string; expiresIn?: string } {
   }
 }
 
-function main(): void {
-  const privateKey = process.env.BILLING_WEBHOOK_JWT_PRIVATE_KEY?.replace(
-    /\\n/g,
-    '\n',
-  );
-  if (!privateKey) {
-    fail(
-      'BILLING_WEBHOOK_JWT_PRIVATE_KEY environment variable is not defined (ES256 EC P-256 private key, PEM).',
-    );
-  }
+async function main(): Promise<void> {
   const { sub, expiresIn } = parseCliArgs();
 
-  const { issuer } = configuration().billing.webhook;
-  const subject = sub ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
+  const config = configuration();
+  const { issuer, kms } = config.billing.webhook;
 
+  const subject = sub ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
   if (!SUBJECT_PATTERN.test(subject)) {
     fail(
       `Invalid --sub value: ${JSON.stringify(subject)}. Allowed: letters, digits, '.', '_', '-' (max 128 chars).`,
@@ -90,20 +87,55 @@ function main(): void {
     );
   }
 
+  const claimsArgs = { issuer, subject, expiresInDays };
+
   let token: string;
+  let publicKeyPem: string | undefined;
+
   try {
-    token = BillingAuthService.mint({
-      privateKey,
-      issuer,
-      subject,
-      expiresInDays,
-    });
+    if (kms.keyId) {
+      // KMS signing mode — the private key never leaves KMS.
+      const signer = new AwsKmsSignerService({
+        keyId: kms.keyId,
+        webIdentityTokenFile: kms.webIdentityTokenFile,
+      });
+      token = await BillingAuthService.mintViaSigner(claimsArgs, (input) =>
+        signer.sign(input),
+      );
+      // Print the matching public key so ops can set BILLING_WEBHOOK_JWT_PUBLIC_KEY.
+      const spkiDer = await signer.getPublicKey();
+      publicKeyPem = createPublicKey({
+        key: spkiDer,
+        format: 'der',
+        type: 'spki',
+      })
+        .export({ format: 'pem', type: 'spki' })
+        .toString();
+    } else {
+      // Local PEM signing mode — dev/CI only; production must sign via KMS.
+      if (config.application.isProduction) {
+        fail(
+          'Production requires KMS signing: set BILLING_WEBHOOK_JWT_KMS_KEY_ID. Minting with a local BILLING_WEBHOOK_JWT_PRIVATE_KEY is not allowed in production.',
+        );
+      }
+      const privateKey = process.env.BILLING_WEBHOOK_JWT_PRIVATE_KEY?.replace(
+        /\\n/g,
+        '\n',
+      );
+      if (!privateKey) {
+        fail(
+          'No signing key configured. Set BILLING_WEBHOOK_JWT_KMS_KEY_ID to sign via KMS, or BILLING_WEBHOOK_JWT_PRIVATE_KEY (ES256 EC P-256 private key, PEM) to sign locally.',
+        );
+      }
+      token = BillingAuthService.mint({ privateKey, ...claimsArgs });
+    }
   } catch (error) {
     fail(
       `Failed to mint token: ${error instanceof Error ? error.message : 'unknown error'}`,
     );
   }
 
+  const signedVia = kms.keyId ? `KMS (${kms.keyId})` : 'local private key';
   console.log(`
 ✓ Generated billing-service webhook token:
 
@@ -112,7 +144,17 @@ ${token}
 • Subject (sub): ${subject}
 • Issuer & Audience (iss/aud): ${issuer}
 • Algorithm: ES256
+• Signed via: ${signedVia}
 • Expires in: ${expiresInDays} days`);
+
+  if (publicKeyPem) {
+    console.log(`
+Configure the verifier with this public key (BILLING_WEBHOOK_JWT_PUBLIC_KEY):
+
+${publicKeyPem}`);
+  }
 }
 
-main();
+main().catch((error) => {
+  fail(error instanceof Error ? error.message : 'unknown error');
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,7 @@ import { AlertsModule } from '@/modules/alerts/alerts.module';
 import { AuthModule } from '@/modules/auth/auth.module';
 import { OidcAuthModule } from '@/modules/auth/oidc/oidc-auth.module';
 import { BalancesModule } from '@/modules/balances/balances.module';
+import { BillingModule } from '@/modules/billing/billing.module';
 import { ChainsModule } from '@/modules/chains/chains.module';
 import { FeatureFlagsModule } from '@/modules/chains/feature-flags/feature-flags.module';
 import { CollectiblesModule } from '@/modules/collectibles/collectibles.module';
@@ -80,6 +81,7 @@ export class AppModule implements NestModule {
       users: isUsersFeatureEnabled,
       email: isEmailFeatureEnabled,
       zerionPositions: isZerionPositionsFeatureEnabled,
+      billingWebhook: isBillingWebhookFeatureEnabled,
     } = configFactory().features;
 
     return {
@@ -91,6 +93,7 @@ export class AppModule implements NestModule {
         ...(isAuthFeatureEnabled ? [AuthModule] : []),
         ...(isOidcAuthFeatureEnabled ? [OidcAuthModule] : []),
         BalancesModule,
+        ...(isBillingWebhookFeatureEnabled ? [BillingModule] : []),
         ...(isZerionPositionsFeatureEnabled ? [PositionsModule] : []),
         PortfolioModule,
         ChainsModule,

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -332,6 +332,39 @@ describe('Configuration validator', () => {
     );
   });
 
+  describe('BILLING_WEBHOOK_JWT_PRIVATE_KEY', () => {
+    it.each([
+      'production',
+      'staging',
+    ])('should reject BILLING_WEBHOOK_JWT_PRIVATE_KEY in %s environment', (env) => {
+      process.env.NODE_ENV = 'production';
+      const config = {
+        ...validConfiguration,
+        CGW_ENV: env,
+        BILLING_WEBHOOK_JWT_PRIVATE_KEY: faker.string.alphanumeric(),
+      };
+
+      expect(() =>
+        configurationValidator(config, RootConfigurationSchema),
+      ).toThrow(
+        'Configuration is invalid: BILLING_WEBHOOK_JWT_PRIVATE_KEY must not be set in production and staging environments; sign via KMS (BILLING_WEBHOOK_JWT_KMS_KEY_ID) instead',
+      );
+    });
+
+    it('should accept BILLING_WEBHOOK_JWT_PRIVATE_KEY outside staging and production', () => {
+      process.env.NODE_ENV = 'production';
+      const config = {
+        ...validConfiguration,
+        CGW_ENV: 'development',
+        BILLING_WEBHOOK_JWT_PRIVATE_KEY: faker.string.alphanumeric(),
+      };
+
+      expect(configurationValidator(config, RootConfigurationSchema)).toBe(
+        config,
+      );
+    });
+  });
+
   describe('RELAY_NO_FEE_CAMPAIGN relay rules validation', () => {
     describe.each([
       'RELAY_NO_FEE_CAMPAIGN_MAINNET_RELAY_RULES',

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -273,7 +273,11 @@ export default (): ReturnType<typeof configuration> => ({
   },
   billing: {
     webhook: {
-      publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY,
+      // PEM keys provided via env often arrive with escaped newlines.
+      publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY?.replace(
+        /\\n/g,
+        '\n',
+      ),
       issuer: process.env.BILLING_WEBHOOK_JWT_ISSUER ?? 'safe-client-gateway',
       kms: {
         keyId: process.env.BILLING_WEBHOOK_JWT_KMS_KEY_ID,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -215,6 +215,7 @@ export default (): ReturnType<typeof configuration> => ({
     configHooksDebugLogs: false,
     auth: false,
     oidc_auth: false,
+    billingWebhook: false,
     counterfactualBalances: false,
     users: false,
     hookHttpPostEvent: false,
@@ -269,6 +270,12 @@ export default (): ReturnType<typeof configuration> => ({
   jwt: {
     issuer: process.env.JWT_TEST_ISSUER || 'dummy-issuer',
     secret: process.env.JWT_TEST_SECRET || 'dummy-secret',
+  },
+  billing: {
+    webhook: {
+      publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY,
+      issuer: process.env.BILLING_WEBHOOK_JWT_ISSUER ?? 'safe-client-gateway',
+    },
   },
   log: {
     level: 'debug',

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -275,6 +275,10 @@ export default (): ReturnType<typeof configuration> => ({
     webhook: {
       publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY,
       issuer: process.env.BILLING_WEBHOOK_JWT_ISSUER ?? 'safe-client-gateway',
+      kms: {
+        keyId: process.env.BILLING_WEBHOOK_JWT_KMS_KEY_ID,
+        webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
+      },
     },
   },
   log: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -427,6 +427,7 @@ export default () => ({
       process.env.FF_CONFIG_HOOKS_DEBUG_LOGS?.toLowerCase() === 'true',
     auth: process.env.FF_AUTH?.toLowerCase() === 'true',
     oidc_auth: process.env.FF_OIDC_AUTH?.toLowerCase() === 'true',
+    billingWebhook: process.env.FF_BILLING_WEBHOOK?.toLowerCase() === 'true',
     counterfactualBalances:
       process.env.FF_COUNTERFACTUAL_BALANCES?.toLowerCase() === 'true',
     users: process.env.FF_USERS?.toLowerCase() === 'true',
@@ -530,6 +531,16 @@ export default () => ({
   jwt: {
     issuer: process.env.JWT_ISSUER,
     secret: process.env.JWT_SECRET,
+  },
+  billing: {
+    // ES256 service-to-service auth for incoming billing-service webhooks.
+    // The CGW verifies tokens against its own public key (no JWKS); the
+    // private key lives only in the provisioning CLI, not the running app.
+    webhook: {
+      publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY,
+      // The CGW's own identifier — a self-issued token uses it as both `iss` and `aud`.
+      issuer: process.env.BILLING_WEBHOOK_JWT_ISSUER ?? 'safe-client-gateway',
+    },
   },
   locking: {
     baseUri:

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -537,7 +537,11 @@ export default () => ({
     // The CGW verifies tokens against its own public key (no JWKS); the
     // private key lives only in the provisioning CLI, not the running app.
     webhook: {
-      publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY,
+      // PEM keys provided via env often arrive with escaped newlines.
+      publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY?.replace(
+        /\\n/g,
+        '\n',
+      ),
       // The CGW's own identifier — a self-issued token uses it as both `iss` and `aud`.
       issuer: process.env.BILLING_WEBHOOK_JWT_ISSUER ?? 'safe-client-gateway',
       // Optional: sign bearer tokens via an asymmetric KMS key (ECC_NIST_P256)

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -540,6 +540,16 @@ export default () => ({
       publicKey: process.env.BILLING_WEBHOOK_JWT_PUBLIC_KEY,
       // The CGW's own identifier — a self-issued token uses it as both `iss` and `aud`.
       issuer: process.env.BILLING_WEBHOOK_JWT_ISSUER ?? 'safe-client-gateway',
+      // Optional: sign bearer tokens via an asymmetric KMS key (ECC_NIST_P256)
+      // instead of a local private key. Consumed only by the provisioning CLI;
+      // the running app never signs (it verifies offline with the public key).
+      kms: {
+        keyId: process.env.BILLING_WEBHOOK_JWT_KMS_KEY_ID,
+        // Region + credentials are resolved by the AWS SDK's default chain
+        // (AWS_REGION, env keys, shared profile, SSO). In EKS, IRSA provides
+        // pod credentials via the web identity token file.
+        webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
+      },
     },
   },
   locking: {

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -54,6 +54,9 @@ export const RootConfigurationSchema = z
     BILLING_WEBHOOK_JWT_PUBLIC_KEY: z.string().optional(),
     BILLING_WEBHOOK_JWT_ISSUER: z.string().optional(),
     BILLING_WEBHOOK_JWT_KMS_KEY_ID: z.string().optional(),
+    // Only consumed by scripts/generate-token.ts, never by the running app.
+    // Declared here so the production guard below can see it.
+    BILLING_WEBHOOK_JWT_PRIVATE_KEY: z.string().optional(),
     AUTH0_CLIENT_SECRET: z.string().optional(),
     AUTH0_REDIRECT_URI: z.url().optional(),
     AUTH0_SCOPE: z.string().optional(),
@@ -191,6 +194,18 @@ export const RootConfigurationSchema = z
     // These fields are only required in deployed (production/staging) environments.
     const isDeployedEnv =
       !!config.CGW_ENV && ['production', 'staging'].includes(config.CGW_ENV);
+
+    // The billing webhook signing key must never live in deployed environments —
+    // tokens are long-lived and minted via KMS there (see scripts/generate-token.ts).
+    if (isDeployedEnv && config.BILLING_WEBHOOK_JWT_PRIVATE_KEY) {
+      ctx.addIssue({
+        code: 'custom',
+        message:
+          'must not be set in production and staging environments; sign via KMS (BILLING_WEBHOOK_JWT_KMS_KEY_ID) instead',
+        path: ['BILLING_WEBHOOK_JWT_PRIVATE_KEY'],
+      });
+    }
+
     if (!isDeployedEnv) {
       return;
     }

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -51,6 +51,8 @@ export const RootConfigurationSchema = z
     AUTH0_API_AUDIENCE: z.string().optional(),
     AUTH0_DOMAIN: DomainSchema.optional(),
     AUTH0_CLIENT_ID: z.string().optional(),
+    BILLING_WEBHOOK_JWT_PUBLIC_KEY: z.string().optional(),
+    BILLING_WEBHOOK_JWT_ISSUER: z.string().optional(),
     AUTH0_CLIENT_SECRET: z.string().optional(),
     AUTH0_REDIRECT_URI: z.url().optional(),
     AUTH0_SCOPE: z.string().optional(),

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -53,6 +53,7 @@ export const RootConfigurationSchema = z
     AUTH0_CLIENT_ID: z.string().optional(),
     BILLING_WEBHOOK_JWT_PUBLIC_KEY: z.string().optional(),
     BILLING_WEBHOOK_JWT_ISSUER: z.string().optional(),
+    BILLING_WEBHOOK_JWT_KMS_KEY_ID: z.string().optional(),
     AUTH0_CLIENT_SECRET: z.string().optional(),
     AUTH0_REDIRECT_URI: z.url().optional(),
     AUTH0_SCOPE: z.string().optional(),

--- a/src/datasources/common/utils/aws-credentials.utils.ts
+++ b/src/datasources/common/utils/aws-credentials.utils.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
+
+/**
+ * Resolves AWS SDK credentials for clients that support IRSA.
+ *
+ * In EKS, IRSA provides pod credentials via a projected web identity token
+ * file. When `webIdentityTokenFile` is set, returns web identity credentials;
+ * otherwise returns `undefined` so the client falls back to the default AWS
+ * provider chain (env keys, shared profile, SSO) — or to an explicit fallback
+ * chained with `??` at the call site.
+ */
+export function resolveAwsCredentials(
+  webIdentityTokenFile: string | undefined,
+): ReturnType<typeof fromTokenFile> | undefined {
+  return webIdentityTokenFile ? fromTokenFile() : undefined;
+}

--- a/src/datasources/jwt/jwt.constants.ts
+++ b/src/datasources/jwt/jwt.constants.ts
@@ -3,3 +3,6 @@
 export const JWT_HS_ALGORITHM = 'HS256' as const;
 // Keep this library-agnostic: Auth0 ID-token verification uses jose, while tests use jsonwebtoken.
 export const JWT_RS_ALGORITHM = 'RS256' as const;
+// ECDSA P-256 (asymmetric): private key signs, public key verifies.
+// Used for the billing-service webhook service-to-service token.
+export const JWT_ES_ALGORITHM = 'ES256' as const;

--- a/src/datasources/jwt/jwt.module.ts
+++ b/src/datasources/jwt/jwt.module.ts
@@ -7,7 +7,7 @@ import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import { toSecondsTimestamp } from '@/domain/common/utils/time';
 
 // Use inferred type
-function jwtClientFactory() {
+export function jwtClientFactory() {
   return {
     sign: <
       T extends object & {

--- a/src/datasources/kms/aws-kms-signer.service.spec.ts
+++ b/src/datasources/kms/aws-kms-signer.service.spec.ts
@@ -13,14 +13,13 @@ const kmsMock = mockClient(KMSClient);
 
 describe('AwsKmsSignerService', () => {
   const keyId = faker.string.uuid();
-  const config = { keyId };
 
   beforeEach(() => {
     kmsMock.reset();
   });
 
   function createSigner(): AwsKmsSignerService {
-    return new AwsKmsSignerService(config);
+    return new AwsKmsSignerService({ keyId });
   }
 
   describe('sign', () => {

--- a/src/datasources/kms/aws-kms-signer.service.spec.ts
+++ b/src/datasources/kms/aws-kms-signer.service.spec.ts
@@ -5,22 +5,45 @@ import {
   KMSClient,
   SignCommand,
 } from '@aws-sdk/client-kms';
+import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 import { faker } from '@faker-js/faker';
 import { mockClient } from 'aws-sdk-client-mock';
 import { AwsKmsSignerService } from '@/datasources/kms/aws-kms-signer.service';
 
 const kmsMock = mockClient(KMSClient);
 
+vi.mock('@aws-sdk/credential-provider-web-identity', () => ({
+  fromTokenFile: vi.fn(),
+}));
+
 describe('AwsKmsSignerService', () => {
   const keyId = faker.string.uuid();
 
   beforeEach(() => {
+    vi.clearAllMocks();
     kmsMock.reset();
   });
 
   function createSigner(): AwsKmsSignerService {
     return new AwsKmsSignerService({ keyId });
   }
+
+  describe('credentials', () => {
+    it('uses web identity (IRSA) credentials when webIdentityTokenFile is set', () => {
+      new AwsKmsSignerService({
+        keyId,
+        webIdentityTokenFile: faker.system.filePath(),
+      });
+
+      expect(fromTokenFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the default provider chain when webIdentityTokenFile is not set', () => {
+      createSigner();
+
+      expect(fromTokenFile).not.toHaveBeenCalled();
+    });
+  });
 
   describe('sign', () => {
     it('sends an ES256 SignCommand and returns the DER signature', async () => {

--- a/src/datasources/kms/aws-kms-signer.service.spec.ts
+++ b/src/datasources/kms/aws-kms-signer.service.spec.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import {
+  GetPublicKeyCommand,
+  KMSClient,
+  SignCommand,
+} from '@aws-sdk/client-kms';
+import { faker } from '@faker-js/faker';
+import { mockClient } from 'aws-sdk-client-mock';
+import { AwsKmsSignerService } from '@/datasources/kms/aws-kms-signer.service';
+
+const kmsMock = mockClient(KMSClient);
+
+describe('AwsKmsSignerService', () => {
+  const keyId = faker.string.uuid();
+  const config = { keyId };
+
+  beforeEach(() => {
+    kmsMock.reset();
+  });
+
+  function createSigner(): AwsKmsSignerService {
+    return new AwsKmsSignerService(config);
+  }
+
+  describe('sign', () => {
+    it('sends an ES256 SignCommand and returns the DER signature', async () => {
+      const signature = Buffer.from(faker.string.hexadecimal({ length: 140 }));
+      kmsMock.on(SignCommand).resolves({ Signature: signature });
+
+      const message = Buffer.from(faker.string.alphanumeric(64));
+      const result = await createSigner().sign(message);
+
+      expect(result).toEqual(signature);
+      expect(
+        kmsMock.commandCalls(SignCommand, {
+          KeyId: keyId,
+          Message: message,
+          MessageType: 'RAW',
+          SigningAlgorithm: 'ECDSA_SHA_256',
+        }),
+      ).toHaveLength(1);
+    });
+
+    it('throws when KMS returns no signature', async () => {
+      kmsMock.on(SignCommand).resolves({});
+
+      await expect(
+        createSigner().sign(Buffer.from(faker.string.alphanumeric(16))),
+      ).rejects.toThrow('KMS did not return a signature');
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('sends a GetPublicKeyCommand and returns the SPKI DER key', async () => {
+      const publicKey = Buffer.from(faker.string.hexadecimal({ length: 182 }));
+      kmsMock.on(GetPublicKeyCommand).resolves({ PublicKey: publicKey });
+
+      const result = await createSigner().getPublicKey();
+
+      expect(result).toEqual(publicKey);
+      expect(
+        kmsMock.commandCalls(GetPublicKeyCommand, { KeyId: keyId }),
+      ).toHaveLength(1);
+    });
+
+    it('throws when KMS returns no public key', async () => {
+      kmsMock.on(GetPublicKeyCommand).resolves({});
+
+      await expect(createSigner().getPublicKey()).rejects.toThrow(
+        'KMS did not return a public key',
+      );
+    });
+  });
+});

--- a/src/datasources/kms/aws-kms-signer.service.ts
+++ b/src/datasources/kms/aws-kms-signer.service.ts
@@ -5,21 +5,9 @@ import {
   KMSClient,
   SignCommand,
 } from '@aws-sdk/client-kms';
-import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
+import { resolveAwsCredentials } from '@/datasources/common/utils/aws-credentials.utils';
+import type { KmsSignerConfig } from '@/datasources/kms/entities/kms-signer-config.entity';
 import type { IKmsSigner } from '@/datasources/kms/kms-signer.interface';
-
-export interface KmsSignerConfig {
-  keyId: string;
-  webIdentityTokenFile?: string;
-}
-
-function resolveCredentials(
-  config: KmsSignerConfig,
-): ReturnType<typeof fromTokenFile> | undefined {
-  // EKS provides pod credentials via IRSA (web identity token). Otherwise fall
-  // back to the default AWS provider chain (env keys).
-  return config.webIdentityTokenFile ? fromTokenFile() : undefined;
-}
 
 /**
  * Signs billing webhook tokens with an asymmetric AWS KMS key
@@ -31,7 +19,9 @@ export class AwsKmsSignerService implements IKmsSigner {
   private readonly client: KMSClient;
 
   constructor(private readonly config: KmsSignerConfig) {
-    this.client = new KMSClient({ credentials: resolveCredentials(config) });
+    this.client = new KMSClient({
+      credentials: resolveAwsCredentials(config.webIdentityTokenFile),
+    });
   }
 
   async sign(message: Buffer): Promise<Buffer> {

--- a/src/datasources/kms/aws-kms-signer.service.ts
+++ b/src/datasources/kms/aws-kms-signer.service.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import {
+  GetPublicKeyCommand,
+  KMSClient,
+  SignCommand,
+} from '@aws-sdk/client-kms';
+import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
+import type { IKmsSigner } from '@/datasources/kms/kms-signer.interface';
+
+export interface KmsSignerConfig {
+  keyId: string;
+  webIdentityTokenFile?: string;
+}
+
+function resolveCredentials(
+  config: KmsSignerConfig,
+): ReturnType<typeof fromTokenFile> | undefined {
+  // EKS provides pod credentials via IRSA (web identity token). Otherwise fall
+  // back to the default AWS provider chain (env keys).
+  return config.webIdentityTokenFile ? fromTokenFile() : undefined;
+}
+
+/**
+ * Signs billing webhook tokens with an asymmetric AWS KMS key
+ * (`ECC_NIST_P256`, `ECDSA_SHA_256`). The private key never leaves KMS.
+ *
+ * Used only by the provisioning CLI, so it is a plain class (no NestJS DI).
+ */
+export class AwsKmsSignerService implements IKmsSigner {
+  private readonly client: KMSClient;
+
+  constructor(private readonly config: KmsSignerConfig) {
+    this.client = new KMSClient({ credentials: resolveCredentials(config) });
+  }
+
+  async sign(message: Buffer): Promise<Buffer> {
+    const response = await this.client.send(
+      new SignCommand({
+        KeyId: this.config.keyId,
+        Message: message,
+        // RAW: KMS applies SHA-256. The JWS signing input is well under the
+        // 4 KB raw-message limit.
+        MessageType: 'RAW',
+        SigningAlgorithm: 'ECDSA_SHA_256',
+      }),
+    );
+    if (!response.Signature) {
+      throw new Error('KMS did not return a signature');
+    }
+    return Buffer.from(response.Signature);
+  }
+
+  async getPublicKey(): Promise<Buffer> {
+    const response = await this.client.send(
+      new GetPublicKeyCommand({ KeyId: this.config.keyId }),
+    );
+    if (!response.PublicKey) {
+      throw new Error('KMS did not return a public key');
+    }
+    return Buffer.from(response.PublicKey);
+  }
+}

--- a/src/datasources/kms/entities/kms-signer-config.entity.ts
+++ b/src/datasources/kms/entities/kms-signer-config.entity.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+export interface KmsSignerConfig {
+  keyId: string;
+  webIdentityTokenFile?: string;
+}

--- a/src/datasources/kms/kms-signer.interface.ts
+++ b/src/datasources/kms/kms-signer.interface.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+/**
+ * Signs messages with, and exposes the public key of, an asymmetric KMS key.
+ */
+export interface IKmsSigner {
+  /**
+   * Signs `message` with the KMS key (ECDSA P-256 / SHA-256) and returns the
+   * DER-encoded signature KMS produces. Convert to JOSE (`R||S`) for JWS.
+   */
+  sign(message: Buffer): Promise<Buffer>;
+
+  /** Returns the SPKI DER-encoded public key of the KMS key. */
+  getPublicKey(): Promise<Buffer>;
+}

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -1,0 +1,121 @@
+# Billing Webhook Authentication
+
+The CGW receives webhooks from the **billing service** at `POST /v1/billing/webhooks` and authenticates their origin with a **service-to-service JWT bearer token**.
+
+The model is **"the receiver issues the credential it later checks."** The CGW mints a long-lived **ES256** (ECDSA P-256) token signed with its **private** key, provisions that token to the billing service as a secret, and the billing service presents it on every webhook call via the `Authorization: Bearer <token>` header. The CGW verifies each incoming token **statelessly/offline** against its own **public** key — no JWKS, no callback, no shared secret over the body.
+
+This guide covers generating that token with the `generate-token` script.
+
+## Quick Start
+
+```bash
+# 1. Generate an ES256 (EC P-256) keypair
+openssl ecparam -genkey -name prime256v1 -noout -out ec-priv.pem
+openssl ec -in ec-priv.pem -pubout -out ec-pub.pem
+
+# 2. Mint a token with the private key (default subject + ~5y expiry)
+BILLING_WEBHOOK_JWT_PRIVATE_KEY="$(cat ec-priv.pem)" yarn generate-token
+
+# Custom subject and expiry (in days)
+BILLING_WEBHOOK_JWT_PRIVATE_KEY="$(cat ec-priv.pem)" \
+  yarn generate-token --sub billing-service --expires-in 1825
+```
+
+Then configure the **running CGW** with the matching public key (see [Deploying](#deploying-the-receiver)) and hand the minted token to the billing service.
+
+## Command Arguments
+
+| Argument | Description | Required | Default |
+|----------|-------------|----------|---------|
+| `--sub` | Subject (`sub`) claim — also used as `data.service_name` | No | `billing-service` |
+| `--expires-in` | Token lifetime in **days** | No | `1825` (~5 years) |
+
+## Environment
+
+The script reads the **private key** directly from the environment (it is never stored in the running app's config). The **issuer** is resolved from the app config the same way the verifier resolves it, so a minted token always matches what the guard expects.
+
+| Variable | Used by | Description | Default |
+|----------|---------|-------------|---------|
+| `BILLING_WEBHOOK_JWT_PRIVATE_KEY` | **script only** | ES256 (EC P-256) private key, PEM. **Required** to mint. | — |
+| `BILLING_WEBHOOK_JWT_ISSUER` | script + app | The CGW's own identifier — used as both `iss` and `aud`. | `safe-client-gateway` |
+
+> PEM keys passed via env often arrive with escaped newlines (`\n`); the script normalizes these automatically.
+
+## Token Structure
+
+```jsonc
+{
+  "iss": "safe-client-gateway",        // issuer = the CGW
+  "sub": "billing-service",
+  "aud": ["safe-client-gateway"],      // audience = the CGW (same identifier as iss)
+  "iat": 1700000000,
+  "exp": 2015360000,                   // iat + (--expires-in days)
+  "roles": ["SERVICE_ACCESS"],
+  "data": {
+    "service_name": "billing-service", // = --sub
+    "permission_type": "SERVICE_ACCESS",
+    "user_type": "SERVICE_USER"
+  }
+}
+```
+
+- **Algorithm:** `ES256` (ECDSA, P-256, SHA-256) — asymmetric. The CGW signs with its private key and verifies with the matching public key.
+- **Lifetime:** long-lived (multi-year), minted once and stored by the billing service as a secret. Not requested per call.
+
+## How the receiver validates each request
+
+The webhook is processed only if **both** layers pass:
+
+1. **Cryptographic / standard claims** — verify the ES256 signature with the public key, and confirm `iss`, `aud`, and `exp`.
+2. **Authorization** — confirm it is a *service* token: either `roles` contains `SERVICE_ACCESS`, **or** `data` carries `permission_type = SERVICE_ACCESS`, `user_type = SERVICE_USER`, and a non-empty `service_name`.
+
+Verification is fully stateless/offline (public key + expected claims; no callback to any other service).
+
+## Deploying the receiver
+
+The webhook endpoint is **gated behind a feature flag** and reads its public key from config:
+
+| Variable | Description |
+|----------|-------------|
+| `FF_BILLING_WEBHOOK` | Set to `true` to enable the `POST /v1/billing/webhooks` endpoint and its auth guard. Off by default. |
+| `BILLING_WEBHOOK_JWT_PUBLIC_KEY` | ES256 public key (PEM) used to verify incoming tokens. |
+| `BILLING_WEBHOOK_JWT_ISSUER` | Must match the issuer used at mint time (default `safe-client-gateway`). |
+
+End-to-end provisioning flow:
+
+1. Generate the EC P-256 keypair (above).
+2. Deploy the CGW with `FF_BILLING_WEBHOOK=true` and `BILLING_WEBHOOK_JWT_PUBLIC_KEY` set to the **public** key.
+3. Mint a token with the **private** key using this script.
+4. Provision the token to the billing service as the bearer credential for its webhook calls.
+
+> The CGW only ever needs the **public** key at runtime. Keep the **private** key out of the running app — use it only at mint time and store it securely.
+
+## Troubleshooting
+
+### `ERROR: BILLING_WEBHOOK_JWT_PRIVATE_KEY environment variable is not defined`
+The script had no private key to sign with. Export `BILLING_WEBHOOK_JWT_PRIVATE_KEY` with the PEM contents of your EC P-256 private key.
+
+### `ERROR: Invalid --expires-in value`
+`--expires-in` must be a positive whole number of days.
+
+### Webhook calls return `401 Unauthorized`
+The token failed verification. Common causes:
+- The token was signed with a private key that doesn't match the deployed `BILLING_WEBHOOK_JWT_PUBLIC_KEY`.
+- `iss`/`aud` in the token don't match the deployed `BILLING_WEBHOOK_JWT_ISSUER` (e.g. minted with a different issuer than the app is configured with).
+- The token has expired.
+- The token lacks the service-token markers (`SERVICE_ACCESS` role / `SERVICE_USER` data).
+
+The CGW logs the specific reason at `warn` level (token-present failures only).
+
+### Webhook calls return `404 Not Found`
+The feature is disabled — set `FF_BILLING_WEBHOOK=true` and redeploy.
+
+### The app fails to boot with a missing-public-key error
+`FF_BILLING_WEBHOOK=true` was set but `BILLING_WEBHOOK_JWT_PUBLIC_KEY` was not provisioned. Either set the public key or disable the flag. (Fail-fast is intentional — enabling the feature asserts the key is provisioned.)
+
+## Security Considerations
+
+1. **Keep the private key out of the app.** Only the mint script needs it; the running CGW verifies with the public key alone.
+2. **Treat the minted token like a password.** Never commit it to version control.
+3. **Rotate keys operationally.** There is no JWKS/`kid` metadata — rotation is coordinated by re-minting against a new keypair and updating both sides.
+4. **Use a descriptive `--sub`** so it's clear which service/credential a token belongs to.

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -44,7 +44,7 @@ In production, sign via an asymmetric AWS KMS key so the private key never exist
 
 The running app **never talks to KMS** — it verifies offline with the public key. KMS affects only minting.
 
-> **Enforced:** when `CGW_ENV=production`, the script requires `BILLING_WEBHOOK_JWT_KMS_KEY_ID` and refuses to mint with a local private key. The local-PEM path is for dev/CI only.
+> **Enforced:** when `CGW_ENV` is `production` or `staging`, the script requires `BILLING_WEBHOOK_JWT_KMS_KEY_ID` and refuses to mint with a local private key, and the app's env validation rejects `BILLING_WEBHOOK_JWT_PRIVATE_KEY` at startup. The local-PEM path is for dev/CI only.
 
 ### IAM: which principal signs
 
@@ -166,15 +166,15 @@ Read the token + public-key PEM from `kubectl logs job/billing-token-mint`, then
 
 Notes:
 - **Issuer must match the verifier.** If the app overrides `BILLING_WEBHOOK_JWT_ISSUER`, set the same value on the mint workload so `iss`/`aud` line up.
-- **`CGW_ENV` is irrelevant in KMS mode** — the production gate only blocks *local-PEM* signing, so the mint workload doesn't need `CGW_ENV=production`.
+- **`CGW_ENV` is irrelevant in KMS mode** — the production/staging gate only blocks *local-PEM* signing, so the mint workload doesn't need `CGW_ENV` set.
 
 ## Troubleshooting
 
 ### `ERROR: No signing key configured`
 The script had nothing to sign with. Set `BILLING_WEBHOOK_JWT_KMS_KEY_ID` (KMS mode) or `BILLING_WEBHOOK_JWT_PRIVATE_KEY` (local PEM). In KMS mode, also set `AWS_REGION`.
 
-### `ERROR: Production requires KMS signing`
-`CGW_ENV=production` but no `BILLING_WEBHOOK_JWT_KMS_KEY_ID` was set. Production must sign via KMS; a local private key is not accepted. Set the KMS key id (or run the mint outside production if you intended local signing).
+### `ERROR: Production and staging require KMS signing`
+`CGW_ENV` is `production` or `staging` but no `BILLING_WEBHOOK_JWT_KMS_KEY_ID` was set. Deployed environments must sign via KMS; a local private key is not accepted. Set the KMS key id (or run the mint outside production/staging if you intended local signing).
 
 ### `ERROR: Invalid --expires-in value`
 `--expires-in` must be a positive whole number of days.

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -30,6 +30,8 @@ Then configure the **running CGW** with the matching public key (see [Deploying]
 | `--sub` | Subject (`sub`) claim — also used as `data.service_name` | No | `billing-service` |
 | `--expires-in` | Token lifetime in **days** | No | `1825` (~5 years) |
 
+Both `--flag value` and `--flag=value` forms are accepted. Unknown flags are rejected (the script exits with an error) rather than ignored, so a typo can't silently mint a token with default values.
+
 ## Environment
 
 The script reads the **private key** directly from the environment (it is never stored in the running app's config). The **issuer** is resolved from the app config the same way the verifier resolves it, so a minted token always matches what the guard expects.

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -42,8 +42,6 @@ In production, sign via an asymmetric AWS KMS key so the private key never exist
    Credentials come from whatever AWS principal runs the script (its IRSA role, an assumed role, or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`); region from `AWS_REGION`.
 4. Set the printed public key as `BILLING_WEBHOOK_JWT_PUBLIC_KEY` on the running CGW, and provision the token to the billing service.
 
-The running app **never talks to KMS** — it verifies offline with the public key. KMS affects only minting.
-
 > **Enforced:** when `CGW_ENV` is `production` or `staging`, the script requires `BILLING_WEBHOOK_JWT_KMS_KEY_ID` and refuses to mint with a local private key, and the app's env validation rejects `BILLING_WEBHOOK_JWT_PRIVATE_KEY` at startup. The local-PEM path is for dev/CI only.
 
 ### IAM: which principal signs
@@ -58,8 +56,6 @@ The running app **never talks to KMS** — it verifies offline with the public k
 |----------|-------------|----------|---------|
 | `--sub` | Subject (`sub`) claim — also used as `data.service_name` | No | `billing-service` |
 | `--expires-in` | Token lifetime in **days** | No | `1825` (~5 years) |
-
-Both `--flag value` and `--flag=value` forms are accepted. Unknown flags are rejected (the script exits with an error) rather than ignored, so a typo can't silently mint a token with default values.
 
 ## Environment
 
@@ -103,8 +99,6 @@ The webhook is processed only if **both** layers pass:
 1. **Cryptographic / standard claims** — verify the ES256 signature with the public key, and confirm `iss`, `aud`, and `exp`.
 2. **Authorization** — confirm it is a *service* token: either `roles` contains `SERVICE_ACCESS`, **or** `data` carries `permission_type = SERVICE_ACCESS`, `user_type = SERVICE_USER`, and a non-empty `service_name`.
 
-Verification is fully stateless/offline (public key + expected claims; no callback to any other service).
-
 ## Deploying the receiver
 
 The webhook endpoint is **gated behind a feature flag** and reads its public key from config:
@@ -128,7 +122,7 @@ End-to-end provisioning flow:
 
 Run the CGW image as a **one-off workload** under the mint principal (see [IAM](#iam-which-principal-signs)) — not the app's runtime role. Invoke the compiled script `node dist/scripts/generate-token.js`.
 
-**Option A — `docker run` on a bastion or CI, with the mint role's credentials:**
+**Option A — `docker run` on a bastion, with the mint role's credentials:**
 ```bash
 # temp creds for a principal that has kms:Sign + kms:GetPublicKey on the billing key
 eval "$(aws sts assume-role \
@@ -151,6 +145,11 @@ kind: Job
 metadata: { name: billing-token-mint }
 spec:
   template:
+    metadata:
+      annotations:
+        # The token prints to stdout — keep it out of shipped logs.
+        # `kubectl logs` still works; this only stops agent collection.
+        ad.datadoghq.com/mint.logs_exclude: "true"
     spec:
       serviceAccountName: billing-token-minter   # IRSA-annotated with the mint role (kms:Sign, kms:GetPublicKey)
       restartPolicy: Never
@@ -165,19 +164,13 @@ spec:
 Read the token + public-key PEM from `kubectl logs job/billing-token-mint`, then delete the Job.
 
 Notes:
+- **The token is a long-lived credential printed to stdout — don't let stdout be persisted anywhere.** The `logs_exclude` annotation above keeps the Job's output out of log collection; read the token, store it, and delete the Job. With Option A, run from a bastion shell rather than a CI job — CI systems retain job output, which would leave the token in build logs. If the token ever transits a log platform, rotate it.
 - **Issuer must match the verifier.** If the app overrides `BILLING_WEBHOOK_JWT_ISSUER`, set the same value on the mint workload so `iss`/`aud` line up.
 - **`CGW_ENV` is irrelevant in KMS mode** — the production/staging gate only blocks *local-PEM* signing, so the mint workload doesn't need `CGW_ENV` set.
 
 ## Troubleshooting
 
-### `ERROR: No signing key configured`
-The script had nothing to sign with. Set `BILLING_WEBHOOK_JWT_KMS_KEY_ID` (KMS mode) or `BILLING_WEBHOOK_JWT_PRIVATE_KEY` (local PEM). In KMS mode, also set `AWS_REGION`.
-
-### `ERROR: Production and staging require KMS signing`
-`CGW_ENV` is `production` or `staging` but no `BILLING_WEBHOOK_JWT_KMS_KEY_ID` was set. Deployed environments must sign via KMS; a local private key is not accepted. Set the KMS key id (or run the mint outside production/staging if you intended local signing).
-
-### `ERROR: Invalid --expires-in value`
-`--expires-in` must be a positive whole number of days.
+Script-side failures print actionable `ERROR:` messages of their own; the entries below cover runtime symptoms whose cause is not visible to the caller.
 
 ### Webhook calls return `401 Unauthorized`
 The token failed verification. Common causes:
@@ -194,9 +187,6 @@ The feature is disabled — set `FF_BILLING_WEBHOOK=true` and redeploy.
 ### The app fails to boot with a missing-public-key error
 `FF_BILLING_WEBHOOK=true` was set but `BILLING_WEBHOOK_JWT_PUBLIC_KEY` was not provisioned. Either set the public key or disable the flag. (Fail-fast is intentional — enabling the feature asserts the key is provisioned.)
 
-## Security Considerations
+## Key rotation
 
-1. **Keep the private key out of the app.** Only the mint script needs it; the running CGW verifies with the public key alone. **Prefer KMS signing in production** so the private key never exists as extractable material anywhere.
-2. **Treat the minted token like a password.** Never commit it to version control.
-3. **Rotate keys operationally.** There is no JWKS/`kid` metadata — rotation is coordinated by re-minting against a new keypair and updating both sides.
-4. **Use a descriptive `--sub`** so it's clear which service/credential a token belongs to.
+There is no JWKS/`kid` metadata — rotation is coordinated operationally: re-mint against a new keypair, then update both sides (`BILLING_WEBHOOK_JWT_PUBLIC_KEY` on the CGW and the stored bearer token on the billing service).

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -8,9 +8,10 @@ The CGW receives webhooks from the **billing service** at `POST /v1/billing/webh
 
 The model is **"the receiver issues the credential it later checks."** The CGW mints a long-lived **ES256** (ECDSA P-256) token signed with its **private** key, provisions that token to the billing service as a secret, and the billing service presents it on every webhook call via the `Authorization: Bearer <token>` header. The CGW verifies each incoming token **statelessly/offline** against its own **public** key — no JWKS, no callback, no shared secret over the body.
 
-This guide covers generating that token with the `generate-token` script.
+This guide covers generating that token with the `generate-token` script, which
+signs either with a **local private key** (dev/CI) or via **AWS KMS** (production).
 
-## Quick Start
+## Quick Start (development only)
 
 ```bash
 # 1. Generate an ES256 (EC P-256) keypair
@@ -27,6 +28,30 @@ BILLING_WEBHOOK_JWT_PRIVATE_KEY="$(cat ec-priv.pem)" \
 
 Then configure the **running CGW** with the matching public key (see [Deploying](#deploying-the-receiver)) and hand the minted token to the billing service.
 
+## Signing with KMS (production)
+
+In production, sign via an asymmetric AWS KMS key so the private key never exists on disk or in the environment.
+
+1. Create a KMS key: type **asymmetric**, spec **`ECC_NIST_P256`**, usage **`SIGN_VERIFY`**.
+2. Grant **`kms:Sign`** and **`kms:GetPublicKey`** on that key to the principal that **runs the mint** (see [IAM](#iam-which-principal-signs) below).
+3. Mint — this signs via KMS and also prints the public key PEM to configure the verifier:
+   ```bash
+   BILLING_WEBHOOK_JWT_KMS_KEY_ID=<arn> \
+     yarn generate-token --sub billing-service --expires-in 1825
+   ```
+   Credentials come from whatever AWS principal runs the script (its IRSA role, an assumed role, or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`); region from `AWS_REGION`.
+4. Set the printed public key as `BILLING_WEBHOOK_JWT_PUBLIC_KEY` on the running CGW, and provision the token to the billing service.
+
+The running app **never talks to KMS** — it verifies offline with the public key. KMS affects only minting.
+
+> **Enforced:** when `CGW_ENV=production`, the script requires `BILLING_WEBHOOK_JWT_KMS_KEY_ID` and refuses to mint with a local private key. The local-PEM path is for dev/CI only.
+
+### IAM: which principal signs
+
+- **The running CGW needs *no* KMS permissions.** It verifies offline with the configured public key and never calls KMS. Do **not** add `kms:Sign` to the app's runtime IRSA role (the same role backing SES, etc.).
+- **Grant `kms:Sign` + `kms:GetPublicKey` to a dedicated mint principal** — e.g. a CI role, a bastion role, or an operator — scoped to the billing key ARN.
+- **Run the mint from that principal, outside the app pod** (CI / bastion / local). Minting is one-time provisioning, so this is the natural place, and it keeps signing capability off the app/SES role.
+
 ## Command Arguments
 
 | Argument | Description | Required | Default |
@@ -38,12 +63,15 @@ Both `--flag value` and `--flag=value` forms are accepted. Unknown flags are rej
 
 ## Environment
 
-The script reads the **private key** directly from the environment (it is never stored in the running app's config). The **issuer** is resolved from the app config the same way the verifier resolves it, so a minted token always matches what the guard expects.
+The signing key (local PEM **or** KMS key id) is read directly from the environment and is never stored in the running app's config. The **issuer** is resolved from the app config the same way the verifier resolves it, so a minted token always matches what the guard expects.
 
 | Variable | Used by | Description | Default |
 |----------|---------|-------------|---------|
-| `BILLING_WEBHOOK_JWT_PRIVATE_KEY` | **script only** | ES256 (EC P-256) private key, PEM. **Required** to mint. | — |
+| `BILLING_WEBHOOK_JWT_KMS_KEY_ID` | **script only** | Asymmetric KMS key id/ARN (`ECC_NIST_P256`). When set, the script signs via KMS. Needs `AWS_REGION` + credentials. | — |
+| `BILLING_WEBHOOK_JWT_PRIVATE_KEY` | **script only** | ES256 (EC P-256) private key, PEM. Used when no KMS key is set (dev/CI). | — |
 | `BILLING_WEBHOOK_JWT_ISSUER` | script + app | The CGW's own identifier — used as both `iss` and `aud`. | `safe-client-gateway` |
+
+Exactly one signing input is required: `BILLING_WEBHOOK_JWT_KMS_KEY_ID` (KMS mode, preferred) **or** `BILLING_WEBHOOK_JWT_PRIVATE_KEY` (local mode). If both are set, KMS wins.
 
 > PEM keys passed via env often arrive with escaped newlines (`\n`); the script normalizes these automatically.
 
@@ -96,10 +124,57 @@ End-to-end provisioning flow:
 
 > The CGW only ever needs the **public** key at runtime. Keep the **private** key out of the running app — use it only at mint time and store it securely.
 
+### Running the token-mint in a deployed environment
+
+Run the CGW image as a **one-off workload** under the mint principal (see [IAM](#iam-which-principal-signs)) — not the app's runtime role. Invoke the compiled script `node dist/scripts/generate-token.js`.
+
+**Option A — `docker run` on a bastion or CI, with the mint role's credentials:**
+```bash
+# temp creds for a principal that has kms:Sign + kms:GetPublicKey on the billing key
+eval "$(aws sts assume-role \
+  --role-arn arn:aws:iam::<acct>:role/billing-token-minter --role-session-name mint \
+  --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text \
+  | awk '{print "export AWS_ACCESS_KEY_ID="$1"\nexport AWS_SECRET_ACCESS_KEY="$2"\nexport AWS_SESSION_TOKEN="$3}')"
+
+docker run --rm \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+  -e AWS_REGION=<region> \
+  -e BILLING_WEBHOOK_JWT_KMS_KEY_ID=<key-arn> \
+  <cgw-image>:<tag> \
+  node dist/scripts/generate-token.js --sub billing-service --expires-in 1825
+```
+
+**Option B — a one-off Kubernetes `Job` using the same image + a mint service account:**
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata: { name: billing-token-mint }
+spec:
+  template:
+    spec:
+      serviceAccountName: billing-token-minter   # IRSA-annotated with the mint role (kms:Sign, kms:GetPublicKey)
+      restartPolicy: Never
+      containers:
+        - name: mint
+          image: <cgw-image>:<tag>
+          command: ["node", "dist/scripts/generate-token.js", "--sub", "billing-service"]
+          env:
+            - { name: BILLING_WEBHOOK_JWT_KMS_KEY_ID, value: "<key-arn>" }
+            - { name: AWS_REGION, value: "<region>" }
+```
+Read the token + public-key PEM from `kubectl logs job/billing-token-mint`, then delete the Job.
+
+Notes:
+- **Issuer must match the verifier.** If the app overrides `BILLING_WEBHOOK_JWT_ISSUER`, set the same value on the mint workload so `iss`/`aud` line up.
+- **`CGW_ENV` is irrelevant in KMS mode** — the production gate only blocks *local-PEM* signing, so the mint workload doesn't need `CGW_ENV=production`.
+
 ## Troubleshooting
 
-### `ERROR: BILLING_WEBHOOK_JWT_PRIVATE_KEY environment variable is not defined`
-The script had no private key to sign with. Export `BILLING_WEBHOOK_JWT_PRIVATE_KEY` with the PEM contents of your EC P-256 private key.
+### `ERROR: No signing key configured`
+The script had nothing to sign with. Set `BILLING_WEBHOOK_JWT_KMS_KEY_ID` (KMS mode) or `BILLING_WEBHOOK_JWT_PRIVATE_KEY` (local PEM). In KMS mode, also set `AWS_REGION`.
+
+### `ERROR: Production requires KMS signing`
+`CGW_ENV=production` but no `BILLING_WEBHOOK_JWT_KMS_KEY_ID` was set. Production must sign via KMS; a local private key is not accepted. Set the KMS key id (or run the mint outside production if you intended local signing).
 
 ### `ERROR: Invalid --expires-in value`
 `--expires-in` must be a positive whole number of days.
@@ -121,7 +196,7 @@ The feature is disabled — set `FF_BILLING_WEBHOOK=true` and redeploy.
 
 ## Security Considerations
 
-1. **Keep the private key out of the app.** Only the mint script needs it; the running CGW verifies with the public key alone.
+1. **Keep the private key out of the app.** Only the mint script needs it; the running CGW verifies with the public key alone. **Prefer KMS signing in production** so the private key never exists as extractable material anywhere.
 2. **Treat the minted token like a password.** Never commit it to version control.
 3. **Rotate keys operationally.** There is no JWKS/`kid` metadata — rotation is coordinated by re-minting against a new keypair and updating both sides.
 4. **Use a descriptive `--sub`** so it's clear which service/credential a token belongs to.

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -1,3 +1,7 @@
+<!--
+  SPDX-License-Identifier: FSL-1.1-MIT
+ -->
+ 
 # Billing Webhook Authentication
 
 The CGW receives webhooks from the **billing service** at `POST /v1/billing/webhooks` and authenticates their origin with a **service-to-service JWT bearer token**.

--- a/src/modules/billing/billing.module.ts
+++ b/src/modules/billing/billing.module.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@/datasources/jwt/jwt.module';
+import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
+import { BillingController } from '@/modules/billing/routes/billing.controller';
+import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+
+@Module({
+  imports: [JwtModule],
+  controllers: [BillingController],
+  providers: [BillingAuthService, BillingWebhookAuthGuard],
+})
+export class BillingModule {}

--- a/src/modules/billing/domain/billing-auth.constants.ts
+++ b/src/modules/billing/domain/billing-auth.constants.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+export const DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT = 'billing-service';

--- a/src/modules/billing/domain/billing-auth.service.spec.ts
+++ b/src/modules/billing/domain/billing-auth.service.spec.ts
@@ -9,10 +9,8 @@ import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
 import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
 import { JwtService } from '@/datasources/jwt/jwt.service';
 import type { ILoggingService } from '@/logging/logging.interface';
-import {
-  BillingAuthService,
-  DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
-} from '@/modules/billing/domain/billing-auth.service';
+import { DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT } from '@/modules/billing/domain/billing-auth.constants';
+import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
 import {
   SERVICE_ACCESS_PERMISSION_TYPE,
   SERVICE_ACCESS_ROLE,

--- a/src/modules/billing/domain/billing-auth.service.spec.ts
+++ b/src/modules/billing/domain/billing-auth.service.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { sign as cryptoSign, generateKeyPairSync } from 'node:crypto';
+import { faker } from '@faker-js/faker';
 import { UnauthorizedException } from '@nestjs/common';
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
@@ -10,7 +11,7 @@ import { JwtService } from '@/datasources/jwt/jwt.service';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
 
-const ISSUER = 'safe-client-gateway';
+const ISSUER = faker.lorem.slug();
 
 function generateKeyPair(): { privateKey: string; publicKey: string } {
   return generateKeyPairSync('ec', {
@@ -35,7 +36,7 @@ describe('BillingAuthService', () => {
       const token = BillingAuthService.mint({
         privateKey,
         issuer: ISSUER,
-        expiresInDays: 365,
+        expiresInDays: faker.number.int({ min: 1, max: 365 }),
       });
 
       expect(jwtClientFactory().decodeWithoutVerification(token)).toMatchObject(
@@ -55,18 +56,19 @@ describe('BillingAuthService', () => {
 
     it('honours a custom subject and reflects it in service_name', () => {
       const { privateKey } = generateKeyPair();
+      const subject = faker.lorem.slug();
 
       const token = BillingAuthService.mint({
         privateKey,
         issuer: ISSUER,
-        expiresInDays: 365,
-        subject: 'billing-service-staging',
+        expiresInDays: faker.number.int({ min: 1, max: 365 }),
+        subject,
       });
 
       expect(jwtClientFactory().decodeWithoutVerification(token)).toMatchObject(
         {
-          sub: 'billing-service-staging',
-          data: { service_name: 'billing-service-staging' },
+          sub: subject,
+          data: { service_name: subject },
         },
       );
     });
@@ -74,8 +76,10 @@ describe('BillingAuthService', () => {
     it('derives iat/exp from the issued-at time and expiresInDays', () => {
       const { privateKey } = generateKeyPair();
       // Whole seconds so the second-based NumericDate comparison is exact.
-      const now = new Date(1_700_000_000_000);
-      const expiresInDays = 365;
+      const now = faker.date.recent();
+      now.setMilliseconds(0);
+      const nowInSeconds = now.getTime() / 1_000;
+      const expiresInDays = faker.number.int({ min: 1, max: 365 });
 
       const token = BillingAuthService.mint({
         privateKey,
@@ -85,8 +89,8 @@ describe('BillingAuthService', () => {
       });
 
       const decoded = jwtClientFactory().decodeWithoutVerification(token);
-      expect(decoded?.iat).toBe(1_700_000_000);
-      expect(decoded?.exp).toBe(1_700_000_000 + expiresInDays * 24 * 60 * 60);
+      expect(decoded?.iat).toBe(nowInSeconds);
+      expect(decoded?.exp).toBe(nowInSeconds + expiresInDays * 24 * 60 * 60);
     });
   });
 
@@ -94,7 +98,8 @@ describe('BillingAuthService', () => {
     function createService(publicKey: string): BillingAuthService {
       const configurationService = new FakeConfigurationService();
       configurationService.set('jwt.issuer', ISSUER);
-      configurationService.set('jwt.secret', 'unused-for-es256');
+      // Arbitrary: the HMAC secret is unused for ES256 verification.
+      configurationService.set('jwt.secret', faker.string.alphanumeric(32));
       configurationService.set('billing.webhook.publicKey', publicKey);
       configurationService.set('billing.webhook.issuer', ISSUER);
 
@@ -112,7 +117,7 @@ describe('BillingAuthService', () => {
       const token = BillingAuthService.mint({
         privateKey,
         issuer: ISSUER,
-        expiresInDays: 365,
+        expiresInDays: faker.number.int({ min: 1, max: 365 }),
       });
 
       expect(service.verify(token)).toMatchObject({
@@ -132,7 +137,11 @@ describe('BillingAuthService', () => {
         );
 
       const token = await BillingAuthService.mintViaSigner(
-        { issuer: ISSUER, subject: 'billing-service', expiresInDays: 365 },
+        {
+          issuer: ISSUER,
+          subject: 'billing-service',
+          expiresInDays: faker.number.int({ min: 1, max: 365 }),
+        },
         sign,
       );
 
@@ -158,12 +167,18 @@ describe('BillingAuthService', () => {
       const token = BillingAuthService.mint({
         privateKey,
         issuer: ISSUER,
-        expiresInDays: 365,
+        expiresInDays: faker.number.int({ min: 1, max: 365 }),
       });
 
-      expect(() => service.verify(`${token.slice(0, -4)}AAAA`)).toThrow(
-        UnauthorizedException,
-      );
+      // Excluding the original characters guarantees the signature changes.
+      const tamperedSuffix = faker.string.alphanumeric({
+        length: 4,
+        exclude: token.slice(-4),
+      });
+
+      expect(() =>
+        service.verify(`${token.slice(0, -4)}${tamperedSuffix}`),
+      ).toThrow(UnauthorizedException);
     });
 
     it('rejects a token signed by a different key', () => {
@@ -174,7 +189,7 @@ describe('BillingAuthService', () => {
       const token = BillingAuthService.mint({
         privateKey: otherPrivateKey,
         issuer: ISSUER,
-        expiresInDays: 365,
+        expiresInDays: faker.number.int({ min: 1, max: 365 }),
       });
 
       expect(() => service.verify(token)).toThrow(UnauthorizedException);
@@ -184,15 +199,14 @@ describe('BillingAuthService', () => {
       const { privateKey, publicKey } = generateKeyPair();
       const service = createService(publicKey);
 
-      // Valid ES256 signature and iss/aud/exp, but missing the service markers
-      // (no SERVICE_ACCESS role and no data), so layer-2 authorization fails.
+      // missing the service markers (no SERVICE_ACCESS role and no data), so layer-2 authorization fails.
       const token = jwtClientFactory().sign(
         {
           iss: ISSUER,
           sub: 'billing-service',
           aud: [ISSUER],
-          exp: new Date(Date.now() + 60 * 60 * 1_000),
-          roles: ['SOME_OTHER_ROLE'],
+          exp: faker.date.future(),
+          roles: [faker.string.alpha({ length: 16, casing: 'upper' })],
         },
         { secretOrPrivateKey: privateKey, algorithm: JWT_ES_ALGORITHM },
       );
@@ -205,7 +219,8 @@ describe('BillingAuthService', () => {
     it('throws when the webhook public key is not configured', () => {
       const configurationService = new FakeConfigurationService();
       configurationService.set('jwt.issuer', ISSUER);
-      configurationService.set('jwt.secret', 'unused-for-es256');
+      // Arbitrary: the HMAC secret is unused for ES256 verification.
+      configurationService.set('jwt.secret', faker.string.alphanumeric(32));
       configurationService.set('billing.webhook.issuer', ISSUER);
       // billing.webhook.publicKey intentionally not set.
 
@@ -216,7 +231,7 @@ describe('BillingAuthService', () => {
             configurationService,
             loggingService,
           ),
-      ).toThrow();
+      ).toThrow('No value set for key billing.webhook.publicKey');
     });
   });
 });

--- a/src/modules/billing/domain/billing-auth.service.spec.ts
+++ b/src/modules/billing/domain/billing-auth.service.spec.ts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { generateKeyPairSync } from 'node:crypto';
+import { UnauthorizedException } from '@nestjs/common';
+import type { MockedObject } from 'vitest';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
+import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
+import { JwtService } from '@/datasources/jwt/jwt.service';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
+
+const ISSUER = 'safe-client-gateway';
+
+function generateKeyPair(): { privateKey: string; publicKey: string } {
+  return generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1',
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+describe('BillingAuthService', () => {
+  const loggingService = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as MockedObject<ILoggingService>;
+
+  describe('mint (static)', () => {
+    it('mints a token with the expected service claims', () => {
+      const { privateKey } = generateKeyPair();
+
+      const token = BillingAuthService.mint({
+        privateKey,
+        issuer: ISSUER,
+        expiresInDays: 365,
+      });
+
+      expect(jwtClientFactory().decodeWithoutVerification(token)).toMatchObject(
+        {
+          iss: ISSUER,
+          sub: 'billing-service',
+          aud: [ISSUER],
+          roles: ['SERVICE_ACCESS'],
+          data: {
+            service_name: 'billing-service',
+            permission_type: 'SERVICE_ACCESS',
+            user_type: 'SERVICE_USER',
+          },
+        },
+      );
+    });
+
+    it('honours a custom subject and reflects it in service_name', () => {
+      const { privateKey } = generateKeyPair();
+
+      const token = BillingAuthService.mint({
+        privateKey,
+        issuer: ISSUER,
+        expiresInDays: 365,
+        subject: 'billing-service-staging',
+      });
+
+      expect(jwtClientFactory().decodeWithoutVerification(token)).toMatchObject(
+        {
+          sub: 'billing-service-staging',
+          data: { service_name: 'billing-service-staging' },
+        },
+      );
+    });
+
+    it('derives iat/exp from the issued-at time and expiresInDays', () => {
+      const { privateKey } = generateKeyPair();
+      // Whole seconds so the second-based NumericDate comparison is exact.
+      const now = new Date(1_700_000_000_000);
+      const expiresInDays = 365;
+
+      const token = BillingAuthService.mint({
+        privateKey,
+        issuer: ISSUER,
+        expiresInDays,
+        now,
+      });
+
+      const decoded = jwtClientFactory().decodeWithoutVerification(token);
+      expect(decoded?.iat).toBe(1_700_000_000);
+      expect(decoded?.exp).toBe(1_700_000_000 + expiresInDays * 24 * 60 * 60);
+    });
+  });
+
+  describe('verify', () => {
+    function createService(publicKey: string): BillingAuthService {
+      const configurationService = new FakeConfigurationService();
+      configurationService.set('jwt.issuer', ISSUER);
+      configurationService.set('jwt.secret', 'unused-for-es256');
+      configurationService.set('billing.webhook.publicKey', publicKey);
+      configurationService.set('billing.webhook.issuer', ISSUER);
+
+      return new BillingAuthService(
+        new JwtService(jwtClientFactory(), configurationService),
+        configurationService,
+        loggingService,
+      );
+    }
+
+    it('verifies a token minted with the matching private key', () => {
+      const { privateKey, publicKey } = generateKeyPair();
+      const service = createService(publicKey);
+
+      const token = BillingAuthService.mint({
+        privateKey,
+        issuer: ISSUER,
+        expiresInDays: 365,
+      });
+
+      expect(service.verify(token)).toMatchObject({
+        roles: ['SERVICE_ACCESS'],
+      });
+    });
+
+    it('rejects a tampered token', () => {
+      const { privateKey, publicKey } = generateKeyPair();
+      const service = createService(publicKey);
+
+      const token = BillingAuthService.mint({
+        privateKey,
+        issuer: ISSUER,
+        expiresInDays: 365,
+      });
+
+      expect(() => service.verify(`${token.slice(0, -4)}AAAA`)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rejects a token signed by a different key', () => {
+      const { publicKey } = generateKeyPair();
+      const { privateKey: otherPrivateKey } = generateKeyPair();
+      const service = createService(publicKey);
+
+      const token = BillingAuthService.mint({
+        privateKey: otherPrivateKey,
+        issuer: ISSUER,
+        expiresInDays: 365,
+      });
+
+      expect(() => service.verify(token)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects a validly-signed token that is not a service token', () => {
+      const { privateKey, publicKey } = generateKeyPair();
+      const service = createService(publicKey);
+
+      // Valid ES256 signature and iss/aud/exp, but missing the service markers
+      // (no SERVICE_ACCESS role and no data), so layer-2 authorization fails.
+      const token = jwtClientFactory().sign(
+        {
+          iss: ISSUER,
+          sub: 'billing-service',
+          aud: [ISSUER],
+          exp: new Date(Date.now() + 60 * 60 * 1_000),
+          roles: ['SOME_OTHER_ROLE'],
+        },
+        { secretOrPrivateKey: privateKey, algorithm: JWT_ES_ALGORITHM },
+      );
+
+      expect(() => service.verify(token)).toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('constructor', () => {
+    it('throws when the webhook public key is not configured', () => {
+      const configurationService = new FakeConfigurationService();
+      configurationService.set('jwt.issuer', ISSUER);
+      configurationService.set('jwt.secret', 'unused-for-es256');
+      configurationService.set('billing.webhook.issuer', ISSUER);
+      // billing.webhook.publicKey intentionally not set.
+
+      expect(
+        () =>
+          new BillingAuthService(
+            new JwtService(jwtClientFactory(), configurationService),
+            configurationService,
+            loggingService,
+          ),
+      ).toThrow();
+    });
+  });
+});

--- a/src/modules/billing/domain/billing-auth.service.spec.ts
+++ b/src/modules/billing/domain/billing-auth.service.spec.ts
@@ -9,7 +9,15 @@ import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
 import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
 import { JwtService } from '@/datasources/jwt/jwt.service';
 import type { ILoggingService } from '@/logging/logging.interface';
-import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
+import {
+  BillingAuthService,
+  DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
+} from '@/modules/billing/domain/billing-auth.service';
+import {
+  SERVICE_ACCESS_PERMISSION_TYPE,
+  SERVICE_ACCESS_ROLE,
+  SERVICE_USER_TYPE,
+} from '@/modules/billing/domain/entities/billing-service-token.entity';
 
 const ISSUER = faker.lorem.slug();
 
@@ -42,13 +50,13 @@ describe('BillingAuthService', () => {
       expect(jwtClientFactory().decodeWithoutVerification(token)).toMatchObject(
         {
           iss: ISSUER,
-          sub: 'billing-service',
+          sub: DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
           aud: [ISSUER],
-          roles: ['SERVICE_ACCESS'],
+          roles: [SERVICE_ACCESS_ROLE],
           data: {
-            service_name: 'billing-service',
-            permission_type: 'SERVICE_ACCESS',
-            user_type: 'SERVICE_USER',
+            service_name: DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
+            permission_type: SERVICE_ACCESS_PERMISSION_TYPE,
+            user_type: SERVICE_USER_TYPE,
           },
         },
       );
@@ -121,7 +129,7 @@ describe('BillingAuthService', () => {
       });
 
       expect(service.verify(token)).toMatchObject({
-        roles: ['SERVICE_ACCESS'],
+        roles: [SERVICE_ACCESS_ROLE],
       });
     });
 
@@ -139,7 +147,7 @@ describe('BillingAuthService', () => {
       const token = await BillingAuthService.mintViaSigner(
         {
           issuer: ISSUER,
-          subject: 'billing-service',
+          subject: DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT,
           expiresInDays: faker.number.int({ min: 1, max: 365 }),
         },
         sign,
@@ -150,13 +158,13 @@ describe('BillingAuthService', () => {
         {
           iss: ISSUER,
           aud: [ISSUER],
-          roles: ['SERVICE_ACCESS'],
-          data: { service_name: 'billing-service' },
+          roles: [SERVICE_ACCESS_ROLE],
+          data: { service_name: DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT },
         },
       );
       // ...and the ES256 signature verifies against the matching public key.
       expect(service.verify(token)).toMatchObject({
-        roles: ['SERVICE_ACCESS'],
+        roles: [SERVICE_ACCESS_ROLE],
       });
     });
 

--- a/src/modules/billing/domain/billing-auth.service.spec.ts
+++ b/src/modules/billing/domain/billing-auth.service.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
-import { generateKeyPairSync } from 'node:crypto';
+import { sign as cryptoSign, generateKeyPairSync } from 'node:crypto';
 import { UnauthorizedException } from '@nestjs/common';
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
@@ -115,6 +115,37 @@ describe('BillingAuthService', () => {
         expiresInDays: 365,
       });
 
+      expect(service.verify(token)).toMatchObject({
+        roles: ['SERVICE_ACCESS'],
+      });
+    });
+
+    it('verifies a token minted via mintViaSigner (KMS-style DER signer)', async () => {
+      const { privateKey, publicKey } = generateKeyPair();
+      const service = createService(publicKey);
+
+      // Mimics AWS KMS Sign (RAW + ECDSA_SHA_256): hashes with SHA-256 and
+      // returns a DER-encoded ECDSA signature.
+      const sign = (input: Buffer): Promise<Buffer> =>
+        Promise.resolve(
+          cryptoSign('sha256', input, { key: privateKey, dsaEncoding: 'der' }),
+        );
+
+      const token = await BillingAuthService.mintViaSigner(
+        { issuer: ISSUER, subject: 'billing-service', expiresInDays: 365 },
+        sign,
+      );
+
+      // Same claim shape as the local-key path...
+      expect(jwtClientFactory().decodeWithoutVerification(token)).toMatchObject(
+        {
+          iss: ISSUER,
+          aud: [ISSUER],
+          roles: ['SERVICE_ACCESS'],
+          data: { service_name: 'billing-service' },
+        },
+      );
+      // ...and the ES256 signature verifies against the matching public key.
       expect(service.verify(token)).toMatchObject({
         roles: ['SERVICE_ACCESS'],
       });

--- a/src/modules/billing/domain/billing-auth.service.ts
+++ b/src/modules/billing/domain/billing-auth.service.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { z } from 'zod';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
+import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
+import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import {
+  type BillingServiceToken,
+  BillingServiceTokenSchema,
+  SERVICE_ACCESS_PERMISSION_TYPE,
+  SERVICE_ACCESS_ROLE,
+  SERVICE_USER_TYPE,
+} from '@/modules/billing/domain/entities/billing-service-token.entity';
+
+export const DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT = 'billing-service';
+
+/**
+ * Owns the billing-service webhook credential lifecycle — the "receiver issues
+ * the credential it later checks" model, where the CGW both mints the token and
+ * verifies it.
+ *
+ * - {@link mint} (static) signs a long-lived ES256 token with the CGW **private**
+ *   key. Used by the provisioning CLI (`scripts/generate-token.ts`); the
+ *   private key is passed in by the caller and is never read from app config.
+ * - {@link verify} validates an incoming token against the CGW **public** key and
+ *   the service-token authorization markers.
+ *
+ * Only instantiated when the `billingWebhook` feature is enabled (the module is
+ * gated in `AppModule`), so the public key is expected to be provisioned; a
+ * missing key therefore fails fast at boot.
+ */
+@Injectable()
+export class BillingAuthService {
+  private readonly publicKey: string;
+  private readonly issuer: string;
+
+  constructor(
+    @Inject(IJwtService) private readonly jwtService: IJwtService,
+    @Inject(IConfigurationService)
+    configurationService: IConfigurationService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {
+    this.publicKey = configurationService
+      .getOrThrow<string>('billing.webhook.publicKey')
+      // PEM keys provided via env often arrive with escaped newlines.
+      .replace(/\\n/g, '\n');
+    this.issuer = configurationService.getOrThrow<string>(
+      'billing.webhook.issuer',
+    );
+  }
+
+  /**
+   * Verifies an incoming bearer token in two layers:
+   *   1. Cryptographic/standard claims — ES256 signature against the CGW public
+   *      key, plus `iss`, `aud` and `exp`.
+   *   2. Authorization — confirm it is a service token.
+   */
+  verify(token: string): BillingServiceToken {
+    try {
+      // Layer 1: signature + standard claims.
+      const payload = this.jwtService.verify<BillingServiceToken>(token, {
+        secretOrPrivateKey: this.publicKey,
+        algorithms: [JWT_ES_ALGORITHM],
+        issuer: this.issuer,
+        audience: this.issuer,
+      });
+
+      // Layer 2: authorization markers.
+      return BillingServiceTokenSchema.parse(payload);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        this.loggingService.warn(
+          `Billing webhook: token authorization failed: ${error.message}`,
+        );
+      } else {
+        this.loggingService.warn(
+          `Billing webhook: token verification failed: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }`,
+        );
+      }
+      throw new UnauthorizedException();
+    }
+  }
+
+  /**
+   * Mints the long-lived ES256 service token the CGW provisions to the billing
+   * service. Pure/static — the private key is supplied by the caller, so this
+   * runs from the CLI without booting the app.
+   */
+  static mint(args: {
+    privateKey: string;
+    issuer: string;
+    expiresInDays: number;
+    subject?: string;
+    /** Injectable clock for deterministic tests. */
+    now?: Date;
+  }): string {
+    const subject = args.subject ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
+    const now = args.now ?? new Date();
+    const exp = new Date(
+      now.getTime() + args.expiresInDays * 24 * 60 * 60 * 1_000, // (now + days × 24h)
+    );
+
+    const claims = {
+      iss: args.issuer,
+      sub: subject,
+      aud: [args.issuer],
+      iat: now,
+      exp,
+      roles: [SERVICE_ACCESS_ROLE],
+      data: {
+        service_name: subject,
+        permission_type: SERVICE_ACCESS_PERMISSION_TYPE,
+        user_type: SERVICE_USER_TYPE,
+      },
+    };
+
+    const client = jwtClientFactory();
+    const token = client.sign(claims, {
+      secretOrPrivateKey: args.privateKey,
+      algorithm: JWT_ES_ALGORITHM,
+    });
+
+    // Self-check: a freshly minted token must satisfy the authorization schema.
+    BillingServiceTokenSchema.parse(client.decodeWithoutVerification(token));
+
+    return token;
+  }
+}

--- a/src/modules/billing/domain/billing-auth.service.ts
+++ b/src/modules/billing/domain/billing-auth.service.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { derToJose } from 'ecdsa-sig-formatter';
 import { z } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
 import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { toSecondsTimestamp } from '@/domain/common/utils/time';
 import {
   type ILoggingService,
   LoggingService,
@@ -19,6 +21,14 @@ import {
 } from '@/modules/billing/domain/entities/billing-service-token.entity';
 
 export const DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT = 'billing-service';
+
+type BillingTokenClaimsArgs = {
+  issuer: string;
+  expiresInDays: number;
+  subject?: string;
+  /** Injectable clock for deterministic tests. */
+  now?: Date;
+};
 
 /**
  * Owns the billing-service webhook credential lifecycle — the "receiver issues
@@ -90,25 +100,30 @@ export class BillingAuthService {
   }
 
   /**
-   * Mints the long-lived ES256 service token the CGW provisions to the billing
-   * service. Pure/static — the private key is supplied by the caller, so this
-   * runs from the CLI without booting the app.
+   * Builds the canonical claim set (single source of truth for both mint paths).
+   * `iat`/`exp` are `Date`s here; they are converted to second-based NumericDates
+   * when the token is signed.
    */
-  static mint(args: {
-    privateKey: string;
-    issuer: string;
-    expiresInDays: number;
-    subject?: string;
-    /** Injectable clock for deterministic tests. */
-    now?: Date;
-  }): string {
+  private static buildClaims(args: BillingTokenClaimsArgs): {
+    iss: string;
+    sub: string;
+    aud: Array<string>;
+    iat: Date;
+    exp: Date;
+    roles: Array<string>;
+    data: {
+      service_name: string;
+      permission_type: string;
+      user_type: string;
+    };
+  } {
     const subject = args.subject ?? DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT;
     const now = args.now ?? new Date();
     const exp = new Date(
       now.getTime() + args.expiresInDays * 24 * 60 * 60 * 1_000, // (now + days × 24h)
     );
 
-    const claims = {
+    return {
       iss: args.issuer,
       sub: subject,
       aud: [args.issuer],
@@ -121,9 +136,16 @@ export class BillingAuthService {
         user_type: SERVICE_USER_TYPE,
       },
     };
+  }
 
+  /**
+   * Mints the long-lived ES256 service token by signing with a **local** private
+   * key. Pure/static — the private key is supplied by the caller, so this runs
+   * from the CLI without booting the app.
+   */
+  static mint(args: BillingTokenClaimsArgs & { privateKey: string }): string {
     const client = jwtClientFactory();
-    const token = client.sign(claims, {
+    const token = client.sign(BillingAuthService.buildClaims(args), {
       secretOrPrivateKey: args.privateKey,
       algorithm: JWT_ES_ALGORITHM,
     });
@@ -132,5 +154,49 @@ export class BillingAuthService {
     BillingServiceTokenSchema.parse(client.decodeWithoutVerification(token));
 
     return token;
+  }
+
+  /**
+   * Mints an ES256 service token whose signing is delegated to AWS KMS: the
+   * private key stays in KMS and `sign` calls KMS `Sign`. Because KMS can't
+   * produce a JWS itself, the token is assembled here by hand.
+   *
+   * @param args - Token claim inputs (issuer, subject, expiry).
+   * @param sign - Given the JWS signing input (`base64url(header).base64url(payload)`),
+   *   returns the DER-encoded ECDSA signature (the format KMS `Sign` returns).
+   * @returns The signed compact JWS (`header.payload.signature`).
+   */
+  static async mintViaSigner(
+    args: BillingTokenClaimsArgs,
+    sign: (signingInput: Buffer) => Promise<Buffer>,
+  ): Promise<string> {
+    const claims = BillingAuthService.buildClaims(args);
+    const header = { alg: JWT_ES_ALGORITHM, typ: 'JWT' };
+    // Second-based NumericDate claims, matching the local sign path.
+    const payload = {
+      ...claims,
+      iat: toSecondsTimestamp(claims.iat),
+      exp: toSecondsTimestamp(claims.exp),
+    };
+
+    const signingInput = `${BillingAuthService.encodeSegment(header)}.${BillingAuthService.encodeSegment(payload)}`;
+    const der = await sign(Buffer.from(signingInput));
+    // KMS returns a DER ECDSA signature; JWS/ES256 needs raw R||S (base64url).
+    const signature = derToJose(der, JWT_ES_ALGORITHM);
+    const token = `${signingInput}.${signature}`;
+
+    // This path hand-assembles the JWS (manual base64url + DER→JOSE), so decode
+    // it back and parse the claims — this catches assembly mistakes and
+    // guarantees the token satisfies the guard's authorization schema before
+    // it's provisioned.
+    BillingServiceTokenSchema.parse(
+      jwtClientFactory().decodeWithoutVerification(token),
+    );
+
+    return token;
+  }
+
+  private static encodeSegment(segment: object): string {
+    return Buffer.from(JSON.stringify(segment)).toString('base64url');
   }
 }

--- a/src/modules/billing/domain/billing-auth.service.ts
+++ b/src/modules/billing/domain/billing-auth.service.ts
@@ -12,6 +12,7 @@ import {
   type ILoggingService,
   LoggingService,
 } from '@/logging/logging.interface';
+import { DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT } from '@/modules/billing/domain/billing-auth.constants';
 import {
   type BillingServiceToken,
   BillingServiceTokenSchema,
@@ -19,16 +20,7 @@ import {
   SERVICE_ACCESS_ROLE,
   SERVICE_USER_TYPE,
 } from '@/modules/billing/domain/entities/billing-service-token.entity';
-
-export const DEFAULT_BILLING_SERVICE_TOKEN_SUBJECT = 'billing-service';
-
-type BillingTokenClaimsArgs = {
-  issuer: string;
-  expiresInDays: number;
-  subject?: string;
-  /** Injectable clock for deterministic tests. */
-  now?: Date;
-};
+import type { BillingTokenClaims } from '@/modules/billing/domain/entities/billing-token-claims.entity';
 
 /**
  * Owns the billing-service webhook credential lifecycle — the "receiver issues
@@ -103,7 +95,7 @@ export class BillingAuthService {
    * `iat`/`exp` are `Date`s here; they are converted to second-based NumericDates
    * when the token is signed.
    */
-  private static buildClaims(args: BillingTokenClaimsArgs): {
+  private static buildClaims(args: BillingTokenClaims): {
     iss: string;
     sub: string;
     aud: Array<string>;
@@ -142,7 +134,7 @@ export class BillingAuthService {
    * key. Pure/static — the private key is supplied by the caller, so this runs
    * from the CLI without booting the app.
    */
-  static mint(args: BillingTokenClaimsArgs & { privateKey: string }): string {
+  static mint(args: BillingTokenClaims & { privateKey: string }): string {
     const client = jwtClientFactory();
     const token = client.sign(BillingAuthService.buildClaims(args), {
       secretOrPrivateKey: args.privateKey,
@@ -166,7 +158,7 @@ export class BillingAuthService {
    * @returns The signed compact JWS (`header.payload.signature`).
    */
   static async mintViaSigner(
-    args: BillingTokenClaimsArgs,
+    args: BillingTokenClaims,
     sign: (signingInput: Buffer) => Promise<Buffer>,
   ): Promise<string> {
     const claims = BillingAuthService.buildClaims(args);

--- a/src/modules/billing/domain/billing-auth.service.ts
+++ b/src/modules/billing/domain/billing-auth.service.ts
@@ -56,10 +56,9 @@ export class BillingAuthService {
     configurationService: IConfigurationService,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
-    this.publicKey = configurationService
-      .getOrThrow<string>('billing.webhook.publicKey')
-      // PEM keys provided via env often arrive with escaped newlines.
-      .replace(/\\n/g, '\n');
+    this.publicKey = configurationService.getOrThrow<string>(
+      'billing.webhook.publicKey',
+    );
     this.issuer = configurationService.getOrThrow<string>(
       'billing.webhook.issuer',
     );

--- a/src/modules/billing/domain/entities/billing-service-token.entity.spec.ts
+++ b/src/modules/billing/domain/entities/billing-service-token.entity.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { BillingServiceTokenSchema } from '@/modules/billing/domain/entities/billing-service-token.entity';
+
+describe('BillingServiceTokenSchema', () => {
+  const baseClaims = {
+    iss: 'safe-client-gateway',
+    sub: 'billing-service',
+    aud: ['safe-client-gateway'],
+  };
+
+  it('accepts a token authorized via the SERVICE_ACCESS role', () => {
+    const result = BillingServiceTokenSchema.safeParse({
+      ...baseClaims,
+      roles: ['SERVICE_ACCESS'],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a token authorized via the data markers', () => {
+    const result = BillingServiceTokenSchema.safeParse({
+      ...baseClaims,
+      data: {
+        service_name: 'billing-service',
+        permission_type: 'SERVICE_ACCESS',
+        user_type: 'SERVICE_USER',
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a token whose roles include SERVICE_ACCESS among others', () => {
+    const result = BillingServiceTokenSchema.safeParse({
+      ...baseClaims,
+      roles: ['BILLING_ADMIN', 'SERVICE_ACCESS'],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a token whose roles do not include SERVICE_ACCESS', () => {
+    const result = BillingServiceTokenSchema.safeParse({
+      ...baseClaims,
+      roles: ['BILLING_ADMIN', 'SOME_OTHER_ROLE'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a token with neither role nor data markers', () => {
+    const result = BillingServiceTokenSchema.safeParse(baseClaims);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects data markers with an empty service_name', () => {
+    const result = BillingServiceTokenSchema.safeParse({
+      ...baseClaims,
+      data: {
+        service_name: '',
+        permission_type: 'SERVICE_ACCESS',
+        user_type: 'SERVICE_USER',
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects data markers with a non-service user_type', () => {
+    const result = BillingServiceTokenSchema.safeParse({
+      ...baseClaims,
+      data: {
+        service_name: 'billing-service',
+        permission_type: 'SERVICE_ACCESS',
+        user_type: 'HUMAN_USER',
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/modules/billing/domain/entities/billing-service-token.entity.spec.ts
+++ b/src/modules/billing/domain/entities/billing-service-token.entity.spec.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
-import { BillingServiceTokenSchema } from '@/modules/billing/domain/entities/billing-service-token.entity';
+import {
+  BillingServiceTokenSchema,
+  SERVICE_ACCESS_PERMISSION_TYPE,
+  SERVICE_ACCESS_ROLE,
+  SERVICE_USER_TYPE,
+} from '@/modules/billing/domain/entities/billing-service-token.entity';
 
 describe('BillingServiceTokenSchema', () => {
   const baseClaims = {
@@ -12,7 +17,7 @@ describe('BillingServiceTokenSchema', () => {
   it('accepts a token authorized via the SERVICE_ACCESS role', () => {
     const result = BillingServiceTokenSchema.safeParse({
       ...baseClaims,
-      roles: ['SERVICE_ACCESS'],
+      roles: [SERVICE_ACCESS_ROLE],
     });
 
     expect(result.success).toBe(true);
@@ -23,8 +28,8 @@ describe('BillingServiceTokenSchema', () => {
       ...baseClaims,
       data: {
         service_name: 'billing-service',
-        permission_type: 'SERVICE_ACCESS',
-        user_type: 'SERVICE_USER',
+        permission_type: SERVICE_ACCESS_PERMISSION_TYPE,
+        user_type: SERVICE_USER_TYPE,
       },
     });
 
@@ -34,7 +39,7 @@ describe('BillingServiceTokenSchema', () => {
   it('accepts a token whose roles include SERVICE_ACCESS among others', () => {
     const result = BillingServiceTokenSchema.safeParse({
       ...baseClaims,
-      roles: ['BILLING_ADMIN', 'SERVICE_ACCESS'],
+      roles: ['BILLING_ADMIN', SERVICE_ACCESS_ROLE],
     });
 
     expect(result.success).toBe(true);
@@ -60,8 +65,8 @@ describe('BillingServiceTokenSchema', () => {
       ...baseClaims,
       data: {
         service_name: '',
-        permission_type: 'SERVICE_ACCESS',
-        user_type: 'SERVICE_USER',
+        permission_type: SERVICE_ACCESS_PERMISSION_TYPE,
+        user_type: SERVICE_USER_TYPE,
       },
     });
 
@@ -73,7 +78,7 @@ describe('BillingServiceTokenSchema', () => {
       ...baseClaims,
       data: {
         service_name: 'billing-service',
-        permission_type: 'SERVICE_ACCESS',
+        permission_type: SERVICE_ACCESS_PERMISSION_TYPE,
         user_type: 'HUMAN_USER',
       },
     });

--- a/src/modules/billing/domain/entities/billing-service-token.entity.ts
+++ b/src/modules/billing/domain/entities/billing-service-token.entity.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { z } from 'zod';
+import { JwtClaimsSchema } from '@/datasources/jwt/jwt-claims.entity';
+
+export const SERVICE_ACCESS_ROLE = 'SERVICE_ACCESS' as const;
+export const SERVICE_ACCESS_PERMISSION_TYPE = 'SERVICE_ACCESS' as const;
+export const SERVICE_USER_TYPE = 'SERVICE_USER' as const;
+
+/**
+ * Service-to-service token presented by the billing service on each webhook
+ * call. Extends the standard JWT claims with the authorization markers used to
+ * confirm the caller is a service.
+ *
+ * Cryptographic/standard-claim validation (signature, `iss`, `aud`, `exp`) is
+ * handled separately by `IJwtService.verify`. This schema enforces the
+ * authorization layer: it is a service token if `roles` contains
+ * `SERVICE_ACCESS`, OR `data` carries `permission_type = SERVICE_ACCESS`,
+ * `user_type = SERVICE_USER`, and a non-empty `service_name`.
+ */
+export const BillingServiceTokenSchema = JwtClaimsSchema.extend({
+  roles: z.array(z.string()).optional(),
+  data: z
+    .object({
+      service_name: z.string().optional(),
+      permission_type: z.string().optional(),
+      user_type: z.string().optional(),
+    })
+    .optional(),
+}).superRefine((token, ctx) => {
+  const hasServiceRole = token.roles?.includes(SERVICE_ACCESS_ROLE) ?? false;
+
+  const hasServiceData =
+    token.data?.permission_type === SERVICE_ACCESS_PERMISSION_TYPE &&
+    token.data?.user_type === SERVICE_USER_TYPE &&
+    !!token.data?.service_name;
+
+  if (!(hasServiceRole || hasServiceData)) {
+    ctx.addIssue({
+      code: 'custom',
+      message:
+        'Not a service token: requires roles to contain SERVICE_ACCESS, or data with permission_type=SERVICE_ACCESS, user_type=SERVICE_USER and a non-empty service_name',
+    });
+  }
+});
+
+export type BillingServiceToken = z.infer<typeof BillingServiceTokenSchema>;

--- a/src/modules/billing/domain/entities/billing-token-claims.entity.ts
+++ b/src/modules/billing/domain/entities/billing-token-claims.entity.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+export type BillingTokenClaims = {
+  issuer: string;
+  expiresInDays: number;
+  subject?: string;
+  /** Injectable clock for deterministic tests. */
+  now?: Date;
+};

--- a/src/modules/billing/routes/billing.controller.ts
+++ b/src/modules/billing/routes/billing.controller.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+
+@Controller({
+  path: '',
+  version: '1',
+})
+@ApiExcludeController()
+export class BillingController {
+  @UseGuards(BillingWebhookAuthGuard)
+  @Post('/billing/webhooks')
+  @HttpCode(202)
+  postWebhook(): void {
+    // Origin is authenticated by BillingWebhookAuthGuard.
+    // TODO(PLA-1678 follow-up): validate and process the webhook payload.
+  }
+}

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -18,7 +18,8 @@ import { BillingAuthService } from '@/modules/billing/domain/billing-auth.servic
 import { BillingController } from '@/modules/billing/routes/billing.controller';
 import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
 
-const ISSUER = 'safe-client-gateway';
+const ISSUER = faker.internet.domainName();
+const SUBJECT = faker.internet.domainWord();
 const PATH = '/v1/billing/webhooks';
 
 describe('BillingWebhookAuthGuard', () => {
@@ -36,12 +37,12 @@ describe('BillingWebhookAuthGuard', () => {
     return client.sign(
       {
         iss: ISSUER,
-        sub: 'billing-service',
+        sub: SUBJECT,
         aud: [ISSUER],
         exp: new Date(Date.now() + 60 * 60 * 1_000),
         roles: ['SERVICE_ACCESS'],
         data: {
-          service_name: 'billing-service',
+          service_name: SUBJECT,
           permission_type: 'SERVICE_ACCESS',
           user_type: 'SERVICE_USER',
         },
@@ -124,7 +125,7 @@ describe('BillingWebhookAuthGuard', () => {
   it('rejects a token signed with the wrong algorithm (HS256)', async () => {
     const token = signServiceToken(
       {},
-      { algorithm: 'HS256', secret: 'shared-secret' },
+      { algorithm: 'HS256', secret: faker.string.alphanumeric(32) },
     );
 
     await request(app.getHttpServer())
@@ -134,7 +135,7 @@ describe('BillingWebhookAuthGuard', () => {
   });
 
   it('rejects a token with the wrong issuer', async () => {
-    const token = signServiceToken({ iss: 'someone-else' });
+    const token = signServiceToken({ iss: faker.internet.domainName() });
 
     await request(app.getHttpServer())
       .post(PATH)
@@ -143,7 +144,7 @@ describe('BillingWebhookAuthGuard', () => {
   });
 
   it('rejects a token with the wrong audience', async () => {
-    const token = signServiceToken({ aud: ['someone-else'] });
+    const token = signServiceToken({ aud: [faker.internet.domainName()] });
 
     await request(app.getHttpServer())
       .post(PATH)
@@ -162,7 +163,7 @@ describe('BillingWebhookAuthGuard', () => {
 
   it('rejects a validly-signed token that is not a service token', async () => {
     const token = signServiceToken({
-      roles: ['SOME_OTHER_ROLE'],
+      roles: [faker.string.alpha({ length: 10, casing: 'upper' })],
       data: undefined,
     });
 

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -65,7 +65,11 @@ describe('BillingWebhookAuthGuard', () => {
     const testConfiguration = (): typeof baseConfiguration => ({
       ...baseConfiguration,
       billing: {
-        webhook: { publicKey, issuer: ISSUER },
+        webhook: {
+          ...baseConfiguration.billing.webhook,
+          publicKey,
+          issuer: ISSUER,
+        },
       },
     });
 

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -103,6 +103,13 @@ describe('BillingWebhookAuthGuard', () => {
       .expect(401);
   });
 
+  it('rejects a Bearer header with an empty token', async () => {
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', 'Bearer   ')
+      .expect(401);
+  });
+
   it('rejects a malformed token', async () => {
     await request(app.getHttpServer())
       .post(PATH)

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -152,6 +152,17 @@ describe('BillingWebhookAuthGuard', () => {
       .expect(401);
   });
 
+  it('accepts a token whose audience list contains the expected issuer among others', async () => {
+    const token = signServiceToken({
+      aud: [ISSUER, faker.internet.domainName()],
+    });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(202);
+  });
+
   it('rejects an expired token', async () => {
     const token = signServiceToken({ exp: new Date(Date.now() - 1_000) });
 

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { generateKeyPairSync } from 'node:crypto';
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { checkGuardIsApplied } from '@/__tests__/util/check-guard';
+import { ConfigurationModule } from '@/config/configuration.module';
+import configuration from '@/config/entities/__tests__/configuration';
+import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
+import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
+import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
+import { BillingModule } from '@/modules/billing/billing.module';
+import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
+import { BillingController } from '@/modules/billing/routes/billing.controller';
+import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+
+const ISSUER = 'safe-client-gateway';
+const PATH = '/v1/billing/webhooks';
+
+describe('BillingWebhookAuthGuard', () => {
+  let app: INestApplication<Server>;
+  let privateKey: string;
+  let publicKey: string;
+
+  const client = jwtClientFactory();
+
+  /** Signs an ES256 token with the CGW private key (defaults to a valid service token). */
+  function signServiceToken(
+    overrides: Record<string, unknown> = {},
+    options?: { algorithm?: 'ES256' | 'HS256'; secret?: string },
+  ): string {
+    return client.sign(
+      {
+        iss: ISSUER,
+        sub: 'billing-service',
+        aud: [ISSUER],
+        exp: new Date(Date.now() + 60 * 60 * 1_000),
+        roles: ['SERVICE_ACCESS'],
+        data: {
+          service_name: 'billing-service',
+          permission_type: 'SERVICE_ACCESS',
+          user_type: 'SERVICE_USER',
+        },
+        ...overrides,
+      },
+      {
+        secretOrPrivateKey: options?.secret ?? privateKey,
+        algorithm: options?.algorithm ?? JWT_ES_ALGORITHM,
+      },
+    );
+  }
+
+  beforeEach(async () => {
+    ({ privateKey, publicKey } = generateKeyPairSync('ec', {
+      namedCurve: 'prime256v1',
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    }));
+
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      billing: {
+        webhook: { publicKey, issuer: ISSUER },
+      },
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TestLoggingModule,
+        ConfigurationModule.register(testConfiguration),
+        BillingModule,
+      ],
+    }).compile();
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('is applied to the webhook endpoint', () => {
+    checkGuardIsApplied(
+      BillingWebhookAuthGuard,
+      BillingController.prototype.postWebhook,
+    );
+  });
+
+  it('rejects a request without an Authorization header', async () => {
+    await request(app.getHttpServer()).post(PATH).expect(401);
+  });
+
+  it('rejects a non-Bearer Authorization header', async () => {
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Basic ${faker.string.alphanumeric()}`)
+      .expect(401);
+  });
+
+  it('rejects a malformed token', async () => {
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${faker.string.alphanumeric()}`)
+      .expect(401);
+  });
+
+  it('rejects a token signed with the wrong algorithm (HS256)', async () => {
+    const token = signServiceToken(
+      {},
+      { algorithm: 'HS256', secret: 'shared-secret' },
+    );
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it('rejects a token with the wrong issuer', async () => {
+    const token = signServiceToken({ iss: 'someone-else' });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const token = signServiceToken({ aud: ['someone-else'] });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it('rejects an expired token', async () => {
+    const token = signServiceToken({ exp: new Date(Date.now() - 1_000) });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it('rejects a validly-signed token that is not a service token', async () => {
+    const token = signServiceToken({
+      roles: ['SOME_OTHER_ROLE'],
+      data: undefined,
+    });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it('rejects a token signed by a different (untrusted) key', async () => {
+    const { privateKey: otherPrivateKey } = generateKeyPairSync('ec', {
+      namedCurve: 'prime256v1',
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const token = signServiceToken({}, { secret: otherPrivateKey });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it('accepts a valid token minted by the provisioning helper', async () => {
+    const token = BillingAuthService.mint({
+      privateKey,
+      issuer: ISSUER,
+      expiresInDays: 365,
+    });
+
+    await request(app.getHttpServer())
+      .post(PATH)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(202);
+  });
+});

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
@@ -36,7 +36,7 @@ export class BillingWebhookAuthGuard implements CanActivate {
   }
 
   private getBearerToken(request: Request): string | null {
-   const AUTH_HEADER_NAME = 'Authorization';
+    const AUTH_HEADER_NAME = 'authorization';
     const header = request.headers[AUTH_HEADER_NAME];
     if (!header?.startsWith('Bearer ')) {
       return null;

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
@@ -36,8 +36,7 @@ export class BillingWebhookAuthGuard implements CanActivate {
   }
 
   private getBearerToken(request: Request): string | null {
-    const AUTH_HEADER_NAME = 'authorization';
-    const header = request.headers[AUTH_HEADER_NAME];
+    const header = request.headers.authorization;
     if (!header?.startsWith('Bearer ')) {
       return null;
     }

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
@@ -36,7 +36,8 @@ export class BillingWebhookAuthGuard implements CanActivate {
   }
 
   private getBearerToken(request: Request): string | null {
-    const header = request.headers.authorization;
+   const AUTH_HEADER_NAME = 'Authorization';
+    const header = request.headers[AUTH_HEADER_NAME];
     if (!header?.startsWith('Bearer ')) {
       return null;
     }

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import {
+  type CanActivate,
+  type ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
+
+/**
+ * Protects the billing-service webhook endpoint with a service-to-service JWT.
+ *
+ * Extracts the `Authorization: Bearer <token>` credential (an HTTP concern) and
+ * delegates verification to {@link BillingAuthService}. Only instantiated
+ * when the `billingWebhook` feature is enabled.
+ */
+@Injectable()
+export class BillingWebhookAuthGuard implements CanActivate {
+  constructor(private readonly tokenService: BillingAuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request: Request = context.switchToHttp().getRequest();
+
+    const token = this.getBearerToken(request);
+    if (!token) {
+      throw new UnauthorizedException(
+        "No bearer token provided in 'Authorization' header",
+      );
+    }
+
+    // Throws UnauthorizedException if the token is invalid or unauthorized.
+    this.tokenService.verify(token);
+    return true;
+  }
+
+  private getBearerToken(request: Request): string | null {
+    const header = request.headers.authorization;
+    if (!header?.startsWith('Bearer ')) {
+      return null;
+    }
+    const token = header.slice('Bearer '.length).trim();
+    return token.length > 0 ? token : null;
+  }
+}

--- a/src/modules/email/ses/datasources/aws-ses-email.service.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.ts
@@ -5,9 +5,9 @@ import {
   type SESv2ClientConfig,
   SendEmailCommand,
 } from '@aws-sdk/client-sesv2';
-import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { resolveAwsCredentials } from '@/datasources/common/utils/aws-credentials.utils';
 import { SesEmailErrorMapper } from '@/modules/email/ses/datasources/ses-email-error.mapper';
 import { IEmailService } from '@/modules/email/ses/domain/interfaces/email-service.interface';
 
@@ -38,16 +38,14 @@ export class AwsSesEmailService implements IEmailService {
     // Local development uses SES-specific static AWS keys. Deployed environments
     // use IRSA via the projected web identity token file, so SES does not pick up
     // the generic AWS keys used by other integrations.
-    this.credentials = webIdentityTokenFile
-      ? fromTokenFile()
-      : {
-          accessKeyId: this.configurationService.getOrThrow<string>(
-            'email.ses.aws.accessKeyId',
-          ),
-          secretAccessKey: this.configurationService.getOrThrow<string>(
-            'email.ses.aws.secretAccessKey',
-          ),
-        };
+    this.credentials = resolveAwsCredentials(webIdentityTokenFile) ?? {
+      accessKeyId: this.configurationService.getOrThrow<string>(
+        'email.ses.aws.accessKeyId',
+      ),
+      secretAccessKey: this.configurationService.getOrThrow<string>(
+        'email.ses.aws.secretAccessKey',
+      ),
+    };
 
     this.client = new SESv2Client({
       maxAttempts: 1, //do not retry at the SDK level, let the JobQueue handle retries with backoff

--- a/yarn.lock
+++ b/yarn.lock
@@ -7230,6 +7230,7 @@ __metadata:
     cache-manager: "npm:7.2.8"
     cookie-parser: "npm:1.4.7"
     csv-stringify: "npm:^6.8.0"
+    ecdsa-sig-formatter: "npm:1.0.11"
     husky: "npm:9.1.7"
     jose: "npm:6.2.3"
     jsonwebtoken: "npm:9.0.3"


### PR DESCRIPTION
## Summary
## [PLA-1678] Billing-service webhook receiver authentication (service-to-service JWT)

### Context
The CGW needs to receive webhooks from the billing service and verify their origin. This implements the **"receiver issues the credential it later checks"** model: the CGW mints a long-lived **ES256** (ECDSA P-256) token, provisions it to the billing service, and verifies each incoming `Authorization: Bearer <token>` **statelessly/offline** against its own public key — no JWKS, no callback, no shared secret over the body.

### Verification (runtime)
- **`BillingWebhookAuthGuard`** — thin guard that extracts the bearer token and delegates to `BillingAuthService`.
- **`BillingAuthService.verify`** — two layers: (1) ES256 signature + `iss`/`aud`/`exp` via `IJwtService`; (2) service-token authorization (Zod schema: `roles` contains `SERVICE_ACCESS`, or `data` has `permission_type=SERVICE_ACCESS` + `user_type=SERVICE_USER` + non-empty `service_name`). Failures log at `warn` and return `401`.
- **Endpoint** — placeholder `POST /v1/billing/webhooks` returning `202` (payload handling is a follow-up).
- **Feature-flag gated** — the module is only wired in when `FF_BILLING_WEBHOOK=true`; the app reads its public key lazily. Enabling the flag without a key fails fast at boot. `iss`/`aud` are a single configured identifier.
- The running app **never signs and never calls KMS** — it only verifies, offline, with the public key.

### Provisioning (`yarn generate-token` / `scripts/generate-token.ts`)
Mints the long-lived token. Dual signing mode, same claim shape either way:
- **KMS (production)** — signs via an asymmetric KMS key (`ECC_NIST_P256`); the private key never leaves KMS. Also prints the public-key PEM to configure the verifier.
- **Local PEM (dev/CI)** — signs with `BILLING_WEBHOOK_JWT_PRIVATE_KEY`.
- **Enforced:** when `CGW_ENV=production`, local-PEM signing is refused (KMS required).
- Strict `parseArgs` (unknown flags rejected); `--sub` is charset-validated.

KMS specifics:
- `AwsKmsSignerService` (`src/datasources/kms/`) — `Sign` (ECDSA_SHA_256) + `GetPublicKey`; credentials via IRSA or the default AWS chain; region from `AWS_REGION`.
- `BillingAuthService.mintViaSigner` hand-assembles the JWS around the KMS signature; DER→JOSE conversion via `ecdsa-sig-formatter` (promoted from a transitive to a direct dependency).

### Configuration
| Variable | Used by | Default |
| -- | -- | -- |
| `FF_BILLING_WEBHOOK` | app (enables endpoint) | `false` |
| `BILLING_WEBHOOK_JWT_PUBLIC_KEY` | app (verify) | — |
| `BILLING_WEBHOOK_JWT_ISSUER` | app + CLI (`iss`/`aud`) | `safe-client-gateway` |
| `BILLING_WEBHOOK_JWT_KMS_KEY_ID` | CLI (KMS signing) | — |
| `BILLING_WEBHOOK_JWT_PRIVATE_KEY` | CLI (local signing) | — |

The app needs **no** KMS permissions; `kms:Sign`/`kms:GetPublicKey` go to a dedicated mint principal (CI/bastion), not the app's runtime role. See `src/modules/billing/README.md`.


### Notes
- Webhook **payload** processing is intentionally out of scope (placeholder endpoint).
- The mint CLI is a dev/ops tool; in the deployed image invoke `node dist/scripts/generate-token.js` (not `yarn`) — see the module README for the KMS/IAM provisioning guide.
- Related: PLA-1679 is the opposite direction (CGW → billing outbound credential); keys/tokens are kept separate.

