### PR TITLE
fix: CF safes: filter deployed Safes from counterfactual space endpoint

### DIFF
--- a/src/modules/counterfactual-safes/counterfactual-safes.module.ts
+++ b/src/modules/counterfactual-safes/counterfactual-safes.module.ts
@@ -12,6 +12,7 @@ import { CounterfactualSafesController } from '@/modules/counterfactual-safes/ro
 import { CounterfactualSafesService } from '@/modules/counterfactual-safes/routes/counterfactual-safes.service';
 import { SpaceCounterfactualSafesController } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.controller';
 import { SpaceCounterfactualSafesService } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.service';
+import { SafeRepositoryModule } from '@/modules/safe/domain/safe.repository.interface';
 import { SpacesModule } from '@/modules/spaces/spaces.module';
 import { UsersModule } from '@/modules/users/users.module';
 
@@ -22,6 +23,7 @@ import { UsersModule } from '@/modules/users/users.module';
     forwardRef(() => AuthModule),
     forwardRef(() => UsersModule),
     forwardRef(() => SpacesModule),
+    SafeRepositoryModule,
   ],
   controllers: [
     CounterfactualSafesController,

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.spec.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.spec.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { counterfactualSafeBuilder } from '@/modules/counterfactual-safes/datasources/entities/__tests__/counterfactual-safe.entity.db.builder';
+import type { ICounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface';
+import { SpaceCounterfactualSafesService } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.service';
+import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+import type { ISpaceSafesRepository } from '@/modules/spaces/domain/safes/space-safes.repository.interface';
+import type { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
+
+const mockMembersRepository = vi.mocked({
+  findOne: vi.fn(),
+} as unknown as MockedObject<IMembersRepository>);
+
+const mockSpaceSafesRepository = vi.mocked({
+  findBySpaceId: vi.fn(),
+} as unknown as MockedObject<ISpaceSafesRepository>);
+
+const mockCounterfactualSafesRepository = vi.mocked({
+  find: vi.fn(),
+} as unknown as MockedObject<ICounterfactualSafesRepository>);
+
+const mockSafeRepository = vi.mocked({
+  isSafe: vi.fn(),
+} as unknown as MockedObject<ISafeRepository>);
+
+describe('SpaceCounterfactualSafesService', () => {
+  let target: SpaceCounterfactualSafesService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    target = new SpaceCounterfactualSafesService(
+      mockMembersRepository,
+      mockSpaceSafesRepository,
+      mockCounterfactualSafesRepository,
+      mockSafeRepository,
+    );
+  });
+
+  const spaceId = faker.string.uuid();
+  const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+  const userId = Number(authPayloadDto.sub);
+  const authPayload = new AuthPayload(authPayloadDto);
+
+  it('excludes counterfactual rows whose Safe is already deployed on-chain', async () => {
+    const chainId = '11155111';
+    const deployed = counterfactualSafeBuilder()
+      .with('chainId', chainId)
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+    const undeployed = counterfactualSafeBuilder()
+      .with('chainId', chainId)
+      .with('address', getAddress(faker.finance.ethereumAddress()))
+      .build();
+
+    mockMembersRepository.findOne.mockResolvedValue({
+      id: userId,
+    } as never);
+    mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
+      { chainId, address: deployed.address },
+      { chainId, address: undeployed.address },
+    ]);
+    mockCounterfactualSafesRepository.find.mockResolvedValue([
+      deployed,
+      undeployed,
+    ]);
+    mockSafeRepository.isSafe.mockImplementation(
+      async ({ address }) => address === deployed.address,
+    );
+
+    const result = await target.get(spaceId as never, authPayload);
+
+    const returned = result.safes[chainId] ?? [];
+    expect(returned).toHaveLength(1);
+    expect(returned[0].address).toBe(undeployed.address);
+  });
+
+  it('returns undeployed counterfactual safes', async () => {
+    const chainId = '11155111';
+    const undeployed = counterfactualSafeBuilder()
+      .with('chainId', chainId)
+      .build();
+
+    mockMembersRepository.findOne.mockResolvedValue({
+      id: userId,
+    } as never);
+    mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
+      { chainId, address: undeployed.address },
+    ]);
+    mockCounterfactualSafesRepository.find.mockResolvedValue([undeployed]);
+    mockSafeRepository.isSafe.mockResolvedValue(false);
+
+    const result = await target.get(spaceId as never, authPayload);
+
+    expect(result.safes[chainId]).toHaveLength(1);
+  });
+
+  it('keeps the Safe when the deployment check fails (fail open)', async () => {
+    const chainId = '11155111';
+    const safe = counterfactualSafeBuilder().with('chainId', chainId).build();
+
+    mockMembersRepository.findOne.mockResolvedValue({ id: userId } as never);
+    mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
+      { chainId, address: safe.address },
+    ]);
+    mockCounterfactualSafesRepository.find.mockResolvedValue([safe]);
+    mockSafeRepository.isSafe.mockRejectedValue(new Error('tx service down'));
+
+    const result = await target.get(spaceId as never, authPayload);
+
+    expect(result.safes[chainId]).toHaveLength(1);
+    expect(result.safes[chainId][0].address).toBe(safe.address);
+  });
+
+  it('returns no safes and skips lookups when the space has no safes', async () => {
+    mockMembersRepository.findOne.mockResolvedValue({ id: userId } as never);
+    mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([]);
+
+    const result = await target.get(spaceId as never, authPayload);
+
+    expect(result).toEqual({ safes: {} });
+    expect(mockCounterfactualSafesRepository.find).not.toHaveBeenCalled();
+    expect(mockSafeRepository.isSafe).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is not a member of the space', async () => {
+    mockMembersRepository.findOne.mockResolvedValue(null as never);
+
+    await expect(target.get(spaceId as never, authPayload)).rejects.toThrow();
+    expect(mockSpaceSafesRepository.findBySpaceId).not.toHaveBeenCalled();
+  });
+
+  it('filters deployed safes per chain across multiple chains', async () => {
+    const chainA = '1';
+    const chainB = '11155111';
+    const deployedA = counterfactualSafeBuilder().with('chainId', chainA).build();
+    const undeployedA = counterfactualSafeBuilder()
+      .with('chainId', chainA)
+      .build();
+    const undeployedB = counterfactualSafeBuilder()
+      .with('chainId', chainB)
+      .build();
+
+    mockMembersRepository.findOne.mockResolvedValue({ id: userId } as never);
+    mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
+      { chainId: chainA, address: deployedA.address },
+      { chainId: chainA, address: undeployedA.address },
+      { chainId: chainB, address: undeployedB.address },
+    ]);
+    mockCounterfactualSafesRepository.find.mockResolvedValue([
+      deployedA,
+      undeployedA,
+      undeployedB,
+    ]);
+    mockSafeRepository.isSafe.mockImplementation(
+      async ({ address }) => address === deployedA.address,
+    );
+
+    const result = await target.get(spaceId as never, authPayload);
+
+    expect(result.safes[chainA]).toHaveLength(1);
+    expect(result.safes[chainA][0].address).toBe(undeployedA.address);
+    expect(result.safes[chainB]).toHaveLength(1);
+    expect(result.safes[chainB][0].address).toBe(undeployedB.address);
+  });
+});

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.spec.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.spec.ts
@@ -10,23 +10,24 @@ import type { ICounterfactualSafesRepository } from '@/modules/counterfactual-sa
 import { SpaceCounterfactualSafesService } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.service';
 import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 import type { ISpaceSafesRepository } from '@/modules/spaces/domain/safes/space-safes.repository.interface';
+import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import type { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
 
 const mockMembersRepository = vi.mocked({
   findOne: vi.fn(),
-} as unknown as MockedObject<IMembersRepository>);
+} as MockedObject<IMembersRepository>);
 
 const mockSpaceSafesRepository = vi.mocked({
   findBySpaceId: vi.fn(),
-} as unknown as MockedObject<ISpaceSafesRepository>);
+} as MockedObject<ISpaceSafesRepository>);
 
 const mockCounterfactualSafesRepository = vi.mocked({
   find: vi.fn(),
-} as unknown as MockedObject<ICounterfactualSafesRepository>);
+} as MockedObject<ICounterfactualSafesRepository>);
 
 const mockSafeRepository = vi.mocked({
   isSafe: vi.fn(),
-} as unknown as MockedObject<ISafeRepository>);
+} as MockedObject<ISafeRepository>);
 
 describe('SpaceCounterfactualSafesService', () => {
   let target: SpaceCounterfactualSafesService;
@@ -41,10 +42,11 @@ describe('SpaceCounterfactualSafesService', () => {
     );
   });
 
-  const spaceId = faker.string.uuid();
+  const spaceId = faker.number.int({ min: 1 });
   const authPayloadDto = siweAuthPayloadDtoBuilder().build();
   const userId = Number(authPayloadDto.sub);
   const authPayload = new AuthPayload(authPayloadDto);
+  const member = memberBuilder().with('id', userId).build();
 
   it('excludes counterfactual rows whose Safe is already deployed on-chain', async () => {
     const chainId = '11155111';
@@ -57,9 +59,7 @@ describe('SpaceCounterfactualSafesService', () => {
       .with('address', getAddress(faker.finance.ethereumAddress()))
       .build();
 
-    mockMembersRepository.findOne.mockResolvedValue({
-      id: userId,
-    } as never);
+    mockMembersRepository.findOne.mockResolvedValue(member);
     mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
       { chainId, address: deployed.address },
       { chainId, address: undeployed.address },
@@ -72,7 +72,7 @@ describe('SpaceCounterfactualSafesService', () => {
       async ({ address }) => address === deployed.address,
     );
 
-    const result = await target.get(spaceId as never, authPayload);
+    const result = await target.get(spaceId, authPayload);
 
     const returned = result.safes[chainId] ?? [];
     expect(returned).toHaveLength(1);
@@ -85,16 +85,14 @@ describe('SpaceCounterfactualSafesService', () => {
       .with('chainId', chainId)
       .build();
 
-    mockMembersRepository.findOne.mockResolvedValue({
-      id: userId,
-    } as never);
+    mockMembersRepository.findOne.mockResolvedValue(member);
     mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
       { chainId, address: undeployed.address },
     ]);
     mockCounterfactualSafesRepository.find.mockResolvedValue([undeployed]);
     mockSafeRepository.isSafe.mockResolvedValue(false);
 
-    const result = await target.get(spaceId as never, authPayload);
+    const result = await target.get(spaceId, authPayload);
 
     expect(result.safes[chainId]).toHaveLength(1);
   });
@@ -103,24 +101,24 @@ describe('SpaceCounterfactualSafesService', () => {
     const chainId = '11155111';
     const safe = counterfactualSafeBuilder().with('chainId', chainId).build();
 
-    mockMembersRepository.findOne.mockResolvedValue({ id: userId } as never);
+    mockMembersRepository.findOne.mockResolvedValue(member);
     mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
       { chainId, address: safe.address },
     ]);
     mockCounterfactualSafesRepository.find.mockResolvedValue([safe]);
     mockSafeRepository.isSafe.mockRejectedValue(new Error('tx service down'));
 
-    const result = await target.get(spaceId as never, authPayload);
+    const result = await target.get(spaceId, authPayload);
 
     expect(result.safes[chainId]).toHaveLength(1);
     expect(result.safes[chainId][0].address).toBe(safe.address);
   });
 
   it('returns no safes and skips lookups when the space has no safes', async () => {
-    mockMembersRepository.findOne.mockResolvedValue({ id: userId } as never);
+    mockMembersRepository.findOne.mockResolvedValue(member);
     mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([]);
 
-    const result = await target.get(spaceId as never, authPayload);
+    const result = await target.get(spaceId, authPayload);
 
     expect(result).toEqual({ safes: {} });
     expect(mockCounterfactualSafesRepository.find).not.toHaveBeenCalled();
@@ -128,9 +126,9 @@ describe('SpaceCounterfactualSafesService', () => {
   });
 
   it('throws when the user is not a member of the space', async () => {
-    mockMembersRepository.findOne.mockResolvedValue(null as never);
+    mockMembersRepository.findOne.mockResolvedValue(null);
 
-    await expect(target.get(spaceId as never, authPayload)).rejects.toThrow();
+    await expect(target.get(spaceId, authPayload)).rejects.toThrow();
     expect(mockSpaceSafesRepository.findBySpaceId).not.toHaveBeenCalled();
   });
 
@@ -147,7 +145,7 @@ describe('SpaceCounterfactualSafesService', () => {
       .with('chainId', chainB)
       .build();
 
-    mockMembersRepository.findOne.mockResolvedValue({ id: userId } as never);
+    mockMembersRepository.findOne.mockResolvedValue(member);
     mockSpaceSafesRepository.findBySpaceId.mockResolvedValue([
       { chainId: chainA, address: deployedA.address },
       { chainId: chainA, address: undeployedA.address },
@@ -162,7 +160,7 @@ describe('SpaceCounterfactualSafesService', () => {
       async ({ address }) => address === deployedA.address,
     );
 
-    const result = await target.get(spaceId as never, authPayload);
+    const result = await target.get(spaceId, authPayload);
 
     expect(result.safes[chainA]).toHaveLength(1);
     expect(result.safes[chainA][0].address).toBe(undeployedA.address);

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.spec.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.spec.ts
@@ -137,7 +137,9 @@ describe('SpaceCounterfactualSafesService', () => {
   it('filters deployed safes per chain across multiple chains', async () => {
     const chainA = '1';
     const chainB = '11155111';
-    const deployedA = counterfactualSafeBuilder().with('chainId', chainA).build();
+    const deployedA = counterfactualSafeBuilder()
+      .with('chainId', chainA)
+      .build();
     const undeployedA = counterfactualSafeBuilder()
       .with('chainId', chainA)
       .build();

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.ts
@@ -3,9 +3,11 @@
 import { Inject, Injectable } from '@nestjs/common';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
 import { ICounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface';
 import { transformCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/counterfactual-safes.utils';
 import type { GetCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
+import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 import type { Space } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
 import { ISpaceSafesRepository } from '@/modules/spaces/domain/safes/space-safes.repository.interface';
 import { assertMember } from '@/modules/spaces/routes/utils/space-assert.utils';
@@ -20,6 +22,8 @@ export class SpaceCounterfactualSafesService {
     private readonly spaceSafesRepository: ISpaceSafesRepository,
     @Inject(ICounterfactualSafesRepository)
     private readonly counterfactualSafesRepository: ICounterfactualSafesRepository,
+    @Inject(ISafeRepository)
+    private readonly safeRepository: ISafeRepository,
   ) {}
 
   public async get(
@@ -44,8 +48,31 @@ export class SpaceCounterfactualSafesService {
       where: whereClause,
     });
 
+    // Stale counterfactual_safes rows aren't cleared on deployment, so drop any
+    // Safe that is actually deployed on-chain before returning.
+    const undeployedSafes = await this.filterUndeployed(counterfactualSafes);
+
     return {
-      safes: transformCounterfactualSafesResponse(counterfactualSafes),
+      safes: transformCounterfactualSafesResponse(undeployedSafes),
     };
+  }
+
+  private async filterUndeployed(
+    safes: Array<CounterfactualSafe>,
+  ): Promise<Array<CounterfactualSafe>> {
+    const deploymentChecks = await Promise.all(
+      safes.map(async (safe) => {
+        try {
+          return await this.safeRepository.isSafe({
+            chainId: safe.chainId,
+            address: safe.address,
+          });
+        } catch {
+          return false;
+        }
+      }),
+    );
+
+    return safes.filter((_, index) => !deploymentChecks[index]);
   }
 }


### PR DESCRIPTION
## Summary

Resolves: [WA-2847](https://linear.app/safe-global/issue/WA-2847/cgw-fix-stop-returning-depolyed-safes-as-cf)
First-aid fix for `GET /v1/spaces/:spaceId/counterfactual-safes` returning already-deployed Safes as counterfactual.

A `counterfactual_safes` row records a *predicted* Safe but is never cleared when that Safe is later deployed on-chain, so a stale row makes a deployed Safe surface on this endpoint as counterfactual. The read path never checked deployment status.

This patch cross-checks each candidate against the transaction service (`isSafe`) and drops the ones that are actually deployed. Fail-open: if the check errors, the row is kept so a transaction-service outage can't hide a genuinely counterfactual Safe.

This is a read-side fix only — it hides deployed Safes from the response but does not stop the bad rows from being written. **Write-side hardening (reject deployed addresses on `POST /counterfactual-safes`, FE guard) and cleanup of existing stale rows will follow in a child PR.**

## Changes

- Filter deployed Safes out of the space counterfactual-safes response (`SpaceCounterfactualSafesService`), via `ISafeRepository.isSafe`, run in parallel, fail-open on error.
- Inject `SafeRepositoryModule` into `CounterfactualSafesModule`.
- Add unit tests for `SpaceCounterfactualSafesService` (first unit spec for this service): deployed filtering, undeployed pass-through, fail-open, empty space, non-member, and multi-chain per-chain filtering.
