### PR TITLE
chore: follow up APIs cleanup

### DIFF
--- a/src/datasources/common/chain-api.manager.spec.ts
+++ b/src/datasources/common/chain-api.manager.spec.ts
@@ -81,6 +81,26 @@ describe('ChainApiManager', () => {
     expect(target.createApi).toHaveBeenCalledTimes(2);
   });
 
+  it('should not evict a replacement entry when a destroyed creation fails', async () => {
+    const chainId = faker.string.numeric();
+    const error = new Error('Creation failed');
+    let rejectCreation!: (error: Error) => void;
+    target.createApi.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectCreation = reject;
+      }),
+    );
+
+    const first = target.getApi(chainId);
+    target.destroyApi(chainId);
+    const second = await target.getApi(chainId);
+    rejectCreation(error);
+
+    await expect(first).rejects.toThrow(error);
+    expect(await target.getApi(chainId)).toBe(second);
+    expect(target.createApi).toHaveBeenCalledTimes(2);
+  });
+
   it('should reject instead of throwing when creation throws synchronously', async () => {
     const chainId = faker.string.numeric();
     const error = new Error('Creation failed');

--- a/src/datasources/common/chain-api.manager.spec.ts
+++ b/src/datasources/common/chain-api.manager.spec.ts
@@ -52,4 +52,42 @@ describe('ChainApiManager', () => {
   it('should not throw when destroying a non-cached API instance', () => {
     expect(() => target.destroyApi(faker.string.numeric())).not.toThrow();
   });
+
+  it('should share one creation between concurrent retrievals', async () => {
+    const chainId = faker.string.numeric();
+    let resolveCreation!: (api: { chainId: string }) => void;
+    target.createApi.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreation = resolve;
+      }),
+    );
+
+    const [first, second] = [target.getApi(chainId), target.getApi(chainId)];
+    resolveCreation({ chainId });
+
+    expect(await first).toBe(await second);
+    expect(target.createApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not cache failed creations', async () => {
+    const chainId = faker.string.numeric();
+    const error = new Error('Creation failed');
+    target.createApi.mockRejectedValueOnce(error);
+
+    await expect(target.getApi(chainId)).rejects.toThrow(error);
+    const api = await target.getApi(chainId);
+
+    expect(api).toStrictEqual({ chainId });
+    expect(target.createApi).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject instead of throwing when creation throws synchronously', async () => {
+    const chainId = faker.string.numeric();
+    const error = new Error('Creation failed');
+    target.createApi.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(target.getApi(chainId)).rejects.toThrow(error);
+  });
 });

--- a/src/datasources/common/chain-api.manager.ts
+++ b/src/datasources/common/chain-api.manager.ts
@@ -9,13 +9,33 @@
  * retrieval builds a fresh instance (e.g. after a chain update).
  */
 export abstract class ChainApiManager<T> {
-  private readonly apis: Record<string, T> = {};
+  private readonly apis: Record<string, Promise<T>> = {};
 
   protected abstract createApi(chainId: string): T | Promise<T>;
 
-  protected async getOrCreateApi(chainId: string): Promise<T> {
-    this.apis[chainId] ??= await this.createApi(chainId);
-    return this.apis[chainId];
+  protected getOrCreateApi(chainId: string): Promise<T> {
+    const cached = this.apis[chainId];
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    // Cache the pending promise so concurrent retrievals share one creation.
+    // Deferring via Promise.resolve().then() turns a synchronous createApi
+    // throw into a rejection instead of letting it escape the caller.
+    const created = Promise.resolve()
+      .then(() => this.createApi(chainId))
+      .catch((error) => {
+        // Do not cache failures; let the next retrieval retry.
+        // Only evict the entry this creation cached, in case it was
+        // already replaced.
+        if (this.apis[chainId] === created) {
+          delete this.apis[chainId];
+        }
+        throw error;
+      });
+    this.apis[chainId] = created;
+
+    return created;
   }
 
   protected hasApi(chainId: string): boolean {
@@ -23,8 +43,6 @@ export abstract class ChainApiManager<T> {
   }
 
   destroyApi(chainId: string): void {
-    if (this.apis[chainId] !== undefined) {
-      delete this.apis[chainId];
-    }
+    delete this.apis[chainId];
   }
 }

--- a/src/modules/balances/datasources/balances-api.manager.ts
+++ b/src/modules/balances/datasources/balances-api.manager.ts
@@ -44,15 +44,11 @@ export class BalancesApiManager
   }
 
   getApi(chainId: string): Promise<IBalancesApi> {
-    return this._getSafeBalancesApi(chainId);
+    return this.getOrCreateApi(chainId);
   }
 
   getFiatCodes(): Promise<Raw<Array<string>>> {
     return this.coingeckoApi.getFiatCodes();
-  }
-
-  private _getSafeBalancesApi(chainId: string): Promise<SafeBalancesApi> {
-    return this.getOrCreateApi(chainId);
   }
 
   protected async createApi(chainId: string): Promise<SafeBalancesApi> {

--- a/src/modules/staking/datasources/kiln-api.manager.spec.ts
+++ b/src/modules/staking/datasources/kiln-api.manager.spec.ts
@@ -78,36 +78,25 @@ describe('KilnApiManager', () => {
   });
 
   it.each([
-    ['staking', (): StakingApiManager => stakingApiManager],
-    ['earn', (): EarnApiManager => earnApiManager],
-  ] as const)('should create a KilnApi from the %s configuration', async (widget, getTarget) => {
-    const chain = chainBuilder().with('isTestnet', false).build();
+    ['staking', false],
+    ['staking', true],
+    ['earn', false],
+    ['earn', true],
+  ] as const)('should create a KilnApi from the %s configuration (testnet: %s)', async (widget, isTestnet) => {
+    const target = { staking: stakingApiManager, earn: earnApiManager }[widget];
+    const env = isTestnet ? 'testnet' : 'mainnet';
+    const chain = chainBuilder().with('isTestnet', isTestnet).build();
     configApi.getChain.mockResolvedValue(rawify(chain));
     mockConfig(widget);
 
-    const api = await getTarget().getApi(chain.chainId);
+    const api = await target.getApi(chain.chainId);
 
     expect(api).toBeInstanceOf(KilnApi);
     expect(configurationService.getOrThrow).toHaveBeenCalledWith(
-      `${widget}.mainnet.baseUri`,
+      `${widget}.${env}.baseUri`,
     );
     expect(configurationService.getOrThrow).toHaveBeenCalledWith(
-      `${widget}.mainnet.apiKey`,
-    );
-  });
-
-  it('should use the testnet configuration for testnet chains', async () => {
-    const chain = chainBuilder().with('isTestnet', true).build();
-    configApi.getChain.mockResolvedValue(rawify(chain));
-    mockConfig('staking');
-
-    await stakingApiManager.getApi(chain.chainId);
-
-    expect(configurationService.getOrThrow).toHaveBeenCalledWith(
-      'staking.testnet.baseUri',
-    );
-    expect(configurationService.getOrThrow).toHaveBeenCalledWith(
-      'staking.testnet.apiKey',
+      `${widget}.${env}.apiKey`,
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-up to the [`ChainApiManager` extraction:](https://github.com/safe-global/safe-client-gateway/pull/3264) makes the per-chain cache single-flight by storing the creation promise instead of the resolved instance, plus small cleanups from review.

### `ChainApiManager<T>` — single-flight creation (`src/datasources/common/chain-api.manager.ts`)

The cache map is now `Record<string, Promise<T>>`:

- **Concurrent `getApi` calls for the same chain share one creation.** Previously both callers observed an empty slot and each invoked `createApi`, with the loser's instance discarded.
- **Failed creations are not cached.** The creation promise evicts its own map entry on rejection, so the next retrieval retries — preserving pre-existing behavior that a naive promise cache would break. The eviction is identity-guarded (`this.apis[chainId] === created`) so a late rejection can't evict a newer entry created after an interleaved `destroyApi`.
- **Synchronous `createApi` throws become rejections** (creation is deferred via `Promise.resolve().then(...)`), so e.g. `SwapsApiFactory`'s sync `getOrThrow` failure surfaces consistently as a rejected promise.
- `destroyApi` drops its redundant existence guard (`delete` on a missing key is a no-op).
