### PR TITLE
feat(datasources): add Queue Service config, network PATCH, and cache

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -702,6 +702,12 @@
     "required": false
   },
   {
+    "name": "FF_QUEUE_SERVICE",
+    "description": "Enable queue service routing for write operations (OPTIONAL)",
+    "defaultValue": false,
+    "required": false
+  },
+  {
     "name": "FF_MESSAGE_VERIFICATION",
     "description": "Enable message verification features (OPTIONAL)",
     "defaultValue": true,
@@ -1158,6 +1164,18 @@
     "required": false
   },
   {
+    "name": "QUEUE_SERVICE_API_KEY",
+    "description": "API key for Queue Service authentication (prevents rate limiting)",
+    "defaultValue": null,
+    "required": false
+  },
+  {
+    "name": "QUEUE_SERVICE_BASE_URI",
+    "description": "Base URL for the queue service API (Optional)",
+    "defaultValue": "https://api.safe.global/queue",
+    "required": false
+  },
+  {
     "name": "REDIS_CONNECT_TIMEOUT",
     "description": "Redis connection timeout in milliseconds",
     "defaultValue": null,
@@ -1550,6 +1568,12 @@
   {
     "name": "TX_SERVICE_API_KEY",
     "description": "API key for Transaction Service authentication (prevents rate limiting)",
+    "defaultValue": null,
+    "required": false
+  },
+  {
+    "name": "USE_QUEUE_SERVICE_VPC_URL",
+    "description": "Use VPC-internal URL for Queue Service",
     "defaultValue": null,
     "required": false
   },

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ data
 
 # Local docs
 /docs
+
+.claude/cache/

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -231,6 +231,7 @@ export default (): ReturnType<typeof configuration> => ({
     lifiTransactionsMapping: false,
     cacheInFlightRequests: false,
     spaceAuditLog: true,
+    queueService: false,
   },
   httpClient: {
     requestTimeout: faker.number.int(),
@@ -409,6 +410,11 @@ export default (): ReturnType<typeof configuration> => ({
       baseUri: faker.internet.url({ appendSlash: false }),
       feePreviewTtlSeconds: 60,
     },
+  },
+  queueService: {
+    baseUri: faker.internet.url({ appendSlash: false }),
+    useVpcUrl: false,
+    apiKey: faker.string.hexadecimal({ length: 32 }),
   },
   safeConfig: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -454,6 +454,7 @@ export default () => ({
       process.env.HTTP_CLIENT_CACHE_IN_FLIGHT_REQUESTS?.toLowerCase() ===
       'true',
     spaceAuditLog: process.env.FF_SPACE_AUDIT_LOG?.toLowerCase() === 'true',
+    queueService: process.env.FF_QUEUE_SERVICE?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.
@@ -737,6 +738,12 @@ export default () => ({
         10,
       ),
     },
+  },
+  queueService: {
+    baseUri:
+      process.env.QUEUE_SERVICE_BASE_URI || 'https://api.safe.global/queue',
+    useVpcUrl: process.env.USE_QUEUE_SERVICE_VPC_URL?.toLowerCase() === 'true',
+    apiKey: process.env.QUEUE_SERVICE_API_KEY,
   },
   safeConfig: {
     baseUri:

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -122,6 +122,9 @@ export const RootConfigurationSchema = z
       .min(1)
       .max(3599)
       .optional(),
+    QUEUE_SERVICE_BASE_URI: z.url().optional(),
+    QUEUE_SERVICE_API_KEY: z.string().trim().min(1).optional(),
+    USE_QUEUE_SERVICE_VPC_URL: z.coerce.boolean().optional(),
     RELAY_PROVIDER_API_KEY_OPTIMISM: z.string(),
     RELAY_PROVIDER_API_KEY_BSC: z.string(),
     RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: z.string(),

--- a/src/datasources/cache/cache.router.spec.ts
+++ b/src/datasources/cache/cache.router.spec.ts
@@ -124,4 +124,128 @@ describe('CacheRouter', () => {
       expect(dirSingle.field).not.toBe(dirMulti.field);
     });
   });
+
+  describe('getQueueMultisigTransactionCacheDir', () => {
+    const chainId = '1';
+    const safeTransactionHash = faker.string.hexadecimal({ length: 64 });
+
+    it('Should produce a key under the queue_multisig_transaction namespace, distinct from the tx-service key', () => {
+      const queueDir = CacheRouter.getQueueMultisigTransactionCacheDir({
+        chainId,
+        safeTransactionHash,
+      });
+      const txDir = CacheRouter.getMultisigTransactionCacheDir({
+        chainId,
+        safeTransactionHash,
+      });
+
+      expect(queueDir.key).not.toBe(txDir.key);
+      expect(queueDir.key).toBe(
+        `${chainId}_queue_multisig_transaction_${safeTransactionHash}`,
+      );
+    });
+  });
+
+  describe('getQueueMultisigTransactionsCacheKey', () => {
+    const chainId = '1';
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('Should produce a key under the queue_multisig_transactions namespace, distinct from the tx-service key', () => {
+      const queueListKey = CacheRouter.getQueueMultisigTransactionsCacheKey({
+        chainId,
+        safeAddress,
+      });
+      const txListKey = CacheRouter.getMultisigTransactionsCacheKey({
+        chainId,
+        safeAddress,
+      });
+
+      expect(queueListKey).not.toBe(txListKey);
+      expect(queueListKey).toBe(
+        `${chainId}_queue_multisig_transactions_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getQueuedTransactionsCacheDir', () => {
+    const chainId = '1';
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('Should produce a cache dir under the queue_multisig_transactions key with a queue_-prefixed field', () => {
+      const dir = CacheRouter.getQueuedTransactionsCacheDir({
+        chainId,
+        safeAddress,
+        nonceOrder: 'asc',
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(dir.key).toBe(
+        `${chainId}_queue_multisig_transactions_${safeAddress}`,
+      );
+      expect(dir.field).toBe('queue_asc_10_0');
+    });
+  });
+
+  describe('getQueueMessageByHashCacheDir', () => {
+    const chainId = '1';
+    const messageHash = faker.string.hexadecimal({ length: 64 });
+
+    it('Should produce a key under the queue_message namespace, distinct from the tx-service key', () => {
+      const queueDir = CacheRouter.getQueueMessageByHashCacheDir({
+        chainId,
+        messageHash,
+      });
+      const txDir = CacheRouter.getMessageByHashCacheDir({
+        chainId,
+        messageHash,
+      });
+
+      expect(queueDir.key).not.toBe(txDir.key);
+      expect(queueDir.key).toBe(`${chainId}_queue_message_${messageHash}`);
+    });
+  });
+
+  describe('getQueueMessagesBySafeCacheDir', () => {
+    const chainId = '1';
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('Should produce a key under the queue_messages namespace, distinct from the tx-service key', () => {
+      const queueDir = CacheRouter.getQueueMessagesBySafeCacheDir({
+        chainId,
+        safeAddress,
+        limit: 5,
+        offset: 0,
+      });
+      const txDir = CacheRouter.getMessagesBySafeCacheDir({
+        chainId,
+        safeAddress,
+        limit: 5,
+        offset: 0,
+      });
+
+      expect(queueDir.key).not.toBe(txDir.key);
+      expect(queueDir.key).toBe(`${chainId}_queue_messages_${safeAddress}`);
+      expect(queueDir.field).toBe('5_0');
+    });
+  });
+
+  describe('getQueueDelegatesCacheKey', () => {
+    const chainId = '1';
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('Should produce a key under the queue_delegates namespace, distinct from the tx-service key', () => {
+      const queueKey = CacheRouter.getQueueDelegatesCacheKey({
+        chainId,
+        safeAddress,
+      });
+      const txKey = CacheRouter.getDelegatesCacheKey({
+        chainId,
+        safeAddress,
+      });
+
+      expect(queueKey).not.toBe(txKey);
+      expect(queueKey).toBe(`${chainId}_queue_delegates_${safeAddress}`);
+    });
+  });
 });

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -32,6 +32,13 @@ export class CacheRouter {
   private static readonly MODULE_TRANSACTIONS_KEY = 'module_transactions';
   private static readonly MULTISIG_TRANSACTION_KEY = 'multisig_transaction';
   private static readonly MULTISIG_TRANSACTIONS_KEY = 'multisig_transactions';
+  private static readonly QUEUE_DELEGATES_KEY = 'queue_delegates';
+  private static readonly QUEUE_MESSAGE_KEY = 'queue_message';
+  private static readonly QUEUE_MESSAGES_KEY = 'queue_messages';
+  private static readonly QUEUE_MULTISIG_TRANSACTION_KEY =
+    'queue_multisig_transaction';
+  private static readonly QUEUE_MULTISIG_TRANSACTIONS_KEY =
+    'queue_multisig_transactions';
   private static readonly NATIVE_COIN_PRICE_KEY = 'native_coin_price';
   private static readonly OWNERS_SAFE_KEY = 'owner_safes';
   private static readonly RATE_LIMIT_KEY = 'rate_limit';
@@ -249,6 +256,28 @@ export class CacheRouter {
     );
   }
 
+  static getQueueDelegatesCacheKey(args: {
+    chainId: string;
+    safeAddress?: Address;
+  }): string {
+    return `${args.chainId}_${CacheRouter.QUEUE_DELEGATES_KEY}_${args.safeAddress}`;
+  }
+
+  static getQueueDelegatesCacheDir(args: {
+    chainId: string;
+    safeAddress?: Address;
+    delegate?: Address;
+    delegator?: Address;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getQueueDelegatesCacheKey(args),
+      `${args.delegate}_${args.delegator}_${args.label}_${args.limit}_${args.offset}`,
+    );
+  }
+
   static getFirebaseOAuth2TokenCacheDir(): CacheDir {
     return new CacheDir(CacheRouter.FIREBASE_OAUTH2_TOKEN_KEY, '');
   }
@@ -374,6 +403,26 @@ export class CacheRouter {
     return `${args.chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${args.safeAddress}`;
   }
 
+  static getQueueMultisigTransactionsCacheKey(args: {
+    chainId: string;
+    safeAddress: Address;
+  }): string {
+    return `${args.chainId}_${CacheRouter.QUEUE_MULTISIG_TRANSACTIONS_KEY}_${args.safeAddress}`;
+  }
+
+  static getQueuedTransactionsCacheDir(args: {
+    chainId: string;
+    safeAddress: Address;
+    nonceOrder?: 'asc' | 'desc';
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getQueueMultisigTransactionsCacheKey(args),
+      `queue_${args.nonceOrder}_${args.limit}_${args.offset}`,
+    );
+  }
+
   static getMultisigTransactionCacheDir(args: {
     chainId: string;
     safeTransactionHash: string;
@@ -386,6 +435,23 @@ export class CacheRouter {
     safeTransactionHash: string;
   }): string {
     return `${args.chainId}_${CacheRouter.MULTISIG_TRANSACTION_KEY}_${args.safeTransactionHash}`;
+  }
+
+  static getQueueMultisigTransactionCacheKey(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.QUEUE_MULTISIG_TRANSACTION_KEY}_${args.safeTransactionHash}`;
+  }
+
+  static getQueueMultisigTransactionCacheDir(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getQueueMultisigTransactionCacheKey(args),
+      '',
+    );
   }
 
   static getCreationTransactionCacheDir(args: {
@@ -533,6 +599,20 @@ export class CacheRouter {
     return new CacheDir(CacheRouter.getMessageByHashCacheKey(args), '');
   }
 
+  static getQueueMessageByHashCacheKey(args: {
+    chainId: string;
+    messageHash: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.QUEUE_MESSAGE_KEY}_${args.messageHash}`;
+  }
+
+  static getQueueMessageByHashCacheDir(args: {
+    chainId: string;
+    messageHash: string;
+  }): CacheDir {
+    return new CacheDir(CacheRouter.getQueueMessageByHashCacheKey(args), '');
+  }
+
   static getMessagesBySafeCacheKey(args: {
     chainId: string;
     safeAddress: Address;
@@ -548,6 +628,25 @@ export class CacheRouter {
   }): CacheDir {
     return new CacheDir(
       CacheRouter.getMessagesBySafeCacheKey(args),
+      `${args.limit}_${args.offset}`,
+    );
+  }
+
+  static getQueueMessagesBySafeCacheKey(args: {
+    chainId: string;
+    safeAddress: Address;
+  }): string {
+    return `${args.chainId}_${CacheRouter.QUEUE_MESSAGES_KEY}_${args.safeAddress}`;
+  }
+
+  static getQueueMessagesBySafeCacheDir(args: {
+    chainId: string;
+    safeAddress: Address;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getQueueMessagesBySafeCacheKey(args),
       `${args.limit}_${args.offset}`,
     );
   }

--- a/src/datasources/circuit-breaker/circuit-breaker.keys.ts
+++ b/src/datasources/circuit-breaker/circuit-breaker.keys.ts
@@ -10,6 +10,7 @@ export class CircuitBreakerKeys {
   private static readonly SERVICE_PREFIX = {
     TRANSACTION_SERVICE: 'txs-service',
     DATA_DECODER_SERVICE: 'data-decoder-service',
+    QUEUE_SERVICE: 'queue-service',
   };
 
   /**
@@ -32,5 +33,18 @@ export class CircuitBreakerKeys {
    */
   static getDataDecoderServiceKey(): string {
     return CircuitBreakerKeys.SERVICE_PREFIX.DATA_DECODER_SERVICE;
+  }
+
+  /**
+   * Generates the circuit breaker key for the Queue Service
+   *
+   * The Queue Service is a single deployment serving all chains (the chain is
+   * passed as a request parameter, not the host), so the key is not
+   * chain-scoped.
+   *
+   * @returns Circuit breaker key: `queue-service`
+   */
+  static getQueueServiceKey(): string {
+    return CircuitBreakerKeys.SERVICE_PREFIX.QUEUE_SERVICE;
   }
 }

--- a/src/datasources/network/__tests__/test.network.module.ts
+++ b/src/datasources/network/__tests__/test.network.module.ts
@@ -11,6 +11,7 @@ export const networkService: INetworkService = {
   get: vi.fn(),
   post: vi.fn(),
   postForm: vi.fn(),
+  patch: vi.fn(),
   delete: vi.fn(),
 };
 

--- a/src/datasources/network/fetch.network.service.spec.ts
+++ b/src/datasources/network/fetch.network.service.spec.ts
@@ -417,6 +417,146 @@ describe('FetchNetworkService', () => {
     });
   });
 
+  describe('PATCH requests', () => {
+    it(`patch uses PATCH method`, async () => {
+      const url = faker.internet.url({ appendSlash: false });
+      const data = { [faker.word.sample()]: faker.string.alphanumeric() };
+
+      await target.patch({ url, data });
+
+      const expectedUrl = `${url}/`;
+      expect(fetchClientMock).toHaveBeenCalledTimes(1);
+      expect(fetchClientMock).toHaveBeenCalledWith(
+        expectedUrl,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(data),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+        undefined,
+        undefined,
+      );
+      expect(loggingService.debug).toHaveBeenCalledTimes(1);
+      expect(loggingService.debug).toHaveBeenCalledWith({
+        type: 'EXTERNAL_REQUEST',
+        method: 'PATCH',
+        url: expectedUrl,
+      });
+    });
+
+    it(`patch calls fetch with request`, async () => {
+      const url = faker.internet.url({ appendSlash: false });
+      const data = { [faker.word.sample()]: faker.string.alphanumeric() };
+      const networkRequest: NetworkRequest = {
+        params: { some_query_param: 'query_param' },
+        headers: {
+          test: 'value',
+        },
+      };
+
+      await target.patch({ url, data, networkRequest });
+
+      const expectedUrl = `${url}/?some_query_param=query_param`;
+      expect(fetchClientMock).toHaveBeenCalledTimes(1);
+      expect(fetchClientMock).toHaveBeenCalledWith(
+        expectedUrl,
+        {
+          method: 'PATCH',
+          headers: {
+            test: 'value',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(data),
+        },
+        undefined,
+        undefined,
+      );
+      expect(loggingService.debug).toHaveBeenCalledTimes(1);
+      expect(loggingService.debug).toHaveBeenCalledWith({
+        type: 'EXTERNAL_REQUEST',
+        method: 'PATCH',
+        url: expectedUrl,
+      });
+    });
+
+    it(`patch omits body and Content-Type when no data is provided`, async () => {
+      const url = faker.internet.url({ appendSlash: false });
+
+      await target.patch({ url });
+
+      const expectedUrl = `${url}/`;
+      expect(fetchClientMock).toHaveBeenCalledTimes(1);
+      expect(fetchClientMock).toHaveBeenCalledWith(
+        expectedUrl,
+        {
+          method: 'PATCH',
+          headers: {},
+        },
+        undefined,
+        undefined,
+      );
+    });
+
+    it(`patch uses custom timeout when provided`, async () => {
+      const url = faker.internet.url({ appendSlash: false });
+      const data = { [faker.word.sample()]: faker.string.alphanumeric() };
+      const timeout = faker.number.int({ min: 1000, max: 10000 });
+      const networkRequest: NetworkRequest = {
+        timeout,
+      };
+
+      await target.patch({ url, data, networkRequest });
+
+      const expectedUrl = `${url}/`;
+      expect(fetchClientMock).toHaveBeenCalledTimes(1);
+      expect(fetchClientMock).toHaveBeenCalledWith(
+        expectedUrl,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(data),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+        timeout,
+        undefined,
+      );
+    });
+
+    it(`patch logs response error`, async () => {
+      const url = faker.internet.url({ appendSlash: false });
+      const error = new NetworkResponseError(
+        new URL(faker.internet.url()),
+        {
+          status: 100,
+          statusText: 'Some error happened',
+        } as Response,
+        'data',
+      );
+      fetchClientMock.mockRejectedValueOnce(error);
+
+      await expect(target.patch({ url, data: {} })).rejects.toThrow(error);
+
+      expect(loggingService.debug).toHaveBeenCalledTimes(2);
+      expect(loggingService.debug).toHaveBeenCalledWith({
+        type: 'EXTERNAL_REQUEST',
+        method: 'PATCH',
+        url: `${url}/`,
+      });
+      expect(loggingService.debug).toHaveBeenCalledWith({
+        type: 'EXTERNAL_REQUEST',
+        protocol: error.url.protocol,
+        target_host: error.url.host,
+        path: error.url.pathname,
+        request_status: error.response.status,
+        detail: error.response.statusText,
+        response_time_ms: expect.any(Number),
+      });
+    });
+  });
+
   describe('DELETE requests', () => {
     it(`delete uses DELETE method`, async () => {
       const url = faker.internet.url({ appendSlash: false });

--- a/src/datasources/network/fetch.network.service.ts
+++ b/src/datasources/network/fetch.network.service.ts
@@ -107,6 +107,41 @@ export class FetchNetworkService implements INetworkService {
     });
   }
 
+  async patch<T>(args: {
+    url: string;
+    data?: object;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>> {
+    const url = this.buildUrl(args.url, args.networkRequest?.params);
+    this.logRequest(url, 'PATCH');
+    const startTimeMs = performance.now();
+
+    const contentTypeHeader = args.data
+      ? { 'Content-Type': 'application/json' }
+      : undefined;
+
+    try {
+      return await this.client<T>(
+        url,
+        {
+          method: 'PATCH',
+          ...(args.data && {
+            body: JSON.stringify(args.data),
+          }),
+          headers: this.mergeHeaders(
+            args.networkRequest?.headers,
+            contentTypeHeader,
+          ),
+        },
+        args.networkRequest?.timeout,
+        args.networkRequest?.circuitBreaker,
+      );
+    } catch (error) {
+      this.logErrorResponse(error, performance.now() - startTimeMs);
+      throw error;
+    }
+  }
+
   async delete<T>(args: {
     url: string;
     data?: object;

--- a/src/datasources/network/network.service.interface.ts
+++ b/src/datasources/network/network.service.interface.ts
@@ -25,6 +25,12 @@ export interface INetworkService {
     networkRequest?: NetworkRequest;
   }): Promise<NetworkResponse<T>>;
 
+  patch<T>(args: {
+    url: string;
+    data?: object;
+    networkRequest?: NetworkRequest;
+  }): Promise<NetworkResponse<T>>;
+
   delete<T>(args: {
     url: string;
     data?: object;


### PR DESCRIPTION
## Summary
  Additive infrastructure for the Queue Service migration — no behavior change. Part 2/6 of the `feat/migrateToQueueService` split.

  ## Changes
  - Add `queueService` config block and the `FF_QUEUE_SERVICE` feature flag (default off).
  - Add `patch()` to `FetchNetworkService` and `INetworkService`.
  - Add queue `CacheRouter` and `CircuitBreakerKeys` entries.
  - Add `.env.sample.json` / `.gitignore` entries.
  - Reconcile `configuration.ts`, `cache.router.ts`, the config test and `.env.sample.json` with `main`'s newer `origin`/`nonce` fields (both sets of changes retained).