### PR TITLE
fix: allow PATCH/PUT/DELETE in local dev CORS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,12 @@ async function bootstrap(): Promise<void> {
     configurationService.getOrThrow('application.allowCors') &&
     configurationService.getOrThrow('application.isDevelopment')
   ) {
-    app.enableCors({ origin: true, credentials: true });
+    // @fastify/cors defaults `methods` to GET,HEAD,POST, rejecting PATCH/PUT/DELETE preflights.
+    app.enableCors({
+      origin: true,
+      credentials: true,
+      methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'],
+    });
   }
 
   await app.listen(applicationPort, applicationHost);


### PR DESCRIPTION
## Summary

- Since the Fastify migration (#3190), local-dev CORS (`enableCors` in `main.ts`) relies on `@fastify/cors` defaults, which only advertise `GET,HEAD,POST` — the Express `cors` default it replaced also included `PUT,PATCH,DELETE`.
- Browsers therefore reject the preflight of every mutating request against a local CGW (e.g. `PATCH /v1/spaces/:spaceId/members/:userId/role` from the web app fails with "CORS Method Not Found"), while GETs and simple POSTs keep working.
- Sets `methods` explicitly so preflighted mutations work again. Dev-only: the block is gated by `ALLOW_CORS` + `CGW_ENV=development`; production CORS is handled by infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)