### PR TITLE
fix(fastify): allow empty JSON bodies

### DIFF
--- a/src/__tests__/test-app.provider.ts
+++ b/src/__tests__/test-app.provider.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/platform-fastify';
 import { TestingModule } from '@nestjs/testing';
 import {
+  configureFastifyBodyParsers,
   configureShutdownHooks,
   configureVersioning,
   createFastifyAdapter,
@@ -18,12 +19,15 @@ export type TestApplication = NestFastifyApplication;
 
 export function createTestApplication(module: TestingModule): TestApplication {
   const app = module.createNestApplication<NestFastifyApplication>(
-    // Match production route matching (trailing slash + long composite ids) so
-    // tests don't pass against behaviour the deployed app never exhibits.
-    // trustProxy/bodyLimit are intentionally left at Fastify defaults: this
-    // lightweight helper has no guaranteed configuration service, and those
-    // settings don't affect routing.
-    new FastifyAdapter({ routerOptions: FASTIFY_ROUTER_OPTIONS }),
+    // Match production route matching (trailing slash + long composite ids)
+    // and body parsing (empty JSON bodies allowed) so tests don't pass against
+    // behaviour the deployed app never exhibits. trustProxy/bodyLimit are
+    // intentionally left at Fastify defaults: this lightweight helper has no
+    // guaranteed configuration service, and those settings don't affect
+    // routing.
+    configureFastifyBodyParsers(
+      new FastifyAdapter({ routerOptions: FASTIFY_ROUTER_OPTIONS }),
+    ),
   );
   // The controllers are URI-versioned, so versioning must be enabled or
   // version-paired controllers (e.g. v1/v2 `/chains`) collide on the same path

--- a/src/app.provider.spec.ts
+++ b/src/app.provider.spec.ts
@@ -2,7 +2,9 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
+  HttpCode,
   type INestApplication,
   Post,
   Req,
@@ -25,6 +27,15 @@ class ProbeController {
   postBody(@Body() body: unknown): unknown {
     return body;
   }
+
+  @Post('body-echo')
+  @HttpCode(200)
+  echoBody(@Body() body: unknown): { parsed: unknown } {
+    return { parsed: body === undefined ? 'undefined' : body };
+  }
+
+  @Delete('resource')
+  deleteResource(): void {}
 }
 
 describe('createFastifyAdapter', () => {
@@ -101,6 +112,46 @@ describe('createFastifyAdapter', () => {
       .post('/body')
       .send({ value: 'too-large' })
       .expect(413);
+  });
+
+  it('accepts an empty body with a JSON content type', async () => {
+    app = await createApp('0');
+
+    await request(app.getHttpServer())
+      .delete('/resource')
+      .set('Content-Type', 'application/json')
+      .expect(200);
+  });
+
+  it('parses an empty JSON body as {} like Express body-parser did', async () => {
+    app = await createApp('0');
+
+    const { body } = await request(app.getHttpServer())
+      .post('/body-echo')
+      .set('Content-Type', 'application/json')
+      .expect(200);
+
+    expect(body).toEqual({ parsed: {} });
+  });
+
+  it('still rejects malformed JSON bodies', async () => {
+    app = await createApp('0');
+
+    await request(app.getHttpServer())
+      .post('/body-echo')
+      .set('Content-Type', 'application/json')
+      .send('{"broken":')
+      .expect(400);
+  });
+
+  it('still rejects prototype-poisoning payloads', async () => {
+    app = await createApp('0');
+
+    await request(app.getHttpServer())
+      .post('/body-echo')
+      .set('Content-Type', 'application/json')
+      .send('{"__proto__": {"polluted": true}}')
+      .expect(400);
   });
 });
 

--- a/src/app.provider.spec.ts
+++ b/src/app.provider.spec.ts
@@ -144,6 +144,21 @@ describe('createFastifyAdapter', () => {
       .expect(400);
   });
 
+  // Guards the urlencoded re-registration in `configureFastifyBodyParsers`:
+  // `useBodyParser` suppresses ALL of Nest's default parsers, not just JSON,
+  // so dropping that block would silently 415 form-encoded requests.
+  it('still parses urlencoded bodies', async () => {
+    app = await createApp('0');
+
+    const { body } = await request(app.getHttpServer())
+      .post('/body-echo')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('a=1&b=2')
+      .expect(200);
+
+    expect(body).toEqual({ parsed: { a: '1', b: '2' } });
+  });
+
   it('still rejects prototype-poisoning payloads', async () => {
     app = await createApp('0');
 

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
+import { parse as parseQuerystring } from 'node:querystring';
 import fastifyCookie from '@fastify/cookie';
 import type { INestApplication } from '@nestjs/common';
 import { VersioningType } from '@nestjs/common';
@@ -73,16 +74,62 @@ export function parseBodyLimit(value: string | undefined): number | undefined {
   return Math.floor(amount * BODY_LIMIT_UNITS[unit]);
 }
 
+// Fastify rejects empty JSON bodies with FST_ERR_CTP_EMPTY_JSON_BODY,
+// so restore the Express semantics while delegating non-empty bodies
+// to Fastify's default parser to keep its prototype-poisoning protection.
+export function configureFastifyBodyParsers(
+  adapter: FastifyAdapter,
+): FastifyAdapter {
+  const instance = adapter.getInstance();
+  const { bodyLimit, onConstructorPoisoning, onProtoPoisoning } =
+    instance.initialConfig;
+  const parseJson = instance.getDefaultJsonParser(
+    onProtoPoisoning || 'error',
+    onConstructorPoisoning || 'error',
+  );
+
+  adapter.useBodyParser(
+    'application/json',
+    false,
+    { bodyLimit },
+    (req, body, done) => {
+      if (body.length === 0) {
+        done(null, {});
+        return;
+      }
+      parseJson(req, body.toString(), done);
+    },
+  );
+
+  // `useBodyParser` marks parsers as registered so that Nest's `app.init()`
+  // does not stack its defaults on top (which throws
+  // FST_ERR_CTP_ALREADY_PRESENT) — but that also skips Nest's urlencoded
+  // parser, so replicate it here. `node:querystring` parses flat key/value
+  // pairs like the `fast-querystring` library Nest uses.
+  adapter.useBodyParser(
+    'application/x-www-form-urlencoded',
+    false,
+    { bodyLimit },
+    (_req, body, done) => {
+      done(null, parseQuerystring(body.toString()));
+    },
+  );
+
+  return adapter;
+}
+
 export function createFastifyAdapterFromConfiguration(
   config: FastifyAdapterConfiguration,
 ): FastifyAdapter {
   const bodyLimit = parseBodyLimit(config.jsonLimit);
 
-  return new FastifyAdapter({
-    trustProxy: parseTrustProxy(config.trustProxy),
-    routerOptions: FASTIFY_ROUTER_OPTIONS,
-    ...(bodyLimit === undefined ? {} : { bodyLimit }),
-  });
+  return configureFastifyBodyParsers(
+    new FastifyAdapter({
+      trustProxy: parseTrustProxy(config.trustProxy),
+      routerOptions: FASTIFY_ROUTER_OPTIONS,
+      ...(bodyLimit === undefined ? {} : { bodyLimit }),
+    }),
+  );
 }
 
 export function createFastifyAdapter(

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -84,8 +84,8 @@ export function configureFastifyBodyParsers(
   const { bodyLimit, onConstructorPoisoning, onProtoPoisoning } =
     instance.initialConfig;
   const parseJson = instance.getDefaultJsonParser(
-    onProtoPoisoning || 'error',
-    onConstructorPoisoning || 'error',
+    onProtoPoisoning ?? 'error',
+    onConstructorPoisoning ?? 'error',
   );
 
   adapter.useBodyParser(


### PR DESCRIPTION
## Summary

Fixes requests with `Content-Type: application/json` and an empty body (e.g. `DELETE /v1/spaces/:id`) failing with `400 Body cannot be empty when content-type is set to 'application/json'` after the Fastify migration (#3190).

Unlike Express' body-parser, which special-cases an empty JSON body as `{}`, Fastify rejects it with `FST_ERR_CTP_EMPTY_JSON_BODY`. Many HTTP clients set the JSON content type header on every request, including bodyless DELETEs, so these started failing after the migration.

## Changes

- **`src/app.provider.ts`** — new `configureFastifyBodyParsers(adapter)` helper, applied in `createFastifyAdapterFromConfiguration` so production and tests share it:
  - Registers an `application/json` parser that returns `{}` for an empty body (Express parity) and delegates non-empty bodies to Fastify's default parser, preserving its prototype-poisoning protection.
  - Uses Nest's `adapter.useBodyParser` rather than raw `addContentTypeParser`: Nest registers its own JSON parser during `app.init()`, which would otherwise collide with ours (`FST_ERR_CTP_ALREADY_PRESENT`).
  - Re-registers the `application/x-www-form-urlencoded` parser: calling `useBodyParser` sets the adapter's `_isParserRegistered` flag, which suppresses *all* of Nest's default parser registration, not just JSON. Uses `node:querystring` (same flat parsing as the `fast-querystring` Nest uses internally).
- **`src/__tests__/test-app.provider.ts`** — wraps the bare adapter in `createTestApplication` with the same helper so tests match production behaviour.
- **`src/app.provider.spec.ts`** — regression tests: empty-body DELETE with a JSON content type succeeds, an empty JSON body parses as `{}`, malformed JSON still returns 400, and prototype-poisoning payloads are still rejected.