### PR TITLE
fix: await Fastify ready when initializing test apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,15 @@ Each external API gets its own datasource:
 
 When adding constructor dependencies, update all spec files that instantiate the class.
 
+## Testing
+
+- **Never call bare `await app.init()` in tests.** The HTTP platform is Fastify: route contexts only get their lifecycle hooks attached once Fastify's `.ready()` resolves, so a supertest request sent after `init()` alone races app boot and crashes inside Fastify's hook runner (`Cannot read properties of undefined (reading 'length')`), hanging the test until timeout. Always initialize test apps with `initTestApplication(app)` from `@/__tests__/test-app.provider`, which awaits both `app.init()` and the Fastify instance's `.ready()`:
+
+  ```typescript
+  app = await new TestAppProvider().provide(moduleFixture);
+  await initTestApplication(app);
+  ```
+
 ## Pre-Commit Checklist
 
 Before creating **EACH** commit, you MUST run the following commands in sequence and fix any issues:

--- a/src/__tests__/test-app.provider.ts
+++ b/src/__tests__/test-app.provider.ts
@@ -32,6 +32,15 @@ export function createTestApplication(module: TestingModule): TestApplication {
   return app;
 }
 
+/**
+ * Initializes a test {@link INestApplication} and waits for the underlying
+ * Fastify instance to be ready.
+ *
+ * Always use this instead of a bare `app.init()`: Fastify attaches route
+ * lifecycle hooks only once `.ready()` resolves, so a request sent after
+ * `init()` alone races app boot and crashes inside Fastify's hook runner,
+ * hanging the test until timeout.
+ */
 export async function initTestApplication(
   app: INestApplication,
 ): Promise<void> {

--- a/src/modules/portfolio/v1/portfolio.controller.integration.spec.ts
+++ b/src/modules/portfolio/v1/portfolio.controller.integration.spec.ts
@@ -5,7 +5,10 @@ import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { getAddress } from 'viem';
-import { TestAppProvider } from '@/__tests__/test-app.provider';
+import {
+  initTestApplication,
+  TestAppProvider,
+} from '@/__tests__/test-app.provider';
 import { createTestModule } from '@/__tests__/testing-module';
 import configuration from '@/config/entities/__tests__/configuration';
 
@@ -27,7 +30,7 @@ describe('Portfolio Controller', () => {
         config: testConfiguration,
       });
       app = await new TestAppProvider().provide(moduleFixture);
-      await app.init();
+      await initTestApplication(app);
     });
 
     afterAll(async () => {
@@ -68,7 +71,7 @@ describe('Portfolio Controller', () => {
         config: testConfiguration,
       });
       app = await new TestAppProvider().provide(moduleFixture);
-      await app.init();
+      await initTestApplication(app);
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## Summary

After the Fastify migration (#3190) and Vitest update, `portfolio.controller.integration.spec.ts` was timing out: under Fastify, route lifecycle hooks are only attached once `.ready()` resolves, so a supertest request sent after a bare `app.init()` races app boot, crashes inside Fastify's hook runner (`TypeError: Cannot read properties of undefined (reading 'length')` in `preParsingHookRunner`), and the test hangs until the 60s timeout.

The migration introduced `initTestApplication()` (which awaits both `app.init()` and the Fastify instance's `.ready()`), but this spec was the one file still calling bare `app.init()`.

## Changes

- Switch `src/modules/portfolio/v1/portfolio.controller.integration.spec.ts` to `initTestApplication()`, matching every other integration spec
- Document the rule in `AGENTS.md` so agents never reintroduce bare `app.init()` in tests
- Add a JSDoc warning on `initTestApplication` explaining the race

