### PR TITLE
feat(safe-apps): resolve SafeApp via origin URL

### DIFF
--- a/src/modules/messages/routes/entities/message.entity.ts
+++ b/src/modules/messages/routes/entities/message.entity.ts
@@ -8,7 +8,8 @@ import {
 import type { Hash, Hex } from 'viem';
 import { MessageConfirmation } from '@/modules/messages/routes/entities/message-confirmation.entity';
 import { TypedData } from '@/modules/messages/routes/entities/typed-data.entity';
-import { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { SafeAppInfo } from '@/modules/transactions/routes/entities/safe-app-info.entity';
+import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export enum MessageStatus {
   NeedsConfirmation = 'NEEDS_CONFIRMATION',
@@ -21,9 +22,11 @@ export class Message {
   messageHash: Hash;
   @ApiProperty({ enum: MessageStatus })
   status: MessageStatus;
-  @ApiPropertyOptional({ type: String, nullable: true })
+  /** @deprecated Read `safeAppInfo.logoUri` instead. */
+  @ApiPropertyOptional({ type: String, nullable: true, deprecated: true })
   logoUri: string | null;
-  @ApiPropertyOptional({ type: String, nullable: true })
+  /** @deprecated Read `safeAppInfo.name` instead. */
+  @ApiPropertyOptional({ type: String, nullable: true, deprecated: true })
   name: string | null;
   @ApiProperty({
     oneOf: [{ type: 'string' }, { $ref: getSchemaPath(TypedData) }],
@@ -45,6 +48,11 @@ export class Message {
   preparedSignature: Hex | null;
   @ApiPropertyOptional({ type: String, nullable: true })
   origin: string | null;
+  @ApiPropertyOptional({ type: SafeAppInfo, nullable: true })
+  safeAppInfo: SafeAppInfo | null;
+  /** @deprecated Read `safeAppInfo.id` instead. */
+  @ApiPropertyOptional({ type: Number, nullable: true, deprecated: true })
+  safeAppId: number | null;
 
   constructor(
     messageHash: Hash,
@@ -60,11 +68,15 @@ export class Message {
     confirmations: Array<MessageConfirmation>,
     preparedSignature: Hex | null,
     origin: string | null,
+    safeAppInfo: SafeAppInfo | null,
+    safeAppId: number | null,
   ) {
     this.messageHash = messageHash;
     this.status = status;
+    /* eslint-disable @typescript-eslint/no-deprecated -- legacy mirror fields populated for backward compatibility */
     this.logoUri = logoUri;
     this.name = name;
+    /* eslint-enable @typescript-eslint/no-deprecated */
     this.message = message;
     this.creationTimestamp = creationTimestamp;
     this.modifiedTimestamp = modifiedTimestamp;
@@ -74,5 +86,8 @@ export class Message {
     this.confirmations = confirmations;
     this.preparedSignature = preparedSignature;
     this.origin = origin;
+    this.safeAppInfo = safeAppInfo;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- legacy mirror of safeAppInfo.id
+    this.safeAppId = safeAppId;
   }
 }

--- a/src/modules/messages/routes/mappers/message-mapper.ts
+++ b/src/modules/messages/routes/mappers/message-mapper.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import type { Message as DomainMessage } from '@/modules/messages/domain/entities/message.entity';
 import type { MessageConfirmation as DomainMessageConfirmation } from '@/modules/messages/domain/entities/message-confirmation.entity';
 import {
@@ -9,15 +9,13 @@ import {
 import { MessageConfirmation } from '@/modules/messages/routes/entities/message-confirmation.entity';
 import { MessageItem } from '@/modules/messages/routes/entities/message-item.entity';
 import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
-import type { SafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository';
-import { ISafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository.interface';
+import { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import { AddressInfoHelper } from '@/routes/common/address-info/address-info.helper';
 
 @Injectable()
 export class MessageMapper {
   constructor(
-    @Inject(ISafeAppsRepository)
-    private readonly safeAppsRepository: SafeAppsRepository,
+    private readonly safeAppInfoMapper: SafeAppInfoMapper,
     private readonly addressInfoHelper: AddressInfoHelper,
   ) {}
 
@@ -29,6 +27,7 @@ export class MessageMapper {
     return Promise.all(
       domainMessages.map(async (domainMessage) => {
         const message = await this.mapMessage(chainId, domainMessage, safe);
+        /* eslint-disable @typescript-eslint/no-deprecated -- forwarding legacy mirror fields to MessageItem */
         return new MessageItem(
           message.messageHash,
           message.status,
@@ -43,7 +42,10 @@ export class MessageMapper {
           message.confirmations,
           message.preparedSignature,
           message.origin,
+          message.safeAppInfo,
+          message.safeAppId,
         );
+        /* eslint-enable @typescript-eslint/no-deprecated */
       }),
     );
   }
@@ -53,9 +55,11 @@ export class MessageMapper {
     message: DomainMessage,
     safe: Safe,
   ): Promise<Message> {
-    const safeApp = message.safeAppId
-      ? await this.safeAppsRepository.getSafeAppById(chainId, message.safeAppId)
-      : null;
+    const safeAppInfo = await this.safeAppInfoMapper.mapSafeAppInfo(
+      chainId,
+      message.origin,
+      message.messageHash,
+    );
     const status =
       message.confirmations.length >= safe.threshold
         ? MessageStatus.Confirmed
@@ -77,8 +81,8 @@ export class MessageMapper {
     return new Message(
       message.messageHash,
       status,
-      safeApp?.iconUrl ?? null,
-      safeApp?.name ?? null,
+      safeAppInfo?.logoUri ?? null,
+      safeAppInfo?.name ?? null,
       message.message,
       message.created.getTime(),
       message.modified.getTime(),
@@ -88,6 +92,8 @@ export class MessageMapper {
       confirmations,
       preparedSignature,
       message.origin,
+      safeAppInfo,
+      safeAppInfo?.id ?? null,
     );
   }
 

--- a/src/modules/queue/helpers/origin.helper.ts
+++ b/src/modules/queue/helpers/origin.helper.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+/**
+ * Parses a TX-service-style origin JSON string into separate name/url/note fields.
+ *
+ * The note is embedded inside the origin JSON by the transactions service (see
+ * `MultisigTransactionNoteMapper`); the queue service expects it as a dedicated
+ * field, so we lift it out here.
+ *
+ * @param origin - The JSON string to parse (typically from the Safe Transaction Service's "origin").
+ *
+ * @returns An object with the extracted originName, originUrl and note fields if present.
+ */
+export function parseOrigin(origin: string | null): {
+  originName?: string;
+  originUrl?: string;
+  note?: string;
+} {
+  const parsedOrigin: {
+    originName?: string;
+    originUrl?: string;
+    note?: string;
+  } = {
+    originName: undefined,
+    originUrl: undefined,
+    note: undefined,
+  };
+  if (!origin) {
+    return parsedOrigin;
+  }
+
+  try {
+    const parsed = JSON.parse(origin);
+    // Guard against valid-but-non-object JSON (e.g. `"hello"` or `42`), which
+    // would otherwise destructure into undefined name/url silently.
+    if (typeof parsed === 'object' && parsed !== null) {
+      const { name, url, note } = parsed;
+      parsedOrigin.originName = name;
+      parsedOrigin.originUrl = url;
+      parsedOrigin.note = note;
+    }
+  } catch {
+    // Ignore, no origin
+  }
+  return parsedOrigin;
+}
+
+/**
+ * Builds a TX-service-style origin JSON string from separate name/url/note fields.
+ *
+ * The note is embedded inside the origin JSON because downstream consumers
+ * (e.g. MultisigTransactionNoteMapper) extract it from there rather than from a
+ * dedicated field — the queue service exposes it separately, so we re-merge it.
+ *
+ * @param originName - Name of the origin (e.g., application or Safe App name).
+ * @param originUrl - URL of the origin (e.g., application or Safe App URL).
+ * @param note - Free-text note attached to the transaction, if any.
+ *
+ * @returns A stringified JSON object containing the name, url and note fields if any exists, otherwise null.
+ */
+export function buildOrigin(
+  originName: string | null,
+  originUrl: string | null,
+  note: string | null = null,
+): string | null {
+  if (!(originName || originUrl || note)) {
+    return null;
+  }
+  // Only emit the note key when present so callers without a note (e.g. messages)
+  // keep their original `{name, url}` shape.
+  return JSON.stringify(
+    note === null
+      ? { name: originName, url: originUrl }
+      : { name: originName, url: originUrl, note },
+  );
+}

--- a/src/modules/safe-apps/mappers/safe-app-info.mapper.spec.ts
+++ b/src/modules/safe-apps/mappers/safe-app-info.mapper.spec.ts
@@ -3,12 +3,11 @@
 import { faker } from '@faker-js/faker';
 import type { MockedObject } from 'vitest';
 import type { ILoggingService } from '@/logging/logging.interface';
-import { multisigTransactionBuilder } from '@/modules/safe/domain/entities/__tests__/multisig-transaction.builder';
 import { safeAppBuilder } from '@/modules/safe-apps/domain/entities/__tests__/safe-app.builder';
 import type { SafeApp } from '@/modules/safe-apps/domain/entities/safe-app.entity';
 import type { SafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository';
+import { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import { SafeAppInfo } from '@/modules/transactions/routes/entities/safe-app-info.entity';
-import { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 
 describe('SafeAppInfo mapper (Unit)', () => {
   const safeAppsRepositoryMock = vi.mocked({
@@ -29,127 +28,132 @@ describe('SafeAppInfo mapper (Unit)', () => {
     mapper = new SafeAppInfoMapper(safeAppsRepositoryMock, mockLoggingService);
   });
 
-  it('should get a null SafeAppInfo for a transaction with no origin', async () => {
+  it('should get a null SafeAppInfo when origin is null', async () => {
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with('origin', null)
-      .build();
+    const safeTxHash = faker.string.hexadecimal({ length: 64 });
     const safeApps = [safeAppBuilder().build(), safeAppBuilder().build()];
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
 
-    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+    const actual = await mapper.mapSafeAppInfo(chainId, null, safeTxHash);
 
     expect(actual).toBeNull();
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(0);
   });
 
-  it('should get a null SafeAppInfo for a transaction with no url into origin', async () => {
+  it('should get a null SafeAppInfo when origin has no url', async () => {
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with('origin', `{ "${faker.word.sample()}": "${faker.word.sample()}" }`)
-      .build();
+    const safeTxHash = faker.string.hexadecimal({ length: 64 });
+    const origin = `{ "${faker.word.sample()}": "${faker.word.sample()}" }`;
     const safeApps = [safeAppBuilder().build(), safeAppBuilder().build()];
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
 
-    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+    const actual = await mapper.mapSafeAppInfo(chainId, origin, safeTxHash);
 
     expect(actual).toBeNull();
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(0);
+    expect(mockLoggingService.debug).toHaveBeenCalledWith(
+      `Safe TX Hash ${safeTxHash} origin produced no URL. origin=${origin}`,
+    );
   });
 
   it('should return null if no SafeApp is found and origin is not null', async () => {
     const chainId = faker.string.numeric();
+    const safeTxHash = faker.string.hexadecimal({ length: 64 });
     const safeApps: Array<SafeApp> = [];
-    const transactionOrigin = {
+    const originPayload = {
       url: faker.internet.url({ appendSlash: false }),
       name: faker.word.words(),
     };
-    const transaction = multisigTransactionBuilder()
-      .with('origin', JSON.stringify(transactionOrigin))
-      .build();
+    const origin = JSON.stringify(originPayload);
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
 
-    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+    const actual = await mapper.mapSafeAppInfo(chainId, origin, safeTxHash);
 
     expect(actual).toBeNull();
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
       chainId,
       onlyListed: false,
-      url: transactionOrigin.url,
+      url: originPayload.url,
     });
+    expect(mockLoggingService.info).toHaveBeenCalledWith(
+      `No Safe Apps matching the origin url ${originPayload.url} (safeTxHash: ${safeTxHash})`,
+    );
   });
 
-  it('should get SafeAppInfo for a transaction with origin', async () => {
+  it('should return SafeAppInfo (including id) when origin matches a SafeApp', async () => {
     const chainId = faker.string.numeric();
+    const safeTxHash = faker.string.hexadecimal({ length: 64 });
     const safeApp = safeAppBuilder().build();
     const anotherSafeApp = safeAppBuilder().build();
     const safeApps = [safeApp, anotherSafeApp];
-    const transactionOrigin = {
+    const originPayload = {
       url: faker.internet.url({ appendSlash: false }),
       name: faker.word.words(),
     };
-    const transaction = multisigTransactionBuilder()
-      .with('origin', JSON.stringify(transactionOrigin))
-      .build();
+    const origin = JSON.stringify(originPayload);
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
     const expected = new SafeAppInfo(
+      safeApp.id,
       safeApp.name,
       safeApp.url,
       safeApp.iconUrl,
     );
 
-    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+    const actual = await mapper.mapSafeAppInfo(chainId, origin, safeTxHash);
 
     expect(actual).toEqual(expected);
+    expect(actual?.id).toBe(safeApp.id);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
       chainId,
       onlyListed: false,
-      url: transactionOrigin.url,
+      url: originPayload.url,
     });
   });
 
-  it('should return null origin on invalid JSON', async () => {
+  it('should return null and log debug on invalid JSON origin', async () => {
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder()
-      .with('origin', faker.string.sample())
-      .build();
+    const safeTxHash = faker.string.hexadecimal({ length: 64 });
+    const origin = faker.string.sample();
 
-    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+    const actual = await mapper.mapSafeAppInfo(chainId, origin, safeTxHash);
 
     expect(actual).toBeNull();
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(0);
+    expect(mockLoggingService.debug).toHaveBeenCalledWith(
+      `Safe TX Hash ${safeTxHash} origin produced no URL. origin=${origin}`,
+    );
   });
 
   it('should replace IPFS origin urls', async () => {
     const chainId = faker.string.numeric();
-    const originUrl = 'https://ipfs.io/test';
-    const safeApp = safeAppBuilder().with('url', originUrl).build();
+    const safeTxHash = faker.string.hexadecimal({ length: 64 });
+    const safeAppUrl = 'https://ipfs.io/test';
+    const safeApp = safeAppBuilder().with('url', safeAppUrl).build();
     const safeApps = [safeApp];
     const expectedUrl = 'https://cloudflare-ipfs.com/test';
-    const transactionOrigin = {
+    const originPayload = {
       url: faker.internet.url({ appendSlash: false }),
       name: faker.word.words(),
     };
-    const transaction = multisigTransactionBuilder()
-      .with('origin', JSON.stringify(transactionOrigin))
-      .build();
+    const origin = JSON.stringify(originPayload);
     safeAppsRepositoryMock.getSafeApps.mockResolvedValue(safeApps);
     const expected = new SafeAppInfo(
+      safeApp.id,
       safeApp.name,
       expectedUrl,
       safeApp.iconUrl,
     );
 
-    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+    const actual = await mapper.mapSafeAppInfo(chainId, origin, safeTxHash);
 
     expect(actual).toEqual(expected);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledTimes(1);
     expect(safeAppsRepositoryMock.getSafeApps).toHaveBeenCalledWith({
       chainId,
       onlyListed: false,
-      url: transactionOrigin.url,
+      url: originPayload.url,
     });
   });
 });

--- a/src/modules/safe-apps/mappers/safe-app-info.mapper.ts
+++ b/src/modules/safe-apps/mappers/safe-app-info.mapper.ts
@@ -4,7 +4,7 @@ import {
   type ILoggingService,
   LoggingService,
 } from '@/logging/logging.interface';
-import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import { parseOrigin } from '@/modules/queue/helpers/origin.helper';
 import type { SafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository';
 import { ISafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository.interface';
 import { SafeAppInfo } from '@/modules/transactions/routes/entities/safe-app-info.entity';
@@ -23,9 +23,10 @@ export class SafeAppInfoMapper {
 
   async mapSafeAppInfo(
     chainId: string,
-    transaction: MultisigTransaction,
+    origin: string | null,
+    safeTxHash: string,
   ): Promise<SafeAppInfo | null> {
-    const originUrl = this.getOriginUrl(transaction);
+    const originUrl = this.getOriginUrl(origin, safeTxHash);
     if (!originUrl) return null;
 
     const [safeApp] = await this.safeAppsRepository.getSafeApps({
@@ -35,12 +36,13 @@ export class SafeAppInfoMapper {
     });
     if (!safeApp) {
       this.loggingService.info(
-        `No Safe Apps matching the origin url ${originUrl} (safeTxHash: ${transaction.safeTxHash})`,
+        `No Safe Apps matching the origin url ${originUrl} (safeTxHash: ${safeTxHash})`,
       );
       return null;
     }
 
     return new SafeAppInfo(
+      safeApp.id,
       safeApp.name,
       safeApp.url.replace(
         SafeAppInfoMapper.IPFS_URL,
@@ -50,14 +52,18 @@ export class SafeAppInfoMapper {
     );
   }
 
-  private getOriginUrl(transaction: MultisigTransaction): string | null {
-    try {
-      return transaction.origin ? JSON.parse(transaction.origin).url : null;
-    } catch {
+  private getOriginUrl(
+    origin: string | null,
+    safeTxHash: string,
+  ): string | null {
+    if (!origin) return null;
+    const { originUrl } = parseOrigin(origin);
+    if (!originUrl) {
       this.loggingService.debug(
-        `Safe TX Hash ${transaction.safeTxHash} origin is not valid JSON. origin=${transaction.origin}`,
+        `Safe TX Hash ${safeTxHash} origin produced no URL. origin=${origin}`,
       );
       return null;
     }
+    return originUrl;
   }
 }

--- a/src/modules/safe-apps/safe-apps.module.ts
+++ b/src/modules/safe-apps/safe-apps.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 import { SafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository';
 import { ISafeAppsRepository } from '@/modules/safe-apps/domain/safe-apps.repository.interface';
+import { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import { SafeAppsController } from '@/modules/safe-apps/routes/safe-apps.controller';
 import { SafeAppsService } from '@/modules/safe-apps/routes/safe-apps.service';
 
@@ -13,9 +14,10 @@ import { SafeAppsService } from '@/modules/safe-apps/routes/safe-apps.service';
       provide: ISafeAppsRepository,
       useClass: SafeAppsRepository,
     },
+    SafeAppInfoMapper,
     SafeAppsService,
   ],
   controllers: [SafeAppsController],
-  exports: [ISafeAppsRepository],
+  exports: [ISafeAppsRepository, SafeAppInfoMapper],
 })
 export class SafeAppsModule {}

--- a/src/modules/transactions/routes/entities/__tests__/safe-app-info.builder.ts
+++ b/src/modules/transactions/routes/entities/__tests__/safe-app-info.builder.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
@@ -5,6 +6,7 @@ import type { SafeAppInfo } from '@/modules/transactions/routes/entities/safe-ap
 
 export function safeAppInfoBuilder(): IBuilder<SafeAppInfo> {
   return new Builder<SafeAppInfo>()
+    .with('id', faker.number.int())
     .with('name', faker.word.words())
     .with('url', faker.internet.url({ appendSlash: false }))
     .with('logoUri', faker.internet.url({ appendSlash: false }));

--- a/src/modules/transactions/routes/entities/safe-app-info.entity.ts
+++ b/src/modules/transactions/routes/entities/safe-app-info.entity.ts
@@ -1,6 +1,9 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SafeAppInfo {
+  @ApiProperty()
+  id: number;
   @ApiProperty()
   name: string;
   @ApiProperty()
@@ -8,7 +11,8 @@ export class SafeAppInfo {
   @ApiPropertyOptional({ type: String, nullable: true })
   logoUri: string | null;
 
-  constructor(name: string, url: string, logoUri: string | null) {
+  constructor(id: number, name: string, url: string, logoUri: string | null) {
+    this.id = id;
     this.name = name;
     this.url = url;
     this.logoUri = logoUri;

--- a/src/modules/transactions/routes/mappers/common/human-description.mapper.ts
+++ b/src/modules/transactions/routes/mappers/common/human-description.mapper.ts
@@ -18,6 +18,7 @@ import { IHumanDescriptionRepository } from '@/modules/human-description/domain/
 import type { ModuleTransaction } from '@/modules/safe/domain/entities/module-transaction.entity';
 import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
 import { isMultisigTransaction } from '@/modules/safe/domain/entities/transaction.entity';
+import { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import type { TokenRepository } from '@/modules/tokens/domain/token.repository';
 import { ITokenRepository } from '@/modules/tokens/domain/token.repository.interface';
 import { MAX_UINT256 } from '@/modules/transactions/routes/constants';
@@ -29,7 +30,6 @@ import {
   RichTextFragment,
   RichTokenValueFragment,
 } from '@/modules/transactions/routes/entities/human-description.entity';
-import { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 
 @Injectable()
 export class HumanDescriptionMapper {
@@ -170,7 +170,11 @@ export class HumanDescriptionMapper {
     chainId: string,
   ): Promise<Array<RichDecodedInfoFragment>> {
     const safeAppInfo = isMultisigTransaction(transaction)
-      ? await this.safeAppInfoMapper.mapSafeAppInfo(chainId, transaction)
+      ? await this.safeAppInfoMapper.mapSafeAppInfo(
+          chainId,
+          transaction.origin,
+          transaction.safeTxHash,
+        )
       : null;
 
     if (safeAppInfo) {

--- a/src/modules/transactions/routes/mappers/common/human-descriptions.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/common/human-descriptions.mapper.spec.ts
@@ -17,13 +17,13 @@ import { HumanDescriptionApi } from '@/modules/human-description/datasources/hum
 import { HumanDescriptionRepository } from '@/modules/human-description/domain/human-description.repository';
 import { multisigTransactionBuilder } from '@/modules/safe/domain/entities/__tests__/multisig-transaction.builder';
 import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import type { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import { tokenBuilder } from '@/modules/tokens/domain/__tests__/token.builder';
 import type { Token } from '@/modules/tokens/domain/entities/token.entity';
 import type { TokenRepository } from '@/modules/tokens/domain/token.repository';
 import { MAX_UINT256 } from '@/modules/transactions/routes/constants';
 import { SafeAppInfo } from '@/modules/transactions/routes/entities/safe-app-info.entity';
 import { HumanDescriptionMapper } from '@/modules/transactions/routes/mappers/common/human-description.mapper';
-import type { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 const tokenRepository = vi.mocked({
@@ -184,6 +184,7 @@ describe('Human descriptions mapper (Unit)', () => {
     tokenRepository.getToken.mockImplementation(() => Promise.resolve(token));
     const mockSafeAppName = faker.word.noun();
     const mockSafeAppInfo = new SafeAppInfo(
+      faker.number.int(),
       mockSafeAppName,
       faker.internet.url(),
       faker.image.avatar(),

--- a/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -13,12 +13,12 @@ import type { DelegatesV2Repository } from '@/modules/delegate/domain/v2/delegat
 import { multisigTransactionBuilder } from '@/modules/safe/domain/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
 import { Operation } from '@/modules/safe/domain/entities/operation.entity';
+import type { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import { safeAppInfoBuilder } from '@/modules/transactions/routes/entities/__tests__/safe-app-info.builder';
 import { transferTransactionInfoBuilder } from '@/modules/transactions/routes/entities/__tests__/transfer-transaction-info.builder';
 import { TransactionStatus } from '@/modules/transactions/routes/entities/transaction-status.entity';
 import { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
 import { multisigExecutionDetailsBuilder } from '@/modules/transactions/routes/mappers/__tests__/multisig-execution-details.builder';
-import type { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 import type { TransactionDataMapper } from '@/modules/transactions/routes/mappers/common/transaction-data.mapper';
 import type { MultisigTransactionInfoMapper } from '@/modules/transactions/routes/mappers/common/transaction-info.mapper';
 import { MultisigTransactionDetailsMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-details.mapper';

--- a/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -5,6 +5,7 @@ import type { Address } from 'viem';
 import type { DataDecoded } from '@/modules/data-decoder/domain/v2/entities/data-decoded.entity';
 import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
 import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
+import { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import {
   MULTISIG_TRANSACTION_PREFIX,
   TRANSACTION_ID_SEPARATOR,
@@ -12,7 +13,6 @@ import {
 import { TransactionData } from '@/modules/transactions/routes/entities/transaction-data.entity';
 import type { TransactionDetails } from '@/modules/transactions/routes/entities/transaction-details/transaction-details.entity';
 import { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
-import { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 import { TransactionDataMapper } from '@/modules/transactions/routes/mappers/common/transaction-data.mapper';
 import { MultisigTransactionInfoMapper } from '@/modules/transactions/routes/mappers/common/transaction-info.mapper';
 import { MultisigTransactionExecutionDetailsMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-execution-details.mapper';
@@ -65,7 +65,11 @@ export class MultisigTransactionDetailsMapper {
         dataDecoded,
       ),
       this.transactionDataMapper.buildAddressInfoIndex(chainId, dataDecoded),
-      this.safeAppInfoMapper.mapSafeAppInfo(chainId, transaction),
+      this.safeAppInfoMapper.mapSafeAppInfo(
+        chainId,
+        transaction.origin,
+        transaction.safeTxHash,
+      ),
       this.transactionInfoMapper.mapTransactionInfo(
         chainId,
         transaction,

--- a/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper.spec.ts
@@ -10,13 +10,13 @@ import {
 import { multisigTransactionBuilder } from '@/modules/safe/domain/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
 import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import type { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import { tokenBuilder } from '@/modules/tokens/domain/__tests__/token.builder';
 import { transferTransactionInfoBuilder } from '@/modules/transactions/routes/entities/__tests__/transfer-transaction-info.builder';
 import { MultisigExecutionInfo } from '@/modules/transactions/routes/entities/multisig-execution-info.entity';
 import { TransactionStatus } from '@/modules/transactions/routes/entities/transaction-status.entity';
 import type { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
 import { DataDecodedParamHelper } from '@/modules/transactions/routes/mappers/common/data-decoded-param.helper';
-import type { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 import type { MultisigTransactionInfoMapper } from '@/modules/transactions/routes/mappers/common/transaction-info.mapper';
 import { MultisigTransactionMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper';
 import type { MultisigTransactionExecutionInfoMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-execution-info.mapper';

--- a/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -5,6 +5,7 @@ import { IDataDecoderRepository } from '@/modules/data-decoder/domain/v2/data-de
 import type { DataDecoded } from '@/modules/data-decoder/domain/v2/entities/data-decoded.entity';
 import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
 import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
+import { SafeAppInfoMapper } from '@/modules/safe-apps/mappers/safe-app-info.mapper';
 import {
   MULTISIG_TRANSACTION_PREFIX,
   TRANSACTION_ID_SEPARATOR,
@@ -12,7 +13,6 @@ import {
 import { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
 import { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
 import { DataDecodedParamHelper } from '@/modules/transactions/routes/mappers/common/data-decoded-param.helper';
-import { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 import { MultisigTransactionInfoMapper } from '@/modules/transactions/routes/mappers/common/transaction-info.mapper';
 import { MultisigTransactionExecutionInfoMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-execution-info.mapper';
 import { MultisigTransactionNoteMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-note.mapper';
@@ -59,7 +59,8 @@ export class MultisigTransactionMapper {
     );
     const safeAppInfo = await this.safeAppInfoMapper.mapSafeAppInfo(
       chainId,
-      transaction,
+      transaction.origin,
+      transaction.safeTxHash,
     );
     const note = this.noteMapper.mapTxNote(transaction);
 

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -33,7 +33,6 @@ import { Erc721TransferMapper } from '@/modules/transactions/routes/mappers/comm
 import { HumanDescriptionMapper } from '@/modules/transactions/routes/mappers/common/human-description.mapper';
 import { NativeCoinTransferMapper } from '@/modules/transactions/routes/mappers/common/native-coin-transfer.mapper';
 import { NativeStakingMapper } from '@/modules/transactions/routes/mappers/common/native-staking.mapper';
-import { SafeAppInfoMapper } from '@/modules/transactions/routes/mappers/common/safe-app-info.mapper';
 import { SettingsChangeMapper } from '@/modules/transactions/routes/mappers/common/settings-change.mapper';
 import { SwapOrderMapperModule } from '@/modules/transactions/routes/mappers/common/swap-order.mapper';
 import { TransactionDataMapper } from '@/modules/transactions/routes/mappers/common/transaction-data.mapper';
@@ -112,7 +111,6 @@ import { AddressInfoModule } from '@/routes/common/address-info/address-info.mod
     NativeCoinTransferMapper,
     NativeStakingMapper,
     QueuedItemsMapper,
-    SafeAppInfoMapper,
     SettingsChangeMapper,
     SwapTransferInfoMapper,
     TransactionDataMapper,


### PR DESCRIPTION
## Summary 
  Resolve a message/transaction's SafeApp by its **origin URL** instead of a stored `safeAppId`, and centralize `SafeAppInfoMapper` in the `safe-apps` module. Always-on (no feature flag). Part 1/6 of the `feat/migrateToQueueService` split — base for the rest of the stack, mergeable on its own.
  
  ## Changes 
  - Move `SafeAppInfoMapper` from `transactions/routes/mappers/common/` to `safe-apps/mappers/`; provide and export it from `SafeAppsModule`, drop the old provider from `TransactionsModule`.
  - Change `mapSafeAppInfo` to `(chainId, origin, safeTxHash)` and resolve the SafeApp by origin URL.
  - Add `id` to `SafeAppInfo`.
  - Expose `safeAppInfo` on the messages route entity; keep `logoUri` / `name` / `safeAppId` as deprecated mirror fields.
  - Update `message-mapper` and the `human-description` / `multisig-transaction` / `multisig-transaction-details` mappers for the new path and signature.
  - Add `queue/helpers/origin.helper` (standalone origin parser the resolution depends on).