### PR TITLE
feat(auth): add loopback for localhost redirect

### DIFF
--- a/src/modules/auth/utils/auth-redirect.helper.spec.ts
+++ b/src/modules/auth/utils/auth-redirect.helper.spec.ts
@@ -202,6 +202,70 @@ describe('Auth-redirect helper functions', () => {
           resolveAndValidateRedirectUrl(config, faker.internet.url()),
         ).toThrow(BadRequestException);
       });
+
+      describe('loopback exception', () => {
+        it.each([
+          { host: 'localhost' },
+          { host: '127.0.0.1' },
+          { host: '[::1]' },
+        ])('should accept http://$host with any port', ({ host }) => {
+          const url = `http://${host}:${faker.internet.port()}/${faker.word.noun()}`;
+
+          expect(resolveAndValidateRedirectUrl(config, url)).toBe(url);
+        });
+
+        it('should accept loopback without a port', () => {
+          const url = `http://localhost/${faker.word.noun()}`;
+
+          expect(resolveAndValidateRedirectUrl(config, url)).toBe(url);
+        });
+
+        it('should accept https loopback', () => {
+          const url = `https://localhost:${faker.internet.port()}/${faker.word.noun()}`;
+
+          expect(resolveAndValidateRedirectUrl(config, url)).toBe(url);
+        });
+
+        it.each([
+          {
+            reason: 'lookalike hostname suffixed with allowed name',
+            url: (): string =>
+              `http://localhost.${faker.internet.domainName()}:3000`,
+          },
+          {
+            reason: 'lookalike hostname prefixed with loopback IP',
+            url: (): string =>
+              `http://127.0.0.1.${faker.internet.domainName()}`,
+          },
+          {
+            reason: 'loopback URL with userinfo',
+            url: (): string => `http://user:pass@localhost:3000`,
+          },
+          {
+            reason: 'non-HTTP scheme on loopback',
+            url: (): string => `ftp://localhost:3000`,
+          },
+        ])('should reject $reason', ({ url }) => {
+          expect(() => resolveAndValidateRedirectUrl(config, url())).toThrow(
+            BadRequestException,
+          );
+        });
+
+        it('should reject loopback in production', () => {
+          const prodConfig: RedirectConfig = {
+            postLoginRedirectUri: config.postLoginRedirectUri,
+            allowedRedirectDomain: allowedDomain,
+            isProduction: true,
+          };
+
+          expect(() =>
+            resolveAndValidateRedirectUrl(
+              prodConfig,
+              `http://localhost:${faker.internet.port()}`,
+            ),
+          ).toThrow(BadRequestException);
+        });
+      });
     });
   });
 });

--- a/src/modules/auth/utils/auth-redirect.helper.ts
+++ b/src/modules/auth/utils/auth-redirect.helper.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from '@nestjs/common';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 
 const AUTH0_LOGOUT_PATH = '/v2/logout';
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 /**
  * Builds the Auth0 {@link https://auth0.com/docs/api/authentication/logout/auth-0-logout}
  * base URL from {@link IConfigurationService}.
@@ -108,35 +109,41 @@ export function resolveAndValidateRedirectUrl(
  * match {@link RedirectConfig.postLoginRedirectUri}'s origin.
  *
  * **Non-production with {@link RedirectConfig.allowedRedirectDomain}** —
- * the target's hostname must equal or be a subdomain of the configured
- * domain. Additionally rejects:
+ * URLs with {@link URL.username} or {@link URL.password} are always
+ * rejected (prevents credential-based open-redirect attacks, e.g.
+ * `https://attacker.com@allowed.dev`); beyond that, two hostname classes
+ * are allowed:
  *
- * - Non-HTTPS schemes (prevents protocol downgrades).
- * - URLs with {@link URL.username} or {@link URL.password} (prevents
- *   credential-based open-redirect attacks, e.g.
- *   `https://attacker.com@allowed.dev`).
- * - URLs with an explicit {@link URL.port} (restricts redirects to
- *   standard HTTPS endpoints).
+ * - **Loopback** (`localhost`, `127.0.0.1`, `[::1]`, matched exactly) over
+ *   `http:` or `https:` with any port. This is the loopback exception of
+ *   {@link https://datatracker.ietf.org/doc/html/rfc8252#section-7.3 RFC 8252},
+ *   letting local frontends authenticate against deployed environments.
+ * - **The configured domain or a subdomain of it**, over `https:` only
+ *   (prevents protocol downgrades) and without an explicit
+ *   {@link URL.port} (restricts redirects to standard HTTPS endpoints).
  *
  * @param target - The resolved redirect {@link URL} to validate.
  * @param config - Pre-loaded redirect configuration.
  * @returns `true` if the redirect target is allowed, `false` otherwise.
  */
 function isAllowedRedirectUrl(target: URL, config: RedirectConfig): boolean {
-  if (!config.isProduction && config.allowedRedirectDomain) {
-    if (
-      target.protocol !== 'https:' ||
-      target.username ||
-      target.password ||
-      target.port
-    ) {
-      return false;
-    }
-    const suffix = `.${config.allowedRedirectDomain}`;
-    return (
-      target.hostname === config.allowedRedirectDomain ||
-      target.hostname.endsWith(suffix)
-    );
+  if (config.isProduction || !config.allowedRedirectDomain) {
+    return target.origin === new URL(config.postLoginRedirectUri).origin;
   }
-  return target.origin === new URL(config.postLoginRedirectUri).origin;
+
+  if (target.username || target.password) {
+    return false;
+  }
+
+  const isHttps = target.protocol === 'https:';
+  if (LOOPBACK_HOSTNAMES.has(target.hostname)) {
+    return target.protocol === 'http:' || isHttps;
+  }
+
+  return (
+    isHttps &&
+    !target.port &&
+    (target.hostname === config.allowedRedirectDomain ||
+      target.hostname.endsWith(`.${config.allowedRedirectDomain}`))
+  );
 }


### PR DESCRIPTION
## Summary
resolves [WA-2807](https://linear.app/safe-global/issue/WA-2807/adjust-cgw-to-allow-auth-from-local-wallet-app)

Allows locally running frontends (e.g. `http://localhost:3000`) to authenticate against deployed non-production CGW instances (staging/dev). Previously the post-login/logout redirect validation rejected localhost targets on three counts — non-HTTPS scheme, explicit port, and hostname outside `AUTH_ALLOWED_REDIRECT_DOMAIN` — making it impossible to develop a web app locally against staging auth.

## Changes

- **Loopback redirect exception** in `src/modules/auth/utils/auth-redirect.helper.ts`: in non-production environments with `AUTH_ALLOWED_REDIRECT_DOMAIN` set, redirect URLs targeting loopback hosts (`localhost`, `127.0.0.1`, `[::1]`) are now allowed over `http:` or `https:` with any port. This follows the loopback exception of [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).
- **Refactored `isAllowedRedirectUrl`** from nested conditionals into flat guards: production same-origin check first, then a shared userinfo rejection, then one policy branch per hostname class (loopback vs. allowed domain).
- **Tests**: new `loopback exception` block covering accepted hosts (with/without port, http/https), lookalike-hostname rejections, userinfo rejection, non-HTTP scheme rejection, and production still rejecting loopback.

## Security considerations

- **Production behavior is unchanged** — strict same-origin validation against `AUTH_POST_LOGIN_REDIRECT_URI`; the loopback branch is unreachable when `application.isProduction` is true.
- **No suffix matching on loopback hosts** — hostnames are compared exactly against a fixed set, so lookalikes such as `localhost.attacker.com` or `127.0.0.1.evil.dev` are still rejected.
- **URLs carrying userinfo** (`http://user:pass@localhost`) are still rejected.
- **Loopback redirects are not remotely exploitable**: the redirect lands on the requesting user's own machine, and no token travels in the URL (the access token is set as an `httpOnly` cookie on the CGW domain before the redirect).

