### PR TITLE
feat(zerion): dedicated assets API key for portfolio and positions endpoints

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1566,8 +1566,8 @@
     "required": false
   },
   {
-    "name": "ZERION_PORTFOLIO_API_KEY",
-    "description": "Dedicated Zerion API key for the portfolio and positions endpoints (falls back to ZERION_API_KEY)",
+    "name": "ZERION_ASSETS_API_KEY",
+    "description": "Dedicated Zerion API key for the assets-page endpoints (/portfolio and /positions; falls back to ZERION_API_KEY)",
     "defaultValue": null,
     "required": false
   },

--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1566,6 +1566,12 @@
     "required": false
   },
   {
+    "name": "ZERION_PORTFOLIO_API_KEY",
+    "description": "Dedicated Zerion API key for the portfolio and positions endpoints (falls back to ZERION_API_KEY)",
+    "defaultValue": null,
+    "required": false
+  },
+  {
     "name": "ZERION_BASE_URI",
     "description": "Base URI for Zerion API",
     "defaultValue": "https://api.zerion.io",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -61,7 +61,7 @@ export default (): ReturnType<typeof configuration> => ({
       },
       zerion: {
         apiKey: faker.string.hexadecimal({ length: 32 }),
-        portfolioApiKey: faker.string.hexadecimal({ length: 32 }),
+        assetsApiKey: faker.string.hexadecimal({ length: 32 }),
         baseUri: faker.internet.url({ appendSlash: false }),
         currencies: Array.from(
           new Set([

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -61,6 +61,7 @@ export default (): ReturnType<typeof configuration> => ({
       },
       zerion: {
         apiKey: faker.string.hexadecimal({ length: 32 }),
+        portfolioApiKey: faker.string.hexadecimal({ length: 32 }),
         baseUri: faker.internet.url({ appendSlash: false }),
         currencies: Array.from(
           new Set([

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -114,10 +114,12 @@ export default () => ({
       },
       zerion: {
         apiKey: process.env.ZERION_API_KEY,
-        // Dedicated key for the /portfolio and /positions endpoints so their
-        // traffic does not consume the main account's rate-limit budget.
-        portfolioApiKey:
-          process.env.ZERION_PORTFOLIO_API_KEY ?? process.env.ZERION_API_KEY,
+        // Dedicated key for the assets-page endpoints (/portfolio and
+        // /positions) so the assets page keeps working with priority,
+        // unaffected by other endpoints exhausting the main account's
+        // rate-limit budget.
+        assetsApiKey:
+          process.env.ZERION_ASSETS_API_KEY ?? process.env.ZERION_API_KEY,
         baseUri: process.env.ZERION_BASE_URI || 'https://api.zerion.io',
         currencies: [
           'USD',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -114,6 +114,10 @@ export default () => ({
       },
       zerion: {
         apiKey: process.env.ZERION_API_KEY,
+        // Dedicated key for the /portfolio and /positions endpoints so their
+        // traffic does not consume the main account's rate-limit budget.
+        portfolioApiKey:
+          process.env.ZERION_PORTFOLIO_API_KEY ?? process.env.ZERION_API_KEY,
         baseUri: process.env.ZERION_BASE_URI || 'https://api.zerion.io',
         currencies: [
           'USD',

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
@@ -56,7 +56,7 @@ describe('ZerionPortfolioApi', () => {
     vi.resetAllMocks();
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set(
-      'balances.providers.zerion.portfolioApiKey',
+      'balances.providers.zerion.assetsApiKey',
       zerionApiKey,
     );
     fakeConfigurationService.set(

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
@@ -14,7 +14,6 @@ import { DataSourceError } from '@/domain/errors/data-source.error';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { ZerionPortfolioApi } from '@/modules/portfolio/datasources/zerion-portfolio-api.service';
 import type { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
-import type { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 
 describe('ZerionPortfolioApi', () => {
   let service: ZerionPortfolioApi;
@@ -53,15 +52,11 @@ describe('ZerionPortfolioApi', () => {
     getChainIdFromNetwork: vi.fn(),
   } as MockedObject<ZerionChainMappingService>);
 
-  const mockZerionRateLimiter = vi.mocked({
-    assertWithinBudget: vi.fn(),
-  } as unknown as MockedObject<ZerionRateLimiter>);
-
   beforeEach(() => {
     vi.resetAllMocks();
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set(
-      'balances.providers.zerion.apiKey',
+      'balances.providers.zerion.portfolioApiKey',
       zerionApiKey,
     );
     fakeConfigurationService.set(
@@ -80,7 +75,6 @@ describe('ZerionPortfolioApi', () => {
       mockLoggingService,
       mockCacheService,
       mockChainMappingService,
-      mockZerionRateLimiter,
     );
   });
 

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -35,7 +35,6 @@ import type { Portfolio } from '@/modules/portfolio/domain/entities/portfolio.en
 import type { TokenBalance } from '@/modules/portfolio/domain/entities/token-balance.entity';
 import { IPortfolioApi } from '@/modules/portfolio/interfaces/portfolio-api.interface';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
-import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 /**
@@ -70,10 +69,9 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     private readonly loggingService: ILoggingService,
     @Inject(CacheService) readonly _cacheService: ICacheService,
     private readonly zerionChainMappingService: ZerionChainMappingService,
-    private readonly zerionRateLimiter: ZerionRateLimiter,
   ) {
     this.apiKey = this.configurationService.get<string>(
-      'balances.providers.zerion.apiKey',
+      'balances.providers.zerion.portfolioApiKey',
     );
     this.baseUri = this.configurationService.getOrThrow<string>(
       'balances.providers.zerion.baseUri',
@@ -116,13 +114,6 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     isTestnet?: boolean;
     sync?: boolean;
   }): Promise<Array<ZerionBalance>> {
-    // Enforce the shared Zerion budget before the network call. A
-    // LimitReachedError here propagates as a 429 (not logged as a request
-    // failure); the limiter already records the rate-limit event.
-    await this.zerionRateLimiter.assertWithinBudget({
-      datasource: 'portfolio',
-    });
-
     try {
       const url = `${this.baseUri}/v1/wallets/${args.address}/positions`;
       const params: Record<string, string> = {

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -71,7 +71,7 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     private readonly zerionChainMappingService: ZerionChainMappingService,
   ) {
     this.apiKey = this.configurationService.get<string>(
-      'balances.providers.zerion.portfolioApiKey',
+      'balances.providers.zerion.assetsApiKey',
     );
     this.baseUri = this.configurationService.getOrThrow<string>(
       'balances.providers.zerion.baseUri',

--- a/src/modules/positions/datasources/zerion-positions-api.service.spec.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.spec.ts
@@ -19,12 +19,7 @@ import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.b
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import { ZerionPositionsApi } from '@/modules/positions/datasources/zerion-positions-api.service';
 import type { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
-import type { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { rawify } from '@/validation/entities/raw.entity';
-
-const mockZerionRateLimiter = vi.mocked({
-  assertWithinBudget: vi.fn(),
-} as unknown as MockedObject<ZerionRateLimiter>);
 
 const loggingService = {
   debug: vi.fn(),
@@ -101,7 +96,7 @@ describe('ZerionPositionsApi', () => {
       cacheService = new FakeCacheService();
       configurationService = new FakeConfigurationService();
       configurationService.set(
-        'balances.providers.zerion.apiKey',
+        'balances.providers.zerion.portfolioApiKey',
         'test-api-key',
       );
       configurationService.set(
@@ -126,7 +121,6 @@ describe('ZerionPositionsApi', () => {
         configurationService as IConfigurationService,
         new HttpErrorFactory(),
         zerionChainMappingService,
-        mockZerionRateLimiter,
       );
     });
 
@@ -249,7 +243,7 @@ describe('ZerionPositionsApi', () => {
       vi.resetAllMocks();
       fakeConfigurationService = new FakeConfigurationService();
       fakeConfigurationService.set(
-        'balances.providers.zerion.apiKey',
+        'balances.providers.zerion.portfolioApiKey',
         zerionApiKey,
       );
       fakeConfigurationService.set(
@@ -272,7 +266,6 @@ describe('ZerionPositionsApi', () => {
         fakeConfigurationService,
         mockHttpErrorFactory,
         mockChainMappingService,
-        mockZerionRateLimiter,
       );
     });
 

--- a/src/modules/positions/datasources/zerion-positions-api.service.spec.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.spec.ts
@@ -96,7 +96,7 @@ describe('ZerionPositionsApi', () => {
       cacheService = new FakeCacheService();
       configurationService = new FakeConfigurationService();
       configurationService.set(
-        'balances.providers.zerion.portfolioApiKey',
+        'balances.providers.zerion.assetsApiKey',
         'test-api-key',
       );
       configurationService.set(
@@ -243,7 +243,7 @@ describe('ZerionPositionsApi', () => {
       vi.resetAllMocks();
       fakeConfigurationService = new FakeConfigurationService();
       fakeConfigurationService.set(
-        'balances.providers.zerion.portfolioApiKey',
+        'balances.providers.zerion.assetsApiKey',
         zerionApiKey,
       );
       fakeConfigurationService.set(

--- a/src/modules/positions/datasources/zerion-positions-api.service.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.ts
@@ -9,7 +9,6 @@ import {
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { LimitReachedError } from '@/datasources/network/entities/errors/limit-reached.error';
 import {
   type INetworkService,
   NetworkService,
@@ -41,7 +40,6 @@ import type {
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import type { Position } from '@/modules/positions/domain/entities/position.entity';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
-import { ZerionRateLimiter } from '@/modules/zerion/datasources/zerion-rate-limiter.service';
 import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 @Injectable()
@@ -59,10 +57,9 @@ export class ZerionPositionsApi implements IPositionsApi {
     private readonly configurationService: IConfigurationService,
     private readonly httpErrorFactory: HttpErrorFactory,
     private readonly zerionChainMappingService: ZerionChainMappingService,
-    private readonly zerionRateLimiter: ZerionRateLimiter,
   ) {
     this.apiKey = this.configurationService.get<string>(
-      'balances.providers.zerion.apiKey',
+      'balances.providers.zerion.portfolioApiKey',
     );
     this.baseUri = this.configurationService.getOrThrow<string>(
       'balances.providers.zerion.baseUri',
@@ -106,9 +103,6 @@ export class ZerionPositionsApi implements IPositionsApi {
     }
 
     try {
-      await this.zerionRateLimiter.assertWithinBudget({
-        datasource: 'positions',
-      });
       const { key, field } = cacheDir;
       this.loggingService.debug({
         type: LogType.CacheMiss,
@@ -143,7 +137,7 @@ export class ZerionPositionsApi implements IPositionsApi {
       );
       return this._mapPositions(chainName, balances);
     } catch (error) {
-      if (error instanceof LimitReachedError || error instanceof ZodError) {
+      if (error instanceof ZodError) {
         throw error;
       }
       throw this.httpErrorFactory.from(error);

--- a/src/modules/positions/datasources/zerion-positions-api.service.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.ts
@@ -59,7 +59,7 @@ export class ZerionPositionsApi implements IPositionsApi {
     private readonly zerionChainMappingService: ZerionChainMappingService,
   ) {
     this.apiKey = this.configurationService.get<string>(
-      'balances.providers.zerion.portfolioApiKey',
+      'balances.providers.zerion.assetsApiKey',
     );
     this.baseUri = this.configurationService.getOrThrow<string>(
       'balances.providers.zerion.baseUri',

--- a/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
+++ b/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
@@ -22,8 +22,9 @@ type RateLimitScope = 'global' | 'per_address';
  *
  * Zerion enforces an account-wide ceiling (~10 RPS), shared by every CGW pod
  * and every datasource on the main API key (balances, collectibles, wallet
- * portfolio). The portfolio and positions endpoints use their own dedicated
- * key and are not throttled here. This
+ * portfolio). The assets-page endpoints (portfolio, positions) use the
+ * dedicated assets key so they keep working even when the main budget is
+ * exhausted; they are not throttled here. This
  * limiter increments a single Redis fixed-window counter so the cluster stays
  * under that ceiling, with an optional per-address sub-budget that prevents one
  * hot wallet from starving the global budget.

--- a/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
+++ b/src/modules/zerion/datasources/zerion-rate-limiter.service.ts
@@ -21,7 +21,9 @@ type RateLimitScope = 'global' | 'per_address';
  * Cross-pod rate limiter for the shared Zerion API account budget.
  *
  * Zerion enforces an account-wide ceiling (~10 RPS), shared by every CGW pod
- * and every Zerion datasource (balances, positions, wallet portfolio…). This
+ * and every datasource on the main API key (balances, collectibles, wallet
+ * portfolio). The portfolio and positions endpoints use their own dedicated
+ * key and are not throttled here. This
  * limiter increments a single Redis fixed-window counter so the cluster stays
  * under that ceiling, with an optional per-address sub-budget that prevents one
  * hot wallet from starving the global budget.


### PR DESCRIPTION
## Summary

Introduces a dedicated Zerion API key for the assets-page endpoints (`/portfolio` and `/positions`) so the assets page works with priority, unaffected by other endpoints exhausting the main account's rate-limit budget.

- Adds `ZERION_ASSETS_API_KEY` (config: `balances.providers.zerion.assetsApiKey`), falling back to `ZERION_API_KEY` when unset so existing environments keep working.
- `ZerionPortfolioApi` and `ZerionPositionsApi` now authenticate with the new key.
- Removes the shared `ZerionRateLimiter` from both services; it now only throttles the main-key consumers (wallet portfolio for `/v2/safes`, balances, collectibles).

Note for deployment: until `ZERION_ASSETS_API_KEY` is set, `/portfolio` and `/positions` hit the main key unthrottled — the env var should ship with this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)