### PR TITLE
feat(delegate): add delegates v3 module with Queue Service routing

### DIFF
--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -77,6 +77,14 @@ export interface ITransactionApi {
     label: string;
   }): Promise<void>;
 
+  updateDelegateV2(args: {
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void>;
+
   deleteDelegate(args: {
     delegate: Address;
     delegator: Address;

--- a/src/modules/delegate/delegate.module.ts
+++ b/src/modules/delegate/delegate.module.ts
@@ -1,15 +1,20 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
 import { DelegateRepositoryModule } from '@/modules/delegate/domain/delegate.repository.interface';
 import { DelegatesV2RepositoryModule } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
+import { DelegatesV3RepositoryModule } from '@/modules/delegate/domain/v3/delegates.v3.repository.interface';
 import { DelegatesModule as DelegatesRoutesModule } from '@/modules/delegate/routes/delegates.module';
 import { DelegatesV2Module as DelegatesV2RoutesModule } from '@/modules/delegate/routes/v2/delegates.v2.module';
+import { DelegatesV3Module as DelegatesV3RoutesModule } from '@/modules/delegate/routes/v3/delegates.v3.module';
 
 @Module({
   imports: [
     DelegateRepositoryModule,
     DelegatesV2RepositoryModule,
+    DelegatesV3RepositoryModule,
     DelegatesRoutesModule,
     DelegatesV2RoutesModule,
+    DelegatesV3RoutesModule,
   ],
 })
 export class DelegateModule {}

--- a/src/modules/delegate/domain/v3/delegates.v3.repository.interface.ts
+++ b/src/modules/delegate/domain/v3/delegates.v3.repository.interface.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { Module } from '@nestjs/common';
+import type { Address } from 'viem';
+import { Page } from '@/domain/entities/page.entity';
+import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
+import { Delegate } from '@/modules/delegate/domain/entities/delegate.entity';
+import { DelegatesV3Repository } from '@/modules/delegate/domain/v3/delegates.v3.repository';
+import { QueueServiceModule } from '@/modules/queue/queue.module';
+
+export const IDelegatesV3Repository = Symbol('IDelegatesV3Repository');
+
+export interface IDelegatesV3Repository {
+  getDelegates(args: {
+    chainId: string;
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Delegate>>;
+
+  clearDelegates(args: {
+    chainId: string;
+    safeAddress?: string;
+  }): Promise<void>;
+
+  postDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void>;
+
+  updateDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void>;
+
+  deleteDelegate(args: {
+    chainId: string;
+    delegate: Address;
+    delegator: Address;
+    safeAddress: Address | null;
+    signature: string;
+  }): Promise<unknown>;
+}
+
+@Module({
+  imports: [TransactionApiManagerModule, QueueServiceModule],
+  providers: [
+    {
+      provide: IDelegatesV3Repository,
+      useClass: DelegatesV3Repository,
+    },
+  ],
+  exports: [IDelegatesV3Repository],
+})
+export class DelegatesV3RepositoryModule {}

--- a/src/modules/delegate/domain/v3/delegates.v3.repository.spec.ts
+++ b/src/modules/delegate/domain/v3/delegates.v3.repository.spec.ts
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import type { Address } from 'viem';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import type { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
+import type { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { delegateBuilder } from '@/modules/delegate/domain/entities/__tests__/delegate.builder';
+import { DelegatePageSchema } from '@/modules/delegate/domain/entities/schemas/delegate.schema';
+import { DelegatesV3Repository } from '@/modules/delegate/domain/v3/delegates.v3.repository';
+import type { QueueDelegate } from '@/modules/queue/entities/delegate.entity';
+import type { IQueueService } from '@/modules/queue/queue.interface';
+import { rawify } from '@/validation/entities/raw.entity';
+
+const mockTransactionApiManager = {
+  getApi: vi.fn(),
+} as MockedObject<ITransactionApiManager>;
+
+const mockTransactionApi = {
+  getDelegatesV2: vi.fn(),
+  postDelegateV2: vi.fn(),
+  updateDelegateV2: vi.fn(),
+  deleteDelegateV2: vi.fn(),
+  clearDelegates: vi.fn(),
+} as MockedObject<ITransactionApi>;
+
+const mockQueueService = {
+  getDelegates: vi.fn(),
+  postDelegate: vi.fn(),
+  updateDelegate: vi.fn(),
+  deleteDelegate: vi.fn(),
+  clearDelegates: vi.fn(),
+} as MockedObject<IQueueService>;
+
+const mockConfigurationService = {
+  getOrThrow: vi.fn(),
+} as MockedObject<IConfigurationService>;
+
+const mockLoggingService = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+describe('DelegatesV3Repository', () => {
+  let repository: DelegatesV3Repository;
+
+  function createRepository(opts: {
+    queueServiceEnabled: boolean;
+  }): DelegatesV3Repository {
+    mockConfigurationService.getOrThrow.mockImplementation((key: string) => {
+      if (key === 'features.queueService') {
+        return opts.queueServiceEnabled;
+      }
+      throw new Error(`Unexpected key: ${key}`);
+    });
+    return new DelegatesV3Repository(
+      mockTransactionApiManager,
+      mockQueueService,
+      mockConfigurationService,
+      mockLoggingService,
+    );
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockTransactionApiManager.getApi.mockResolvedValue(mockTransactionApi);
+  });
+
+  describe('queueService disabled (flag OFF)', () => {
+    beforeEach(() => {
+      repository = createRepository({ queueServiceEnabled: false });
+    });
+
+    describe('getDelegates', () => {
+      it('uses the transaction service and returns parsed delegates', async () => {
+        const chainId = faker.string.numeric();
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const delegates = [
+          delegateBuilder().build(),
+          delegateBuilder().build(),
+        ];
+        const page = pageBuilder()
+          .with('results', delegates)
+          .with('count', delegates.length)
+          .build();
+        mockTransactionApi.getDelegatesV2.mockResolvedValue(rawify(page));
+
+        const result = await repository.getDelegates({ chainId, safeAddress });
+
+        expect(mockTransactionApiManager.getApi).toHaveBeenCalledWith(chainId);
+        expect(mockTransactionApi.getDelegatesV2).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.getDelegates).not.toHaveBeenCalled();
+        expect(result).toStrictEqual(DelegatePageSchema.parse(page));
+      });
+    });
+
+    describe('postDelegate', () => {
+      it('uses the transaction service and not the queue service', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+          label: faker.word.sample(),
+        };
+
+        await repository.postDelegate(args);
+
+        expect(mockTransactionApi.postDelegateV2).toHaveBeenCalledTimes(1);
+        expect(mockTransactionApi.postDelegateV2).toHaveBeenCalledWith({
+          safeAddress: args.safeAddress,
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+          label: args.label,
+        });
+        expect(mockQueueService.postDelegate).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('updateDelegate', () => {
+      it('uses the transaction service and not the queue service', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+          label: faker.word.sample(),
+        };
+
+        await repository.updateDelegate(args);
+
+        expect(mockTransactionApi.updateDelegateV2).toHaveBeenCalledTimes(1);
+        expect(mockTransactionApi.updateDelegateV2).toHaveBeenCalledWith({
+          safeAddress: args.safeAddress,
+          delegate: args.delegate,
+          delegator: args.delegator,
+          signature: args.signature,
+          label: args.label,
+        });
+        expect(mockQueueService.updateDelegate).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('deleteDelegate', () => {
+      it('uses the transaction service and not the queue service', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+        };
+
+        await repository.deleteDelegate(args);
+
+        expect(mockTransactionApi.deleteDelegateV2).toHaveBeenCalledTimes(1);
+        expect(mockTransactionApi.deleteDelegateV2).toHaveBeenCalledWith({
+          delegate: args.delegate,
+          delegator: args.delegator,
+          safeAddress: args.safeAddress,
+          signature: args.signature,
+        });
+        expect(mockQueueService.deleteDelegate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('queueService enabled (flag ON)', () => {
+    beforeEach(() => {
+      repository = createRepository({ queueServiceEnabled: true });
+    });
+
+    describe('getDelegates', () => {
+      it('uses the queue service and maps results to the domain shape', async () => {
+        const chainId = faker.string.numeric();
+        const safe = getAddress(faker.finance.ethereumAddress());
+        const delegate = getAddress(faker.finance.ethereumAddress());
+        const delegator = getAddress(faker.finance.ethereumAddress());
+        const queueDelegate = {
+          delegate,
+          delegator,
+          chainId,
+          safe,
+          label: null,
+          created: faker.date.recent().toISOString(),
+          modified: faker.date.recent().toISOString(),
+        };
+        const page = pageBuilder<QueueDelegate>()
+          .with('results', [queueDelegate as unknown as QueueDelegate])
+          .with('count', 1)
+          .build();
+        mockQueueService.getDelegates.mockResolvedValue(rawify(page) as never);
+
+        const result = await repository.getDelegates({
+          chainId,
+          safeAddress: safe,
+        });
+
+        expect(mockQueueService.getDelegates).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.getDelegates).toHaveBeenCalledWith({
+          chainId,
+          safeAddress: safe,
+        });
+        expect(mockTransactionApiManager.getApi).not.toHaveBeenCalled();
+        expect(result.results).toStrictEqual([
+          {
+            safe,
+            delegate,
+            delegator,
+            // null label from the queue is normalized to an empty string
+            label: '',
+          },
+        ]);
+      });
+
+      it('passes a null safe through unchanged', async () => {
+        const chainId = faker.string.numeric();
+        const delegate = getAddress(faker.finance.ethereumAddress());
+        const delegator = getAddress(faker.finance.ethereumAddress());
+        const queueDelegate = {
+          delegate,
+          delegator,
+          chainId,
+          safe: null,
+          label: faker.word.sample(),
+          created: faker.date.recent().toISOString(),
+          modified: faker.date.recent().toISOString(),
+        };
+        const page = pageBuilder<QueueDelegate>()
+          .with('results', [queueDelegate as unknown as QueueDelegate])
+          .with('count', 1)
+          .build();
+        mockQueueService.getDelegates.mockResolvedValue(rawify(page) as never);
+
+        const result = await repository.getDelegates({ chainId });
+
+        expect(result.results[0].safe).toBeNull();
+        expect(result.results[0].label).toBe(queueDelegate.label);
+      });
+    });
+
+    describe('postDelegate', () => {
+      it('uses the queue service, not the tx-service, and invalidates cache', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+          label: faker.word.sample(),
+        };
+
+        await repository.postDelegate(args);
+
+        expect(mockQueueService.postDelegate).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.postDelegate).toHaveBeenCalledWith(args);
+        expect(mockTransactionApi.postDelegateV2).not.toHaveBeenCalled();
+
+        // fire-and-forget cache invalidation
+        await new Promise(setImmediate);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledWith({
+          chainId: args.chainId,
+          safeAddress: args.safeAddress,
+        });
+      });
+    });
+
+    describe('updateDelegate', () => {
+      it('uses the queue service, not the tx-service, and invalidates cache', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+          label: faker.word.sample(),
+        };
+
+        await repository.updateDelegate(args);
+
+        expect(mockQueueService.updateDelegate).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.updateDelegate).toHaveBeenCalledWith(args);
+        expect(mockTransactionApi.updateDelegateV2).not.toHaveBeenCalled();
+
+        await new Promise(setImmediate);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledWith({
+          chainId: args.chainId,
+          safeAddress: args.safeAddress,
+        });
+      });
+    });
+
+    describe('deleteDelegate', () => {
+      it('uses the queue service, not the tx-service, and invalidates cache', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: getAddress(faker.finance.ethereumAddress()),
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+        };
+
+        await repository.deleteDelegate(args);
+
+        expect(mockQueueService.deleteDelegate).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.deleteDelegate).toHaveBeenCalledWith(args);
+        expect(mockTransactionApi.deleteDelegateV2).not.toHaveBeenCalled();
+
+        await new Promise(setImmediate);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledTimes(1);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledWith({
+          chainId: args.chainId,
+          safeAddress: args.safeAddress,
+        });
+      });
+
+      it('handles a null safeAddress when invalidating cache', async () => {
+        const args = {
+          chainId: faker.string.numeric(),
+          safeAddress: null as Address | null,
+          delegate: getAddress(faker.finance.ethereumAddress()),
+          delegator: getAddress(faker.finance.ethereumAddress()),
+          signature: faker.string.hexadecimal(),
+        };
+
+        await repository.deleteDelegate(args);
+
+        await new Promise(setImmediate);
+        expect(mockQueueService.clearDelegates).toHaveBeenCalledWith({
+          chainId: args.chainId,
+          safeAddress: undefined,
+        });
+      });
+    });
+  });
+});

--- a/src/modules/delegate/domain/v3/delegates.v3.repository.ts
+++ b/src/modules/delegate/domain/v3/delegates.v3.repository.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { Inject, Injectable } from '@nestjs/common';
+import type { Address } from 'viem';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { Page } from '@/domain/entities/page.entity';
+import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { Delegate } from '@/modules/delegate/domain/entities/delegate.entity';
+import { DelegatePageSchema } from '@/modules/delegate/domain/entities/schemas/delegate.schema';
+import { IDelegatesV3Repository } from '@/modules/delegate/domain/v3/delegates.v3.repository.interface';
+import { QueueDelegatePageSchema } from '@/modules/queue/entities/delegate.entity';
+import { IQueueService } from '@/modules/queue/queue.interface';
+
+@Injectable()
+export class DelegatesV3Repository implements IDelegatesV3Repository {
+  private readonly queueServiceEnabled: boolean;
+
+  constructor(
+    @Inject(ITransactionApiManager)
+    private readonly transactionApiManager: ITransactionApiManager,
+    @Inject(IQueueService)
+    private readonly queueService: IQueueService,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
+  ) {
+    this.queueServiceEnabled = this.configurationService.getOrThrow<boolean>(
+      'features.queueService',
+    );
+  }
+
+  async getDelegates(args: {
+    chainId: string;
+    safeAddress?: Address;
+    delegate?: Address;
+    delegator?: Address;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Delegate>> {
+    if (this.queueServiceEnabled) {
+      const page = await this.queueService.getDelegates(args);
+      const parsed = QueueDelegatePageSchema.parse(page);
+      return {
+        ...parsed,
+        results: parsed.results.map((d) => ({
+          safe: d.safe,
+          delegate: d.delegate,
+          delegator: d.delegator,
+          // The queue allows a null label; the domain Delegate (and the
+          // tx-service v2 path) require a string. Coerce to '' so both backends
+          // represent "no label" identically for downstream consumers.
+          label: d.label ?? '',
+        })),
+      };
+    }
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
+    );
+    const page = await transactionService.getDelegatesV2({
+      safeAddress: args.safeAddress,
+      delegate: args.delegate,
+      delegator: args.delegator,
+      label: args.label,
+      limit: args.limit,
+      offset: args.offset,
+    });
+    return DelegatePageSchema.parse(page);
+  }
+
+  async clearDelegates(args: {
+    chainId: string;
+    safeAddress?: Address;
+  }): Promise<void> {
+    if (this.queueServiceEnabled) {
+      await this.queueService.clearDelegates(args);
+      return;
+    }
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
+    );
+    await transactionService.clearDelegates(args.safeAddress);
+  }
+
+  async postDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void> {
+    if (this.queueServiceEnabled) {
+      await this.queueService.postDelegate(args);
+      this._invalidateDelegatesCache(args.chainId, args.safeAddress);
+      return;
+    }
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
+    );
+    await transactionService.postDelegateV2({
+      safeAddress: args.safeAddress,
+      delegate: args.delegate,
+      delegator: args.delegator,
+      signature: args.signature,
+      label: args.label,
+    });
+    this._invalidateDelegatesCache(args.chainId, args.safeAddress);
+  }
+
+  async updateDelegate(args: {
+    chainId: string;
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void> {
+    if (this.queueServiceEnabled) {
+      await this.queueService.updateDelegate(args);
+      this._invalidateDelegatesCache(args.chainId, args.safeAddress);
+      return;
+    }
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
+    );
+    await transactionService.updateDelegateV2({
+      safeAddress: args.safeAddress,
+      delegate: args.delegate,
+      delegator: args.delegator,
+      signature: args.signature,
+      label: args.label,
+    });
+    this._invalidateDelegatesCache(args.chainId, args.safeAddress);
+  }
+
+  async deleteDelegate(args: {
+    chainId: string;
+    delegate: Address;
+    delegator: Address;
+    safeAddress: Address | null;
+    signature: string;
+  }): Promise<unknown> {
+    if (this.queueServiceEnabled) {
+      const result = await this.queueService.deleteDelegate(args);
+      this._invalidateDelegatesCache(args.chainId, args.safeAddress);
+      return result;
+    }
+    const transactionService = await this.transactionApiManager.getApi(
+      args.chainId,
+    );
+    const result = await transactionService.deleteDelegateV2({
+      delegate: args.delegate,
+      delegator: args.delegator,
+      safeAddress: args.safeAddress,
+      signature: args.signature,
+    });
+    this._invalidateDelegatesCache(args.chainId, args.safeAddress);
+    return result;
+  }
+
+  private _invalidateDelegatesCache(
+    chainId: string,
+    safeAddress: Address | null,
+  ): void {
+    this.clearDelegates({
+      chainId,
+      safeAddress: safeAddress ?? undefined,
+    }).catch((error) => {
+      this.loggingService.warn(
+        `Failed to clear delegates cache. chainId=${chainId}, safeAddress=${safeAddress}, error=${error}`,
+      );
+    });
+  }
+}

--- a/src/modules/delegate/routes/entities/delegate.entity.ts
+++ b/src/modules/delegate/routes/entities/delegate.entity.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class Delegate {

--- a/src/modules/delegate/routes/v3/delegates.v3.controller.integration.spec.ts
+++ b/src/modules/delegate/routes/v3/delegates.v3.controller.integration.spec.ts
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import omit from 'lodash/omit';
+import request from 'supertest';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { delegateBuilder } from '@/modules/delegate/domain/entities/__tests__/delegate.builder';
+import { createDelegateDtoBuilder } from '@/modules/delegate/routes/entities/__tests__/create-delegate.dto.builder';
+import { deleteDelegateV3DtoBuilder } from '@/modules/delegate/routes/v3/entities/__tests__/delete-delegate.v3.dto.builder';
+import { updateDelegateV3DtoBuilder } from '@/modules/delegate/routes/v3/entities/__tests__/update-delegate.v3.dto.builder';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('Delegates controller (v3)', () => {
+  let app: INestApplication<Server>;
+  let safeConfigUrl: string;
+  let networkService: MockedObject<INetworkService>;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const baseConfig = configuration();
+
+    const testConfiguration: typeof configuration = () => ({
+      ...baseConfig,
+      features: {
+        ...baseConfig.features,
+      },
+    });
+
+    const moduleFixture = await createTestModule({
+      config: testConfiguration,
+    });
+
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET delegates for a Safe (v3)', () => {
+    it('success', async () => {
+      const safe = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const delegatesPage = pageBuilder()
+        .with('count', 2)
+        .with('next', null)
+        .with('previous', null)
+        .with('results', [
+          delegateBuilder().with('safe', safe).build(),
+          delegateBuilder().with('safe', safe).build(),
+        ])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        }
+        if (url === `${chain.transactionService}/api/v2/delegates/`) {
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v3/chains/${chain.chainId}/delegates?safe=${safe}`)
+        .expect(200)
+        .expect(delegatesPage);
+    });
+
+    it('should return a validation error', async () => {
+      const safe = getAddress(faker.finance.ethereumAddress());
+      const chain = chainBuilder().build();
+      const delegatesPage = pageBuilder()
+        .with('count', 2)
+        .with('next', null)
+        .with('previous', null)
+        .with('results', [
+          delegateBuilder().with('safe', safe).build(),
+          { ...delegateBuilder().with('safe', safe).build(), label: true },
+        ])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        }
+        if (url === `${chain.transactionService}/api/v2/delegates/`) {
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v3/chains/${chain.chainId}/delegates?safe=${safe}`)
+        .expect(502)
+        .expect({ statusCode: 502, message: 'Bad gateway' });
+    });
+
+    it('should return empty result', async () => {
+      const safe = faker.finance.ethereumAddress();
+      const chain = chainBuilder().build();
+      const delegatesPage = pageBuilder()
+        .with('count', 0)
+        .with('next', null)
+        .with('previous', null)
+        .with('results', [])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        }
+        if (url === `${chain.transactionService}/api/v2/delegates/`) {
+          return Promise.resolve({ data: rawify(delegatesPage), status: 200 });
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v3/chains/${chain.chainId}/delegates?safe=${safe}`)
+        .expect(200)
+        .expect(delegatesPage);
+    });
+
+    it('should fail with bad request', async () => {
+      const chain = chainBuilder().build();
+
+      await request(app.getHttpServer())
+        .get(`/v3/chains/${chain.chainId}/delegates`)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message: 'At least one property is required',
+          path: [],
+        });
+    });
+  });
+
+  describe('POST delegates for a Safe', () => {
+    it('success', async () => {
+      const createDelegateDto = createDelegateDtoBuilder().build();
+      const chain = chainBuilder().build();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      networkService.post.mockImplementation(({ url }) =>
+        url === `${chain.transactionService}/api/v2/delegates/`
+          ? Promise.resolve({ status: 201, data: rawify({}) })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .post(`/v3/chains/${chain.chainId}/delegates/`)
+        .send(createDelegateDto)
+        .expect(200);
+    });
+
+    it('should get a validation error', async () => {
+      const createDelegateDto = createDelegateDtoBuilder().build();
+
+      await request(app.getHttpServer())
+        .post(`/v3/chains/${faker.string.numeric()}/delegates/`)
+        .send(omit(createDelegateDto, 'signature'))
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'invalid_type',
+          expected: 'string',
+          path: ['signature'],
+          message: 'Invalid input: expected string, received undefined',
+        });
+    });
+
+    it('success with null safe', async () => {
+      const createDelegateDto = createDelegateDtoBuilder().build();
+      createDelegateDto.safe = null;
+      const chain = chainBuilder().build();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      networkService.post.mockImplementation(({ url }) =>
+        url === `${chain.transactionService}/api/v2/delegates/`
+          ? Promise.resolve({ status: 201, data: rawify({}) })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .post(`/v3/chains/${chain.chainId}/delegates/`)
+        .send(createDelegateDto)
+        .expect(200);
+    });
+
+    it('should return the tx-service error message', async () => {
+      const createDelegateDto = createDelegateDtoBuilder().build();
+      const chain = chainBuilder().build();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/`;
+      const error = new NetworkResponseError(
+        new URL(transactionServiceUrl),
+        {
+          status: 400,
+        } as Response,
+        { message: 'Malformed body', status: 400 },
+      );
+      networkService.post.mockImplementation(({ url }) =>
+        url === transactionServiceUrl
+          ? Promise.reject(error)
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .post(`/v3/chains/${chain.chainId}/delegates/`)
+        .send(createDelegateDto)
+        .expect(400)
+        .expect({
+          message: 'Malformed body',
+          code: 400,
+        });
+    });
+
+    it('should fail with An error occurred', async () => {
+      const createDelegateDto = createDelegateDtoBuilder().build();
+      const chain = chainBuilder().build();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/`;
+      const error = new NetworkResponseError(new URL(transactionServiceUrl), {
+        status: 503,
+      } as Response);
+      networkService.post.mockImplementation(({ url }) =>
+        url === transactionServiceUrl
+          ? Promise.reject(error)
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .post(`/v3/chains/${chain.chainId}/delegates/`)
+        .send(createDelegateDto)
+        .expect(503)
+        .expect({
+          message: 'An error occurred',
+          code: 503,
+        });
+    });
+  });
+
+  describe('PATCH delegates for a Safe (v3)', () => {
+    it('success', async () => {
+      const updateDelegateDto = updateDelegateV3DtoBuilder().build();
+      const chain = chainBuilder().build();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      networkService.patch.mockImplementation(({ url }) =>
+        url ===
+        `${chain.transactionService}/api/v2/delegates/${updateDelegateDto.delegate}`
+          ? Promise.resolve({ status: 200, data: rawify({}) })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .patch(`/v3/chains/${chain.chainId}/delegates`)
+        .send(updateDelegateDto)
+        .expect(200);
+    });
+
+    it('should get a validation error', async () => {
+      const updateDelegateDto = updateDelegateV3DtoBuilder().build();
+
+      await request(app.getHttpServer())
+        .patch(`/v3/chains/${faker.string.numeric()}/delegates`)
+        .send(omit(updateDelegateDto, 'signature'))
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'invalid_type',
+          expected: 'string',
+          path: ['signature'],
+          message: 'Invalid input: expected string, received undefined',
+        });
+    });
+  });
+
+  describe('DELETE delegates for a Safe', () => {
+    it('should delete by delegate, delegator and safe', async () => {
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder().build();
+      const chain = chainBuilder().build();
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      networkService.delete.mockImplementation(({ url }) =>
+        url ===
+        `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
+          ? Promise.resolve({ data: rawify({}), status: 204 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send(deleteDelegateV3Dto)
+        .expect(200);
+
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: `${chain.transactionService}/api/v2/delegates/${delegateAddress}`,
+        data: {
+          delegator: deleteDelegateV3Dto.delegator,
+          safe: deleteDelegateV3Dto.safe,
+          signature: deleteDelegateV3Dto.signature,
+        },
+      });
+    });
+
+    it('should delete by delegate and delegator', async () => {
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder()
+        .with('safe', null)
+        .build();
+      const chain = chainBuilder().build();
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      networkService.delete.mockImplementation(({ url }) =>
+        url ===
+        `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
+          ? Promise.resolve({ data: rawify({}), status: 204 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send(deleteDelegateV3Dto)
+        .expect(200);
+
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: `${chain.transactionService}/api/v2/delegates/${delegateAddress}`,
+        data: {
+          delegator: deleteDelegateV3Dto.delegator,
+          safe: null,
+          signature: deleteDelegateV3Dto.signature,
+        },
+      });
+    });
+
+    it('should delete by delegate and safe', async () => {
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder()
+        .with('delegator', null)
+        .build();
+      const chain = chainBuilder().build();
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      const delegatorAddress = getAddress(faker.finance.ethereumAddress());
+      const delegatesPage = pageBuilder()
+        .with('count', 1)
+        .with('next', null)
+        .with('previous', null)
+        .with('results', [
+          delegateBuilder()
+            .with('delegate', delegateAddress)
+            .with('delegator', delegatorAddress)
+            .with('safe', deleteDelegateV3Dto.safe)
+            .build(),
+        ])
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: rawify(chain), status: 200 });
+          case `${chain.transactionService}/api/v2/delegates/`:
+            return Promise.resolve({
+              data: rawify(delegatesPage),
+              status: 200,
+            });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+      networkService.delete.mockImplementation(({ url }) =>
+        url ===
+        `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
+          ? Promise.resolve({ data: rawify({}), status: 204 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send(deleteDelegateV3Dto)
+        .expect(200);
+
+      expect(networkService.delete).toHaveBeenCalledWith({
+        url: `${chain.transactionService}/api/v2/delegates/${delegateAddress}`,
+        data: {
+          delegator: delegatorAddress,
+          safe: deleteDelegateV3Dto.safe,
+          signature: deleteDelegateV3Dto.signature,
+        },
+      });
+    });
+
+    it('should return the tx-service error message', async () => {
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder().build();
+      const chain = chainBuilder().build();
+      const errorMessage = faker.word.words();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/${delegateAddress}`;
+      const error = new NetworkResponseError(
+        new URL(transactionServiceUrl),
+        {
+          status: 400,
+        } as Response,
+        { message: errorMessage, status: 400 },
+      );
+      networkService.delete.mockImplementation(({ url }) =>
+        url === transactionServiceUrl
+          ? Promise.reject(error)
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send(deleteDelegateV3Dto)
+        .expect(400)
+        .expect({
+          message: errorMessage,
+          code: 400,
+        });
+    });
+
+    it('should fail with An error occurred', async () => {
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder().build();
+      const chain = chainBuilder().build();
+      networkService.get.mockImplementation(({ url }) =>
+        url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
+          ? Promise.resolve({ data: rawify(chain), status: 200 })
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+      const transactionServiceUrl = `${chain.transactionService}/api/v2/delegates/${delegateAddress}`;
+      const error = new NetworkResponseError(new URL(transactionServiceUrl), {
+        status: 503,
+      } as Response);
+      networkService.delete.mockImplementation(({ url }) =>
+        url ===
+        `${chain.transactionService}/api/v2/delegates/${delegateAddress}`
+          ? Promise.reject(error)
+          : Promise.reject(`No matching rule for url: ${url}`),
+      );
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send(deleteDelegateV3Dto)
+        .expect(503)
+        .expect({
+          message: 'An error occurred',
+          code: 503,
+        });
+    });
+
+    it('should get a validation error if the signature is not valid', async () => {
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder().build();
+      const chain = chainBuilder().build();
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send({ ...deleteDelegateV3Dto, signature: faker.number.int() })
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'invalid_type',
+          expected: 'string',
+          path: ['signature'],
+          message: 'Invalid input: expected string, received number',
+        });
+    });
+
+    it('should get a validation error if both delegator and safe are not defined', async () => {
+      const delegateAddress = getAddress(faker.finance.ethereumAddress());
+      const deleteDelegateV3Dto = deleteDelegateV3DtoBuilder().build();
+      // @ts-expect-error - inferred types don't allow optional fields
+      deleteDelegateV3Dto.delegator = undefined;
+      // @ts-expect-error - inferred types don't allow optional fields
+      deleteDelegateV3Dto.safe = undefined;
+      const chain = chainBuilder().build();
+
+      await request(app.getHttpServer())
+        .delete(`/v3/chains/${chain.chainId}/delegates/${delegateAddress}`)
+        .send(deleteDelegateV3Dto)
+        .expect(422)
+        .expect({
+          statusCode: 422,
+          code: 'custom',
+          message:
+            "At least one of the fields 'safe' or 'delegator' is required",
+          path: [],
+        });
+    });
+  });
+});

--- a/src/modules/delegate/routes/v3/delegates.v3.controller.ts
+++ b/src/modules/delegate/routes/v3/delegates.v3.controller.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { Address } from 'viem';
+import { CreateDelegateDto } from '@/modules/delegate/routes/entities/create-delegate.dto.entity';
+import type { Delegate } from '@/modules/delegate/routes/entities/delegate.entity';
+import { DelegatePage } from '@/modules/delegate/routes/entities/delegate.page.entity';
+import type { GetDelegateDto } from '@/modules/delegate/routes/entities/get-delegate.dto.entity';
+import { CreateDelegateDtoSchema } from '@/modules/delegate/routes/entities/schemas/create-delegate.dto.schema';
+import { GetDelegateDtoSchema } from '@/modules/delegate/routes/entities/schemas/get-delegate.dto.schema';
+import { DelegatesV3Service } from '@/modules/delegate/routes/v3/delegates.v3.service';
+import { DeleteDelegateV3Dto } from '@/modules/delegate/routes/v3/entities/delete-delegate.v3.dto.entity';
+import { DeleteDelegateV3DtoSchema } from '@/modules/delegate/routes/v3/entities/schemas/delete-delegate.v3.dto.schema';
+import { UpdateDelegateV3DtoSchema } from '@/modules/delegate/routes/v3/entities/schemas/update-delegate.v3.dto.schema';
+import { UpdateDelegateV3Dto } from '@/modules/delegate/routes/v3/entities/update-delegate.v3.dto.entity';
+import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
+import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
+import type { Page } from '@/routes/common/entities/page.entity';
+import type { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+
+@ApiTags('delegates')
+@Controller({ version: '3' })
+export class DelegatesV3Controller {
+  constructor(private readonly service: DelegatesV3Service) {}
+
+  @ApiOperation({
+    summary: 'Get delegates',
+    description:
+      'Retrieves a paginated list of delegates for a specific chain with optional filtering by Safe, delegate, delegator, or label.',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID where delegates are registered',
+    example: '1',
+  })
+  @ApiQuery({
+    name: 'safe',
+    required: false,
+    type: String,
+    description: 'Filter by Safe address (0x prefixed hex string)',
+  })
+  @ApiQuery({
+    name: 'delegate',
+    required: false,
+    type: String,
+    description: 'Filter by delegate address (0x prefixed hex string)',
+  })
+  @ApiQuery({
+    name: 'delegator',
+    required: false,
+    type: String,
+    description: 'Filter by delegator address (0x prefixed hex string)',
+  })
+  @ApiQuery({
+    name: 'label',
+    required: false,
+    type: String,
+    description: 'Filter by delegate label or name',
+  })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+    description: 'Pagination cursor for retrieving the next set of results',
+  })
+  @ApiOkResponse({
+    type: DelegatePage,
+    description: 'Paginated list of delegates retrieved successfully',
+  })
+  @Get('chains/:chainId/delegates')
+  getDelegates(
+    @Param('chainId') chainId: string,
+    @RouteUrlDecorator() routeUrl: URL,
+    @Query(new ValidationPipe(GetDelegateDtoSchema))
+    getDelegateDto: GetDelegateDto,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<Page<Delegate>> {
+    return this.service.getDelegates({
+      chainId,
+      routeUrl,
+      getDelegateDto,
+      paginationData,
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Create delegate',
+    description:
+      'Creates a new delegate relationship between a Safe and a delegate address. Requires proper authorization signature.',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID where the delegate will be registered',
+    example: '1',
+  })
+  @ApiBody({
+    type: CreateDelegateDto,
+    description:
+      'Delegate creation data including Safe address, delegate address, label, and authorization signature',
+  })
+  @ApiNoContentResponse({
+    description: 'Delegate created successfully',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Invalid delegate data, signature, or unauthorized creation attempt',
+  })
+  @HttpCode(200)
+  @Post('chains/:chainId/delegates')
+  async postDelegate(
+    @Param('chainId') chainId: string,
+    @Body(new ValidationPipe(CreateDelegateDtoSchema))
+    createDelegateDto: CreateDelegateDto,
+  ): Promise<void> {
+    await this.service.postDelegate({ chainId, createDelegateDto });
+  }
+
+  @ApiOperation({
+    summary: 'Update delegate',
+    description:
+      'Updates an existing delegate relationship (e.g. the delegate label). Requires proper authorization signature.',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID where the delegate is registered',
+    example: '1',
+  })
+  @ApiBody({
+    type: UpdateDelegateV3Dto,
+    description:
+      'Delegate update data including Safe address, delegate address, delegator, label, and authorization signature',
+  })
+  @ApiNoContentResponse({
+    description: 'Delegate updated successfully',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Invalid delegate data, signature, or unauthorized update attempt',
+  })
+  @HttpCode(200)
+  @Patch('chains/:chainId/delegates')
+  async updateDelegate(
+    @Param('chainId') chainId: string,
+    @Body(new ValidationPipe(UpdateDelegateV3DtoSchema))
+    updateDelegateV3Dto: UpdateDelegateV3Dto,
+  ): Promise<void> {
+    await this.service.updateDelegate({ chainId, updateDelegateV3Dto });
+  }
+
+  @ApiOperation({
+    summary: 'Delete delegate',
+    description:
+      'Removes a delegate relationship for a specific delegate address. Requires proper authorization signature.',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID where the delegate is registered',
+    example: '1',
+  })
+  @ApiParam({
+    name: 'delegateAddress',
+    type: 'string',
+    description: 'Delegate address to remove (0x prefixed hex string)',
+  })
+  @ApiBody({
+    type: DeleteDelegateV3Dto,
+    description:
+      'Signature and data proving authorization to delete the delegate',
+  })
+  @ApiNoContentResponse({
+    description: 'Delegate deleted successfully',
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid signature or unauthorized deletion attempt',
+  })
+  @Delete('chains/:chainId/delegates/:delegateAddress')
+  deleteDelegate(
+    @Param('chainId') chainId: string,
+    @Param('delegateAddress') delegateAddress: Address,
+    @Body(new ValidationPipe(DeleteDelegateV3DtoSchema))
+    deleteDelegateV3Dto: DeleteDelegateV3Dto,
+  ): Promise<unknown> {
+    return this.service.deleteDelegate({
+      chainId,
+      delegateAddress,
+      deleteDelegateV3Dto,
+    });
+  }
+}

--- a/src/modules/delegate/routes/v3/delegates.v3.module.ts
+++ b/src/modules/delegate/routes/v3/delegates.v3.module.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Module } from '@nestjs/common';
+import { DelegatesV3RepositoryModule } from '@/modules/delegate/domain/v3/delegates.v3.repository.interface';
+import { DelegatesV3Controller } from '@/modules/delegate/routes/v3/delegates.v3.controller';
+import { DelegatesV3Service } from '@/modules/delegate/routes/v3/delegates.v3.service';
+
+@Module({
+  imports: [DelegatesV3RepositoryModule],
+  controllers: [DelegatesV3Controller],
+  providers: [DelegatesV3Service],
+})
+export class DelegatesV3Module {}

--- a/src/modules/delegate/routes/v3/delegates.v3.service.ts
+++ b/src/modules/delegate/routes/v3/delegates.v3.service.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import type { Address } from 'viem';
+import type { Page } from '@/domain/entities/page.entity';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import type { Delegate } from '@/modules/delegate/domain/entities/delegate.entity';
+import { IDelegatesV3Repository } from '@/modules/delegate/domain/v3/delegates.v3.repository.interface';
+import type { CreateDelegateDto } from '@/modules/delegate/routes/entities/create-delegate.dto.entity';
+import type { GetDelegateDto } from '@/modules/delegate/routes/entities/get-delegate.dto.entity';
+import type { DeleteDelegateV3Dto } from '@/modules/delegate/routes/v3/entities/delete-delegate.v3.dto.entity';
+import type { UpdateDelegateV3Dto } from '@/modules/delegate/routes/v3/entities/update-delegate.v3.dto.entity';
+import {
+  cursorUrlFromLimitAndOffset,
+  type PaginationData,
+} from '@/routes/common/pagination/pagination.data';
+
+@Injectable()
+export class DelegatesV3Service {
+  constructor(
+    @Inject(IDelegatesV3Repository)
+    private readonly repository: IDelegatesV3Repository,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
+  ) {}
+
+  async getDelegates(args: {
+    chainId: string;
+    routeUrl: Readonly<URL>;
+    getDelegateDto: GetDelegateDto;
+    paginationData: PaginationData;
+  }): Promise<Page<Delegate>> {
+    const delegates = await this.repository.getDelegates({
+      chainId: args.chainId,
+      safeAddress: args.getDelegateDto.safe,
+      delegate: args.getDelegateDto.delegate,
+      delegator: args.getDelegateDto.delegator,
+      label: args.getDelegateDto.label,
+      limit: args.paginationData.limit,
+      offset: args.paginationData.offset,
+    });
+
+    const nextURL = cursorUrlFromLimitAndOffset(args.routeUrl, delegates.next);
+    const previousURL = cursorUrlFromLimitAndOffset(
+      args.routeUrl,
+      delegates.previous,
+    );
+
+    return {
+      count: delegates.count,
+      next: nextURL?.toString() ?? null,
+      previous: previousURL?.toString() ?? null,
+      results: delegates.results,
+    };
+  }
+
+  async postDelegate(args: {
+    chainId: string;
+    createDelegateDto: CreateDelegateDto;
+  }): Promise<void> {
+    await this.repository.postDelegate({
+      chainId: args.chainId,
+      safeAddress: args.createDelegateDto.safe,
+      delegate: args.createDelegateDto.delegate,
+      delegator: args.createDelegateDto.delegator,
+      signature: args.createDelegateDto.signature,
+      label: args.createDelegateDto.label,
+    });
+  }
+
+  async updateDelegate(args: {
+    chainId: string;
+    updateDelegateV3Dto: UpdateDelegateV3Dto;
+  }): Promise<void> {
+    await this.repository.updateDelegate({
+      chainId: args.chainId,
+      safeAddress: args.updateDelegateV3Dto.safe,
+      delegate: args.updateDelegateV3Dto.delegate,
+      delegator: args.updateDelegateV3Dto.delegator,
+      signature: args.updateDelegateV3Dto.signature,
+      label: args.updateDelegateV3Dto.label,
+    });
+  }
+
+  async deleteDelegate(args: {
+    chainId: string;
+    delegateAddress: Address;
+    deleteDelegateV3Dto: DeleteDelegateV3Dto;
+  }): Promise<unknown> {
+    const { deleteDelegateV3Dto } = args;
+    let { delegator } = deleteDelegateV3Dto;
+
+    if (!delegator) {
+      if (!deleteDelegateV3Dto.safe) {
+        // Note: this point shouldn't be reached, schema validation should cover it
+        throw Error(
+          'Either safe or delegator should be non-null when deleting a delegate',
+        );
+      }
+      delegator = await this._getDelegatorForDelegateAndSafe(
+        args.chainId,
+        args.delegateAddress,
+        deleteDelegateV3Dto.safe,
+      );
+    }
+
+    return await this.repository.deleteDelegate({
+      chainId: args.chainId,
+      delegate: args.delegateAddress,
+      delegator,
+      safeAddress: deleteDelegateV3Dto.safe,
+      signature: deleteDelegateV3Dto.signature,
+    });
+  }
+
+  private async _getDelegatorForDelegateAndSafe(
+    chainId: string,
+    delegate: Address,
+    safeAddress: Address,
+  ): Promise<Address> {
+    const response = await this.repository.getDelegates({
+      chainId,
+      delegate,
+      safeAddress,
+    });
+
+    if (!response.results.length) {
+      this.loggingService.warn(
+        `Delegator for delegate ${delegate} and Safe ${safeAddress} not found`,
+      );
+      throw new NotFoundException();
+    }
+
+    return response.results[0].delegator;
+  }
+}

--- a/src/modules/delegate/routes/v3/entities/__tests__/delete-delegate.v3.dto.builder.ts
+++ b/src/modules/delegate/routes/v3/entities/__tests__/delete-delegate.v3.dto.builder.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { type Address, getAddress } from 'viem';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import type { DeleteDelegateV3Dto } from '@/modules/delegate/routes/v3/entities/delete-delegate.v3.dto.entity';
+
+export function deleteDelegateV3DtoBuilder(): IBuilder<DeleteDelegateV3Dto> {
+  return new Builder<DeleteDelegateV3Dto>()
+    .with('delegator', getAddress(faker.finance.ethereumAddress()))
+    .with('safe', getAddress(faker.finance.ethereumAddress()))
+    .with('signature', faker.string.hexadecimal({ length: 32 }) as Address);
+}

--- a/src/modules/delegate/routes/v3/entities/__tests__/update-delegate.v3.dto.builder.ts
+++ b/src/modules/delegate/routes/v3/entities/__tests__/update-delegate.v3.dto.builder.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import type { UpdateDelegateV3Dto } from '@/modules/delegate/routes/v3/entities/update-delegate.v3.dto.entity';
+
+export function updateDelegateV3DtoBuilder(): IBuilder<UpdateDelegateV3Dto> {
+  return new Builder<UpdateDelegateV3Dto>()
+    .with('safe', getAddress(faker.finance.ethereumAddress()))
+    .with('delegate', getAddress(faker.finance.ethereumAddress()))
+    .with('delegator', getAddress(faker.finance.ethereumAddress()))
+    .with('signature', faker.string.hexadecimal({ length: 32 }))
+    .with('label', faker.string.hexadecimal({ length: 32 }));
+}

--- a/src/modules/delegate/routes/v3/entities/delete-delegate.v3.dto.entity.ts
+++ b/src/modules/delegate/routes/v3/entities/delete-delegate.v3.dto.entity.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { Address } from 'viem';
+import type { z } from 'zod';
+import type { DeleteDelegateV3DtoSchema } from '@/modules/delegate/routes/v3/entities/schemas/delete-delegate.v3.dto.schema';
+
+export class DeleteDelegateV3Dto
+  implements z.infer<typeof DeleteDelegateV3DtoSchema>
+{
+  @ApiPropertyOptional({ type: String, nullable: true })
+  delegator!: Address | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  safe!: Address | null;
+  @ApiProperty()
+  signature!: string;
+}

--- a/src/modules/delegate/routes/v3/entities/schemas/delete-delegate.v3.dto.schema.ts
+++ b/src/modules/delegate/routes/v3/entities/schemas/delete-delegate.v3.dto.schema.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { NullableAddressSchema } from '@/validation/entities/schemas/nullable.schema';
+
+export const DeleteDelegateV3DtoSchema = z
+  .object({
+    delegator: NullableAddressSchema,
+    safe: NullableAddressSchema,
+    signature: z.string(),
+  })
+  .refine((value) => value.delegator || value.safe, {
+    error: `At least one of the fields 'safe' or 'delegator' is required`,
+  });

--- a/src/modules/delegate/routes/v3/entities/schemas/update-delegate.v3.dto.schema.ts
+++ b/src/modules/delegate/routes/v3/entities/schemas/update-delegate.v3.dto.schema.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NullableAddressSchema } from '@/validation/entities/schemas/nullable.schema';
+
+export const UpdateDelegateV3DtoSchema = z.object({
+  safe: NullableAddressSchema,
+  delegate: AddressSchema,
+  delegator: AddressSchema,
+  signature: z.string(),
+  label: z.string(),
+});

--- a/src/modules/delegate/routes/v3/entities/update-delegate.v3.dto.entity.ts
+++ b/src/modules/delegate/routes/v3/entities/update-delegate.v3.dto.entity.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { Address } from 'viem';
+import type { z } from 'zod';
+import type { UpdateDelegateV3DtoSchema } from '@/modules/delegate/routes/v3/entities/schemas/update-delegate.v3.dto.schema';
+
+export class UpdateDelegateV3Dto
+  implements z.infer<typeof UpdateDelegateV3DtoSchema>
+{
+  @ApiPropertyOptional({ type: String, nullable: true })
+  safe!: Address | null;
+  @ApiProperty()
+  delegate!: Address;
+  @ApiProperty()
+  delegator!: Address;
+  @ApiProperty()
+  signature!: string;
+  @ApiProperty()
+  label!: string;
+}

--- a/src/modules/transactions/datasources/transaction-api.service.ts
+++ b/src/modules/transactions/datasources/transaction-api.service.ts
@@ -398,6 +398,29 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  async updateDelegateV2(args: {
+    safeAddress: Address | null;
+    delegate: Address;
+    delegator: Address;
+    signature: string;
+    label: string;
+  }): Promise<void> {
+    try {
+      const url = `${this.baseUrl}/api/v2/delegates/${args.delegate}`;
+      await this.networkService.patch({
+        url,
+        data: {
+          safe: args.safeAddress,
+          delegator: args.delegator,
+          signature: args.signature,
+          label: args.label,
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(this.mapError(error));
+    }
+  }
+
   async deleteDelegate(args: {
     delegate: Address;
     delegator: Address;


### PR DESCRIPTION
## Summary
  Add a delegates **v3** module (update + delete) that routes to the Queue Service when `FF_QUEUE_SERVICE` is enabled, falling back to the Transaction Service v2 endpoints when off. Part 5/6 of the `feat/migrateToQueueService` split.

  ## Changes
  - Add the v3 delegates controller, service, repository, DTOs, schemas, and tests.
  - Route delegate operations to the Queue Service when the flag is on; otherwise use Transaction Service v2.
  - Add `updateDelegateV2` to the Transaction API interface and implementation.
  - Register the v3 module/repository in `DelegateModule`.