### PR TITLE
feat(queue): add Queue Service client module

### DIFF
--- a/src/__tests__/testing-module.ts
+++ b/src/__tests__/testing-module.ts
@@ -24,6 +24,8 @@ import { CsvExportModule } from '@/modules/csv-export/csv-export.module';
 import { TestCsvExportModule } from '@/modules/csv-export/v1/__tests__/test.csv-export.module';
 import { TestPushNotificationModule } from '@/modules/notifications/domain/push/__tests__/test.push-notification.module';
 import { PushNotificationModule } from '@/modules/notifications/domain/push/push-notification.module';
+import { TestQueueServiceModule } from '@/modules/queue/__tests__/test.queue.module';
+import { QueueServiceModule } from '@/modules/queue/queue.module';
 import { TestQueuesApiModule } from '@/modules/queues/datasources/__tests__/test.queues-api.module';
 import { QueuesApiModule } from '@/modules/queues/datasources/queues-api.module';
 import { TestTargetedMessagingDatasourceModule } from '@/modules/targeted-messaging/datasources/__tests__/test.targeted-messaging.datasource.module';
@@ -86,6 +88,10 @@ export function createTestModule(
       {
         originalModule: TxAuthNetworkModule,
         testModule: TestTxAuthNetworkModule,
+      },
+      {
+        originalModule: QueueServiceModule,
+        testModule: TestQueueServiceModule,
       },
       ...additionalOverrides,
     ],

--- a/src/datasources/network/auth/queue-auth-headers.helper.spec.ts
+++ b/src/datasources/network/auth/queue-auth-headers.helper.spec.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { Mocked } from 'vitest';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { getQueueAuthHeaders } from '@/datasources/network/auth/queue-auth-headers.helper';
+
+describe('getQueueAuthHeaders', () => {
+  let mockConfigService: Mocked<IConfigurationService>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockConfigService = {
+      getOrThrow: vi.fn(),
+      get: vi.fn(),
+    } as Mocked<IConfigurationService>;
+  });
+
+  it('should return Authorization header when Queue auth is enabled', () => {
+    const apiKey = 'test-api-key-123';
+    mockConfigService.getOrThrow.mockImplementation((key: string) => {
+      if (key === 'application.isDevelopment') return true;
+      if (key === 'queueService.useVpcUrl') return false;
+      throw new Error(`Unexpected key: ${key}`);
+    });
+    mockConfigService.get.mockReturnValue(apiKey);
+
+    const result = getQueueAuthHeaders(mockConfigService);
+
+    expect(result).toEqual({
+      Authorization: `Bearer ${apiKey}`,
+    });
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+      'application.isDevelopment',
+    );
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+      'queueService.useVpcUrl',
+    );
+    expect(mockConfigService.get).toHaveBeenCalledWith('queueService.apiKey');
+  });
+
+  it.each([
+    {
+      description: 'not in development mode',
+      isDevelopment: false,
+      useVpcUrl: false,
+      apiKey: 'test-key',
+    },
+    {
+      description: 'useVpcUrl is true',
+      isDevelopment: true,
+      useVpcUrl: true,
+      apiKey: 'test-key',
+    },
+    {
+      description: 'API key is undefined',
+      isDevelopment: true,
+      useVpcUrl: false,
+      apiKey: undefined,
+    },
+    {
+      description: 'API key is empty string',
+      isDevelopment: true,
+      useVpcUrl: false,
+      apiKey: '',
+    },
+    {
+      description: 'in production with VPC URL',
+      isDevelopment: false,
+      useVpcUrl: true,
+      apiKey: 'test-key',
+    },
+  ])('should return undefined when $description', ({
+    isDevelopment,
+    useVpcUrl,
+    apiKey,
+  }) => {
+    mockConfigService.getOrThrow.mockImplementation((key: string) => {
+      if (key === 'application.isDevelopment') return isDevelopment;
+      if (key === 'queueService.useVpcUrl') return useVpcUrl;
+      throw new Error(`Unexpected key: ${key}`);
+    });
+    mockConfigService.get.mockReturnValue(apiKey);
+
+    const result = getQueueAuthHeaders(mockConfigService);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/datasources/network/auth/queue-auth-headers.helper.ts
+++ b/src/datasources/network/auth/queue-auth-headers.helper.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+
+/**
+ * Returns Queue Service auth headers when running in development
+ * against the public Queue Service.
+ *
+ * @param configurationService - Configuration service used to read settings
+ * @returns An object containing the `Authorization` header (`{ Authorization: `Bearer ${apiKey}` }`)
+ *          when Queue auth is enabled and an API key is configured; otherwise `undefined`.
+ */
+export function getQueueAuthHeaders(
+  configurationService: IConfigurationService,
+): Record<string, string> | undefined {
+  const isDevelopment = configurationService.getOrThrow<boolean>(
+    'application.isDevelopment',
+  );
+  const useVpcUrl = configurationService.getOrThrow<boolean>(
+    'queueService.useVpcUrl',
+  );
+  const apiKey = configurationService.get<string | undefined>(
+    'queueService.apiKey',
+  );
+
+  const isQueueAuthEnabled = isDevelopment && !useVpcUrl;
+  if (!(isQueueAuthEnabled && apiKey)) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${apiKey}`,
+  };
+}

--- a/src/modules/messages/domain/entities/message.entity.ts
+++ b/src/modules/messages/domain/entities/message.entity.ts
@@ -7,7 +7,6 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import {
   NullableHexSchema,
-  NullableNumberSchema,
   NullableStringSchema,
 } from '@/validation/entities/schemas/nullable.schema';
 
@@ -20,7 +19,6 @@ export const MessageSchema = z.object({
   messageHash: HexSchema,
   message: z.union([z.string(), TypedDataSchema]),
   proposedBy: AddressSchema,
-  safeAppId: NullableNumberSchema,
   confirmations: z.array(MessageConfirmationSchema),
   preparedSignature: NullableHexSchema,
   origin: NullableStringSchema,

--- a/src/modules/queue/__tests__/queue.mock.ts
+++ b/src/modules/queue/__tests__/queue.mock.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { MockedObject } from 'vitest';
+import type { IQueueService } from '@/modules/queue/queue.interface';
+
+export function createMockQueueService(): MockedObject<IQueueService> {
+  return {
+    getMultisigTransaction: vi.fn(),
+    getMultisigTransactionsBatch: vi.fn(),
+    getTransactionQueue: vi.fn(),
+    proposeTransaction: vi.fn(),
+    postConfirmation: vi.fn(),
+    deleteTransaction: vi.fn(),
+    getDelegates: vi.fn(),
+    postDelegate: vi.fn(),
+    deleteDelegate: vi.fn(),
+    getMessageByHash: vi.fn(),
+    getMessagesBySafe: vi.fn(),
+    postMessage: vi.fn(),
+    postMessageSignature: vi.fn(),
+    clearMultisigTransaction: vi.fn(),
+    clearAllTransactions: vi.fn(),
+    clearMessagesBySafe: vi.fn(),
+    clearMessagesByHash: vi.fn(),
+    clearDelegates: vi.fn(),
+  } as MockedObject<IQueueService>;
+}

--- a/src/modules/queue/__tests__/test.queue.module.ts
+++ b/src/modules/queue/__tests__/test.queue.module.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Module } from '@nestjs/common';
+import type { MockedObject } from 'vitest';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { networkService } from '@/datasources/network/__tests__/test.network.module';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { IQueueService } from '@/modules/queue/queue.interface';
+import { QueueService } from '@/modules/queue/queue.service';
+
+/**
+ * Test module that overrides {@link QueueServiceModule} with mocked dependencies.
+ *
+ * Key points:
+ * - Reuses the same NetworkService mock instance from {@link TestNetworkModule}
+ * - Provides real CacheFirstDataSource & HttpErrorFactory (with mocked NetworkService injected)
+ */
+@Module({
+  providers: [
+    {
+      provide: NetworkService,
+      useFactory: (): MockedObject<INetworkService> => {
+        return vi.mocked(networkService);
+      },
+    },
+    CacheFirstDataSource,
+    HttpErrorFactory,
+    { provide: IQueueService, useClass: QueueService },
+  ],
+  exports: [IQueueService],
+})
+export class TestQueueServiceModule {}

--- a/src/modules/queue/entities/__tests__/queue-multisig-transaction.builder.ts
+++ b/src/modules/queue/entities/__tests__/queue-multisig-transaction.builder.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import type { Hex } from 'viem';
+import { getAddress } from 'viem';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import type { QueueMultisigTransactionEntity } from '@/modules/queue/entities/multisig-transaction.entity';
+import { Operation } from '@/modules/safe/domain/entities/operation.entity';
+
+export function queueMultisigTransactionBuilder(): IBuilder<QueueMultisigTransactionEntity> {
+  return new Builder<QueueMultisigTransactionEntity>()
+    .with('safeTxHash', faker.string.hexadecimal({ length: 64 }) as Hex)
+    .with('chainId', faker.string.numeric())
+    .with('safe', getAddress(faker.finance.ethereumAddress()))
+    .with('nonce', faker.number.int({ min: 0, max: 100 }))
+    .with('proposer', getAddress(faker.finance.ethereumAddress()))
+    .with('proposedByDelegate', null)
+    .with('to', getAddress(faker.finance.ethereumAddress()))
+    .with('value', faker.string.numeric())
+    .with('data', null)
+    .with('operation', Operation.CALL)
+    .with('safeTxGas', null)
+    .with('baseGas', null)
+    .with('gasPrice', null)
+    .with('gasToken', null)
+    .with('refundReceiver', null)
+    .with('failed', false)
+    .with('notes', null)
+    .with('originName', null)
+    .with('originUrl', null)
+    .with('txHash', faker.string.hexadecimal({ length: 64 }) as Hex)
+    .with('created', faker.date.recent())
+    .with('modified', faker.date.recent())
+    .with('confirmations', []);
+}

--- a/src/modules/queue/entities/delegate.entity.ts
+++ b/src/modules/queue/entities/delegate.entity.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { z } from 'zod';
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import {
+  NullableAddressSchema,
+  NullableStringSchema,
+} from '@/validation/entities/schemas/nullable.schema';
+
+export type QueueDelegate = z.infer<typeof QueueDelegateSchema>;
+
+export const QueueDelegateSchema = z.object({
+  delegate: AddressSchema,
+  delegator: AddressSchema,
+  chainId: ChainIdSchema,
+  safe: NullableAddressSchema,
+  label: NullableStringSchema,
+  created: z.coerce.date(),
+  modified: z.coerce.date(),
+});
+
+export const QueueDelegatePageSchema = buildPageSchema(QueueDelegateSchema);

--- a/src/modules/queue/entities/message.entity.ts
+++ b/src/modules/queue/entities/message.entity.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { z } from 'zod';
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { TypedDataSchema } from '@/modules/messages/domain/entities/typed-data.entity';
+import {
+  OriginNameSchema,
+  OriginUrlSchema,
+} from '@/modules/queue/entities/schemas/origin.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
+import { NullableHexSchema } from '@/validation/entities/schemas/nullable.schema';
+
+export type QueueMessageConfirmation = z.infer<
+  typeof QueueMessageConfirmationSchema
+>;
+
+export type QueueMessage = z.infer<typeof QueueMessageSchema>;
+
+export const QueueMessageConfirmationSchema = z.object({
+  owner: AddressSchema,
+  signature: HexBytesSchema,
+  signatureType: z.enum(SignatureType),
+  created: z.coerce.date(),
+  modified: z.coerce.date(),
+});
+
+export const QueueMessageSchema = z.object({
+  messageHash: HexSchema,
+  chainId: z.coerce.number(),
+  safe: AddressSchema,
+  message: z.union([z.string(), TypedDataSchema]),
+  proposedBy: AddressSchema,
+  preparedSignature: NullableHexSchema,
+  originName: OriginNameSchema,
+  originUrl: OriginUrlSchema,
+  created: z.coerce.date(),
+  modified: z.coerce.date(),
+  confirmations: z.array(QueueMessageConfirmationSchema),
+});
+
+export const QueueMessagePageSchema = buildPageSchema(QueueMessageSchema);

--- a/src/modules/queue/entities/multisig-transaction.entity.ts
+++ b/src/modules/queue/entities/multisig-transaction.entity.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { z } from 'zod';
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import {
+  OriginNameSchema,
+  OriginUrlSchema,
+} from '@/modules/queue/entities/schemas/origin.schema';
+import { Operation } from '@/modules/safe/domain/entities/operation.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
+import {
+  NullableAddressSchema,
+  NullableHexSchema,
+  NullableStringSchema,
+} from '@/validation/entities/schemas/nullable.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+
+export type QueueConfirmation = z.infer<typeof QueueConfirmationSchema>;
+
+export type QueueMultisigTransactionEntity = z.infer<
+  typeof QueueMultisigTransactionSchema
+>;
+
+export const QueueConfirmationSchema = z.object({
+  owner: AddressSchema,
+  signature: HexBytesSchema,
+  signatureType: z.enum(SignatureType),
+  created: z.coerce.date(),
+  modified: z.coerce.date(),
+});
+
+export const QueueMultisigTransactionSchema = z.object({
+  safeTxHash: HexSchema,
+  chainId: NumericStringSchema,
+  safe: AddressSchema,
+  nonce: CoercedNumberSchema,
+  proposer: NullableAddressSchema,
+  proposedByDelegate: NullableAddressSchema,
+  to: AddressSchema,
+  value: NumericStringSchema,
+  data: NullableHexSchema,
+  operation: z.enum(Operation),
+  safeTxGas: NumericStringSchema.nullable(),
+  baseGas: NumericStringSchema.nullable(),
+  gasPrice: NumericStringSchema.nullable(),
+  gasToken: NullableAddressSchema,
+  refundReceiver: NullableAddressSchema,
+  failed: z.boolean().nullable(),
+  notes: NullableStringSchema,
+  originName: OriginNameSchema,
+  originUrl: OriginUrlSchema,
+  txHash: NullableHexSchema,
+  created: z.coerce.date(),
+  modified: z.coerce.date(),
+  confirmations: z.array(QueueConfirmationSchema),
+});
+
+export const QueueMultisigTransactionPageSchema = buildPageSchema(
+  QueueMultisigTransactionSchema,
+);
+
+export const QueueMultisigTransactionListSchema = z.array(
+  QueueMultisigTransactionSchema,
+);

--- a/src/modules/queue/entities/schemas/__tests__/origin.schema.spec.ts
+++ b/src/modules/queue/entities/schemas/__tests__/origin.schema.spec.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { queueMultisigTransactionBuilder } from '@/modules/queue/entities/__tests__/queue-multisig-transaction.builder';
+import { QueueMultisigTransactionListSchema } from '@/modules/queue/entities/multisig-transaction.entity';
+import {
+  OriginNameSchema,
+  OriginUrlSchema,
+} from '@/modules/queue/entities/schemas/origin.schema';
+
+describe('OriginNameSchema', () => {
+  it('accepts a normal string', () => {
+    expect(OriginNameSchema.parse('Uniswap')).toBe('Uniswap');
+  });
+
+  it('defaults to null when missing', () => {
+    expect(OriginNameSchema.parse(undefined)).toBeNull();
+  });
+
+  it('coerces an oversized name to null', () => {
+    const oversized = 'a'.repeat(257);
+    expect(OriginNameSchema.parse(oversized)).toBeNull();
+  });
+
+  it('coerces a non-string value to null', () => {
+    expect(OriginNameSchema.parse(123 as unknown)).toBeNull();
+  });
+});
+
+describe('OriginUrlSchema', () => {
+  it('accepts an https URL', () => {
+    expect(OriginUrlSchema.parse('https://app.example.com')).toBe(
+      'https://app.example.com',
+    );
+  });
+
+  it('defaults to null when missing', () => {
+    expect(OriginUrlSchema.parse(undefined)).toBeNull();
+  });
+
+  it('coerces a javascript: URL to null', () => {
+    expect(OriginUrlSchema.parse('javascript:alert(1)')).toBeNull();
+  });
+
+  it('coerces a data: URL to null', () => {
+    expect(
+      OriginUrlSchema.parse('data:text/html,<script>1</script>'),
+    ).toBeNull();
+  });
+
+  it('coerces a non-URL string to null', () => {
+    expect(OriginUrlSchema.parse('not a url')).toBeNull();
+  });
+
+  it('coerces an http URL to null', () => {
+    expect(OriginUrlSchema.parse('http://app.example.com')).toBeNull();
+  });
+
+  it('coerces an oversized URL to null', () => {
+    const oversized = `https://example.com/${'a'.repeat(2048)}`;
+    expect(OriginUrlSchema.parse(oversized)).toBeNull();
+  });
+});
+
+describe('queue entity parsing with bad origin fields', () => {
+  it('keeps a row but coerces its bad origin URL to null without poisoning the batch', () => {
+    const good = queueMultisigTransactionBuilder()
+      .with('originName', 'AppOk')
+      .with('originUrl', 'https://ok.example')
+      .build();
+    const bad = queueMultisigTransactionBuilder()
+      .with('originName', 'AppBad')
+      .with('originUrl', 'javascript:alert(1)' as unknown as string)
+      .build();
+
+    const parsed = QueueMultisigTransactionListSchema.parse([good, bad]);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].originUrl).toBe('https://ok.example');
+    expect(parsed[1].originUrl).toBeNull();
+    expect(parsed[1].originName).toBe('AppBad');
+  });
+});

--- a/src/modules/queue/entities/schemas/origin.schema.ts
+++ b/src/modules/queue/entities/schemas/origin.schema.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+const MAX_ORIGIN_NAME_LENGTH = 256;
+const MAX_ORIGIN_URL_LENGTH = 2048;
+const ALLOWED_ORIGIN_URL_PROTOCOLS = new Set(['https:']);
+
+export const OriginNameSchema = z
+  .string()
+  .max(MAX_ORIGIN_NAME_LENGTH)
+  .nullish()
+  .default(null)
+  .catch(null);
+
+// z.url() in zod 4 hands invalid inputs to chained refines rather than rejecting
+// upfront, so the refine has to guard `new URL()` itself; otherwise the throw
+// escapes `.catch(null)` and a single bad row poisons the whole batch.
+export const OriginUrlSchema = z
+  .url()
+  .max(MAX_ORIGIN_URL_LENGTH)
+  .refine(
+    (value) => {
+      try {
+        return ALLOWED_ORIGIN_URL_PROTOCOLS.has(new URL(value).protocol);
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Invalid origin URL protocol' },
+  )
+  .nullish()
+  .default(null)
+  .catch(null);

--- a/src/modules/queue/mappers/message.mapper.ts
+++ b/src/modules/queue/mappers/message.mapper.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Message } from '@/modules/messages/domain/entities/message.entity';
+import type { QueueMessage } from '@/modules/queue/entities/message.entity';
+import { buildOrigin } from '@/modules/queue/helpers/origin.helper';
+
+export function mapQueueToMessage(msg: QueueMessage): Message {
+  return {
+    ...msg,
+    origin: buildOrigin(msg.originName, msg.originUrl),
+  };
+}

--- a/src/modules/queue/mappers/transaction.mapper.spec.ts
+++ b/src/modules/queue/mappers/transaction.mapper.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { queueMultisigTransactionBuilder } from '@/modules/queue/entities/__tests__/queue-multisig-transaction.builder';
+import { mapQueueToMultisigTransaction } from '@/modules/queue/mappers/transaction.mapper';
+import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
+
+describe('mapQueueToMultisigTransaction', () => {
+  it('embeds the note into the origin JSON so it can be extracted downstream', () => {
+    const note = faker.lorem.sentence();
+    const originName = faker.company.name();
+    const originUrl = faker.internet.url({ appendSlash: false });
+    const tx = queueMultisigTransactionBuilder()
+      .with('notes', note)
+      .with('originName', originName)
+      .with('originUrl', originUrl)
+      .build();
+    const safe = safeBuilder().build();
+
+    const result = mapQueueToMultisigTransaction(tx, safe);
+
+    expect(result.origin).not.toBeNull();
+    expect(JSON.parse(result.origin as string)).toMatchObject({
+      name: originName,
+      url: originUrl,
+      note,
+    });
+  });
+
+  it('embeds the note even when origin name and url are absent', () => {
+    const note = faker.lorem.sentence();
+    const tx = queueMultisigTransactionBuilder()
+      .with('notes', note)
+      .with('originName', null)
+      .with('originUrl', null)
+      .build();
+    const safe = safeBuilder().build();
+
+    const result = mapQueueToMultisigTransaction(tx, safe);
+
+    expect(JSON.parse(result.origin as string)).toMatchObject({ note });
+  });
+
+  it('returns a null origin when neither origin fields nor note are present', () => {
+    const tx = queueMultisigTransactionBuilder()
+      .with('notes', null)
+      .with('originName', null)
+      .with('originUrl', null)
+      .build();
+    const safe = safeBuilder().build();
+
+    const result = mapQueueToMultisigTransaction(tx, safe);
+
+    expect(result.origin).toBeNull();
+  });
+});

--- a/src/modules/queue/mappers/transaction.mapper.ts
+++ b/src/modules/queue/mappers/transaction.mapper.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Hex } from 'viem';
+import type {
+  QueueConfirmation,
+  QueueMultisigTransactionEntity,
+} from '@/modules/queue/entities/multisig-transaction.entity';
+import { buildOrigin } from '@/modules/queue/helpers/origin.helper';
+import type {
+  Confirmation,
+  MultisigTransaction,
+} from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
+
+function mapConfirmation(
+  c: QueueConfirmation,
+  transactionHash: Hex | null,
+): Confirmation {
+  return {
+    ...c,
+    submissionDate: c.created,
+    transactionHash,
+  };
+}
+
+export function mapQueueToMultisigTransaction(
+  tx: QueueMultisigTransactionEntity,
+  safe: Safe,
+): MultisigTransaction {
+  return {
+    ...tx,
+    safeTxGas: tx.safeTxGas ? Number(tx.safeTxGas) : null,
+    baseGas: tx.baseGas ? Number(tx.baseGas) : null,
+    submissionDate: tx.created,
+    transactionHash: tx.txHash,
+    isExecuted: tx.txHash !== null,
+    isSuccessful: !tx.failed,
+    origin: buildOrigin(tx.originName, tx.originUrl, tx.notes),
+    executionDate: null,
+    blockNumber: null,
+    executor: null,
+    payment: null,
+    ethGasPrice: null,
+    gasUsed: null,
+    fee: null,
+    signatures: null,
+    confirmationsRequired: safe.threshold,
+    trusted: true,
+    confirmations: tx.confirmations?.map((c) => mapConfirmation(c, tx.txHash)),
+  };
+}

--- a/src/modules/queue/queue.interface.ts
+++ b/src/modules/queue/queue.interface.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Address, Hex } from 'viem';
+import type { Page } from '@/domain/entities/page.entity';
+import type { Delegate } from '@/modules/delegate/domain/entities/delegate.entity';
+import type { QueueMessage } from '@/modules/queue/entities/message.entity';
+import type { QueueMultisigTransactionEntity } from '@/modules/queue/entities/multisig-transaction.entity';
+import type { ProposeTransactionDto } from '@/modules/transactions/domain/entities/propose-transaction.dto.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
+
+export const IQueueService = Symbol('IQueueService');
+
+export interface IQueueService {
+  proposeTransaction(args: {
+    chainId: string;
+    safeAddress: Address;
+    proposeTransactionDto: ProposeTransactionDto;
+  }): Promise<unknown>;
+
+  getMultisigTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+  }): Promise<Raw<QueueMultisigTransactionEntity>>;
+
+  getMultisigTransactionsBatch(args: {
+    chainId: string;
+    safeTxHashes: ReadonlyArray<string>;
+  }): Promise<Raw<Array<QueueMultisigTransactionEntity>>>;
+
+  getTransactionQueue(args: {
+    chainId: string;
+    safeAddress: Address;
+    // The queue service can only order the queue by nonce. Callers translate
+    // their desired tx-service ordering into a nonce direction explicitly.
+    nonceOrder?: 'asc' | 'desc';
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<QueueMultisigTransactionEntity>>>;
+
+  postConfirmation(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<unknown>;
+
+  deleteTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void>;
+
+  getDelegates(args: {
+    chainId: string;
+    safeAddress?: Address;
+    delegate?: Address;
+    delegator?: Address;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<Delegate>>>;
+
+  postDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void>;
+
+  updateDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void>;
+
+  deleteDelegate(args: {
+    chainId: string;
+    delegate: Address;
+    delegator: Address;
+    safeAddress: Address | null;
+    signature: string;
+  }): Promise<unknown>;
+
+  getMessageByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<Raw<QueueMessage>>;
+
+  getMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: Address;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<QueueMessage>>>;
+
+  postMessage(args: {
+    chainId: string;
+    safeAddress: Address;
+    message: unknown;
+    signature: string;
+    origin: string | null;
+  }): Promise<unknown>;
+
+  postMessageSignature(args: {
+    chainId: string;
+    messageHash: string;
+    signature: Hex;
+  }): Promise<unknown>;
+
+  // Cache clearing
+  clearMultisigTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+  }): Promise<void>;
+
+  clearAllTransactions(args: {
+    chainId: string;
+    safeAddress: Address;
+  }): Promise<void>;
+
+  clearMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: Address;
+  }): Promise<void>;
+
+  clearMessagesByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<void>;
+
+  clearDelegates(args: {
+    chainId: string;
+    safeAddress?: Address;
+  }): Promise<void>;
+}

--- a/src/modules/queue/queue.module.ts
+++ b/src/modules/queue/queue.module.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Module } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { getQueueAuthHeaders } from '@/datasources/network/auth/queue-auth-headers.helper';
+import { FetchNetworkService } from '@/datasources/network/fetch.network.service';
+import type { FetchClient } from '@/datasources/network/network.module';
+import { FetchClientToken } from '@/datasources/network/network.module';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { IQueueService } from '@/modules/queue/queue.interface';
+import { QueueService } from '@/modules/queue/queue.service';
+
+/**
+ * Provides the QueueService backed by a {@link NetworkService} pre-configured
+ * with Queue Service authentication headers and a local {@link CacheFirstDataSource}
+ * that uses the same authenticated NetworkService.
+ */
+@Module({
+  providers: [
+    {
+      provide: NetworkService,
+      useFactory: (
+        client: FetchClient,
+        loggingService: ILoggingService,
+        configService: IConfigurationService,
+      ): FetchNetworkService => {
+        const queueHeaders = getQueueAuthHeaders(configService);
+        return new FetchNetworkService(client, loggingService, queueHeaders);
+      },
+      inject: [FetchClientToken, LoggingService, IConfigurationService],
+    },
+    CacheFirstDataSource,
+    HttpErrorFactory,
+    { provide: IQueueService, useClass: QueueService },
+  ],
+  exports: [IQueueService],
+})
+export class QueueServiceModule {}

--- a/src/modules/queue/queue.service.spec.ts
+++ b/src/modules/queue/queue.service.spec.ts
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { type Address, getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { CircuitBreakerKeys } from '@/datasources/circuit-breaker/circuit-breaker.keys';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { delegateBuilder } from '@/modules/delegate/domain/entities/__tests__/delegate.builder';
+import { messageBuilder } from '@/modules/messages/domain/entities/__tests__/message.builder';
+import { queueMultisigTransactionBuilder } from '@/modules/queue/entities/__tests__/queue-multisig-transaction.builder';
+import { QueueService } from '@/modules/queue/queue.service';
+import { proposeTransactionDtoBuilder } from '@/modules/transactions/routes/entities/__tests__/propose-transaction.dto.builder';
+import { rawify } from '@/validation/entities/raw.entity';
+
+const dataSource = {
+  get: vi.fn(),
+} as MockedObject<CacheFirstDataSource>;
+const mockDataSource = vi.mocked(dataSource);
+
+const cacheService = {
+  deleteByKey: vi.fn(),
+} as unknown as MockedObject<ICacheService>;
+const mockCacheService = vi.mocked(cacheService);
+
+const configurationService = {
+  getOrThrow: vi.fn(),
+} as MockedObject<IConfigurationService>;
+const mockConfigurationService = vi.mocked(configurationService);
+
+const networkService = vi.mocked({
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+} as MockedObject<INetworkService>);
+
+describe('QueueService', () => {
+  const chainId = faker.string.numeric();
+  const baseUri = faker.internet.url({ appendSlash: false });
+  const safeAddress = getAddress(faker.finance.ethereumAddress());
+  const safeTxHash = faker.string.hexadecimal({ length: 64 });
+  const messageHash = faker.string.hexadecimal({ length: 64 });
+  let service: QueueService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'queueService.baseUri') return baseUri;
+      if (key === 'expirationTimeInSeconds.default') return 60;
+      if (key === 'expirationTimeInSeconds.notFound.default') return 30;
+      throw new Error(`Unexpected key: ${key}`);
+    });
+
+    service = new QueueService(
+      mockConfigurationService,
+      networkService,
+      mockCacheService,
+      mockDataSource,
+      new HttpErrorFactory(),
+    );
+  });
+
+  describe('getMultisigTransaction', () => {
+    it('Should read the queue_multisig_transaction cache key, not the tx-service multisig_transaction key', async () => {
+      const tx = queueMultisigTransactionBuilder()
+        .with('safeTxHash', safeTxHash as `0x${string}`)
+        .build();
+      mockDataSource.get.mockResolvedValueOnce(rawify(tx));
+
+      await service.getMultisigTransaction({ chainId, safeTxHash });
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      const cacheDir = (
+        mockDataSource.get.mock.calls[0][0] as { cacheDir: CacheDir }
+      ).cacheDir;
+      expect(cacheDir.key).toBe(
+        `${chainId}_queue_multisig_transaction_${safeTxHash}`,
+      );
+      expect(cacheDir.key).not.toBe(
+        `${chainId}_multisig_transaction_${safeTxHash}`,
+      );
+    });
+  });
+
+  describe('getTransactionQueue', () => {
+    it('Should read the queue_multisig_transactions cache key, not the tx-service multisig_transactions key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(rawify({ results: [] }));
+
+      await service.getTransactionQueue({ chainId, safeAddress });
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      const cacheDir = (
+        mockDataSource.get.mock.calls[0][0] as { cacheDir: CacheDir }
+      ).cacheDir;
+      expect(cacheDir.key).toBe(
+        `${chainId}_queue_multisig_transactions_${safeAddress}`,
+      );
+      expect(cacheDir.key).not.toBe(
+        `${chainId}_multisig_transactions_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getMessageByHash', () => {
+    it('Should read the queue_message cache key, not the tx-service message key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify(messageBuilder().build()),
+      );
+
+      await service.getMessageByHash({ chainId, messageHash });
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      const cacheDir = (
+        mockDataSource.get.mock.calls[0][0] as { cacheDir: CacheDir }
+      ).cacheDir;
+      expect(cacheDir.key).toBe(`${chainId}_queue_message_${messageHash}`);
+      expect(cacheDir.key).not.toBe(`${chainId}_message_${messageHash}`);
+    });
+  });
+
+  describe('getMessagesBySafe', () => {
+    it('Should read the queue_messages cache key, not the tx-service messages key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(rawify({ results: [] }));
+
+      await service.getMessagesBySafe({ chainId, safeAddress });
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      const cacheDir = (
+        mockDataSource.get.mock.calls[0][0] as { cacheDir: CacheDir }
+      ).cacheDir;
+      expect(cacheDir.key).toBe(`${chainId}_queue_messages_${safeAddress}`);
+      expect(cacheDir.key).not.toBe(`${chainId}_messages_${safeAddress}`);
+    });
+  });
+
+  describe('getDelegates', () => {
+    it('Should read the queue_delegates cache key, not the tx-service delegates key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify({ results: [delegateBuilder().build()] }),
+      );
+
+      await service.getDelegates({ chainId, safeAddress });
+
+      expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+      const cacheDir = (
+        mockDataSource.get.mock.calls[0][0] as { cacheDir: CacheDir }
+      ).cacheDir;
+      expect(cacheDir.key).toBe(`${chainId}_queue_delegates_${safeAddress}`);
+      expect(cacheDir.key).not.toBe(`${chainId}_delegates_${safeAddress}`);
+    });
+  });
+
+  describe('clearMultisigTransaction', () => {
+    it('Should delete the queue_multisig_transaction cache key', async () => {
+      await service.clearMultisigTransaction({ chainId, safeTxHash });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_queue_multisig_transaction_${safeTxHash}`,
+      );
+    });
+  });
+
+  describe('clearAllTransactions', () => {
+    it('Should delete the queue_multisig_transactions cache key (regression: previously deleted unrelated all_transactions key)', async () => {
+      await service.clearAllTransactions({ chainId, safeAddress });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_queue_multisig_transactions_${safeAddress}`,
+      );
+      expect(mockCacheService.deleteByKey).not.toHaveBeenCalledWith(
+        `${chainId}_all_transactions_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('clearMessagesBySafe', () => {
+    it('Should delete the queue_messages cache key', async () => {
+      await service.clearMessagesBySafe({ chainId, safeAddress });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_queue_messages_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('clearMessagesByHash', () => {
+    it('Should delete the queue_message cache key', async () => {
+      await service.clearMessagesByHash({ chainId, messageHash });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_queue_message_${messageHash}`,
+      );
+    });
+  });
+
+  describe('clearDelegates', () => {
+    it('Should delete the queue_delegates cache key', async () => {
+      await service.clearDelegates({
+        chainId,
+        safeAddress: safeAddress as Address,
+      });
+
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toHaveBeenCalledWith(
+        `${chainId}_queue_delegates_${safeAddress}`,
+      );
+    });
+  });
+
+  describe('getMultisigTransactionsBatch chunking', () => {
+    // Each `safe_tx_hash=0x<64 hex>&` query pair is ~81 bytes. nginx's default
+    // `large_client_header_buffers 4 8k` rejects request lines over ~8KB, AWS
+    // ALB caps at 16KB, and many WAFs cap at 8KB. With 200 hashes the URL grows
+    // past 16KB. Chunking at 50 keeps each request under ~4KB.
+    it('chunks a 200-hash batch across multiple parallel calls under the URL safety threshold', async () => {
+      const hashes = Array.from({ length: 200 }, () =>
+        faker.string.hexadecimal({ length: 64 }),
+      );
+      networkService.get.mockResolvedValue({ data: rawify([]), status: 200 });
+
+      await service.getMultisigTransactionsBatch({
+        chainId,
+        safeTxHashes: hashes,
+      });
+
+      expect(networkService.get).toHaveBeenCalledTimes(4);
+    });
+
+    it('issues a single call when input fits within one chunk', async () => {
+      const hashes = Array.from({ length: 30 }, () =>
+        faker.string.hexadecimal({ length: 64 }),
+      );
+      networkService.get.mockResolvedValueOnce({
+        data: rawify([]),
+        status: 200,
+      });
+
+      await service.getMultisigTransactionsBatch({
+        chainId,
+        safeTxHashes: hashes,
+      });
+
+      expect(networkService.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty without hitting the network when input is empty', async () => {
+      const result = await service.getMultisigTransactionsBatch({
+        chainId,
+        safeTxHashes: [],
+      });
+
+      expect(networkService.get).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('proposeTransaction note handling', () => {
+    it('sends the note (embedded in the origin) to the queue service as notes', async () => {
+      const note = faker.lorem.sentence();
+      const dto = proposeTransactionDtoBuilder()
+        .with(
+          'origin',
+          JSON.stringify({
+            name: faker.company.name(),
+            url: faker.internet.url({ appendSlash: false }),
+            note,
+          }),
+        )
+        .build();
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 201,
+      });
+
+      await service.proposeTransaction({
+        chainId,
+        safeAddress,
+        proposeTransactionDto: dto,
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ notes: note }),
+        }),
+      );
+    });
+
+    it('sends a null note when the origin has no note', async () => {
+      const dto = proposeTransactionDtoBuilder()
+        .with(
+          'origin',
+          JSON.stringify({
+            name: faker.company.name(),
+            url: faker.internet.url({ appendSlash: false }),
+          }),
+        )
+        .build();
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 201,
+      });
+
+      await service.proposeTransaction({
+        chainId,
+        safeAddress,
+        proposeTransactionDto: dto,
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ notes: null }),
+        }),
+      );
+    });
+  });
+
+  describe('circuit breaker', () => {
+    const withCircuitBreakerKey = expect.objectContaining({
+      networkRequest: expect.objectContaining({
+        circuitBreaker: {
+          key: CircuitBreakerKeys.getQueueServiceKey(),
+        },
+      }),
+    });
+
+    it('proposeTransaction includes the queue circuit breaker key', async () => {
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 201,
+      });
+
+      await service.proposeTransaction({
+        chainId,
+        safeAddress,
+        proposeTransactionDto: proposeTransactionDtoBuilder().build(),
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('getMultisigTransaction includes the queue circuit breaker key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify(queueMultisigTransactionBuilder().build()),
+      );
+
+      await service.getMultisigTransaction({ chainId, safeTxHash });
+
+      expect(mockDataSource.get).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('getMultisigTransactionsBatch includes the queue circuit breaker key', async () => {
+      networkService.get.mockResolvedValueOnce({
+        data: rawify([]),
+        status: 200,
+      });
+
+      await service.getMultisigTransactionsBatch({
+        chainId,
+        safeTxHashes: [safeTxHash],
+      });
+
+      expect(networkService.get).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('getTransactionQueue includes the queue circuit breaker key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(rawify({ results: [] }));
+
+      await service.getTransactionQueue({ chainId, safeAddress });
+
+      expect(mockDataSource.get).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('postConfirmation includes the queue circuit breaker key', async () => {
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 200,
+      });
+
+      await service.postConfirmation({
+        chainId,
+        safeTxHash,
+        signature: faker.string.hexadecimal({ length: 16 }),
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('deleteTransaction includes the queue circuit breaker key', async () => {
+      networkService.delete.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 204,
+      });
+
+      await service.deleteTransaction({
+        chainId,
+        safeTxHash,
+        signature: faker.string.hexadecimal({ length: 16 }),
+      });
+
+      expect(networkService.delete).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('getDelegates includes the queue circuit breaker key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify({ results: [delegateBuilder().build()] }),
+      );
+
+      await service.getDelegates({ chainId, safeAddress });
+
+      expect(mockDataSource.get).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('postDelegate includes the queue circuit breaker key', async () => {
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 201,
+      });
+
+      await service.postDelegate({
+        chainId,
+        safeAddress,
+        delegate: getAddress(faker.finance.ethereumAddress()),
+        delegator: getAddress(faker.finance.ethereumAddress()),
+        signature: faker.string.hexadecimal({ length: 16 }),
+        label: faker.lorem.word(),
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('deleteDelegate includes the queue circuit breaker key', async () => {
+      networkService.delete.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 204,
+      });
+
+      await service.deleteDelegate({
+        chainId,
+        delegate: getAddress(faker.finance.ethereumAddress()),
+        delegator: getAddress(faker.finance.ethereumAddress()),
+        safeAddress,
+        signature: faker.string.hexadecimal({ length: 16 }),
+      });
+
+      expect(networkService.delete).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('getMessageByHash includes the queue circuit breaker key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify(messageBuilder().build()),
+      );
+
+      await service.getMessageByHash({ chainId, messageHash });
+
+      expect(mockDataSource.get).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('getMessagesBySafe includes the queue circuit breaker key', async () => {
+      mockDataSource.get.mockResolvedValueOnce(rawify({ results: [] }));
+
+      await service.getMessagesBySafe({ chainId, safeAddress });
+
+      expect(mockDataSource.get).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('postMessage includes the queue circuit breaker key', async () => {
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 201,
+      });
+
+      await service.postMessage({
+        chainId,
+        safeAddress,
+        message: faker.lorem.sentence(),
+        signature: faker.string.hexadecimal({ length: 16 }),
+        origin: null,
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+
+    it('postMessageSignature includes the queue circuit breaker key', async () => {
+      networkService.post.mockResolvedValueOnce({
+        data: rawify({}),
+        status: 200,
+      });
+
+      await service.postMessageSignature({
+        chainId,
+        messageHash,
+        signature: faker.string.hexadecimal({ length: 16 }) as `0x${string}`,
+      });
+
+      expect(networkService.post).toHaveBeenCalledWith(withCircuitBreakerKey);
+    });
+  });
+});

--- a/src/modules/queue/queue.service.ts
+++ b/src/modules/queue/queue.service.ts
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { Inject, Injectable } from '@nestjs/common';
+import type { Address, Hex } from 'viem';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { CircuitBreakerKeys } from '@/datasources/circuit-breaker/circuit-breaker.keys';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import {
+  INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import type { Page } from '@/domain/entities/page.entity';
+import type { Delegate } from '@/modules/delegate/domain/entities/delegate.entity';
+import { QueueMessage } from '@/modules/queue/entities/message.entity';
+import type { QueueMultisigTransactionEntity } from '@/modules/queue/entities/multisig-transaction.entity';
+import {
+  QueueMultisigTransactionListSchema,
+  QueueMultisigTransactionSchema,
+} from '@/modules/queue/entities/multisig-transaction.entity';
+import { parseOrigin } from '@/modules/queue/helpers/origin.helper';
+import type { IQueueService } from '@/modules/queue/queue.interface';
+import type { ProposeTransactionDto } from '@/modules/transactions/domain/entities/propose-transaction.dto.entity';
+import type { Raw } from '@/validation/entities/raw.entity';
+import { rawify } from '@/validation/entities/raw.entity';
+
+@Injectable()
+export class QueueService implements IQueueService {
+  // Chunk size for multisig batch fetches. Each `safe_tx_hash=0x<64 hex>&`
+  // pair is ~81 bytes; nginx's default `large_client_header_buffers 4 8k`
+  // and many WAFs reject request lines beyond 8KB, so we cap each call at
+  // 50 hashes (~4KB URL) to stay safely under that limit.
+  private static readonly MAX_BATCH_HASHES_PER_CALL = 50;
+
+  private readonly baseUri: string;
+  private readonly defaultExpirationTimeInSeconds: number;
+  private readonly defaultNotFoundExpirationTimeSeconds: number;
+
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(NetworkService)
+    private readonly networkService: INetworkService,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
+    private readonly dataSource: CacheFirstDataSource,
+    private readonly httpErrorFactory: HttpErrorFactory,
+  ) {
+    this.baseUri = this.configurationService.getOrThrow<string>(
+      'queueService.baseUri',
+    );
+    this.defaultExpirationTimeInSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.default',
+      );
+    this.defaultNotFoundExpirationTimeSeconds =
+      this.configurationService.getOrThrow<number>(
+        'expirationTimeInSeconds.notFound.default',
+      );
+  }
+
+  async proposeTransaction(args: {
+    chainId: string;
+    safeAddress: Address;
+    proposeTransactionDto: ProposeTransactionDto;
+  }): Promise<unknown> {
+    try {
+      const dto = args.proposeTransactionDto;
+      const { originName, originUrl, note } = parseOrigin(dto.origin);
+
+      const url = `${this.baseUri}/api/v1/multisig-transactions`;
+      const { data } = await this.networkService.post<unknown>({
+        url,
+        data: {
+          chainId: Number(args.chainId),
+          safe: args.safeAddress,
+          to: dto.to,
+          value: dto.value,
+          data: dto.data,
+          nonce: Number(dto.nonce),
+          operation: dto.operation,
+          safeTxGas: dto.safeTxGas,
+          baseGas: dto.baseGas,
+          gasPrice: dto.gasPrice,
+          gasToken: dto.gasToken,
+          refundReceiver: dto.refundReceiver,
+          originName,
+          originUrl,
+          notes: note ?? null,
+          signatures: dto.signature ? [dto.signature] : [],
+        },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getMultisigTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+  }): Promise<Raw<QueueMultisigTransactionEntity>> {
+    try {
+      const cacheDir = CacheRouter.getQueueMultisigTransactionCacheDir({
+        chainId: args.chainId,
+        safeTransactionHash: args.safeTxHash,
+      });
+      const url = `${this.baseUri}/api/v1/multisig-transactions/${encodeURIComponent(args.safeTxHash)}`;
+      const data = await this.dataSource.get({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return rawify(QueueMultisigTransactionSchema.parse(data));
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getMultisigTransactionsBatch(args: {
+    chainId: string;
+    safeTxHashes: ReadonlyArray<string>;
+  }): Promise<Raw<Array<QueueMultisigTransactionEntity>>> {
+    try {
+      if (args.safeTxHashes.length === 0) {
+        return rawify([]);
+      }
+      const chunkSize = QueueService.MAX_BATCH_HASHES_PER_CALL;
+      const chunks: Array<ReadonlyArray<string>> = [];
+      for (let i = 0; i < args.safeTxHashes.length; i += chunkSize) {
+        chunks.push(args.safeTxHashes.slice(i, i + chunkSize));
+      }
+      // Use allSettled so a single failing chunk (e.g. a 5xx) doesn't discard
+      // the transactions returned by the other chunks. Hashes belonging to a
+      // failed chunk simply won't appear in the merged result; the caller
+      // detects and logs those omissions, preserving partial enrichment.
+      const responses = await Promise.allSettled(
+        chunks.map((chunk) => {
+          const query = new URLSearchParams();
+          for (const hash of chunk) {
+            query.append('safe_tx_hash', hash);
+          }
+          const url = `${this.baseUri}/api/v1/multisig-transactions/batch?${query.toString()}`;
+          return this.networkService.get({
+            url,
+            networkRequest: {
+              circuitBreaker: {
+                key: CircuitBreakerKeys.getQueueServiceKey(),
+              },
+            },
+          });
+        }),
+      );
+      const merged = responses.flatMap((response) =>
+        response.status === 'fulfilled'
+          ? QueueMultisigTransactionListSchema.parse(response.value.data)
+          : [],
+      );
+      return rawify(merged);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getTransactionQueue(args: {
+    chainId: string;
+    safeAddress: Address;
+    nonceOrder?: 'asc' | 'desc';
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<QueueMultisigTransactionEntity>>> {
+    try {
+      const cacheDir = CacheRouter.getQueuedTransactionsCacheDir(args);
+      const url = `${this.baseUri}/api/v1/multisig-transactions/queue`;
+      const nonceOrder = args.nonceOrder ?? 'asc';
+      return await this.dataSource.get<Page<QueueMultisigTransactionEntity>>({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            safes: `${args.safeAddress}:${args.chainId}`,
+            nonce_order: nonceOrder,
+            limit: args.limit,
+            offset: args.offset,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async postConfirmation(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<unknown> {
+    try {
+      const url = `${this.baseUri}/api/v1/multisig-transactions/${encodeURIComponent(args.safeTxHash)}/signatures`;
+      const { data } = await this.networkService.post<unknown>({
+        url,
+        data: { signatures: [args.signature] },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async deleteTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+    signature: string;
+  }): Promise<void> {
+    try {
+      const url = `${this.baseUri}/api/v1/multisig-transactions/${encodeURIComponent(args.safeTxHash)}`;
+      await this.networkService.delete({
+        url,
+        data: { signature: args.signature },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getDelegates(args: {
+    chainId: string;
+    safeAddress?: Address;
+    delegate?: Address;
+    delegator?: Address;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<Delegate>>> {
+    try {
+      const cacheDir = CacheRouter.getQueueDelegatesCacheDir(args);
+      const url = `${this.baseUri}/api/v1/delegates`;
+      const data = await this.dataSource.get({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            chainId: Number(args.chainId),
+            safe: args.safeAddress,
+            delegate: args.delegate,
+            delegator: args.delegator,
+            limit: args.limit,
+            offset: args.offset,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async postDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void> {
+    try {
+      const url = `${this.baseUri}/api/v1/delegates`;
+      await this.networkService.post({
+        url,
+        data: {
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+          chainId: Number(args.chainId),
+          safe: args.safeAddress ?? undefined,
+          label: args.label,
+        },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async updateDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void> {
+    try {
+      const url = `${this.baseUri}/api/v1/delegates`;
+      await this.networkService.patch({
+        url,
+        data: {
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+          chainId: Number(args.chainId),
+          safe: args.safeAddress ?? undefined,
+          label: args.label,
+        },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async deleteDelegate(args: {
+    chainId: string;
+    delegate: Address;
+    delegator: Address;
+    safeAddress: Address | null;
+    signature: string;
+  }): Promise<void> {
+    try {
+      const url = `${this.baseUri}/api/v1/delegates`;
+      await this.networkService.delete({
+        url,
+        data: {
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+          chainId: Number(args.chainId),
+          safe: args.safeAddress ?? undefined,
+        },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getMessageByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<Raw<QueueMessage>> {
+    try {
+      const cacheDir = CacheRouter.getQueueMessageByHashCacheDir({
+        chainId: args.chainId,
+        messageHash: args.messageHash,
+      });
+      const url = `${this.baseUri}/api/v1/messages/${encodeURIComponent(args.messageHash)}`;
+      const data = await this.dataSource.get({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: Address;
+    limit?: number;
+    offset?: number;
+  }): Promise<Raw<Page<QueueMessage>>> {
+    try {
+      const cacheDir = CacheRouter.getQueueMessagesBySafeCacheDir({
+        chainId: args.chainId,
+        safeAddress: args.safeAddress,
+        limit: args.limit,
+        offset: args.offset,
+      });
+      const url = `${this.baseUri}/api/v1/safes/${encodeURIComponent(args.safeAddress)}/messages`;
+      const data = await this.dataSource.get({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+        networkRequest: {
+          params: {
+            chainId: Number(args.chainId),
+            limit: args.limit,
+            offset: args.offset,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async postMessage(args: {
+    chainId: string;
+    safeAddress: Address;
+    message: unknown;
+    signature: string;
+    origin: string | null;
+  }): Promise<unknown> {
+    try {
+      const { originName, originUrl } = parseOrigin(args.origin);
+      const url = `${this.baseUri}/api/v1/safes/${encodeURIComponent(args.safeAddress)}/messages`;
+      const { data } = await this.networkService.post<unknown>({
+        url,
+        data: {
+          chainId: Number(args.chainId),
+          message: args.message,
+          signatures: [args.signature],
+          originName,
+          originUrl,
+        },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async postMessageSignature(args: {
+    chainId: string;
+    messageHash: string;
+    signature: Hex;
+  }): Promise<unknown> {
+    try {
+      const url = `${this.baseUri}/api/v1/messages/${encodeURIComponent(args.messageHash)}/signatures`;
+      const { data } = await this.networkService.post({
+        url,
+        data: { signatures: [args.signature] },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getQueueServiceKey(),
+          },
+        },
+      });
+      return data;
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async clearMultisigTransaction(args: {
+    chainId: string;
+    safeTxHash: string;
+  }): Promise<void> {
+    const key = CacheRouter.getQueueMultisigTransactionCacheKey({
+      chainId: args.chainId,
+      safeTransactionHash: args.safeTxHash,
+    });
+    await this.cacheService.deleteByKey(key);
+  }
+
+  async clearAllTransactions(args: {
+    chainId: string;
+    safeAddress: Address;
+  }): Promise<void> {
+    const key = CacheRouter.getQueueMultisigTransactionsCacheKey({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+    });
+    await this.cacheService.deleteByKey(key);
+  }
+
+  async clearMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: Address;
+  }): Promise<void> {
+    const key = CacheRouter.getQueueMessagesBySafeCacheKey({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+    });
+    await this.cacheService.deleteByKey(key);
+  }
+
+  async clearMessagesByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<void> {
+    const key = CacheRouter.getQueueMessageByHashCacheKey({
+      chainId: args.chainId,
+      messageHash: args.messageHash,
+    });
+    await this.cacheService.deleteByKey(key);
+  }
+
+  async clearDelegates(args: {
+    chainId: string;
+    safeAddress?: Address;
+  }): Promise<void> {
+    const key = CacheRouter.getQueueDelegatesCacheKey({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+    });
+    await this.cacheService.deleteByKey(key);
+  }
+}


### PR DESCRIPTION
## Summary
  Add the Queue Service client module. Self-contained and not yet wired into any repository (zero runtime effect). Part 3/6 of the `feat/migrateToQueueService` split.

  ## Changes
  - Add `src/modules/queue/*`: `IQueueService` interface, `QueueService`, schemas, entities, mappers (transaction + message), helpers, `QueueServiceModule`, and unit tests/mocks.
  - Add the queue auth-header helper.
  - Wire the queue test module into the shared testing module.
  - Remove the vestigial `safeAppId` from the domain `Message` schema (required by the queue message mapper).