### PR TITLE
chore: refactor Manager API classes

### DIFF
--- a/src/datasources/common/chain-api.manager.spec.ts
+++ b/src/datasources/common/chain-api.manager.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
+
+class TestApiManager extends ChainApiManager<{ chainId: string }> {
+  createApi = vi.fn((chainId: string) => Promise.resolve({ chainId }));
+
+  getApi(chainId: string): Promise<{ chainId: string }> {
+    return this.getOrCreateApi(chainId);
+  }
+}
+
+describe('ChainApiManager', () => {
+  let target: TestApiManager;
+
+  beforeEach(() => {
+    target = new TestApiManager();
+  });
+
+  it('should create an API instance on first retrieval and cache it', async () => {
+    const chainId = faker.string.numeric();
+
+    const first = await target.getApi(chainId);
+    const second = await target.getApi(chainId);
+
+    expect(second).toBe(first);
+    expect(target.createApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cache API instances per chain', async () => {
+    const firstChainId = '1';
+    const secondChainId = '2';
+
+    const first = await target.getApi(firstChainId);
+    const second = await target.getApi(secondChainId);
+
+    expect(first).not.toBe(second);
+    expect(target.createApi).toHaveBeenCalledTimes(2);
+  });
+
+  it('should create a new API instance after destruction', async () => {
+    const chainId = faker.string.numeric();
+
+    const first = await target.getApi(chainId);
+    target.destroyApi(chainId);
+    const second = await target.getApi(chainId);
+
+    expect(second).not.toBe(first);
+    expect(target.createApi).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not throw when destroying a non-cached API instance', () => {
+    expect(() => target.destroyApi(faker.string.numeric())).not.toThrow();
+  });
+});

--- a/src/datasources/common/chain-api.manager.ts
+++ b/src/datasources/common/chain-api.manager.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+/**
+ * Caches API instances per chain.
+ *
+ * Subclasses define how an instance is built via {@link createApi}.
+ * {@link getOrCreateApi} returns the cached instance for a chain, creating
+ * and caching it on first use; {@link destroyApi} evicts it so the next
+ * retrieval builds a fresh instance (e.g. after a chain update).
+ */
+export abstract class ChainApiManager<T> {
+  private readonly apis: Record<string, T> = {};
+
+  protected abstract createApi(chainId: string): T | Promise<T>;
+
+  protected async getOrCreateApi(chainId: string): Promise<T> {
+    this.apis[chainId] ??= await this.createApi(chainId);
+    return this.apis[chainId];
+  }
+
+  protected hasApi(chainId: string): boolean {
+    return this.apis[chainId] !== undefined;
+  }
+
+  destroyApi(chainId: string): void {
+    if (this.apis[chainId] !== undefined) {
+      delete this.apis[chainId];
+    }
+  }
+}

--- a/src/modules/balances/datasources/balances-api.manager.ts
+++ b/src/modules/balances/datasources/balances-api.manager.ts
@@ -6,6 +6,7 @@ import {
   CacheService,
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import {
   type INetworkService,
@@ -20,8 +21,10 @@ import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.sche
 import type { Raw } from '@/validation/entities/raw.entity';
 
 @Injectable()
-export class BalancesApiManager implements IBalancesApiManager {
-  private safeBalancesApiMap: Record<string, SafeBalancesApi> = {};
+export class BalancesApiManager
+  extends ChainApiManager<SafeBalancesApi>
+  implements IBalancesApiManager
+{
   private readonly useVpcUrl: boolean;
 
   constructor(
@@ -34,6 +37,7 @@ export class BalancesApiManager implements IBalancesApiManager {
     @Inject(IPricesApi) private readonly coingeckoApi: IPricesApi,
     @Inject(NetworkService) private readonly networkService: INetworkService,
   ) {
+    super();
     this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
       'safeTransaction.useVpcUrl',
     );
@@ -47,14 +51,16 @@ export class BalancesApiManager implements IBalancesApiManager {
     return this.coingeckoApi.getFiatCodes();
   }
 
-  private async _getSafeBalancesApi(chainId: string): Promise<SafeBalancesApi> {
-    const safeBalancesApi = this.safeBalancesApiMap[chainId];
-    if (safeBalancesApi !== undefined) return safeBalancesApi;
+  private _getSafeBalancesApi(chainId: string): Promise<SafeBalancesApi> {
+    return this.getOrCreateApi(chainId);
+  }
 
+  protected async createApi(chainId: string): Promise<SafeBalancesApi> {
     const chain = await this.configApi
       .getChain(chainId)
       .then(ChainSchema.parse);
-    this.safeBalancesApiMap[chainId] = new SafeBalancesApi(
+
+    return new SafeBalancesApi(
       chainId,
       this.useVpcUrl ? chain.vpcTransactionService : chain.transactionService,
       this.dataSource,
@@ -64,12 +70,5 @@ export class BalancesApiManager implements IBalancesApiManager {
       this.coingeckoApi,
       this.networkService,
     );
-    return this.safeBalancesApiMap[chainId];
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.safeBalancesApiMap[chainId] !== undefined) {
-      delete this.safeBalancesApiMap[chainId];
-    }
   }
 }

--- a/src/modules/blockchain/datasources/blockchain-api.manager.ts
+++ b/src/modules/blockchain/datasources/blockchain-api.manager.ts
@@ -14,6 +14,7 @@ import {
   CacheService,
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
 import type { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import type { Chain as DomainChain } from '@/modules/chains/domain/entities/chain.entity';
@@ -21,9 +22,11 @@ import { RpcUriAuthentication } from '@/modules/chains/domain/entities/rpc-uri-a
 import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
 
 @Injectable()
-export class BlockchainApiManager implements IBlockchainApiManager {
+export class BlockchainApiManager
+  extends ChainApiManager<PublicClient>
+  implements IBlockchainApiManager
+{
   private static readonly INFURA_URL_PATTERN = 'infura';
-  private readonly blockchainApiMap: Record<string, PublicClient> = {};
   private readonly infuraApiKey: string;
   private readonly rpcExpirationTimeInSeconds: number;
 
@@ -33,6 +36,7 @@ export class BlockchainApiManager implements IBlockchainApiManager {
     @Inject(IConfigApi) private readonly configApi: IConfigApi,
     @Inject(CacheService) private readonly cacheService: ICacheService,
   ) {
+    super();
     this.infuraApiKey = this.configurationService.getOrThrow<string>(
       'blockchain.infura.apiKey',
     );
@@ -42,26 +46,24 @@ export class BlockchainApiManager implements IBlockchainApiManager {
       );
   }
 
-  async getApi(chainId: string): Promise<PublicClient> {
-    const blockchainApi = this.blockchainApiMap[chainId];
-    if (blockchainApi) {
-      return blockchainApi;
-    }
+  getApi(chainId: string): Promise<PublicClient> {
+    return this.getOrCreateApi(chainId);
+  }
 
+  protected async createApi(chainId: string): Promise<PublicClient> {
     const chain = await this.configApi
       .getChain(chainId)
       .then(ChainSchema.parse);
-    this.blockchainApiMap[chainId] = this._createCachedRpcClient(chain);
 
-    return this.blockchainApiMap[chainId];
+    return this._createCachedRpcClient(chain);
   }
 
-  destroyApi(chainId: string): void {
-    if (!this.blockchainApiMap?.[chainId]) {
+  override destroyApi(chainId: string): void {
+    if (!this.hasApi(chainId)) {
       return;
     }
 
-    delete this.blockchainApiMap[chainId];
+    super.destroyApi(chainId);
 
     const key = CacheRouter.getRpcRequestsKey(chainId);
     this.cacheService.deleteByKey(key).catch(() => {

--- a/src/modules/bridge/datasources/bridge-api.factory.ts
+++ b/src/modules/bridge/datasources/bridge-api.factory.ts
@@ -2,6 +2,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import {
   type INetworkService,
@@ -12,9 +13,10 @@ import type { IBridgeApi } from '@/domain/interfaces/bridge-api.inferface';
 import { LifiBridgeApi } from '@/modules/bridge/datasources/lifi-api.service';
 
 @Injectable()
-export class BridgeApiFactory implements IBridgeApiFactory {
-  private readonly apis: Record<string, IBridgeApi> = {};
-
+export class BridgeApiFactory
+  extends ChainApiManager<IBridgeApi>
+  implements IBridgeApiFactory
+{
   private readonly baseUrl: string;
   private readonly apiKey: string;
 
@@ -26,17 +28,18 @@ export class BridgeApiFactory implements IBridgeApiFactory {
     @Inject(CacheFirstDataSource)
     private readonly cacheFirstDataSource: CacheFirstDataSource,
   ) {
+    super();
     this.baseUrl =
       this.configurationService.getOrThrow<string>('bridge.baseUri');
     this.apiKey = this.configurationService.getOrThrow<string>('bridge.apiKey');
   }
 
   getApi(chainId: string): Promise<IBridgeApi> {
-    if (this.apis[chainId]) {
-      return Promise.resolve(this.apis[chainId]);
-    }
+    return this.getOrCreateApi(chainId);
+  }
 
-    this.apis[chainId] = new LifiBridgeApi(
+  protected createApi(chainId: string): IBridgeApi {
+    return new LifiBridgeApi(
       chainId,
       this.baseUrl,
       this.apiKey,
@@ -45,13 +48,5 @@ export class BridgeApiFactory implements IBridgeApiFactory {
       this.httpErrorFactory,
       this.configurationService,
     );
-
-    return Promise.resolve(this.apis[chainId]);
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.apis[chainId] !== undefined) {
-      delete this.apis[chainId];
-    }
   }
 }

--- a/src/modules/csv-export/v1/datasources/export-api.manager.ts
+++ b/src/modules/csv-export/v1/datasources/export-api.manager.ts
@@ -2,6 +2,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
@@ -10,8 +11,10 @@ import type { IExportApi } from './export-api.interface';
 import { ExportApi } from './export-api.service';
 
 @Injectable()
-export class ExportApiManager implements IExportApiManager {
-  private readonly exportApiMap: Record<string, ExportApi> = {};
+export class ExportApiManager
+  extends ChainApiManager<IExportApi>
+  implements IExportApiManager
+{
   private readonly useVpcUrl: boolean;
 
   constructor(
@@ -21,34 +24,30 @@ export class ExportApiManager implements IExportApiManager {
     private readonly dataSource: CacheFirstDataSource,
     private readonly httpErrorFactory: HttpErrorFactory,
   ) {
+    super();
     this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
       'safeTransaction.useVpcUrl',
     );
   }
 
-  async getApi(chainId: string): Promise<IExportApi> {
-    const api = this.exportApiMap[chainId];
-    if (api) return api;
+  getApi(chainId: string): Promise<IExportApi> {
+    return this.getOrCreateApi(chainId);
+  }
 
+  protected async createApi(chainId: string): Promise<IExportApi> {
     const chain = await this.configApi
       .getChain(chainId)
       .then(ChainSchema.parse);
     const baseUrl = this.useVpcUrl
       ? chain.vpcTransactionService
       : chain.transactionService;
-    this.exportApiMap[chainId] = new ExportApi(
+
+    return new ExportApi(
       chainId,
       baseUrl,
       this.dataSource,
       this.configurationService,
       this.httpErrorFactory,
     );
-    return this.exportApiMap[chainId];
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.exportApiMap[chainId]) {
-      delete this.exportApiMap[chainId];
-    }
   }
 }

--- a/src/modules/earn/datasources/earn-api.manager.ts
+++ b/src/modules/earn/datasources/earn-api.manager.ts
@@ -1,72 +1,11 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable } from '@nestjs/common';
-import { IConfigurationService } from '@/config/configuration.service.interface';
-import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
-import {
-  CacheService,
-  type ICacheService,
-} from '@/datasources/cache/cache.service.interface';
-import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { IConfigApi } from '@/domain/interfaces/config-api.interface';
-import type { IStakingApi } from '@/domain/interfaces/staking-api.interface';
-import type { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
-import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
-import { KilnApi } from '@/modules/staking/datasources/kiln-api.service';
+import { Injectable } from '@nestjs/common';
+import { KilnApiManager } from '@/modules/staking/datasources/kiln-api.manager';
 
-// Note: This mirrors that of StakingApiManager but as each widget deployment
-// is its own Kiln "organization", deployments have different base URLs when
-// compared to the staking API.
+// Note: each widget deployment is its own Kiln "organization", so earn
+// deployments have different base URLs when compared to the staking API.
 
 @Injectable()
-export class EarnApiManager implements IStakingApiManager {
-  private readonly apis: Record<string, IStakingApi> = {};
-
-  constructor(
-    private readonly dataSource: CacheFirstDataSource,
-    @Inject(IConfigurationService)
-    private readonly configurationService: IConfigurationService,
-    @Inject(IConfigApi) private readonly configApi: IConfigApi,
-    private readonly httpErrorFactory: HttpErrorFactory,
-    @Inject(CacheService)
-    private readonly cacheService: ICacheService,
-  ) {}
-
-  async getApi(chainId: string): Promise<IStakingApi> {
-    if (this.apis[chainId]) {
-      return Promise.resolve(this.apis[chainId]);
-    }
-
-    const chain = await this.configApi
-      .getChain(chainId)
-      .then(ChainSchema.parse);
-
-    const env = chain.isTestnet ? 'testnet' : 'mainnet';
-
-    // Note: only difference to StakingApiManager logic
-    const baseUrl = this.configurationService.getOrThrow<string>(
-      `earn.${env}.baseUri`,
-    );
-    const apiKey = this.configurationService.getOrThrow<string>(
-      `earn.${env}.apiKey`,
-    );
-
-    this.apis[chainId] = new KilnApi(
-      baseUrl,
-      apiKey,
-      this.dataSource,
-      this.httpErrorFactory,
-      this.configurationService,
-      this.cacheService,
-      chain.chainId,
-      'earn',
-    );
-
-    return Promise.resolve(this.apis[chainId]);
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.apis[chainId] !== undefined) {
-      delete this.apis[chainId];
-    }
-  }
+export class EarnApiManager extends KilnApiManager {
+  protected readonly widget = 'earn';
 }

--- a/src/modules/staking/datasources/kiln-api.manager.spec.ts
+++ b/src/modules/staking/datasources/kiln-api.manager.spec.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { Test } from '@nestjs/testing';
+import type { MockedObject } from 'vitest';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { EarnApiManager } from '@/modules/earn/datasources/earn-api.manager';
+import { KilnApi } from '@/modules/staking/datasources/kiln-api.service';
+import { StakingApiManager } from '@/modules/staking/datasources/staking-api.manager';
+import { rawify } from '@/validation/entities/raw.entity';
+
+const configurationService = {
+  getOrThrow: vi.fn(),
+} as MockedObject<IConfigurationService>;
+
+const configApi = {
+  getChain: vi.fn(),
+} as MockedObject<IConfigApi>;
+
+const dataSource = {
+  get: vi.fn(),
+} as MockedObject<CacheFirstDataSource>;
+
+const cacheService = {} as MockedObject<ICacheService>;
+
+const httpErrorFactory = {} as MockedObject<HttpErrorFactory>;
+
+describe('KilnApiManager', () => {
+  let stakingApiManager: StakingApiManager;
+  let earnApiManager: EarnApiManager;
+
+  const mainnetBaseUri = faker.internet.url({ appendSlash: false });
+  const mainnetApiKey = faker.string.hexadecimal({ length: 32 });
+  const testnetBaseUri = faker.internet.url({ appendSlash: false });
+  const testnetApiKey = faker.string.hexadecimal({ length: 32 });
+
+  function mockConfig(widget: 'staking' | 'earn'): void {
+    configurationService.getOrThrow.mockImplementation((key) => {
+      if (key === `${widget}.mainnet.baseUri`) return mainnetBaseUri;
+      if (key === `${widget}.mainnet.apiKey`) return mainnetApiKey;
+      if (key === `${widget}.testnet.baseUri`) return testnetBaseUri;
+      if (key === `${widget}.testnet.apiKey`) return testnetApiKey;
+      if (key === 'expirationTimeInSeconds.staking') return faker.number.int();
+      if (key === 'expirationTimeInSeconds.notFound.default')
+        return faker.number.int();
+
+      throw new Error(`Unexpected key: ${key}`);
+    });
+  }
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    // Instantiate through Nest to cover the constructor being inherited
+    // from the abstract KilnApiManager, as the modules provide these
+    // classes via dependency injection.
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StakingApiManager,
+        EarnApiManager,
+        { provide: CacheFirstDataSource, useValue: dataSource },
+        { provide: IConfigurationService, useValue: configurationService },
+        { provide: IConfigApi, useValue: configApi },
+        { provide: HttpErrorFactory, useValue: httpErrorFactory },
+        { provide: CacheService, useValue: cacheService },
+      ],
+    }).compile();
+
+    stakingApiManager = moduleRef.get(StakingApiManager);
+    earnApiManager = moduleRef.get(EarnApiManager);
+  });
+
+  it.each([
+    ['staking', (): StakingApiManager => stakingApiManager],
+    ['earn', (): EarnApiManager => earnApiManager],
+  ] as const)('should create a KilnApi from the %s configuration', async (widget, getTarget) => {
+    const chain = chainBuilder().with('isTestnet', false).build();
+    configApi.getChain.mockResolvedValue(rawify(chain));
+    mockConfig(widget);
+
+    const api = await getTarget().getApi(chain.chainId);
+
+    expect(api).toBeInstanceOf(KilnApi);
+    expect(configurationService.getOrThrow).toHaveBeenCalledWith(
+      `${widget}.mainnet.baseUri`,
+    );
+    expect(configurationService.getOrThrow).toHaveBeenCalledWith(
+      `${widget}.mainnet.apiKey`,
+    );
+  });
+
+  it('should use the testnet configuration for testnet chains', async () => {
+    const chain = chainBuilder().with('isTestnet', true).build();
+    configApi.getChain.mockResolvedValue(rawify(chain));
+    mockConfig('staking');
+
+    await stakingApiManager.getApi(chain.chainId);
+
+    expect(configurationService.getOrThrow).toHaveBeenCalledWith(
+      'staking.testnet.baseUri',
+    );
+    expect(configurationService.getOrThrow).toHaveBeenCalledWith(
+      'staking.testnet.apiKey',
+    );
+  });
+
+  it('should cache the KilnApi instance per chain', async () => {
+    const chain = chainBuilder().with('isTestnet', false).build();
+    configApi.getChain.mockResolvedValue(rawify(chain));
+    mockConfig('staking');
+
+    const first = await stakingApiManager.getApi(chain.chainId);
+    const second = await stakingApiManager.getApi(chain.chainId);
+
+    expect(second).toBe(first);
+    expect(configApi.getChain).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a new KilnApi instance after destruction', async () => {
+    const chain = chainBuilder().with('isTestnet', false).build();
+    configApi.getChain.mockResolvedValue(rawify(chain));
+    mockConfig('staking');
+
+    const first = await stakingApiManager.getApi(chain.chainId);
+    stakingApiManager.destroyApi(chain.chainId);
+    const second = await stakingApiManager.getApi(chain.chainId);
+
+    expect(second).not.toBe(first);
+    expect(configApi.getChain).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/modules/staking/datasources/kiln-api.manager.ts
+++ b/src/modules/staking/datasources/kiln-api.manager.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import type { IStakingApi } from '@/domain/interfaces/staking-api.interface';
+import type { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
+import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
+import { KilnApi } from '@/modules/staking/datasources/kiln-api.service';
+
+/**
+ * Manages per-chain {@link KilnApi} instances for a given widget deployment.
+ *
+ * Each widget deployment (`staking`, `earn`) is its own Kiln "organization",
+ * so each has its own base URLs and API keys in configuration.
+ */
+export abstract class KilnApiManager
+  extends ChainApiManager<IStakingApi>
+  implements IStakingApiManager
+{
+  protected abstract readonly widget: 'staking' | 'earn';
+
+  constructor(
+    private readonly dataSource: CacheFirstDataSource,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(IConfigApi) private readonly configApi: IConfigApi,
+    private readonly httpErrorFactory: HttpErrorFactory,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
+  ) {
+    super();
+  }
+
+  getApi(chainId: string): Promise<IStakingApi> {
+    return this.getOrCreateApi(chainId);
+  }
+
+  protected async createApi(chainId: string): Promise<IStakingApi> {
+    const chain = await this.configApi
+      .getChain(chainId)
+      .then(ChainSchema.parse);
+
+    const env = chain.isTestnet ? 'testnet' : 'mainnet';
+
+    const baseUrl = this.configurationService.getOrThrow<string>(
+      `${this.widget}.${env}.baseUri`,
+    );
+    const apiKey = this.configurationService.getOrThrow<string>(
+      `${this.widget}.${env}.apiKey`,
+    );
+
+    return new KilnApi(
+      baseUrl,
+      apiKey,
+      this.dataSource,
+      this.httpErrorFactory,
+      this.configurationService,
+      this.cacheService,
+      chain.chainId,
+      this.widget,
+    );
+  }
+}

--- a/src/modules/staking/datasources/staking-api.manager.ts
+++ b/src/modules/staking/datasources/staking-api.manager.ts
@@ -1,67 +1,8 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable } from '@nestjs/common';
-import { IConfigurationService } from '@/config/configuration.service.interface';
-import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
-import {
-  CacheService,
-  type ICacheService,
-} from '@/datasources/cache/cache.service.interface';
-import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { IConfigApi } from '@/domain/interfaces/config-api.interface';
-import type { IStakingApi } from '@/domain/interfaces/staking-api.interface';
-import type { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
-import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
-import { KilnApi } from '@/modules/staking/datasources/kiln-api.service';
+import { Injectable } from '@nestjs/common';
+import { KilnApiManager } from '@/modules/staking/datasources/kiln-api.manager';
 
 @Injectable()
-export class StakingApiManager implements IStakingApiManager {
-  private readonly apis: Record<string, IStakingApi> = {};
-
-  constructor(
-    private readonly dataSource: CacheFirstDataSource,
-    @Inject(IConfigurationService)
-    private readonly configurationService: IConfigurationService,
-    @Inject(IConfigApi) private readonly configApi: IConfigApi,
-    private readonly httpErrorFactory: HttpErrorFactory,
-    @Inject(CacheService)
-    private readonly cacheService: ICacheService,
-  ) {}
-
-  async getApi(chainId: string): Promise<IStakingApi> {
-    if (this.apis[chainId]) {
-      return Promise.resolve(this.apis[chainId]);
-    }
-
-    const chain = await this.configApi
-      .getChain(chainId)
-      .then(ChainSchema.parse);
-
-    const env = chain.isTestnet ? 'testnet' : 'mainnet';
-
-    const baseUrl = this.configurationService.getOrThrow<string>(
-      `staking.${env}.baseUri`,
-    );
-    const apiKey = this.configurationService.getOrThrow<string>(
-      `staking.${env}.apiKey`,
-    );
-
-    this.apis[chainId] = new KilnApi(
-      baseUrl,
-      apiKey,
-      this.dataSource,
-      this.httpErrorFactory,
-      this.configurationService,
-      this.cacheService,
-      chain.chainId,
-      'staking',
-    );
-
-    return Promise.resolve(this.apis[chainId]);
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.apis[chainId] !== undefined) {
-      delete this.apis[chainId];
-    }
-  }
+export class StakingApiManager extends KilnApiManager {
+  protected readonly widget = 'staking';
 }

--- a/src/modules/swaps/datasources/swaps-api.factory.ts
+++ b/src/modules/swaps/datasources/swaps-api.factory.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import {
   type INetworkService,
@@ -11,36 +12,28 @@ import type { ISwapsApi } from '@/domain/interfaces/swaps-api.interface';
 import { CowSwapApi } from '@/modules/swaps/datasources/cowswap-api.service';
 
 @Injectable()
-export class SwapsApiFactory implements ISwapsApiFactory {
-  private readonly apis: Record<string, ISwapsApi> = {};
-
+export class SwapsApiFactory
+  extends ChainApiManager<ISwapsApi>
+  implements ISwapsApiFactory
+{
   constructor(
     @Inject(NetworkService) private readonly networkService: INetworkService,
     private readonly httpErrorFactory: HttpErrorFactory,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
-  ) {}
+  ) {
+    super();
+  }
 
   getApi(chainId: string): Promise<ISwapsApi> {
-    if (this.apis[chainId]) {
-      return Promise.resolve(this.apis[chainId]);
-    }
+    return this.getOrCreateApi(chainId);
+  }
 
+  protected createApi(chainId: string): ISwapsApi {
     const baseUrl = this.configurationService.getOrThrow<string>(
       `swaps.api.${chainId}`,
     );
 
-    this.apis[chainId] = new CowSwapApi(
-      baseUrl,
-      this.networkService,
-      this.httpErrorFactory,
-    );
-    return Promise.resolve(this.apis[chainId]);
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.apis[chainId] !== undefined) {
-      delete this.apis[chainId];
-    }
+    return new CowSwapApi(baseUrl, this.networkService, this.httpErrorFactory);
   }
 }

--- a/src/modules/transactions/datasources/transaction-api.manager.ts
+++ b/src/modules/transactions/datasources/transaction-api.manager.ts
@@ -6,6 +6,7 @@ import {
   CacheService,
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
+import { ChainApiManager } from '@/datasources/common/chain-api.manager';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import {
   type INetworkService,
@@ -21,9 +22,10 @@ import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.sche
 import { TransactionApi } from '@/modules/transactions/datasources/transaction-api.service';
 
 @Injectable()
-export class TransactionApiManager implements ITransactionApiManager {
-  private transactionApiMap: Record<string, TransactionApi> = {};
-
+export class TransactionApiManager
+  extends ChainApiManager<TransactionApi>
+  implements ITransactionApiManager
+{
   private readonly useVpcUrl: boolean;
 
   constructor(
@@ -36,19 +38,22 @@ export class TransactionApiManager implements ITransactionApiManager {
     @Inject(NetworkService) private readonly networkService: INetworkService,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {
+    super();
     this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
       'safeTransaction.useVpcUrl',
     );
   }
 
-  async getApi(chainId: string): Promise<TransactionApi> {
-    const transactionApi = this.transactionApiMap[chainId];
-    if (transactionApi !== undefined) return transactionApi;
+  getApi(chainId: string): Promise<TransactionApi> {
+    return this.getOrCreateApi(chainId);
+  }
 
+  protected async createApi(chainId: string): Promise<TransactionApi> {
     const chain = await this.configApi
       .getChain(chainId)
       .then(ChainSchema.parse);
-    this.transactionApiMap[chainId] = new TransactionApi(
+
+    return new TransactionApi(
       chainId,
       this.useVpcUrl ? chain.vpcTransactionService : chain.transactionService,
       this.dataSource,
@@ -58,12 +63,5 @@ export class TransactionApiManager implements ITransactionApiManager {
       this.networkService,
       this.loggingService,
     );
-    return this.transactionApiMap[chainId];
-  }
-
-  destroyApi(chainId: string): void {
-    if (this.transactionApiMap[chainId] !== undefined) {
-      delete this.transactionApiMap[chainId];
-    }
   }
 }


### PR DESCRIPTION
## Summary

Extracts the per-chain API caching boilerplate — duplicated across 8 datasource managers/factories — into a single generic base class, and collapses the near-verbatim `EarnApiManager`/`StakingApiManager` clone pair into one shared implementation.

### New: `ChainApiManager<T>`

`src/datasources/common/chain-api.manager.ts` owns the lazy per-chain cache that every manager previously reimplemented:

- `protected abstract createApi(chainId)` — subclasses define only how an instance is built
- `protected getOrCreateApi(chainId)` — returns the cached instance or creates and caches it (`??=`, preserving the original lazy/memoized semantics)
- `destroyApi(chainId)` — evicts, so the next retrieval rebuilds (e.g. after `CHAIN_UPDATED`)
- `protected hasApi(chainId)` — for subclasses that need to know whether anything was cached

The base deliberately exposes no public `getApi`: each subclass declares its own one-line `getApi` (keeping interface conformance explicit), which also lets `BalancesApiManager` reuse the cache mechanics despite a different public API.

### Refactored to extend it

- `staking-api.manager.ts`, `earn-api.manager.ts`, `swaps-api.factory.ts`, `bridge-api.factory.ts`, `transaction-api.manager.ts`, `balances-api.manager.ts`, `csv-export/v1/datasources/export-api.manager.ts`, `blockchain-api.manager.ts`
- Special cases preserved exactly:
  - `BlockchainApiManager` overrides `destroyApi` to keep its best-effort RPC cache eviction, including the early return when no client was cached
  - `BalancesApiManager` keeps its own `getApi` and inherits the cache for `SafeBalancesApi` instances

### Earn/Staking collapse

`EarnApiManager` was an author-acknowledged copy of `StakingApiManager` (only the config key prefix and the `KilnApi` widget arg differed). The shared logic now lives in abstract `KilnApiManager` (`src/modules/staking/datasources/kiln-api.manager.ts`), parameterized by a `widget: 'staking' | 'earn'` field; both concrete classes are now 8 lines and keep their names, so `staking.module.ts` / `earn.module.ts` providers are untouched.