### PR TITLE
fix(tests): resolve remaining flaky tests after Vitest migration

### DIFF
--- a/src/datasources/job-queue/__tests__/job-queue.service.integration.spec.ts
+++ b/src/datasources/job-queue/__tests__/job-queue.service.integration.spec.ts
@@ -68,7 +68,7 @@ describe('JobQueueService & TestJobConsumer integration', () => {
 
   afterAll(async () => {
     await queue.close();
-    await app.close();
+    await app?.close();
   });
 
   it('should process a job added to the queue', async () => {

--- a/src/datasources/network/network.module.integration.spec.ts
+++ b/src/datasources/network/network.module.integration.spec.ts
@@ -97,7 +97,7 @@ describe('NetworkModule', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     it(`fetch client is created with timeout and is kept alive`, async () => {
@@ -188,7 +188,7 @@ describe('NetworkModule', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     it('caches GET requests based on URL and options', async () => {
@@ -421,7 +421,7 @@ describe('NetworkModule', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     beforeEach(() => {
@@ -524,7 +524,7 @@ describe('NetworkModule', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     beforeEach(() => {

--- a/src/domain/common/entities/name.builder.ts
+++ b/src/domain/common/entities/name.builder.ts
@@ -23,5 +23,7 @@ export function nameBuilder(): string {
   // Pad to the min and trim to the max to respect the default bounds.
   const padded =
     pick.length < NAME_MIN_LENGTH ? pick.padEnd(NAME_MIN_LENGTH, 'x') : pick;
-  return [...padded].slice(0, NAME_MAX_LENGTH).join('');
+  // Truncating to the max can cut right after a space and re-introduce trailing
+  // whitespace, so sanitize again to keep the result a fixed point of sanitizeName.
+  return sanitizeName([...padded].slice(0, NAME_MAX_LENGTH).join(''));
 }

--- a/src/modules/alerts/routes/alerts.controller.integration.spec.ts
+++ b/src/modules/alerts/routes/alerts.controller.integration.spec.ts
@@ -112,7 +112,7 @@ describe('Alerts Controller', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     describe('GET /v1/alerts', () => {
@@ -868,7 +868,7 @@ describe('Alerts Controller', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     it('returns 404 (Not found) for valid signature/invalid payload', async () => {

--- a/src/modules/auth/routes/decorators/auth.decorator.integration.spec.ts
+++ b/src/modules/auth/routes/decorators/auth.decorator.integration.spec.ts
@@ -81,7 +81,7 @@ describe('Auth decorator', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('no token', async () => {

--- a/src/modules/auth/routes/guards/auth.guard.integration.spec.ts
+++ b/src/modules/auth/routes/guards/auth.guard.integration.spec.ts
@@ -71,7 +71,7 @@ describe('AuthGuard', () => {
 
   afterEach(async () => {
     vi.useRealTimers();
-    await app.close();
+    await app?.close();
   });
 
   it('should not allow access if there is no token', async () => {

--- a/src/modules/auth/routes/guards/optional-auth.guard.integration.spec.ts
+++ b/src/modules/auth/routes/guards/optional-auth.guard.integration.spec.ts
@@ -72,7 +72,7 @@ describe('OptionalAuthGuard', () => {
 
   afterEach(async () => {
     vi.useRealTimers();
-    await app.close();
+    await app?.close();
   });
 
   it('should allow access if there is no token', async () => {

--- a/src/modules/balances/routes/__tests__/controllers/zerion-balances.controller.integration.spec.ts
+++ b/src/modules/balances/routes/__tests__/controllers/zerion-balances.controller.integration.spec.ts
@@ -76,7 +76,7 @@ describe('Balances Controller', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {

--- a/src/modules/balances/routes/balances.controller.integration.spec.ts
+++ b/src/modules/balances/routes/balances.controller.integration.spec.ts
@@ -55,7 +55,7 @@ describe('Balances Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET /balances', () => {

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -87,7 +87,7 @@ describe('BillingWebhookAuthGuard', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('is applied to the webhook endpoint', () => {

--- a/src/modules/bridge/domain/entities/bridge-name.entity.spec.ts
+++ b/src/modules/bridge/domain/entities/bridge-name.entity.spec.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import {
   BridgeNameSchema,
   BridgeNames,
+  isBridgeName,
 } from '@/modules/bridge/domain/entities/bridge-name.entity';
 
 describe('BridgeStatusSchema', () => {
@@ -15,7 +16,12 @@ describe('BridgeStatusSchema', () => {
   });
 
   it('should not allow an unknown bridge name', () => {
-    const name = faker.word.noun();
+    // faker.word.noun() can itself be a bridge name (e.g. "omni", "polygon"),
+    // so resample until the word is genuinely not one.
+    let name = faker.word.noun();
+    while (isBridgeName(name)) {
+      name = faker.word.noun();
+    }
 
     const result = BridgeNameSchema.safeParse(name);
 

--- a/src/modules/chains/feature-flags/feature-flag.service.integration.spec.ts
+++ b/src/modules/chains/feature-flags/feature-flag.service.integration.spec.ts
@@ -20,7 +20,7 @@ describe('FeatureFlagService Integration', () => {
   let configurationService: IConfigurationService;
 
   afterEach(async () => {
-    if (app) await app.close();
+    if (app) await app?.close();
   });
 
   describe('with default config', () => {
@@ -94,7 +94,7 @@ describe('FeatureFlagService Integration', () => {
           url: expect.stringContaining(`/api/v2/chains/${CUSTOM_CGW_KEY}/1`),
         }),
       );
-      await app.close();
+      await app?.close();
     });
   });
 });

--- a/src/modules/chains/feature-flags/feature-flag.service.integration.spec.ts
+++ b/src/modules/chains/feature-flags/feature-flag.service.integration.spec.ts
@@ -20,7 +20,7 @@ describe('FeatureFlagService Integration', () => {
   let configurationService: IConfigurationService;
 
   afterEach(async () => {
-    if (app) await app?.close();
+    await app?.close();
   });
 
   describe('with default config', () => {

--- a/src/modules/chains/routes/chains.controller.integration.spec.ts
+++ b/src/modules/chains/routes/chains.controller.integration.spec.ts
@@ -74,7 +74,7 @@ describe('Chains Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET /chains', () => {

--- a/src/modules/chains/routes/v2/chains.v2.controller.integration.spec.ts
+++ b/src/modules/chains/routes/v2/chains.v2.controller.integration.spec.ts
@@ -56,7 +56,7 @@ describe('Chains V2 Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET /v2/chains', () => {

--- a/src/modules/collectibles/routes/__tests__/controllers/zerion-collectibles.controller.integration.spec.ts
+++ b/src/modules/collectibles/routes/__tests__/controllers/zerion-collectibles.controller.integration.spec.ts
@@ -53,7 +53,7 @@ describe('Zerion Collectibles Controller', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {

--- a/src/modules/collectibles/routes/collectibles.controller.integration.spec.ts
+++ b/src/modules/collectibles/routes/collectibles.controller.integration.spec.ts
@@ -59,7 +59,7 @@ describe('Collectibles Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET /v2/collectibles', () => {

--- a/src/modules/community/routes/community.controller.integration.spec.ts
+++ b/src/modules/community/routes/community.controller.integration.spec.ts
@@ -70,7 +70,7 @@ describe('Community Controller', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {

--- a/src/modules/contracts/routes/contracts.controller.integration.spec.ts
+++ b/src/modules/contracts/routes/contracts.controller.integration.spec.ts
@@ -38,7 +38,7 @@ describe('Contracts controller', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {

--- a/src/modules/delegate/routes/delegates.controller.integration.spec.ts
+++ b/src/modules/delegate/routes/delegates.controller.integration.spec.ts
@@ -45,7 +45,7 @@ describe('Delegates controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET delegates for a Safe', () => {

--- a/src/modules/delegate/routes/v2/delegates.v2.controller.integration.spec.ts
+++ b/src/modules/delegate/routes/v2/delegates.v2.controller.integration.spec.ts
@@ -52,7 +52,7 @@ describe('Delegates controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET delegates for a Safe (v2)', () => {

--- a/src/modules/estimations/routes/estimations.controller.integration.spec.ts
+++ b/src/modules/estimations/routes/estimations.controller.integration.spec.ts
@@ -46,7 +46,7 @@ describe('Estimations Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('Get estimations', () => {

--- a/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
@@ -57,7 +57,7 @@ describe('Fees Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should return 400 if relay-fee is not available for the chain', async () => {

--- a/src/modules/fees/routes/__tests__/gas-tokens.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/gas-tokens.fees.controller.integration.spec.ts
@@ -37,7 +37,7 @@ describe('Fees Controller - gas tokens', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('Success', async () => {

--- a/src/modules/health/routes/health.controller.integration.spec.ts
+++ b/src/modules/health/routes/health.controller.integration.spec.ts
@@ -97,6 +97,6 @@ describe('Health Controller tests', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 });

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -82,7 +82,7 @@ describe('Hook Events for Cache', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it.each([

--- a/src/modules/hooks/routes/hooks-notifications.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-notifications.integration.spec.ts
@@ -74,7 +74,7 @@ describe('Hook Events for Notifications', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it.each(

--- a/src/modules/hooks/routes/hooks.controller.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks.controller.integration.spec.ts
@@ -25,7 +25,7 @@ describe('HooksController', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     it('should return 410 if the hook is not CHAIN_UPDATE or SAFE_APPS_UPDATE', async () => {
@@ -86,7 +86,7 @@ describe('HooksController', () => {
     });
 
     afterAll(async () => {
-      await app.close();
+      await app?.close();
     });
 
     it('should not return 410 if the feature flag is enabled', async () => {

--- a/src/modules/messages/routes/messages.controller.integration.spec.ts
+++ b/src/modules/messages/routes/messages.controller.integration.spec.ts
@@ -46,9 +46,7 @@ describe('Messages controller', () => {
   let blocklistService: MockedObject<IBlocklistService>;
 
   async function initApp(config: typeof configuration): Promise<void> {
-    if (app) {
-      await app?.close();
-    }
+    await app?.close();
 
     const moduleFixture: TestingModule = await createTestModule({
       config,

--- a/src/modules/messages/routes/messages.controller.integration.spec.ts
+++ b/src/modules/messages/routes/messages.controller.integration.spec.ts
@@ -47,7 +47,7 @@ describe('Messages controller', () => {
 
   async function initApp(config: typeof configuration): Promise<void> {
     if (app) {
-      await app.close();
+      await app?.close();
     }
 
     const moduleFixture: TestingModule = await createTestModule({
@@ -83,7 +83,7 @@ describe('Messages controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET messages by hash', () => {

--- a/src/modules/notifications/domain/push/push-notification.integration.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.integration.spec.ts
@@ -157,7 +157,7 @@ describe('Push notification queue integration', () => {
 
   afterAll(async () => {
     await queue.close();
-    await app.close();
+    await app?.close();
   });
 
   describe('non-notifiable events', () => {

--- a/src/modules/notifications/routes/v1/notifications.controller.integration.spec.ts
+++ b/src/modules/notifications/routes/v1/notifications.controller.integration.spec.ts
@@ -63,7 +63,7 @@ describe('Notifications Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   const buildInputDto = async (

--- a/src/modules/notifications/routes/v2/notifications.controller.integration.spec.ts
+++ b/src/modules/notifications/routes/v2/notifications.controller.integration.spec.ts
@@ -78,7 +78,7 @@ describe('Notifications Controller V2', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {

--- a/src/modules/owners/routes/owners.controller.v1.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v1.integration.spec.ts
@@ -37,7 +37,7 @@ describe('Owners Controller (Unit)', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET safes by owner address', () => {

--- a/src/modules/owners/routes/owners.controller.v2.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v2.integration.spec.ts
@@ -50,7 +50,7 @@ describe('Owners Controller (Unit)', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET all safes by owner address', () => {

--- a/src/modules/owners/routes/owners.controller.v3.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v3.integration.spec.ts
@@ -49,7 +49,7 @@ describe('Owners Controller V3 (Unit)', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET all safes by owner address', () => {

--- a/src/modules/recovery/routes/recovery.controller.integration.spec.ts
+++ b/src/modules/recovery/routes/recovery.controller.integration.spec.ts
@@ -85,7 +85,7 @@ describe('Recovery Controller', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   afterEach(() => {

--- a/src/modules/relay/routes/relay.controller.integration.spec.ts
+++ b/src/modules/relay/routes/relay.controller.integration.spec.ts
@@ -161,7 +161,7 @@ describe('Relay controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   // Regular relay tests for chains without no-fee campaign configuration

--- a/src/modules/root/routes/root.controller.integration.spec.ts
+++ b/src/modules/root/routes/root.controller.integration.spec.ts
@@ -17,7 +17,7 @@ describe('Root Controller tests', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should redirect / to /api', async () => {

--- a/src/modules/safe-apps/routes/safe-apps.controller.integration.spec.ts
+++ b/src/modules/safe-apps/routes/safe-apps.controller.integration.spec.ts
@@ -36,7 +36,7 @@ describe('Safe Apps Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('Get Safe Apps', () => {

--- a/src/modules/safe-shield/safe-shield.controller.integration.spec.ts
+++ b/src/modules/safe-shield/safe-shield.controller.integration.spec.ts
@@ -60,7 +60,7 @@ describe('SafeShieldController', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('POST /v1/chains/:chainId/security/:safeAddress/threat-analysis', () => {

--- a/src/modules/safe/routes/safes.controller.integration.spec.ts
+++ b/src/modules/safe/routes/safes.controller.integration.spec.ts
@@ -58,7 +58,7 @@ describe('Safes Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('safe info is correctly serialised', async () => {

--- a/src/modules/safe/routes/safes.controller.nonces.integration.spec.ts
+++ b/src/modules/safe/routes/safes.controller.nonces.integration.spec.ts
@@ -38,7 +38,7 @@ describe('Safes Controller Nonces', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('returns latest transaction nonce + 1 if greater than safe nonce', async () => {

--- a/src/modules/safe/routes/safes.controller.overview.integration.spec.ts
+++ b/src/modules/safe/routes/safes.controller.overview.integration.spec.ts
@@ -70,7 +70,7 @@ describe('Safes Controller Overview', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET /safes', () => {

--- a/src/modules/safe/routes/v2/__tests__/safes.v2.controller.overview.integration.spec.ts
+++ b/src/modules/safe/routes/v2/__tests__/safes.v2.controller.overview.integration.spec.ts
@@ -73,7 +73,7 @@ describe('Safes V2 Controller Overview', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GET /v2/safes', () => {

--- a/src/modules/surveys/routes/surveys.controller.integration.spec.ts
+++ b/src/modules/surveys/routes/surveys.controller.integration.spec.ts
@@ -62,7 +62,7 @@ describe('SurveysController', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   /**

--- a/src/modules/targeted-messaging/routes/targeted-messaging.controller.integration.spec.ts
+++ b/src/modules/targeted-messaging/routes/targeted-messaging.controller.integration.spec.ts
@@ -45,7 +45,7 @@ describe('TargetedMessagingController', () => {
 
   afterEach(async () => {
     vi.resetAllMocks();
-    await app.close();
+    await app?.close();
   });
 
   describe('GET targeted Safe', () => {

--- a/src/modules/transactions/routes/__tests__/controllers/add-transaction-confirmations.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/add-transaction-confirmations.transactions.controller.integration.spec.ts
@@ -111,7 +111,7 @@ describe('Add transaction confirmations - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should throw a validation error', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/delete-transaction.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/delete-transaction.transactions.controller.integration.spec.ts
@@ -45,7 +45,7 @@ describe('Delete Transaction - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should throw a validation error', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/get-creation-transaction.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/get-creation-transaction.transactions.controller.integration.spec.ts
@@ -41,7 +41,7 @@ describe('Get creation transaction', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should return the creation transaction', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/get-transaction-by-id.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/get-transaction-by-id.transactions.controller.integration.spec.ts
@@ -97,7 +97,7 @@ describe('Get by id - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
   it('Failure: Config API fails', async () => {
     const chainId = faker.string.numeric();

--- a/src/modules/transactions/routes/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.integration.spec.ts
@@ -55,7 +55,7 @@ describe('List incoming transfers by Safe - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('Failure: Config API fails', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.integration.spec.ts
@@ -41,7 +41,7 @@ describe('List module transactions by Safe - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('Failure: Config API fails', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.integration.spec.ts
@@ -85,7 +85,7 @@ describe('List queued transactions by Safe - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('Failure: data page validation fails', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/preview-transaction-cow-swap.transactions.controller.integration.spec.ts
@@ -71,7 +71,7 @@ describe('Preview transaction - CoW Swap - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('Swaps', () => {

--- a/src/modules/transactions/routes/__tests__/controllers/preview-transaction-kiln.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/preview-transaction-kiln.transactions.controller.integration.spec.ts
@@ -66,7 +66,7 @@ describe('Preview transaction - Kiln - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('Native (dedicated) staking', () => {

--- a/src/modules/transactions/routes/__tests__/controllers/preview-transaction.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/preview-transaction.transactions.controller.integration.spec.ts
@@ -46,7 +46,7 @@ describe('Preview transaction - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should throw a validation error', async () => {

--- a/src/modules/transactions/routes/__tests__/controllers/propose-transaction.transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/__tests__/controllers/propose-transaction.transactions.controller.integration.spec.ts
@@ -94,7 +94,7 @@ describe('Propose transaction - Transactions Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should throw a validation error', async () => {

--- a/src/modules/transactions/routes/transactions-history.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/transactions-history.controller.integration.spec.ts
@@ -89,7 +89,7 @@ describe('Transactions History Controller', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('Failure: Config API fails', async () => {

--- a/src/modules/transactions/routes/transactions-history.imitation-transactions.controller.integration.spec.ts
+++ b/src/modules/transactions/routes/transactions-history.imitation-transactions.controller.integration.spec.ts
@@ -97,7 +97,7 @@ describe('Transactions History Controller - Imitation Transactions', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   function getImitationAddress(address: Address): Address {

--- a/src/routes/common/decorators/pagination.data.decorator.integration.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.integration.spec.ts
@@ -35,7 +35,7 @@ describe('PaginationDataDecorator', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('no cursor', async () => {

--- a/src/routes/common/filters/global-error.filter.integration.spec.ts
+++ b/src/routes/common/filters/global-error.filter.integration.spec.ts
@@ -68,7 +68,7 @@ describe('GlobalErrorFilter tests', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   beforeEach(() => {

--- a/src/routes/common/filters/zod-error.filter.integration.spec.ts
+++ b/src/routes/common/filters/zod-error.filter.integration.spec.ts
@@ -93,7 +93,7 @@ describe('ZodErrorFilter tests', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('ZodErrorWithCode exception returns first issue', async () => {

--- a/src/routes/common/interceptors/cache-control.interceptor.integration.spec.ts
+++ b/src/routes/common/interceptors/cache-control.interceptor.integration.spec.ts
@@ -42,7 +42,7 @@ describe('CacheControlInterceptor tests', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should set the Cache-Control header to no-cache', () => {

--- a/src/routes/common/interceptors/route-logger.interceptor.integration.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.integration.spec.ts
@@ -116,7 +116,7 @@ describe('RouteLoggerInterceptor tests', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('500 error triggers error level', async () => {


### PR DESCRIPTION
## Summary

Fixes three tests that kept flaking **after** #3139. All three were visible in Datadog CI Pipeline Health but missed by our own flaky-test report, whose log parser is Jest-specific and went blind once the suite moved to Vitest (#3136).

- **`name.builder`** — `nameBuilder()` sanitized (trimmed) the faker name and *then* truncated to `NAME_MAX_LENGTH`; the cut could land right after a space and re-introduce trailing whitespace, so `sanitizeName(name) !== name`. Now re-`sanitizeName()` after truncation so the result is a fixed point.
- **`bridge-name.entity.spec`** — the "unknown bridge name" case used `faker.word.noun()`, which can itself be a bridge name (`omni`, `polygon`, `across`, `gnosis`, …), making `safeParse` succeed and the assertion flip to `expected false to deeply equal …`. Now resamples until the word is genuinely not a bridge name.
- **Integration specs (61 files)** — `afterEach`/`afterAll` called `await app.close()` unguarded, so any `beforeEach` failure left `app` undefined and every test in the file reported `Cannot read properties of undefined (reading 'close')` instead of the real error (the "27 tests fail at teardown" cascade). Guarded with `await app?.close()`.

## Testing

- `yarn test:unit` for `name.builder` + `bridge-name.entity` → pass
- `biome check` clean; `tsc` introduces no new errors

## Related

- WA-1753
- Follows #3139 (clearMocks + seeded faker)
