### PR TITLE
feat: Filter spam token push notifications

### DIFF
--- a/src/domain/common/entities/log-type.entity.ts
+++ b/src/domain/common/entities/log-type.entity.ts
@@ -30,6 +30,7 @@ export enum LogType {
   NotificationSent = 'NOTIFICATION_SENT',
   NotificationEventProcessed = 'NOTIFICATION_EVENT_PROCESSED',
   NotificationDeliveryQueued = 'NOTIFICATION_DELIVERY_QUEUED',
+  NotificationSpamTokenDropped = 'NOTIFICATION_SPAM_TOKEN_DROPPED',
   PortfolioDegradedServe = 'PORTFOLIO_DEGRADED_SERVE',
   PortfolioRequestError = 'PORTFOLIO_REQUEST_ERROR',
   RateLimit = 'RATE_LIMIT',

--- a/src/modules/hooks/routes/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/modules/hooks/routes/__tests__/event-hooks-queue.e2e-spec.ts
@@ -64,6 +64,7 @@ describe('Events queue processing e2e tests', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_ETHER',
@@ -79,6 +80,7 @@ describe('Events queue processing e2e tests', () => {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears balances', async (payload) => {
     const cacheDir = new CacheDir(
@@ -261,11 +263,13 @@ describe('Events queue processing e2e tests', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears safe collectibles', async (payload) => {
     const cacheDir = new CacheDir(
@@ -307,11 +311,13 @@ describe('Events queue processing e2e tests', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears safe collectible transfers', async (payload) => {
     const cacheDir = new CacheDir(
@@ -345,6 +351,7 @@ describe('Events queue processing e2e tests', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'INCOMING_ETHER',
@@ -429,6 +436,7 @@ describe('Events queue processing e2e tests', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_ETHER',
@@ -444,6 +452,7 @@ describe('Events queue processing e2e tests', () => {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears all transactions', async (payload) => {
     const cacheDir = new CacheDir(

--- a/src/modules/hooks/routes/entities/__tests__/incoming-token.builder.ts
+++ b/src/modules/hooks/routes/entities/__tests__/incoming-token.builder.ts
@@ -12,5 +12,6 @@ export function incomingTokenEventBuilder(): IBuilder<IncomingToken> {
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('chainId', faker.string.numeric())
     .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
-    .with('txHash', faker.string.hexadecimal());
+    .with('txHash', faker.string.hexadecimal())
+    .with('trusted', true);
 }

--- a/src/modules/hooks/routes/entities/__tests__/outgoing-token.builder.ts
+++ b/src/modules/hooks/routes/entities/__tests__/outgoing-token.builder.ts
@@ -12,5 +12,6 @@ export function outgoingTokenEventBuilder(): IBuilder<OutgoingToken> {
     .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('chainId', faker.string.numeric())
     .with('tokenAddress', getAddress(faker.finance.ethereumAddress()))
-    .with('txHash', faker.string.hexadecimal());
+    .with('txHash', faker.string.hexadecimal())
+    .with('trusted', true);
 }

--- a/src/modules/hooks/routes/entities/schemas/__tests__/incoming-token.schema.spec.ts
+++ b/src/modules/hooks/routes/entities/schemas/__tests__/incoming-token.schema.spec.ts
@@ -68,12 +68,39 @@ describe('IncomingTokenEventSchema', () => {
     );
   });
 
+  it.each([true, false])('should allow a trusted value of %s', (trusted) => {
+    const incomingTokenEvent = incomingTokenEventBuilder()
+      .with('trusted', trusted)
+      .build();
+
+    const result = IncomingTokenEventSchema.safeParse(incomingTokenEvent);
+
+    expect(result.success && result.data.trusted).toBe(trusted);
+  });
+
+  it('should not allow a non-boolean trusted value', () => {
+    const incomingTokenEvent = incomingTokenEventBuilder()
+      .with('trusted', 'true' as unknown as boolean)
+      .build();
+
+    const result = IncomingTokenEventSchema.safeParse(incomingTokenEvent);
+
+    expect(!result.success && result.error.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid_type',
+        expected: 'boolean',
+        path: ['trusted'],
+      }),
+    ]);
+  });
+
   it.each([
     'type' as const,
     'address' as const,
     'chainId' as const,
     'tokenAddress' as const,
     'txHash' as const,
+    'trusted' as const,
   ])(`should not allow a missing %s`, (field) => {
     const incomingTokenEvent = incomingTokenEventBuilder().build();
     delete incomingTokenEvent[field];

--- a/src/modules/hooks/routes/entities/schemas/__tests__/outgoing-token.schema.spec.ts
+++ b/src/modules/hooks/routes/entities/schemas/__tests__/outgoing-token.schema.spec.ts
@@ -68,12 +68,39 @@ describe('OutgoingTokenEventSchema', () => {
     );
   });
 
+  it.each([true, false])('should allow a trusted value of %s', (trusted) => {
+    const outgoingTokenEvent = outgoingTokenEventBuilder()
+      .with('trusted', trusted)
+      .build();
+
+    const result = OutgoingTokenEventSchema.safeParse(outgoingTokenEvent);
+
+    expect(result.success && result.data.trusted).toBe(trusted);
+  });
+
+  it('should not allow a non-boolean trusted value', () => {
+    const outgoingTokenEvent = outgoingTokenEventBuilder()
+      .with('trusted', 'true' as unknown as boolean)
+      .build();
+
+    const result = OutgoingTokenEventSchema.safeParse(outgoingTokenEvent);
+
+    expect(!result.success && result.error.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid_type',
+        expected: 'boolean',
+        path: ['trusted'],
+      }),
+    ]);
+  });
+
   it.each([
     'type' as const,
     'address' as const,
     'chainId' as const,
     'tokenAddress' as const,
     'txHash' as const,
+    'trusted' as const,
   ])(`should not allow a missing %s`, (field) => {
     const outgoingTokenEvent = outgoingTokenEventBuilder().build();
     delete outgoingTokenEvent[field];

--- a/src/modules/hooks/routes/entities/schemas/incoming-token.schema.ts
+++ b/src/modules/hooks/routes/entities/schemas/incoming-token.schema.ts
@@ -8,6 +8,7 @@ export const IncomingTokenEventSchema = HookEventBaseSchema.extend({
   type: z.literal(TransactionEventType.INCOMING_TOKEN),
   tokenAddress: AddressSchema,
   txHash: z.string(),
+  trusted: z.boolean(),
 });
 
 export type IncomingTokenEvent = z.infer<typeof IncomingTokenEventSchema>;

--- a/src/modules/hooks/routes/entities/schemas/outgoing-token.schema.ts
+++ b/src/modules/hooks/routes/entities/schemas/outgoing-token.schema.ts
@@ -8,4 +8,5 @@ export const OutgoingTokenEventSchema = HookEventBaseSchema.extend({
   type: z.literal(TransactionEventType.OUTGOING_TOKEN),
   tokenAddress: AddressSchema,
   txHash: z.string(),
+  trusted: z.boolean(),
 });

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -90,6 +90,7 @@ describe('Hook Events for Cache', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_ETHER',
@@ -105,6 +106,7 @@ describe('Hook Events for Cache', () => {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears balances', async (payload) => {
     const chainId = faker.string.numeric();
@@ -796,11 +798,13 @@ describe('Hook Events for Cache', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears safe collectibles', async (payload) => {
     const chainId = faker.string.numeric();
@@ -854,11 +858,13 @@ describe('Hook Events for Cache', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears safe collectible transfers', async (payload) => {
     const safeAddress = faker.finance.ethereumAddress();
@@ -900,6 +906,7 @@ describe('Hook Events for Cache', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'INCOMING_ETHER',
@@ -1000,6 +1007,7 @@ describe('Hook Events for Cache', () => {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
     {
       type: 'OUTGOING_ETHER',
@@ -1015,6 +1023,7 @@ describe('Hook Events for Cache', () => {
       type: 'OUTGOING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.string.hexadecimal({ length: 32 }),
+      trusted: true,
     },
   ])('$type clears all transactions', async (payload) => {
     const safeAddress = faker.finance.ethereumAddress();

--- a/src/modules/hooks/routes/hooks.controller.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks.controller.integration.spec.ts
@@ -33,6 +33,7 @@ describe('HooksController', () => {
         type: 'INCOMING_TOKEN',
         tokenAddress: faker.finance.ethereumAddress(),
         txHash: faker.string.hexadecimal({ length: 32 }),
+        trusted: true,
       };
       const safeAddress = faker.finance.ethereumAddress();
       const chainId = faker.string.numeric();
@@ -93,6 +94,7 @@ describe('HooksController', () => {
         type: 'INCOMING_TOKEN',
         tokenAddress: faker.finance.ethereumAddress(),
         txHash: faker.string.hexadecimal({ length: 32 }),
+        trusted: true,
       };
       const safeAddress = faker.finance.ethereumAddress();
       const chainId = faker.string.numeric();

--- a/src/modules/notifications/domain/push/push-notification.integration.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.integration.spec.ts
@@ -365,6 +365,33 @@ describe('Push notification queue integration', () => {
         notificationsRepository.enqueueNotification,
       ).not.toHaveBeenCalled();
     });
+
+    it('should suppress INCOMING_TOKEN when the token is not trusted (spam)', async () => {
+      const safeAddress = addr();
+      const event = incomingTokenEventBuilder()
+        .with('address', safeAddress)
+        .with('trusted', false)
+        .build();
+      currentChainId = event.chainId;
+      const subs = createSubscribers(1);
+
+      notificationsRepository.getSubscribersBySafe.mockResolvedValue(subs);
+
+      await pushNotificationService.enqueueEvent(event);
+
+      await retry(async () => {
+        const counts = await queue.getJobCounts();
+        expect(counts.active + counts.waiting + counts.delayed).toBe(0);
+      });
+
+      // Dropped before subscriber resolution — no lookups, no delivery
+      expect(
+        notificationsRepository.getSubscribersBySafe,
+      ).not.toHaveBeenCalled();
+      expect(
+        notificationsRepository.enqueueNotification,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe('PENDING_MULTISIG_TRANSACTION filtering', () => {

--- a/src/modules/notifications/domain/push/push-notification.service.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.spec.ts
@@ -199,6 +199,36 @@ describe('PushNotificationService (Unit)', () => {
       });
     });
 
+    it('should strip the trusted flag from the delivery notification payload (FCM data must be strings)', async () => {
+      const event = incomingTokenEventBuilder().with('trusted', true).build();
+      mockNotificationsRepository.getSubscribersBySafe.mockResolvedValue([
+        createSubscriber(),
+      ]);
+      mockSafeRepository.getIncomingTransfers.mockResolvedValue(
+        pageBuilder<Transfer>()
+          .with('results', [
+            nativeTokenTransferBuilder()
+              .with('transactionHash', event.txHash as Hash)
+              .with('from', addr())
+              .build(),
+          ])
+          .build(),
+      );
+      mockJobQueueService.addJob.mockResolvedValue({} as Job);
+
+      const result = await service.processEvent(event);
+
+      expect(result).toBe(1);
+      expect(mockJobQueueService.addJob).toHaveBeenCalledWith(
+        JobType.PUSH_NOTIFICATION_DELIVERY,
+        expect.objectContaining({
+          notification: {
+            data: expect.not.objectContaining({ trusted: expect.anything() }),
+          },
+        }),
+      );
+    });
+
     it('should process INCOMING_TOKEN events with trusted === true', async () => {
       const event = incomingTokenEventBuilder().with('trusted', true).build();
       mockNotificationsRepository.getSubscribersBySafe.mockResolvedValue([]);

--- a/src/modules/notifications/domain/push/push-notification.service.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.spec.ts
@@ -177,6 +177,46 @@ describe('PushNotificationService (Unit)', () => {
     });
   });
 
+  // ── processEvent: Spam Token Filtering ──
+
+  describe('processEvent - spam token filtering (trusted flag)', () => {
+    it('should drop INCOMING_TOKEN events with trusted === false before resolving subscribers', async () => {
+      const event = incomingTokenEventBuilder().with('trusted', false).build();
+
+      const result = await service.processEvent(event);
+
+      expect(result).toBe(0);
+      expect(
+        mockNotificationsRepository.getSubscribersBySafe,
+      ).not.toHaveBeenCalled();
+      expect(mockJobQueueService.addJob).not.toHaveBeenCalled();
+      expect(mockLoggingService.info).toHaveBeenCalledWith({
+        type: LogType.NotificationSpamTokenDropped,
+        eventType: event.type,
+        chainId: event.chainId,
+        address: event.address,
+        tokenAddress: event.tokenAddress,
+      });
+    });
+
+    it('should process INCOMING_TOKEN events with trusted === true', async () => {
+      const event = incomingTokenEventBuilder().with('trusted', true).build();
+      mockNotificationsRepository.getSubscribersBySafe.mockResolvedValue([]);
+
+      const result = await service.processEvent(event);
+
+      expect(result).toBe(0);
+      expect(
+        mockNotificationsRepository.getSubscribersBySafe,
+      ).toHaveBeenCalled();
+      expect(mockLoggingService.info).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: LogType.NotificationSpamTokenDropped,
+        }),
+      );
+    });
+  });
+
   // ── processEvent: Subscriber Resolution ──
 
   describe('processEvent - subscriber resolution', () => {

--- a/src/modules/notifications/domain/push/push-notification.service.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.ts
@@ -88,6 +88,18 @@ export class PushNotificationService implements IPushNotificationService {
       return 0;
     }
 
+    // Drop transfers the Transaction Service flagged as untrusted.
+    if (event.type === TransactionEventType.INCOMING_TOKEN && !event.trusted) {
+      this.loggingService.info({
+        type: LogType.NotificationSpamTokenDropped,
+        eventType: event.type,
+        chainId: event.chainId,
+        address: event.address,
+        tokenAddress: event.tokenAddress,
+      });
+      return 0;
+    }
+
     // Fetch Safe once for the entire event processing (eliminates N+1 getSafe calls)
     const safe = this.isOwnerOrDelegateOnlyEventToNotify(event)
       ? await this.safeRepository.getSafe({

--- a/src/modules/notifications/domain/push/push-notification.service.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.ts
@@ -436,6 +436,12 @@ export class PushNotificationService implements IPushNotificationService {
       return null;
     }
 
+    if (event.type === TransactionEventType.INCOMING_TOKEN) {
+      // Strip the boolean `trusted` flag: FirebaseNotification['data'] only accepts strings
+      const { trusted: _trusted, ...notification } = event;
+      return notification;
+    }
+
     return event;
   }
 

--- a/src/modules/notifications/domain/v2/entities/notification.entity.ts
+++ b/src/modules/notifications/domain/v2/entities/notification.entity.ts
@@ -31,7 +31,8 @@ export type ExecutedMultisigTransactionNotification = ExecutedTransactionEvent;
 
 export type IncomingEtherNotification = IncomingEtherEvent;
 
-export type IncomingTokenNotification = IncomingTokenEvent;
+// `trusted` is only filtering metadata
+export type IncomingTokenNotification = Omit<IncomingTokenEvent, 'trusted'>;
 
 export type ModuleTransactionNotification = ModuleTransactionEvent;
 


### PR DESCRIPTION
## Summary

Resolves [WA-1677](https://linear.app/safe-global/issue/WA-1677/filter-spam-token-push-notifications-on-mobile)

Safe{Mobile} sends push notifications for incoming ERC20 transfers that the app itself then hides as spam — the user gets a push, opens the app, and sees nothing.

Since [PLA-1661](https://linear.app/safe-global/issue/PLA-1661) ([safe-transaction-service#2906](https://github.com/safe-global/safe-transaction-service/pull/2906)), `INCOMING_TOKEN` / `OUTGOING_TOKEN` webhook events carry a `trusted` boolean resolved by the Transaction Service from its curated trusted-token set. This PR parses that flag and drops incoming-token push notifications when the token is not trusted, so pushes match what the app actually shows.

This supersedes the earlier Zerion/balances-lookup approach (#3160) — no extra lookups are needed anymore; the decision ships on the event itself.

## Changes

- **Event schemas** (`src/modules/hooks/routes/entities/schemas/incoming-token.schema.ts`, `outgoing-token.schema.ts`): added `trusted: z.boolean()`. The field is **required**: the Transaction Service emits it unconditionally for both directions and both ERC20/ERC721 (verified against the upstream PR — unknown tokens come through as `trusted: false`, never omitted), and no deployments predate the flag. `OUTGOING_TOKEN` never triggers pushes; its schema change is wire-format parity only.
- **Push notification filtering** (`src/modules/notifications/domain/push/push-notification.service.ts`): `processEvent` drops `INCOMING_TOKEN` events with `trusted: false` right after the notifiable-type gate, before any Safe/subscriber lookups. Each drop is logged with the new `NOTIFICATION_SPAM_TOKEN_DROPPED` log type (`src/domain/common/entities/log-type.entity.ts`) for observability.
- **FCM payload unchanged**: the `trusted` flag is stripped before the delivery job is queued (`mapIncomingAssetEventNotification`), and `IncomingTokenNotification` is now `Omit<IncomingTokenEvent, 'trusted'>` (`src/modules/notifications/domain/v2/entities/notification.entity.ts`). `FirebaseNotification['data']` only accepts string values, so passing the boolean through would have made FCM reject every delivered token push — and the flag carries no information for the client anyway (only trusted events survive filtering). The push payload mobile receives is byte-identical to today's.
- **Tests**: event builders default to `trusted: true`; inline token-event payloads in the hooks integration/e2e specs gained the now-required field; new cases cover schema validation (accepts booleans, rejects missing/non-boolean), the drop path (no delivery jobs, no subscriber fetch, spam log emitted), the send path (`trusted: true` flows as before, end-to-end through the queue), and that the delivery payload contains no `trusted` key.

## Behavior

| Event | Before | After |
|---|---|---|
| `INCOMING_TOKEN`, `trusted: true` | push sent | push sent (unchanged payload) |
| `INCOMING_TOKEN`, `trusted: false` (spam/unknown token) | push sent | **dropped**, logged as `NOTIFICATION_SPAM_TOKEN_DROPPED` |
| `INCOMING_ETHER`, executed/pending/message/module events | push sent | unchanged |

Note: `INCOMING_TOKEN` covers ERC721 as well, so incoming-NFT pushes follow the same trusted-set semantics decided upstream in PLA-1661. No new notification settings are introduced.
