### PR TITLE
feat(safe): route multisig transactions through Queue Service

### DIFF
--- a/src/modules/safe/domain/safe.repository.interface.ts
+++ b/src/modules/safe/domain/safe.repository.interface.ts
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+
 import { Module } from '@nestjs/common';
 import type { Address } from 'viem';
-import type { Page } from '@/domain/entities/page.entity';
+import { Page } from '@/domain/entities/page.entity';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
 import { ChainsModule } from '@/modules/chains/chains.module';
 import { ContractsModule } from '@/modules/contracts/contracts.module';
 import { DelegatesV2RepositoryModule } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
-import type { CreationTransaction } from '@/modules/safe/domain/entities/creation-transaction.entity';
-import type { ModuleTransaction } from '@/modules/safe/domain/entities/module-transaction.entity';
-import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
-import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
-import type { SafeList } from '@/modules/safe/domain/entities/safe-list.entity';
-import type { SafesByChainId } from '@/modules/safe/domain/entities/safes-by-chain-id.entity';
-import type { Transaction } from '@/modules/safe/domain/entities/transaction.entity';
-import type { Transfer } from '@/modules/safe/domain/entities/transfer.entity';
+import { QueueServiceModule } from '@/modules/queue/queue.module';
+import { CreationTransaction } from '@/modules/safe/domain/entities/creation-transaction.entity';
+import { ModuleTransaction } from '@/modules/safe/domain/entities/module-transaction.entity';
+import { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import { Safe } from '@/modules/safe/domain/entities/safe.entity';
+import { SafeList } from '@/modules/safe/domain/entities/safe-list.entity';
+import { SafesByChainId } from '@/modules/safe/domain/entities/safes-by-chain-id.entity';
+import { Transaction } from '@/modules/safe/domain/entities/transaction.entity';
+import { Transfer } from '@/modules/safe/domain/entities/transfer.entity';
 import { SafeRepository } from '@/modules/safe/domain/safe.repository';
-import type { AddConfirmationDto } from '@/modules/transactions/domain/entities/add-confirmation.dto.entity';
-import type { ProposeTransactionDto } from '@/modules/transactions/domain/entities/propose-transaction.dto.entity';
+import { AddConfirmationDto } from '@/modules/transactions/domain/entities/add-confirmation.dto.entity';
+import { ProposeTransactionDto } from '@/modules/transactions/domain/entities/propose-transaction.dto.entity';
 import { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
 
 export const ISafeRepository = Symbol('ISafeRepository');
@@ -230,6 +232,7 @@ export interface ISafeRepository {
     TransactionApiManagerModule,
     DelegatesV2RepositoryModule,
     ContractsModule,
+    QueueServiceModule,
   ],
   providers: [
     {

--- a/src/modules/safe/domain/safe.repository.spec.ts
+++ b/src/modules/safe/domain/safe.repository.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
-import type { Address } from 'viem';
+import type { Address, Hex } from 'viem';
 import { getAddress } from 'viem';
 import type { MockedObject } from 'vitest';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
@@ -12,8 +12,26 @@ import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api
 import type { ILoggingService } from '@/logging/logging.interface';
 import type { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { createMockQueueService } from '@/modules/queue/__tests__/queue.mock';
+import { queueMultisigTransactionBuilder } from '@/modules/queue/entities/__tests__/queue-multisig-transaction.builder';
+import type { QueueMultisigTransactionEntity } from '@/modules/queue/entities/multisig-transaction.entity';
+import { buildOrigin } from '@/modules/queue/helpers/origin.helper';
+import {
+  ethereumTransactionBuilder,
+  toJson as ethereumTransactionToJson,
+} from '@/modules/safe/domain/entities/__tests__/ethereum-transaction.builder';
+import {
+  moduleTransactionBuilder,
+  toJson as moduleTransactionToJson,
+} from '@/modules/safe/domain/entities/__tests__/module-transaction.builder';
+import {
+  multisigTransactionBuilder,
+  toJson as multisigTransactionToJson,
+} from '@/modules/safe/domain/entities/__tests__/multisig-transaction.builder';
+import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
 import type { SafeV2 } from '@/modules/safe/domain/entities/safe.entity';
 import { SafeRepository } from '@/modules/safe/domain/safe.repository';
+import { proposeTransactionDtoBuilder } from '@/modules/transactions/routes/entities/__tests__/propose-transaction.dto.builder';
 import type { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
 import { rawify } from '@/validation/entities/raw.entity';
 
@@ -23,6 +41,16 @@ const mockTransactionApiManager = {
 
 const mockTransactionApi = {
   getSafesByOwnerV2: vi.fn(),
+  getAllTransactions: vi.fn(),
+  getSafe: vi.fn(),
+  getMultisigTransaction: vi.fn(),
+  getMultisigTransactionWithNoCache: vi.fn(),
+  getMultisigTransactions: vi.fn(),
+  getMultisigTransactionsWithNoCache: vi.fn(),
+  deleteTransaction: vi.fn(),
+  postMultisigTransaction: vi.fn(),
+  clearMultisigTransaction: vi.fn(),
+  clearMultisigTransactions: vi.fn(),
 } as MockedObject<ITransactionApi>;
 
 const mockLoggingService = {
@@ -46,27 +74,38 @@ const mockConfigurationService = {
   getOrThrow: vi.fn(),
 } as MockedObject<IConfigurationService>;
 
+const mockQueueService = createMockQueueService();
+
 describe('SafeRepository', () => {
   let repository: SafeRepository;
   const maxSequentialPages = 5;
 
-  beforeEach(() => {
-    vi.resetAllMocks();
+  function createRepository(opts: {
+    queueServiceEnabled: boolean;
+  }): SafeRepository {
     mockConfigurationService.getOrThrow.mockImplementation((key: string) => {
       if (key === 'safeConfig.safes.maxSequentialPages') {
         return maxSequentialPages;
       }
+      if (key === 'features.queueService') {
+        return opts.queueServiceEnabled;
+      }
       throw new Error(`Unexpected key: ${key}`);
     });
-    mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
-
-    repository = new SafeRepository(
+    return new SafeRepository(
       mockTransactionApiManager,
       mockLoggingService,
       mockChainsRepository,
       mockTransactionVerifier,
       mockConfigurationService,
+      mockQueueService,
     );
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+    repository = createRepository({ queueServiceEnabled: true });
   });
 
   describe('getSafesByOwnerV2', () => {
@@ -441,6 +480,1129 @@ describe('SafeRepository', () => {
       await expect(
         repository.getAllSafesByOwnerV2({ ownerAddress }),
       ).rejects.toThrow('Failed to get chains');
+    });
+  });
+
+  describe('getTransactionHistory', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    const buildQueueEntityForSafe = (overrides: {
+      safeTxHash: Hex;
+      originName: string | null;
+      originUrl: string | null;
+      notes?: string | null;
+    }): QueueMultisigTransactionEntity =>
+      queueMultisigTransactionBuilder()
+        .with('chainId', chainId)
+        .with('safe', safeAddress)
+        .with('safeTxHash', overrides.safeTxHash)
+        .with('originName', overrides.originName)
+        .with('originUrl', overrides.originUrl)
+        .with('notes', overrides.notes ?? null)
+        .build();
+
+    it('should replace origin on every multisig entry with queue-service metadata', async () => {
+      const multisigA = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-A')
+        .build();
+      const multisigB = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-B')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [
+          multisigTransactionToJson(multisigA),
+          multisigTransactionToJson(multisigB),
+        ])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      const queueA = buildQueueEntityForSafe({
+        safeTxHash: multisigA.safeTxHash,
+        originName: 'AppA',
+        originUrl: 'https://a.example',
+      });
+      const queueB = buildQueueEntityForSafe({
+        safeTxHash: multisigB.safeTxHash,
+        originName: 'AppB',
+        originUrl: 'https://b.example',
+      });
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([queueA, queueB]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(mockTransactionApi.getAllTransactions).toHaveBeenCalledWith({
+        chainId,
+        safeAddress,
+        executed: true,
+        queued: false,
+      });
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).toHaveBeenCalledWith({
+        chainId,
+        safeTxHashes: [multisigA.safeTxHash, multisigB.safeTxHash],
+      });
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0]).toMatchObject({
+        safeTxHash: multisigA.safeTxHash,
+        origin: buildOrigin('AppA', 'https://a.example'),
+      });
+      expect(result.results[1]).toMatchObject({
+        safeTxHash: multisigB.safeTxHash,
+        origin: buildOrigin('AppB', 'https://b.example'),
+      });
+    });
+
+    it('should preserve the queue note in the batch origin overlay', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          buildQueueEntityForSafe({
+            safeTxHash: multisig.safeTxHash,
+            originName: 'App',
+            originUrl: 'https://app.example',
+            notes: 'a note',
+          }),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0]).toMatchObject({
+        safeTxHash: multisig.safeTxHash,
+        origin: buildOrigin('App', 'https://app.example', 'a note'),
+      });
+    });
+
+    it('should keep tx-service origin when the queue record has only a note (no name/url)', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', buildOrigin('TxName', 'https://tx.example'))
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          buildQueueEntityForSafe({
+            safeTxHash: multisig.safeTxHash,
+            originName: null,
+            originUrl: null,
+            notes: 'a note',
+          }),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0]).toMatchObject({
+        safeTxHash: multisig.safeTxHash,
+        origin: buildOrigin('TxName', 'https://tx.example'),
+      });
+    });
+
+    it('should leave non-multisig entries (ethereum, module) untouched', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      const ethereum = ethereumTransactionBuilder().build();
+      const moduleTx = moduleTransactionBuilder()
+        .with('safe', safeAddress)
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [
+          multisigTransactionToJson(multisig),
+          ethereumTransactionToJson(ethereum),
+          moduleTransactionToJson(moduleTx),
+        ])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          buildQueueEntityForSafe({
+            safeTxHash: multisig.safeTxHash,
+            originName: 'App',
+            originUrl: 'https://app.example',
+          }),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).toHaveBeenCalledWith({
+        chainId,
+        safeTxHashes: [multisig.safeTxHash],
+      });
+
+      const [resultMultisig, resultEthereum, resultModule] = result.results;
+      expect(resultMultisig).toMatchObject({
+        safeTxHash: multisig.safeTxHash,
+        origin: buildOrigin('App', 'https://app.example'),
+      });
+      expect(resultEthereum).toMatchObject({
+        txHash: ethereum.txHash,
+        from: ethereum.from,
+      });
+      expect(resultModule).toMatchObject({
+        transactionHash: moduleTx.transactionHash,
+        module: moduleTx.module,
+      });
+    });
+
+    it('should fall back to tx-service origin for hashes the batch response omits', async () => {
+      const multisigOk = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-ok')
+        .build();
+      const multisigMissing = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-fail')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [
+          multisigTransactionToJson(multisigOk),
+          multisigTransactionToJson(multisigMissing),
+        ])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          buildQueueEntityForSafe({
+            safeTxHash: multisigOk.safeTxHash,
+            originName: 'AppOk',
+            originUrl: 'https://ok.example',
+          }),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0]).toMatchObject({
+        safeTxHash: multisigOk.safeTxHash,
+        origin: buildOrigin('AppOk', 'https://ok.example'),
+      });
+      expect(result.results[1]).toMatchObject({
+        safeTxHash: multisigMissing.safeTxHash,
+        origin: 'tx-service-origin-fail',
+      });
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining(multisigMissing.safeTxHash),
+      );
+    });
+
+    it('should keep tx-service origin on every entry when the batch call fails', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockRejectedValue(
+        new Error('queue unreachable'),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0]).toMatchObject({
+        safeTxHash: multisig.safeTxHash,
+        origin: 'tx-service-origin',
+      });
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining(chainId),
+      );
+    });
+
+    it('should skip queue-service calls entirely when the page has no multisig entries', async () => {
+      const ethereum = ethereumTransactionBuilder().build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [ethereumTransactionToJson(ethereum)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+
+      await repository.getTransactionHistory({ chainId, safeAddress });
+
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should preserve the tx-service origin when the queue record has no originName and no originUrl', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          buildQueueEntityForSafe({
+            safeTxHash: multisig.safeTxHash,
+            originName: null,
+            originUrl: null,
+          }),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      // An empty queue origin (e.g. a not-yet-backfilled entry) must not clobber
+      // the existing tx-service origin.
+      expect(result.results[0]).toMatchObject({
+        safeTxHash: multisig.safeTxHash,
+        origin: 'tx-service-origin',
+      });
+    });
+
+    it('should coerce a javascript: originUrl to null without leaking the URI', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          buildQueueEntityForSafe({
+            safeTxHash: multisig.safeTxHash,
+            originName: 'Evil',
+            originUrl: 'javascript:alert(1)' as unknown as string,
+          }),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      const origin = (result.results[0] as { origin: string | null }).origin;
+      expect(origin).not.toBeNull();
+      expect(origin).not.toContain('javascript');
+      expect(JSON.parse(origin as string).url).toBeNull();
+      expect(JSON.parse(origin as string).name).toBe('Evil');
+    });
+
+    it('should drop the override when the queue record reports a different chainId', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          queueMultisigTransactionBuilder()
+            .with('chainId', `${Number(chainId) + 1}`)
+            .with('safe', safeAddress)
+            .with('safeTxHash', multisig.safeTxHash)
+            .with('originName', 'CrossChain')
+            .with('originUrl', 'https://crosschain.example')
+            .build(),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0]).toMatchObject({ origin: 'tx-service-origin' });
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Queue origin reconciliation rejected'),
+      );
+    });
+
+    it('should drop the override when the queue record reports a different safe', async () => {
+      const multisig = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(multisig)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getAllTransactions.mockResolvedValue(rawify(page));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', getAddress(faker.finance.ethereumAddress()))
+            .with('safeTxHash', multisig.safeTxHash)
+            .with('originName', 'WrongSafe')
+            .with('originUrl', 'https://wrongsafe.example')
+            .build(),
+        ]),
+      );
+
+      const result = await repository.getTransactionHistory({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0]).toMatchObject({ origin: 'tx-service-origin' });
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Queue origin reconciliation rejected'),
+      );
+    });
+  });
+
+  describe('getMultiSigTransaction', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('should override origin with the queue-service value', async () => {
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', tx.safeTxHash)
+            .with('originName', 'App')
+            .with('originUrl', 'https://app.example')
+            .build(),
+        ),
+      );
+
+      const result = await repository.getMultiSigTransaction({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe(buildOrigin('App', 'https://app.example'));
+      expect(mockQueueService.getMultisigTransaction).toHaveBeenCalledWith({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+      });
+    });
+
+    it('should preserve the queue note in the executed-tx origin overlay', async () => {
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', tx.safeTxHash)
+            .with('originName', 'App')
+            .with('originUrl', 'https://app.example')
+            .with('notes', 'a note')
+            .build(),
+        ),
+      );
+
+      const result = await repository.getMultiSigTransaction({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe(
+        buildOrigin('App', 'https://app.example', 'a note'),
+      );
+    });
+
+    it('should keep tx-service origin when the queue call fails', async () => {
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockQueueService.getMultisigTransaction.mockRejectedValue(
+        new Error('queue unreachable'),
+      );
+
+      const result = await repository.getMultiSigTransaction({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe('tx-service-origin');
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining(tx.safeTxHash),
+      );
+    });
+
+    it('should drop the override when the queue record reports a different chainId or safe', async () => {
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(
+          queueMultisigTransactionBuilder()
+            .with('chainId', `${Number(chainId) + 1}`)
+            .with('safe', getAddress(faker.finance.ethereumAddress()))
+            .with('safeTxHash', tx.safeTxHash)
+            .with('originName', 'CrossChain')
+            .with('originUrl', 'https://crosschain.example')
+            .build(),
+        ),
+      );
+
+      const result = await repository.getMultiSigTransaction({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe('tx-service-origin');
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Queue origin reconciliation rejected'),
+      );
+    });
+
+    it('should skip the queue call entirely when FF_QUEUE_SERVICE is off', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+
+      const result = await repo.getMultiSigTransaction({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe('tx-service-origin');
+      expect(mockQueueService.getMultisigTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should use the queue transaction as the source of truth when it is not executed', async () => {
+      const safe = safeBuilder().with('address', safeAddress).build();
+      const queueTx = queueMultisigTransactionBuilder()
+        .with('chainId', chainId)
+        .with('safe', safeAddress)
+        .with('txHash', null)
+        .with('originName', 'App')
+        .with('originUrl', 'https://app.example')
+        .build();
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(queueTx),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+
+      const result = await repository.getMultiSigTransaction({
+        chainId,
+        safeTransactionHash: queueTx.safeTxHash,
+      });
+
+      expect(result.isExecuted).toBe(false);
+      expect(result.safeTxHash).toBe(queueTx.safeTxHash);
+      expect(result.origin).toBe(buildOrigin('App', 'https://app.example'));
+      expect(result.confirmationsRequired).toBe(safe.threshold);
+      expect(mockTransactionApi.getMultisigTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMultiSigTransactionWithNoCache', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const safe = safeBuilder().with('address', safeAddress).build();
+
+    it('should override origin with the queue-service value', async () => {
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransactionWithNoCache.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', tx.safeTxHash)
+            .with('originName', 'App')
+            .with('originUrl', 'https://app.example')
+            .build(),
+        ),
+      );
+
+      const result = await repository.getMultiSigTransactionWithNoCache({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe(buildOrigin('App', 'https://app.example'));
+    });
+
+    it('should skip the queue call entirely when FF_QUEUE_SERVICE is off', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      mockTransactionApi.getMultisigTransactionWithNoCache.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+
+      const result = await repo.getMultiSigTransactionWithNoCache({
+        chainId,
+        safeTransactionHash: tx.safeTxHash,
+      });
+
+      expect(result.origin).toBe('tx-service-origin');
+      expect(mockQueueService.getMultisigTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should use the queue transaction as the source of truth and verify it when not executed', async () => {
+      const queueTx = queueMultisigTransactionBuilder()
+        .with('chainId', chainId)
+        .with('safe', safeAddress)
+        .with('txHash', null)
+        .with('originName', 'App')
+        .with('originUrl', 'https://app.example')
+        .build();
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(queueTx),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+
+      const result = await repository.getMultiSigTransactionWithNoCache({
+        chainId,
+        safeTransactionHash: queueTx.safeTxHash,
+      });
+
+      expect(result.isExecuted).toBe(false);
+      expect(result.origin).toBe(buildOrigin('App', 'https://app.example'));
+      expect(
+        mockTransactionApi.getMultisigTransactionWithNoCache,
+      ).not.toHaveBeenCalled();
+      expect(mockTransactionVerifier.verifyApiTransaction).toHaveBeenCalledWith(
+        {
+          chainId,
+          safe,
+          transaction: result,
+        },
+      );
+    });
+  });
+
+  describe('getMultisigTransactions', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('should override origin on each entry from the batch response', async () => {
+      const txA = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-A')
+        .build();
+      const txB = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-B')
+        .build();
+      const page = pageBuilder<unknown>()
+        .with('results', [
+          multisigTransactionToJson(txA),
+          multisigTransactionToJson(txB),
+        ])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getMultisigTransactions.mockResolvedValue(
+        rawify(page),
+      );
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', txA.safeTxHash)
+            .with('originName', 'AppA')
+            .with('originUrl', 'https://a.example')
+            .build(),
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', txB.safeTxHash)
+            .with('originName', 'AppB')
+            .with('originUrl', 'https://b.example')
+            .build(),
+        ]),
+      );
+
+      const result = await repository.getMultisigTransactions({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0].origin).toBe(
+        buildOrigin('AppA', 'https://a.example'),
+      );
+      expect(result.results[1].origin).toBe(
+        buildOrigin('AppB', 'https://b.example'),
+      );
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).toHaveBeenCalledWith({
+        chainId,
+        safeTxHashes: [txA.safeTxHash, txB.safeTxHash],
+      });
+    });
+
+    it('should keep tx-service origin for hashes the batch omits', async () => {
+      const txKept = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-kept')
+        .build();
+      const txMissing = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin-missing')
+        .build();
+      const page = pageBuilder<unknown>()
+        .with('results', [
+          multisigTransactionToJson(txKept),
+          multisigTransactionToJson(txMissing),
+        ])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getMultisigTransactions.mockResolvedValue(
+        rawify(page),
+      );
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', txKept.safeTxHash)
+            .with('originName', 'AppKept')
+            .with('originUrl', 'https://kept.example')
+            .build(),
+        ]),
+      );
+
+      const result = await repository.getMultisigTransactions({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0].origin).toBe(
+        buildOrigin('AppKept', 'https://kept.example'),
+      );
+      expect(result.results[1].origin).toBe('tx-service-origin-missing');
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.stringContaining(txMissing.safeTxHash),
+      );
+    });
+
+    it('should skip the queue call entirely when FF_QUEUE_SERVICE is off', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(tx)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getMultisigTransactions.mockResolvedValue(
+        rawify(page),
+      );
+
+      const result = await repo.getMultisigTransactions({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0].origin).toBe('tx-service-origin');
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMultisigTransactionsWithNoCache', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const safe = safeBuilder().with('address', safeAddress).build();
+
+    it('should override origin on each entry from the batch response', async () => {
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(tx)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getMultisigTransactionsWithNoCache.mockResolvedValue(
+        rawify(page),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+      mockQueueService.getMultisigTransactionsBatch.mockResolvedValue(
+        rawify([
+          queueMultisigTransactionBuilder()
+            .with('chainId', chainId)
+            .with('safe', safeAddress)
+            .with('safeTxHash', tx.safeTxHash)
+            .with('originName', 'App')
+            .with('originUrl', 'https://app.example')
+            .build(),
+        ]),
+      );
+
+      const result = await repository.getMultisigTransactionsWithNoCache({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0].origin).toBe(
+        buildOrigin('App', 'https://app.example'),
+      );
+    });
+
+    it('should skip the queue call entirely when FF_QUEUE_SERVICE is off', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const tx = multisigTransactionBuilder()
+        .with('safe', safeAddress)
+        .with('origin', 'tx-service-origin')
+        .build();
+      const page = pageBuilder<unknown>()
+        .with('results', [multisigTransactionToJson(tx)])
+        .with('next', null)
+        .with('previous', null)
+        .build();
+
+      mockTransactionApi.getMultisigTransactionsWithNoCache.mockResolvedValue(
+        rawify(page),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+
+      const result = await repo.getMultisigTransactionsWithNoCache({
+        chainId,
+        safeAddress,
+      });
+
+      expect(result.results[0].origin).toBe('tx-service-origin');
+      expect(
+        mockQueueService.getMultisigTransactionsBatch,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteTransaction', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('should clear both tx-service and queue caches when FF_QUEUE_SERVICE is on', async () => {
+      const tx = multisigTransactionBuilder().with('safe', safeAddress).build();
+      const signature = faker.string.hexadecimal({ length: 16 });
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockQueueService.deleteTransaction.mockResolvedValue(undefined);
+
+      await repository.deleteTransaction({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+        signature,
+      });
+
+      expect(mockQueueService.deleteTransaction).toHaveBeenCalledWith({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+        signature,
+      });
+      expect(mockTransactionApi.deleteTransaction).not.toHaveBeenCalled();
+      expect(mockTransactionApi.clearMultisigTransaction).toHaveBeenCalledWith(
+        tx.safeTxHash,
+      );
+      expect(mockTransactionApi.clearMultisigTransactions).toHaveBeenCalledWith(
+        tx.safe,
+      );
+      expect(mockQueueService.clearMultisigTransaction).toHaveBeenCalledWith({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+      });
+      expect(mockQueueService.clearAllTransactions).toHaveBeenCalledWith({
+        chainId,
+        safeAddress: tx.safe,
+      });
+    });
+
+    it('should only clear tx-service cache when FF_QUEUE_SERVICE is off', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const tx = multisigTransactionBuilder().with('safe', safeAddress).build();
+      const signature = faker.string.hexadecimal({ length: 16 });
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockTransactionApi.deleteTransaction.mockResolvedValue(undefined);
+
+      await repo.deleteTransaction({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+        signature,
+      });
+
+      expect(mockTransactionApi.deleteTransaction).toHaveBeenCalledWith({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+        signature,
+      });
+      expect(mockQueueService.deleteTransaction).not.toHaveBeenCalled();
+      expect(mockTransactionApi.clearMultisigTransaction).toHaveBeenCalledWith(
+        tx.safeTxHash,
+      );
+      expect(mockTransactionApi.clearMultisigTransactions).toHaveBeenCalledWith(
+        tx.safe,
+      );
+      expect(mockQueueService.clearMultisigTransaction).not.toHaveBeenCalled();
+      expect(mockQueueService.clearAllTransactions).not.toHaveBeenCalled();
+    });
+
+    it('should invalidate the queue cache so executed/deleted transactions disappear from the queue', async () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+      await repository.clearMultisigTransactions({ chainId, safeAddress });
+
+      expect(mockTransactionApi.clearMultisigTransactions).toHaveBeenCalledWith(
+        safeAddress,
+      );
+      expect(mockQueueService.clearAllTransactions).toHaveBeenCalledWith({
+        chainId,
+        safeAddress,
+      });
+    });
+
+    it('should only clear the tx-service cache when FF_QUEUE_SERVICE is off (clearMultisigTransactions)', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+      await repo.clearMultisigTransactions({ chainId, safeAddress });
+
+      expect(mockTransactionApi.clearMultisigTransactions).toHaveBeenCalledWith(
+        safeAddress,
+      );
+      expect(mockQueueService.clearAllTransactions).not.toHaveBeenCalled();
+    });
+
+    it('should warn with chainId, safeTxHash and error when fire-and-forget cache clear fails', async () => {
+      const tx = multisigTransactionBuilder().with('safe', safeAddress).build();
+      const signature = faker.string.hexadecimal({ length: 16 });
+      mockTransactionApi.getMultisigTransaction.mockResolvedValue(
+        rawify(multisigTransactionToJson(tx)),
+      );
+      mockQueueService.deleteTransaction.mockResolvedValue(undefined);
+      mockQueueService.clearMultisigTransaction.mockRejectedValue(
+        new Error('cache down'),
+      );
+
+      await repository.deleteTransaction({
+        chainId,
+        safeTxHash: tx.safeTxHash,
+        signature,
+      });
+      // Yield one microtask tick so the fire-and-forget Promise.all .catch runs
+      await Promise.resolve();
+
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        `Failed to immediately clear deleted transaction from cache. chainId=${chainId}, safeTxHash=${tx.safeTxHash}, error=Error: cache down`,
+      );
+    });
+  });
+
+  describe('proposeTransaction', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('should propose via the queue service without explicitly clearing the queue cache (relies on TTL/upstream)', async () => {
+      const safe = safeBuilder().with('address', safeAddress).build();
+      const proposeTransactionDto = proposeTransactionDtoBuilder().build();
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+      mockTransactionApi.getMultisigTransactionWithNoCache.mockRejectedValue(
+        new Error('not found'),
+      );
+      mockQueueService.proposeTransaction.mockResolvedValue(rawify({}));
+
+      await repository.proposeTransaction({
+        chainId,
+        safeAddress,
+        proposeTransactionDto,
+      });
+
+      expect(mockQueueService.proposeTransaction).toHaveBeenCalledWith({
+        chainId,
+        safeAddress,
+        proposeTransactionDto,
+      });
+      expect(mockQueueService.clearAllTransactions).not.toHaveBeenCalled();
+      expect(mockQueueService.clearMultisigTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should not touch the queue cache when FF_QUEUE_SERVICE is off', async () => {
+      const repo = createRepository({ queueServiceEnabled: false });
+      const safe = safeBuilder().with('address', safeAddress).build();
+      const proposeTransactionDto = proposeTransactionDtoBuilder().build();
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+      mockTransactionApi.getMultisigTransactionWithNoCache.mockRejectedValue(
+        new Error('not found'),
+      );
+      mockTransactionApi.deleteTransaction.mockResolvedValue(undefined);
+
+      await repo.proposeTransaction({
+        chainId,
+        safeAddress,
+        proposeTransactionDto,
+      });
+
+      expect(mockQueueService.proposeTransaction).not.toHaveBeenCalled();
+      expect(mockQueueService.clearAllTransactions).not.toHaveBeenCalled();
+      expect(mockQueueService.clearMultisigTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addConfirmation', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    it('should post the confirmation to the queue service without explicitly clearing the queue cache (relies on TTL/upstream)', async () => {
+      const safe = safeBuilder().with('address', safeAddress).build();
+      const queueTx = queueMultisigTransactionBuilder()
+        .with('chainId', chainId)
+        .with('safe', safeAddress)
+        .with('txHash', null)
+        .build();
+      mockQueueService.getMultisigTransaction.mockResolvedValue(
+        rawify(queueTx),
+      );
+      mockTransactionApi.getSafe.mockResolvedValue(rawify(safe));
+      mockQueueService.postConfirmation.mockResolvedValue(rawify({}));
+
+      await repository.addConfirmation({
+        chainId,
+        safeTxHash: queueTx.safeTxHash,
+        addConfirmationDto: {
+          signature: getAddress(faker.finance.ethereumAddress()),
+        },
+      });
+
+      expect(mockQueueService.postConfirmation).toHaveBeenCalled();
+      expect(mockQueueService.clearMultisigTransaction).not.toHaveBeenCalled();
+      expect(mockQueueService.clearAllTransactions).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/safe/domain/safe.repository.ts
+++ b/src/modules/safe/domain/safe.repository.ts
@@ -5,28 +5,34 @@ import type { Address } from 'viem';
 import { z } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { SAFE_TRANSACTION_SERVICE_MAX_LIMIT } from '@/domain/common/constants';
-import type { Page } from '@/domain/entities/page.entity';
+import { Page } from '@/domain/entities/page.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
-import {
-  type ILoggingService,
-  LoggingService,
-} from '@/logging/logging.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
-import type { CreationTransaction } from '@/modules/safe/domain/entities/creation-transaction.entity';
 import {
-  type ModuleTransaction,
+  type QueueMultisigTransactionEntity,
+  QueueMultisigTransactionListSchema,
+  QueueMultisigTransactionPageSchema,
+  QueueMultisigTransactionSchema,
+} from '@/modules/queue/entities/multisig-transaction.entity';
+import { buildOrigin } from '@/modules/queue/helpers/origin.helper';
+import { mapQueueToMultisigTransaction } from '@/modules/queue/mappers/transaction.mapper';
+import { IQueueService } from '@/modules/queue/queue.interface';
+import { CreationTransaction } from '@/modules/safe/domain/entities/creation-transaction.entity';
+import {
+  ModuleTransaction,
   ModuleTransactionPageSchema,
   ModuleTransactionSchema,
 } from '@/modules/safe/domain/entities/module-transaction.entity';
 import {
-  type MultisigTransaction,
+  MultisigTransaction,
   MultisigTransactionPageSchema,
   MultisigTransactionSchema,
 } from '@/modules/safe/domain/entities/multisig-transaction.entity';
-import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
-import type { SafeList } from '@/modules/safe/domain/entities/safe-list.entity';
-import type { SafesByChainId } from '@/modules/safe/domain/entities/safes-by-chain-id.entity';
+import { Safe } from '@/modules/safe/domain/entities/safe.entity';
+import { SafeList } from '@/modules/safe/domain/entities/safe-list.entity';
+import { SafesByChainId } from '@/modules/safe/domain/entities/safes-by-chain-id.entity';
 import { CreationTransactionSchema } from '@/modules/safe/domain/entities/schemas/creation-transaction.schema';
 import {
   SafePageV2Schema,
@@ -34,21 +40,24 @@ import {
 } from '@/modules/safe/domain/entities/schemas/safe.schema';
 import { SafeListSchema } from '@/modules/safe/domain/entities/schemas/safe-list.schema';
 import { TransactionTypePageSchema } from '@/modules/safe/domain/entities/schemas/transaction-type.schema';
-import type { Transaction } from '@/modules/safe/domain/entities/transaction.entity';
 import {
-  type Transfer,
+  isMultisigTransaction,
+  Transaction,
+} from '@/modules/safe/domain/entities/transaction.entity';
+import {
+  Transfer,
   TransferPageSchema,
   TransferSchema,
 } from '@/modules/safe/domain/entities/transfer.entity';
-import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
-import type { AddConfirmationDto } from '@/modules/transactions/domain/entities/add-confirmation.dto.entity';
-import type { ProposeTransactionDto } from '@/modules/transactions/domain/entities/propose-transaction.dto.entity';
+import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+import { ProposeTransactionDto } from '@/modules/transactions/domain/entities/propose-transaction.dto.entity';
 import { TransactionVerifierHelper } from '@/modules/transactions/routes/helpers/transaction-verifier.helper';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
   private readonly maxSequentialPages: number;
+  private readonly queueServiceEnabled: boolean;
 
   constructor(
     @Inject(ITransactionApiManager)
@@ -59,9 +68,14 @@ export class SafeRepository implements ISafeRepository {
     private readonly transactionVerifier: TransactionVerifierHelper,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    @Inject(IQueueService)
+    private readonly queueService: IQueueService,
   ) {
     this.maxSequentialPages = this.configurationService.getOrThrow<number>(
       'safeConfig.safes.maxSequentialPages',
+    );
+    this.queueServiceEnabled = this.configurationService.getOrThrow<boolean>(
+      'features.queueService',
     );
   }
 
@@ -171,12 +185,8 @@ export class SafeRepository implements ISafeRepository {
   async addConfirmation(args: {
     chainId: string;
     safeTxHash: string;
-    addConfirmationDto: AddConfirmationDto;
+    addConfirmationDto: { signature: Address };
   }): Promise<void> {
-    const transactionService = await this.transactionApiManager.getApi(
-      args.chainId,
-    );
-
     const transaction = await this.getMultiSigTransaction({
       chainId: args.chainId,
       safeTransactionHash: args.safeTxHash,
@@ -194,7 +204,18 @@ export class SafeRepository implements ISafeRepository {
       signature: args.addConfirmationDto.signature,
     });
 
-    await transactionService.postConfirmation(args);
+    if (this.queueServiceEnabled) {
+      await this.queueService.postConfirmation({
+        chainId: args.chainId,
+        safeTxHash: args.safeTxHash,
+        signature: args.addConfirmationDto.signature,
+      });
+    } else {
+      const transactionService = await this.transactionApiManager.getApi(
+        args.chainId,
+      );
+      await transactionService.postConfirmation(args);
+    }
   }
 
   async getModuleTransaction(args: {
@@ -268,18 +289,42 @@ export class SafeRepository implements ISafeRepository {
     ordering: string;
     limit?: number;
     offset?: number;
-    trusted?: boolean;
   }): Promise<Page<MultisigTransaction>> {
-    const transactionService = await this.transactionApiManager.getApi(
-      args.chainId,
-    );
-    const page = await transactionService.getMultisigTransactions({
-      ...args,
+    if (!this.queueServiceEnabled) {
+      const transactionService = await this.transactionApiManager.getApi(
+        args.chainId,
+      );
+      const page = await transactionService.getMultisigTransactions({
+        ...args,
+        safeAddress: args.safe.address,
+        executed: false,
+        nonceGte: args.safe.nonce,
+      });
+      return MultisigTransactionPageSchema.parse(page);
+    }
+    // The queue service can only order the queue by nonce, so we translate the
+    // tx-service ordering into a nonce direction explicitly. A leading '-'
+    // denotes descending. NOTE: getTransactionQueueByModified asks for
+    // '-modified' ordering, which the queue cannot honour — it degrades to
+    // descending nonce. Callers relying on true modified-date ordering (e.g.
+    // the queued-transaction cache tag) get a best-effort nonce-desc result.
+    const nonceOrder = args.ordering.startsWith('-') ? 'desc' : 'asc';
+    const page = await this.queueService.getTransactionQueue({
+      chainId: args.chainId,
       safeAddress: args.safe.address,
-      executed: false,
-      nonceGte: args.safe.nonce,
+      nonceOrder,
+      limit: args.limit,
+      offset: args.offset,
     });
-    return MultisigTransactionPageSchema.parse(page);
+    const parsed = QueueMultisigTransactionPageSchema.parse(page);
+    return {
+      count: parsed.count,
+      next: parsed.next,
+      previous: parsed.previous,
+      results: parsed.results.map((tx) =>
+        mapQueueToMultisigTransaction(tx, args.safe),
+      ),
+    };
   }
 
   async getCreationTransaction(args: {
@@ -328,12 +373,99 @@ export class SafeRepository implements ISafeRepository {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-    const page = await transactionService.getAllTransactions({
+    const rawPage = await transactionService.getAllTransactions({
       ...args,
       executed: true,
       queued: false,
     });
-    return TransactionTypePageSchema.parse(page);
+    const page: Page<Transaction> = TransactionTypePageSchema.parse(rawPage);
+    await this.bindQueueOrigins(page.results, args.chainId);
+    return page;
+  }
+
+  private async fetchQueueMultisigByHash(
+    chainId: string,
+    safeTxHashes: Array<string>,
+  ): Promise<Map<string, QueueMultisigTransactionEntity>> {
+    const byHash = new Map<string, QueueMultisigTransactionEntity>();
+    if (safeTxHashes.length === 0) return byHash;
+    try {
+      const raw = await this.queueService.getMultisigTransactionsBatch({
+        chainId,
+        safeTxHashes,
+      });
+      const transactions = QueueMultisigTransactionListSchema.parse(raw);
+      for (const queue of transactions) byHash.set(queue.safeTxHash, queue);
+      const missing = safeTxHashes.filter((hash) => !byHash.has(hash));
+      if (missing.length > 0) {
+        this.loggingService.warn(
+          `Queue service omitted ${missing.length} hash(es) from batch response. chainId=${chainId}, missing=${missing.join(',')}`,
+        );
+      }
+    } catch (error) {
+      this.loggingService.warn(
+        `Failed to fetch origins from queue service. chainId=${chainId}, hashes=${safeTxHashes.length}, error=${error}`,
+      );
+    }
+    return byHash;
+  }
+
+  private isQueueOriginAuthoritative(
+    queue: { chainId: string; safe: Address; safeTxHash: string },
+    expected: { chainId: string; safe: Address },
+  ): boolean {
+    if (queue.chainId !== expected.chainId || queue.safe !== expected.safe) {
+      this.loggingService.warn(
+        `Queue origin reconciliation rejected. safeTxHash=${queue.safeTxHash}, expectedChainId=${expected.chainId}, queueChainId=${queue.chainId}, expectedSafe=${expected.safe}, queueSafe=${queue.safe}`,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Overlays the queue's origin metadata onto a tx-service transaction.
+   *
+   * Only overlays when the queue carries an actual origin identity (a name or
+   * url). Two cases must NOT touch the existing tx-service origin:
+   * - a not-yet-backfilled queue entry (all of name/url/notes null) would
+   *   otherwise wipe the origin to null;
+   * - a notes-only entry (name and url both null) would otherwise blank out
+   *   the tx-service name/url, keeping only the note.
+   * When name/url are present the queue is authoritative, so its note is
+   * layered on via buildOrigin.
+   */
+  private overlayQueueOrigin(
+    tx: MultisigTransaction,
+    queue: {
+      originName: string | null;
+      originUrl: string | null;
+      notes: string | null;
+    },
+  ): void {
+    if (!(queue.originName || queue.originUrl)) return;
+    tx.origin = buildOrigin(queue.originName, queue.originUrl, queue.notes);
+  }
+
+  private async bindQueueOrigins(
+    txs: ReadonlyArray<Transaction>,
+    chainId: string,
+  ): Promise<void> {
+    if (!this.queueServiceEnabled) return;
+    const multisigs = txs.filter(isMultisigTransaction);
+    if (multisigs.length === 0) return;
+    const byHash = await this.fetchQueueMultisigByHash(
+      chainId,
+      multisigs.map((tx) => tx.safeTxHash),
+    );
+    for (const tx of multisigs) {
+      const queue = byHash.get(tx.safeTxHash);
+      if (queue === undefined) continue;
+      if (!this.isQueueOriginAuthoritative(queue, { chainId, safe: tx.safe })) {
+        continue;
+      }
+      this.overlayQueueOrigin(tx, queue);
+    }
   }
 
   async clearAllExecutedTransactions(args: {
@@ -343,8 +475,30 @@ export class SafeRepository implements ISafeRepository {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-
-    return transactionService.clearAllTransactions(args.safeAddress);
+    // The tx-service and queue caches are independent layers, so a failure in
+    // one must not skip invalidating the other. Run both, then surface a
+    // generic failure if either rejected so the webhook retries the whole
+    // invalidation.
+    const results = await Promise.allSettled([
+      transactionService.clearAllTransactions(args.safeAddress),
+      ...(this.queueServiceEnabled
+        ? [
+            this.queueService.clearAllTransactions({
+              chainId: args.chainId,
+              safeAddress: args.safeAddress,
+            }),
+          ]
+        : []),
+    ]);
+    const errors = results
+      .filter((r) => r.status === 'rejected')
+      .map((r) => r.reason);
+    if (errors.length > 0) {
+      this.loggingService.debug(
+        `Failed to clear all executed transactions from one or more caches. errors=${errors}`,
+      );
+      throw new Error('Failed to clear all executed transactions');
+    }
   }
 
   async clearMultisigTransaction(args: {
@@ -354,48 +508,119 @@ export class SafeRepository implements ISafeRepository {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-    return transactionService.clearMultisigTransaction(
-      args.safeTransactionHash,
-    );
+    // The tx-service and queue caches are independent layers, so a failure in
+    // one must not skip invalidating the other. Run both, then surface a
+    // generic failure if either rejected so the webhook retries the whole
+    // invalidation.
+    const results = await Promise.allSettled([
+      transactionService.clearMultisigTransaction(args.safeTransactionHash),
+      ...(this.queueServiceEnabled
+        ? [
+            this.queueService.clearMultisigTransaction({
+              chainId: args.chainId,
+              safeTxHash: args.safeTransactionHash,
+            }),
+          ]
+        : []),
+    ]);
+    const errors = results
+      .filter((r) => r.status === 'rejected')
+      .map((r) => r.reason);
+    if (errors.length > 0) {
+      this.loggingService.debug(
+        `Failed to clear multisig transaction from one or more caches. errors=${errors}`,
+      );
+      throw new Error('Failed to clear multisig transaction');
+    }
   }
 
   async getMultiSigTransaction(args: {
     chainId: string;
     safeTransactionHash: string;
   }): Promise<MultisigTransaction> {
+    return await this.resolveMultisigTransaction(args, { noCache: false });
+  }
+
+  private async fetchTxServiceMultisig(
+    args: { chainId: string; safeTransactionHash: string },
+    opts: { noCache: boolean },
+  ): Promise<MultisigTransaction> {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-    const multiSigTransaction = await transactionService.getMultisigTransaction(
-      args.safeTransactionHash,
-    );
+    const raw = opts.noCache
+      ? await transactionService.getMultisigTransactionWithNoCache(
+          args.safeTransactionHash,
+        )
+      : await transactionService.getMultisigTransaction(
+          args.safeTransactionHash,
+        );
+    return MultisigTransactionSchema.parse(raw);
+  }
 
-    return MultisigTransactionSchema.parse(multiSigTransaction);
+  private async resolveMultisigTransaction(
+    args: { chainId: string; safeTransactionHash: string },
+    opts: { noCache: boolean },
+  ): Promise<MultisigTransaction> {
+    if (!this.queueServiceEnabled) {
+      return this.fetchTxServiceMultisig(args, opts);
+    }
+
+    let queue: QueueMultisigTransactionEntity;
+    try {
+      const raw = await this.queueService.getMultisigTransaction({
+        chainId: args.chainId,
+        safeTxHash: args.safeTransactionHash,
+      });
+      queue = QueueMultisigTransactionSchema.parse(raw);
+    } catch (error) {
+      this.loggingService.warn(
+        `Failed to fetch transaction from queue service. chainId=${args.chainId}, safeTxHash=${args.safeTransactionHash}, error=${error}`,
+      );
+      return this.fetchTxServiceMultisig(args, opts);
+    }
+
+    if (queue.txHash !== null) {
+      // Executed: the tx service is the source of truth. Overlay the origin
+      // from the queue entity we already fetched (no second queue call).
+      const tx = await this.fetchTxServiceMultisig(args, opts);
+      if (
+        this.isQueueOriginAuthoritative(queue, {
+          chainId: args.chainId,
+          safe: tx.safe,
+        })
+      ) {
+        this.overlayQueueOrigin(tx, queue);
+      }
+      return tx;
+    }
+
+    // Not executed: the queue service is the source of truth.
+    const safe = await this.getSafe({
+      chainId: args.chainId,
+      address: queue.safe,
+    });
+    return mapQueueToMultisigTransaction(queue, safe);
   }
 
   async getMultiSigTransactionWithNoCache(args: {
     chainId: string;
     safeTransactionHash: string;
   }): Promise<MultisigTransaction> {
-    const transactionService = await this.transactionApiManager.getApi(
-      args.chainId,
-    );
-    const multisigTransaction = await transactionService
-      .getMultisigTransactionWithNoCache(args.safeTransactionHash)
-      .then(MultisigTransactionSchema.parse);
+    const tx = await this.resolveMultisigTransaction(args, { noCache: true });
 
     const safe = await this.getSafe({
       chainId: args.chainId,
-      address: multisigTransaction.safe,
+      address: tx.safe,
     });
 
     this.transactionVerifier.verifyApiTransaction({
       chainId: args.chainId,
-      transaction: multisigTransaction,
+      transaction: tx,
       safe: safe,
     });
 
-    return multisigTransaction;
+    return tx;
   }
 
   async deleteTransaction(args: {
@@ -410,15 +635,33 @@ export class SafeRepository implements ISafeRepository {
       args.safeTxHash,
     );
     const { safe } = MultisigTransactionSchema.parse(transaction);
-    await transactionService.deleteTransaction(args);
+
+    if (this.queueServiceEnabled) {
+      await this.queueService.deleteTransaction(args);
+    } else {
+      await transactionService.deleteTransaction(args);
+    }
 
     // Ensure transaction is removed from cache in case event is not received
-    Promise.all([
+    const cacheClears: Array<Promise<void>> = [
       transactionService.clearMultisigTransaction(args.safeTxHash),
       transactionService.clearMultisigTransactions(safe),
-    ]).catch(() => {
+    ];
+    if (this.queueServiceEnabled) {
+      cacheClears.push(
+        this.queueService.clearMultisigTransaction({
+          chainId: args.chainId,
+          safeTxHash: args.safeTxHash,
+        }),
+        this.queueService.clearAllTransactions({
+          chainId: args.chainId,
+          safeAddress: safe,
+        }),
+      );
+    }
+    Promise.all(cacheClears).catch((error) => {
       this.loggingService.warn(
-        'Failed to immediately clear deleted transaction from cache',
+        `Failed to immediately clear deleted transaction from cache. chainId=${args.chainId}, safeTxHash=${args.safeTxHash}, error=${error}`,
       );
     });
   }
@@ -430,7 +673,30 @@ export class SafeRepository implements ISafeRepository {
     const transactionService = await this.transactionApiManager.getApi(
       args.chainId,
     );
-    return transactionService.clearMultisigTransactions(args.safeAddress);
+    // The tx-service and queue caches are independent layers, so a failure in
+    // one must not skip invalidating the other. Run both, then surface a
+    // generic failure if either rejected so the webhook retries the whole
+    // invalidation.
+    const results = await Promise.allSettled([
+      transactionService.clearMultisigTransactions(args.safeAddress),
+      ...(this.queueServiceEnabled
+        ? [
+            this.queueService.clearAllTransactions({
+              chainId: args.chainId,
+              safeAddress: args.safeAddress,
+            }),
+          ]
+        : []),
+    ]);
+    const errors = results
+      .filter((r) => r.status === 'rejected')
+      .map((r) => r.reason);
+    if (errors.length > 0) {
+      this.loggingService.debug(
+        `Failed to clear multisig transactions from one or more caches. errors=${errors}`,
+      );
+      throw new Error('Failed to clear multisig transactions');
+    }
   }
 
   async getMultisigTransactionsWithNoCache(args: {
@@ -482,6 +748,7 @@ export class SafeRepository implements ISafeRepository {
       });
     }
 
+    await this.bindQueueOrigins(multisigTransactions.results, args.chainId);
     return multisigTransactions;
   }
 
@@ -506,7 +773,9 @@ export class SafeRepository implements ISafeRepository {
       ordering: '-nonce',
       trusted: true,
     });
-    return MultisigTransactionPageSchema.parse(page);
+    const parsed = MultisigTransactionPageSchema.parse(page);
+    await this.bindQueueOrigins(parsed.results, args.chainId);
+    return parsed;
   }
 
   async getTransfer(args: {
@@ -694,6 +963,13 @@ export class SafeRepository implements ISafeRepository {
       transaction,
     });
 
+    if (this.queueServiceEnabled) {
+      return await this.queueService.proposeTransaction({
+        chainId: args.chainId,
+        safeAddress: args.safeAddress,
+        proposeTransactionDto: args.proposeTransactionDto,
+      });
+    }
     return transactionService.postMultisigTransaction({
       address: args.safeAddress,
       data: args.proposeTransactionDto,

--- a/src/modules/safe/safe.module.ts
+++ b/src/modules/safe/safe.module.ts
@@ -7,6 +7,7 @@ import { FeatureFlagsModule } from '@/modules/chains/feature-flags/feature-flags
 import { ContractsModule } from '@/modules/contracts/contracts.module';
 import { DelegatesV2RepositoryModule } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
 import { MessagesModule } from '@/modules/messages/messages.module';
+import { QueueServiceModule } from '@/modules/queue/queue.module';
 import { SafeRepository } from '@/modules/safe/domain/safe.repository';
 import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 import { SafesController } from '@/modules/safe/routes/safes.controller';
@@ -26,6 +27,7 @@ import { AddressInfoModule } from '@/routes/common/address-info/address-info.mod
     DelegatesV2RepositoryModule,
     ContractsModule,
     FeatureFlagsModule,
+    QueueServiceModule,
   ],
   controllers: [SafesController, SafesV2Controller],
   providers: [

--- a/src/modules/transactions/routes/__tests__/controllers/add-transaction-confirmations.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/add-transaction-confirmations.transactions.controller.integration.spec.ts
@@ -32,6 +32,8 @@ import {
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
 import { contractBuilder } from '@/modules/data-decoder/domain/v2/entities/__tests__/contract.builder';
 import { dataDecodedBuilder } from '@/modules/data-decoder/domain/v2/entities/__tests__/data-decoded.builder';
+import { TestQueueServiceModule } from '@/modules/queue/__tests__/test.queue.module';
+import { QueueServiceModule } from '@/modules/queue/queue.module';
 import {
   toJson as multisigToJson,
   multisigTransactionBuilder,
@@ -77,6 +79,8 @@ describe('Add transaction confirmations - Transactions Controller', () => {
     })
       .overrideModule(TxAuthNetworkModule)
       .useModule(TestTxAuthNetworkModule)
+      .overrideModule(QueueServiceModule)
+      .useModule(TestQueueServiceModule)
       .compile();
 
     const configurationService = moduleFixture.get<IConfigurationService>(

--- a/src/modules/transactions/routes/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
+++ b/src/modules/transactions/routes/entities/schemas/__tests__/propose-transaction.dto.schema.spec.ts
@@ -191,4 +191,36 @@ describe('ProposeTransactionDtoSchema', () => {
       }),
     ]);
   });
+
+  describe('origin', () => {
+    it('should accept an origin within the size bound', () => {
+      const proposeTransactionDto = proposeTransactionDtoBuilder()
+        .with('origin', 'a'.repeat(2048))
+        .build();
+
+      const result = ProposeTransactionDtoSchema.safeParse(
+        proposeTransactionDto,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject an origin exceeding 2048 chars', () => {
+      const proposeTransactionDto = proposeTransactionDtoBuilder()
+        .with('origin', 'a'.repeat(2049))
+        .build();
+
+      const result = ProposeTransactionDtoSchema.safeParse(
+        proposeTransactionDto,
+      );
+
+      expect(!result.success && result.error.issues).toEqual([
+        expect.objectContaining({
+          code: 'too_big',
+          maximum: 2048,
+          path: ['origin'],
+        }),
+      ]);
+    });
+  });
 });

--- a/src/modules/transactions/routes/entities/schemas/propose-transaction.dto.schema.ts
+++ b/src/modules/transactions/routes/entities/schemas/propose-transaction.dto.schema.ts
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
 import { TransactionBaseSchema } from '@/domain/common/schemas/transaction-base.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 import {
   NullableAddressSchema,
   NullableHexSchema,
-  NullableStringSchema,
 } from '@/validation/entities/schemas/nullable.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { SignatureSchema } from '@/validation/entities/schemas/signature.schema';
+
+export const MAX_ORIGIN_DTO_LENGTH = 2048;
 
 export const ProposeTransactionDtoSchema = TransactionBaseSchema.extend({
   data: NullableHexSchema,
@@ -21,5 +23,5 @@ export const ProposeTransactionDtoSchema = TransactionBaseSchema.extend({
   safeTxHash: HexSchema,
   sender: AddressSchema,
   signature: SignatureSchema.nullish().default(null),
-  origin: NullableStringSchema,
+  origin: z.string().max(MAX_ORIGIN_DTO_LENGTH).nullish().default(null),
 });


### PR DESCRIPTION
 ## Summary
  Route multisig transactions through the Queue Service when `FF_QUEUE_SERVICE` is enabled (default off → behavior unchanged). Part 4/6 of the `feat/migrateToQueueService` split.

  ## Changes
  - `SafeRepository`: when the flag is on, serve multisig transaction reads/writes and queue listings from the Queue Service (queue-first), with origin overlay and cache invalidation; otherwise fall back to the Transaction Service.
  - Import `QueueServiceModule` into `SafeModule`.
  - Cap `propose-transaction` origin length (`MAX_ORIGIN_DTO_LENGTH = 2048`).