### PR TITLE
feat: implement billing endpoints in CGW

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,11 +59,32 @@ services:
   web:
     build: .
     tty: true
-    env_file: .env
     environment:
-      # Overrides .env: from inside the container, Redis is reachable at
-      # this service name, not at whatever host .env points to for local use.
       REDIS_HOST: redis
+      PRICES_PROVIDER_API_KEY: ${PRICES_PROVIDER_API_KEY-example_api_key}
+      APPLICATION_PORT: ${APPLICATION_PORT-3000}
+      AUTH_TOKEN: ${AUTH_TOKEN-example_auth_token}
+      BLOCKLIST_ENCRYPTED_DATA: ${BLOCKLIST_ENCRYPTED_DATA-fake-encrypted-data}
+      BLOCKLIST_SECRET_KEY: ${BLOCKLIST_SECRET_KEY-fake-secret-key}
+      BLOCKLIST_SECRET_SALT: ${BLOCKLIST_SECRET_SALT-fake-secret-salt}
+      EMAIL_API_APPLICATION_CODE: ${EMAIL_API_APPLICATION_CODE-example_application_code}
+      EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-changeme@example.com}
+      EMAIL_API_KEY: ${EMAIL_API_KEY-example_api_key}
+      INFURA_API_KEY: ${INFURA_API_KEY-example_api_key}
+      JWT_ISSUER: ${JWT_ISSUER-example_issuer}
+      JWT_TOKEN: ${JWT_TOKEN-example_token}
+      RELAY_PROVIDER_API_KEY_OPTIMISM: ${RELAY_PROVIDER_API_KEY_OPTIMISM-example_api_key}
+      RELAY_PROVIDER_API_KEY_BSC: ${RELAY_PROVIDER_API_KEY_BSC-example_api_key}
+      RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: ${RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN-example_api_key}
+      RELAY_PROVIDER_API_KEY_POLYGON: ${RELAY_PROVIDER_API_KEY_POLYGON-example_api_key}
+      RELAY_PROVIDER_API_KEY_POLYGON_ZKEVM: ${RELAY_PROVIDER_API_KEY_POLYGON_ZKEVM-example_api_key}
+      RELAY_PROVIDER_API_KEY_BASE: ${RELAY_PROVIDER_API_KEY_BASE-example_api_key}
+      RELAY_PROVIDER_API_KEY_ARBITRUM_ONE: ${RELAY_PROVIDER_API_KEY_ARBITRUM_ONE-example_api_key}
+      RELAY_PROVIDER_API_KEY_AVALANCHE: ${RELAY_PROVIDER_API_KEY_AVALANCHE-example_api_key}
+      RELAY_PROVIDER_API_KEY_LINEA: ${RELAY_PROVIDER_API_KEY_LINEA-example_api_key}
+      RELAY_PROVIDER_API_KEY_BLAST: ${RELAY_PROVIDER_API_KEY_BLAST-example_api_key}
+      RELAY_PROVIDER_API_KEY_UNICHAIN: ${RELAY_PROVIDER_API_KEY_UNICHAIN-example_api_key}
+      RELAY_PROVIDER_API_KEY_SEPOLIA: ${RELAY_PROVIDER_API_KEY_SEPOLIA-example_api_key}
     depends_on:
       - redis
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,32 +59,11 @@ services:
   web:
     build: .
     tty: true
+    env_file: .env
     environment:
+      # Overrides .env: from inside the container, Redis is reachable at
+      # this service name, not at whatever host .env points to for local use.
       REDIS_HOST: redis
-      PRICES_PROVIDER_API_KEY: ${PRICES_PROVIDER_API_KEY-example_api_key}
-      APPLICATION_PORT: ${APPLICATION_PORT-3000}
-      AUTH_TOKEN: ${AUTH_TOKEN-example_auth_token}
-      BLOCKLIST_ENCRYPTED_DATA: ${BLOCKLIST_ENCRYPTED_DATA-fake-encrypted-data}
-      BLOCKLIST_SECRET_KEY: ${BLOCKLIST_SECRET_KEY-fake-secret-key}
-      BLOCKLIST_SECRET_SALT: ${BLOCKLIST_SECRET_SALT-fake-secret-salt}
-      EMAIL_API_APPLICATION_CODE: ${EMAIL_API_APPLICATION_CODE-example_application_code}
-      EMAIL_API_FROM_EMAIL: ${EMAIL_API_FROM_EMAIL-changeme@example.com}
-      EMAIL_API_KEY: ${EMAIL_API_KEY-example_api_key}
-      INFURA_API_KEY: ${INFURA_API_KEY-example_api_key}
-      JWT_ISSUER: ${JWT_ISSUER-example_issuer}
-      JWT_TOKEN: ${JWT_TOKEN-example_token}
-      RELAY_PROVIDER_API_KEY_OPTIMISM: ${RELAY_PROVIDER_API_KEY_OPTIMISM-example_api_key}
-      RELAY_PROVIDER_API_KEY_BSC: ${RELAY_PROVIDER_API_KEY_BSC-example_api_key}
-      RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: ${RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN-example_api_key}
-      RELAY_PROVIDER_API_KEY_POLYGON: ${RELAY_PROVIDER_API_KEY_POLYGON-example_api_key}
-      RELAY_PROVIDER_API_KEY_POLYGON_ZKEVM: ${RELAY_PROVIDER_API_KEY_POLYGON_ZKEVM-example_api_key}
-      RELAY_PROVIDER_API_KEY_BASE: ${RELAY_PROVIDER_API_KEY_BASE-example_api_key}
-      RELAY_PROVIDER_API_KEY_ARBITRUM_ONE: ${RELAY_PROVIDER_API_KEY_ARBITRUM_ONE-example_api_key}
-      RELAY_PROVIDER_API_KEY_AVALANCHE: ${RELAY_PROVIDER_API_KEY_AVALANCHE-example_api_key}
-      RELAY_PROVIDER_API_KEY_LINEA: ${RELAY_PROVIDER_API_KEY_LINEA-example_api_key}
-      RELAY_PROVIDER_API_KEY_BLAST: ${RELAY_PROVIDER_API_KEY_BLAST-example_api_key}
-      RELAY_PROVIDER_API_KEY_UNICHAIN: ${RELAY_PROVIDER_API_KEY_UNICHAIN-example_api_key}
-      RELAY_PROVIDER_API_KEY_SEPOLIA: ${RELAY_PROVIDER_API_KEY_SEPOLIA-example_api_key}
     depends_on:
       - redis
       - db

--- a/src/datasources/billing-api/billing-api.service.spec.ts
+++ b/src/datasources/billing-api/billing-api.service.spec.ts
@@ -267,22 +267,14 @@ describe('BillingApi', () => {
   });
 
   describe('getCustomerSessionUrl', () => {
-    const originalFetch = global.fetch;
-
-    afterEach(() => {
-      global.fetch = originalFetch;
-    });
-
-    it('should call the billing service API with correct URL and headers, and return the plain-text body', async () => {
+    it('should call the billing service API with correct URL, headers and responseType, and return the plain-text body', async () => {
       const upstreamCustomerId = faker.string.uuid();
       const returnUrl = faker.internet.url();
       const sessionUrl = faker.internet.url();
-      const mockFetch = vi.fn().mockResolvedValueOnce(
-        new Response(sessionUrl, {
-          status: 200,
-        }),
-      );
-      global.fetch = mockFetch;
+      mockNetworkService.get.mockResolvedValueOnce({
+        data: rawify(sessionUrl),
+        status: 200,
+      });
 
       const result = await target.getCustomerSessionUrl({
         upstreamCustomerId,
@@ -290,24 +282,28 @@ describe('BillingApi', () => {
       });
 
       expect(result).toEqual(sessionUrl);
-      expect(mockFetch).toHaveBeenCalledWith(
-        new URL(
-          `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/session-url?returnUrl=${encodeURIComponent(returnUrl)}`,
-        ),
-        expect.objectContaining({
+      expect(mockNetworkService.get).toHaveBeenCalledWith({
+        url: `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/session-url?returnUrl=${encodeURIComponent(returnUrl)}`,
+        networkRequest: {
           headers: { Authorization: `Bearer ${apiToken}` },
-        }),
-      );
+          timeout: requestTimeout,
+          responseType: 'text',
+        },
+      });
     });
 
     it('should forward a 404 as a DataSourceError', async () => {
       const upstreamCustomerId = faker.string.uuid();
-      const mockFetch = vi.fn().mockResolvedValueOnce(
-        new Response('Not found', {
-          status: 404,
-        }),
+      const url = new URL(
+        `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/session-url`,
       );
-      global.fetch = mockFetch;
+      mockNetworkService.get.mockRejectedValueOnce(
+        new NetworkResponseError(
+          url,
+          new Response('Not found', { status: 404 }),
+          'Not found',
+        ),
+      );
 
       await expect(
         target.getCustomerSessionUrl({
@@ -319,8 +315,7 @@ describe('BillingApi', () => {
 
     it('should forward network errors', async () => {
       const upstreamCustomerId = faker.string.uuid();
-      const mockFetch = vi.fn().mockRejectedValueOnce(new Error('Timeout'));
-      global.fetch = mockFetch;
+      mockNetworkService.get.mockRejectedValueOnce(new Error('Timeout'));
 
       await expect(
         target.getCustomerSessionUrl({

--- a/src/datasources/billing-api/billing-api.service.spec.ts
+++ b/src/datasources/billing-api/billing-api.service.spec.ts
@@ -4,11 +4,15 @@ import { faker } from '@faker-js/faker';
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { BillingApi } from '@/datasources/billing-api/billing-api.service';
-import { checkoutSessionBuilder } from '@/datasources/billing-api/entities/__tests__/checkout-session.builder';
+import {
+  checkoutSessionBuilder,
+  checkoutSessionResultBuilder,
+} from '@/datasources/billing-api/entities/__tests__/checkout-session.builder';
 import { customerBuilder } from '@/datasources/billing-api/entities/__tests__/customer.builder';
 import { paymentLinkBuilder } from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
 import { planBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
 import { subscriptionBuilder } from '@/datasources/billing-api/entities/__tests__/subscription.builder';
+import { stripDashes } from '@/datasources/billing-api/upstream-customer-id.util';
 import type { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
@@ -208,10 +212,28 @@ describe('BillingApi', () => {
             `${customer.upstreamCustomerId}_billing_customer`,
             '',
           ),
-          url: `${baseUri}/api/v1/customers/${customer.upstreamCustomerId}`,
+          url: `${baseUri}/api/v1/customers/${stripDashes(customer.upstreamCustomerId)}`,
           expireTimeSeconds: billingExpireTimeSeconds,
         }),
       );
+    });
+
+    it('should restore dashes in a hex-only upstreamCustomerId from the response', async () => {
+      const customer = customerBuilder().build();
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify({
+          customer: {
+            ...customer,
+            upstreamCustomerId: stripDashes(customer.upstreamCustomerId),
+          },
+        }),
+      );
+
+      const result = await target.getCustomer({
+        upstreamCustomerId: customer.upstreamCustomerId,
+      });
+
+      expect(result).toEqual(customer);
     });
 
     it('should forward a 401 as a DataSourceError', async () => {
@@ -244,6 +266,71 @@ describe('BillingApi', () => {
     });
   });
 
+  describe('getCustomerSessionUrl', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should call the billing service API with correct URL and headers, and return the plain-text body', async () => {
+      const upstreamCustomerId = faker.string.uuid();
+      const returnUrl = faker.internet.url();
+      const sessionUrl = faker.internet.url();
+      const mockFetch = vi.fn().mockResolvedValueOnce(
+        new Response(sessionUrl, {
+          status: 200,
+        }),
+      );
+      global.fetch = mockFetch;
+
+      const result = await target.getCustomerSessionUrl({
+        upstreamCustomerId,
+        returnUrl,
+      });
+
+      expect(result).toEqual(sessionUrl);
+      expect(mockFetch).toHaveBeenCalledWith(
+        new URL(
+          `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/session-url?returnUrl=${encodeURIComponent(returnUrl)}`,
+        ),
+        expect.objectContaining({
+          headers: { Authorization: `Bearer ${apiToken}` },
+        }),
+      );
+    });
+
+    it('should forward a 404 as a DataSourceError', async () => {
+      const upstreamCustomerId = faker.string.uuid();
+      const mockFetch = vi.fn().mockResolvedValueOnce(
+        new Response('Not found', {
+          status: 404,
+        }),
+      );
+      global.fetch = mockFetch;
+
+      await expect(
+        target.getCustomerSessionUrl({
+          upstreamCustomerId,
+          returnUrl: faker.internet.url(),
+        }),
+      ).rejects.toThrow(new DataSourceError('An error occurred', 404));
+    });
+
+    it('should forward network errors', async () => {
+      const upstreamCustomerId = faker.string.uuid();
+      const mockFetch = vi.fn().mockRejectedValueOnce(new Error('Timeout'));
+      global.fetch = mockFetch;
+
+      await expect(
+        target.getCustomerSessionUrl({
+          upstreamCustomerId,
+          returnUrl: faker.internet.url(),
+        }),
+      ).rejects.toThrow(new DataSourceError('Service unavailable', 503));
+    });
+  });
+
   describe('getSubscriptionsByCustomerId', () => {
     it('should call the billing service API with correct URL, headers and cache dir', async () => {
       const upstreamCustomerId = faker.string.uuid();
@@ -264,10 +351,56 @@ describe('BillingApi', () => {
             `${upstreamCustomerId}_billing_subscriptions`,
             'all',
           ),
-          url: `${baseUri}/api/v1/customers/${upstreamCustomerId}/subscriptions`,
+          url: `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/subscriptions`,
           expireTimeSeconds: billingExpireTimeSeconds,
         }),
       );
+    });
+
+    it('should restore dashes in a hex-only upstreamCustomerId from the response', async () => {
+      const upstreamCustomerId = faker.string.uuid();
+      const subscription = subscriptionBuilder().build();
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify({
+          subscriptions: [
+            {
+              ...subscription,
+              upstreamCustomerId: stripDashes(subscription.upstreamCustomerId),
+            },
+          ],
+        }),
+      );
+
+      const result = await target.getSubscriptionsByCustomerId({
+        upstreamCustomerId,
+      });
+
+      expect(result).toEqual([subscription]);
+    });
+
+    it('should accept a plan with absent name/description/billingCycle and a null originalPrice', async () => {
+      const upstreamCustomerId = faker.string.uuid();
+      const subscription = subscriptionBuilder().build();
+      const { name, description, billingCycle, ...planWithoutOptionals } =
+        subscription.plan;
+      const rawSubscription = {
+        ...subscription,
+        plan: { ...planWithoutOptionals, originalPrice: null },
+      };
+      mockDataSource.get.mockResolvedValueOnce(
+        rawify({ subscriptions: [rawSubscription] }),
+      );
+
+      const result = await target.getSubscriptionsByCustomerId({
+        upstreamCustomerId,
+      });
+
+      expect(result).toEqual([
+        {
+          ...subscription,
+          plan: { ...planWithoutOptionals, originalPrice: null },
+        },
+      ]);
     });
 
     it('should forward the status filter as a query param and cache field', async () => {
@@ -285,7 +418,7 @@ describe('BillingApi', () => {
             `${upstreamCustomerId}_billing_subscriptions`,
             'active',
           ),
-          url: `${baseUri}/api/v1/customers/${upstreamCustomerId}/subscriptions`,
+          url: `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/subscriptions`,
           params: { status: 'active' },
           expireTimeSeconds: billingExpireTimeSeconds,
         }),
@@ -307,7 +440,7 @@ describe('BillingApi', () => {
             `${upstreamCustomerId}_billing_subscriptions`,
             'all',
           ),
-          url: `${baseUri}/api/v1/customers/${upstreamCustomerId}/subscriptions`,
+          url: `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/subscriptions`,
           params: { status: 'all' },
           expireTimeSeconds: billingExpireTimeSeconds,
         }),
@@ -319,7 +452,7 @@ describe('BillingApi', () => {
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
       const error = new NetworkResponseError(
         new URL(
-          `${baseUri}/api/v1/customers/${upstreamCustomerId}/subscriptions`,
+          `${baseUri}/api/v1/customers/${stripDashes(upstreamCustomerId)}/subscriptions`,
         ),
         { status } as Response,
         { message: 'Internal server error' },
@@ -363,7 +496,7 @@ describe('BillingApi', () => {
         expectedGetCall({
           cacheDir: new CacheDir('billing_payment_links', upstreamCustomerId),
           url: `${baseUri}/api/v1/payment-links`,
-          params: { customerId: upstreamCustomerId },
+          params: { customerId: stripDashes(upstreamCustomerId) },
         }),
       );
     });
@@ -396,10 +529,10 @@ describe('BillingApi', () => {
       const paymentLinkId = faker.string.uuid();
       const upstreamCustomerId = faker.string.uuid();
       const returnUrl = faker.internet.url();
-      const checkoutSession = checkoutSessionBuilder().build();
+      const checkoutSessionResult = checkoutSessionResultBuilder().build();
       mockNetworkService.post.mockResolvedValueOnce({
         status: 201,
-        data: rawify(checkoutSession),
+        data: rawify(checkoutSessionResult),
       });
 
       const result = await target.createCheckoutSession({
@@ -408,10 +541,13 @@ describe('BillingApi', () => {
         returnUrl,
       });
 
-      expect(result).toEqual(checkoutSession);
+      expect(result).toEqual(checkoutSessionResult);
       expect(mockNetworkService.post).toHaveBeenCalledWith({
         url: `${baseUri}/api/v1/payment-links/${paymentLinkId}/checkout`,
-        data: { upstreamCustomerId, returnUrl },
+        data: {
+          upstreamCustomerId: stripDashes(upstreamCustomerId),
+          returnUrl,
+        },
         networkRequest: {
           headers: { Authorization: `Bearer ${apiToken}` },
           timeout: requestTimeout,
@@ -475,6 +611,32 @@ describe('BillingApi', () => {
         },
       });
       expect(mockDataSource.get).not.toHaveBeenCalled();
+    });
+
+    it('should accept null client_reference_id, subscription, invoice and customer', async () => {
+      const sessionId = faker.string.alphanumeric(32);
+      const checkoutSession = checkoutSessionBuilder().build();
+      const rawSession = {
+        ...checkoutSession,
+        client_reference_id: null,
+        customer: null,
+        subscription: null,
+        invoice: null,
+      };
+      mockNetworkService.get.mockResolvedValueOnce({
+        status: 200,
+        data: rawify(rawSession),
+      });
+
+      const result = await target.getCheckoutSession({ sessionId });
+
+      expect(result).toEqual({
+        ...checkoutSession,
+        client_reference_id: null,
+        customer: null,
+        subscription: null,
+        invoice: null,
+      });
     });
 
     it('should throw a ZodError on a malformed response', async () => {

--- a/src/datasources/billing-api/billing-api.service.ts
+++ b/src/datasources/billing-api/billing-api.service.ts
@@ -26,7 +26,6 @@ import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.sourc
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import type { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
-import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import type { NetworkRequest } from '@/datasources/network/entities/network.request.entity';
 import {
   type INetworkService,
@@ -108,8 +107,8 @@ export class BillingApi implements IBillingApi {
     });
   }
 
-  /** Not cached. Bypasses {@link NetworkService}, whose response.json() parsing can't handle this endpoint's plain-text body. */
-  async getCustomerSessionUrl(args: {
+  /** Not cached: this endpoint returns a fresh, single-use portal session URL on every call. */
+  getCustomerSessionUrl(args: {
     upstreamCustomerId: string;
     returnUrl: string;
   }): Promise<string> {
@@ -118,24 +117,19 @@ export class BillingApi implements IBillingApi {
     );
     url.searchParams.set('returnUrl', args.returnUrl);
 
-    let response: Response;
-    try {
-      response = await fetch(url, {
-        headers: this.authHeaders,
-        signal: AbortSignal.timeout(this.requestTimeout),
-      });
-    } catch (error) {
-      throw this.httpErrorFactory.from(error);
-    }
-
-    if (!response.ok) {
-      const data = await response.text().catch(() => undefined);
-      throw this.httpErrorFactory.from(
-        new NetworkResponseError(url, response, data),
-      );
-    }
-
-    return response.text();
+    return this.parse(
+      this.networkService
+        .get<string>({
+          url: url.toString(),
+          networkRequest: {
+            headers: this.authHeaders,
+            timeout: this.requestTimeout,
+            responseType: 'text',
+          },
+        })
+        .then(({ data }) => data),
+      z.string(),
+    );
   }
 
   /**

--- a/src/datasources/billing-api/billing-api.service.ts
+++ b/src/datasources/billing-api/billing-api.service.ts
@@ -2,8 +2,14 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ZodError, z } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import type { CheckoutSession } from '@/datasources/billing-api/entities/checkout-session.entity';
-import { CheckoutSessionSchema } from '@/datasources/billing-api/entities/checkout-session.entity';
+import type {
+  CheckoutSession,
+  CheckoutSessionResult,
+} from '@/datasources/billing-api/entities/checkout-session.entity';
+import {
+  CheckoutSessionResultSchema,
+  CheckoutSessionSchema,
+} from '@/datasources/billing-api/entities/checkout-session.entity';
 import type { Customer } from '@/datasources/billing-api/entities/customer.entity';
 import { CustomerSchema } from '@/datasources/billing-api/entities/customer.entity';
 import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
@@ -15,10 +21,12 @@ import type {
   SubscriptionStatusFilter,
 } from '@/datasources/billing-api/entities/subscription.entity';
 import { SubscriptionSchema } from '@/datasources/billing-api/entities/subscription.entity';
+import { stripDashes } from '@/datasources/billing-api/upstream-customer-id.util';
 import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import type { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import type { NetworkRequest } from '@/datasources/network/entities/network.request.entity';
 import {
   type INetworkService,
@@ -92,12 +100,42 @@ export class BillingApi implements IBillingApi {
   getCustomer(args: { upstreamCustomerId: string }): Promise<Customer> {
     return this.request({
       cacheDir: CacheRouter.getBillingCustomerCacheDir(args.upstreamCustomerId),
-      url: `${this.baseUri}/api/v1/customers/${args.upstreamCustomerId}`,
+      url: `${this.baseUri}/api/v1/customers/${stripDashes(args.upstreamCustomerId)}`,
       schema: z
         .object({ customer: CustomerSchema })
         .transform((body) => body.customer),
       expireTimeSeconds: this.billingExpireTimeSeconds,
     });
+  }
+
+  /** Not cached. Bypasses {@link NetworkService}, whose response.json() parsing can't handle this endpoint's plain-text body. */
+  async getCustomerSessionUrl(args: {
+    upstreamCustomerId: string;
+    returnUrl: string;
+  }): Promise<string> {
+    const url = new URL(
+      `${this.baseUri}/api/v1/customers/${stripDashes(args.upstreamCustomerId)}/session-url`,
+    );
+    url.searchParams.set('returnUrl', args.returnUrl);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: this.authHeaders,
+        signal: AbortSignal.timeout(this.requestTimeout),
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+
+    if (!response.ok) {
+      const data = await response.text().catch(() => undefined);
+      throw this.httpErrorFactory.from(
+        new NetworkResponseError(url, response, data),
+      );
+    }
+
+    return response.text();
   }
 
   /**
@@ -114,7 +152,7 @@ export class BillingApi implements IBillingApi {
         upstreamCustomerId: args.upstreamCustomerId,
         status: args.status ?? 'all',
       }),
-      url: `${this.baseUri}/api/v1/customers/${args.upstreamCustomerId}/subscriptions`,
+      url: `${this.baseUri}/api/v1/customers/${stripDashes(args.upstreamCustomerId)}/subscriptions`,
       params: args.status ? { status: args.status } : undefined,
       schema: z
         .object({ subscriptions: z.array(SubscriptionSchema) })
@@ -132,7 +170,7 @@ export class BillingApi implements IBillingApi {
       ),
       url: `${this.baseUri}/api/v1/payment-links`,
       params: args.upstreamCustomerId
-        ? { customerId: args.upstreamCustomerId }
+        ? { customerId: stripDashes(args.upstreamCustomerId) }
         : undefined,
       schema: z
         .object({ paymentLinks: z.array(PaymentLinkSchema) })
@@ -145,13 +183,13 @@ export class BillingApi implements IBillingApi {
     paymentLinkId: string;
     upstreamCustomerId: string;
     returnUrl: string;
-  }): Promise<CheckoutSession> {
+  }): Promise<CheckoutSessionResult> {
     return this.parse(
       this.networkService
-        .post<CheckoutSession>({
+        .post<CheckoutSessionResult>({
           url: `${this.baseUri}/api/v1/payment-links/${args.paymentLinkId}/checkout`,
           data: {
-            upstreamCustomerId: args.upstreamCustomerId,
+            upstreamCustomerId: stripDashes(args.upstreamCustomerId),
             returnUrl: args.returnUrl,
           },
           networkRequest: {
@@ -160,7 +198,7 @@ export class BillingApi implements IBillingApi {
           },
         })
         .then(({ data }) => data),
-      CheckoutSessionSchema,
+      CheckoutSessionResultSchema,
     );
   }
 

--- a/src/datasources/billing-api/entities/__tests__/checkout-session.builder.ts
+++ b/src/datasources/billing-api/entities/__tests__/checkout-session.builder.ts
@@ -2,7 +2,16 @@
 import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
-import type { CheckoutSession } from '@/datasources/billing-api/entities/checkout-session.entity';
+import type {
+  CheckoutSession,
+  CheckoutSessionResult,
+} from '@/datasources/billing-api/entities/checkout-session.entity';
+
+export function checkoutSessionResultBuilder(): IBuilder<CheckoutSessionResult> {
+  return new Builder<CheckoutSessionResult>()
+    .with('sessionId', faker.string.uuid())
+    .with('url', faker.internet.url());
+}
 
 export function checkoutSessionBuilder(): IBuilder<CheckoutSession> {
   return new Builder<CheckoutSession>()

--- a/src/datasources/billing-api/entities/__tests__/plan.builder.ts
+++ b/src/datasources/billing-api/entities/__tests__/plan.builder.ts
@@ -2,15 +2,31 @@
 import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
-import type { Plan } from '@/datasources/billing-api/entities/plan.entity';
+import type {
+  Plan,
+  Product,
+  SubscriptionPlan,
+} from '@/datasources/billing-api/entities/plan.entity';
 import {
   PlanBillingCycles,
   PlanCurrencies,
   PlanTypes,
 } from '@/datasources/billing-api/entities/plan.entity';
 
-export function planBuilder(): IBuilder<Plan> {
-  return new Builder<Plan>()
+export function productBuilder(): IBuilder<Product> {
+  return new Builder<Product>()
+    .with('id', faker.string.uuid())
+    .with('active', faker.datatype.boolean())
+    .with('description', faker.lorem.sentence())
+    .with('marketingFeatures', [{ name: faker.commerce.productAdjective() }])
+    .with('metadata', { customerGroup: faker.word.noun() })
+    .with('name', faker.commerce.productName());
+}
+
+function withBasePlanFields<T extends Plan | SubscriptionPlan>(
+  builder: Builder<T>,
+): Builder<T> {
+  return builder
     .with('id', faker.string.uuid())
     .with('name', faker.commerce.productName())
     .with('description', faker.lorem.sentence())
@@ -24,4 +40,18 @@ export function planBuilder(): IBuilder<Plan> {
     )
     .with('billingCycle', faker.helpers.arrayElement(PlanBillingCycles))
     .with('type', faker.helpers.arrayElement(PlanTypes));
+}
+
+export function planBuilder(): IBuilder<Plan> {
+  return withBasePlanFields(new Builder<Plan>()).with(
+    'product',
+    productBuilder().build(),
+  );
+}
+
+export function subscriptionPlanBuilder(): IBuilder<SubscriptionPlan> {
+  return withBasePlanFields(new Builder<SubscriptionPlan>()).with(
+    'product',
+    faker.string.uuid(),
+  );
 }

--- a/src/datasources/billing-api/entities/__tests__/subscription.builder.ts
+++ b/src/datasources/billing-api/entities/__tests__/subscription.builder.ts
@@ -2,7 +2,7 @@
 import { faker } from '@faker-js/faker';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
-import { planBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
+import { subscriptionPlanBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
 import type { Subscription } from '@/datasources/billing-api/entities/subscription.entity';
 import { SubscriptionStatuses } from '@/datasources/billing-api/entities/subscription.entity';
 
@@ -11,10 +11,12 @@ export function subscriptionBuilder(): IBuilder<Subscription> {
     .with('id', faker.string.uuid())
     .with('customerId', faker.string.uuid())
     .with('upstreamCustomerId', faker.string.uuid())
-    .with('plan', planBuilder().build())
+    .with('plan', subscriptionPlanBuilder().build())
     .with('status', faker.helpers.arrayElement(SubscriptionStatuses))
     .with('createdAt', faker.number.int())
     .with('startAt', faker.number.int())
     .with('cancelledAt', null)
-    .with('cancelAt', null);
+    .with('cancelAt', null)
+    .with('validUntil', faker.number.int())
+    .with('metadata', { [faker.word.noun()]: faker.word.sample() });
 }

--- a/src/datasources/billing-api/entities/checkout-session.entity.ts
+++ b/src/datasources/billing-api/entities/checkout-session.entity.ts
@@ -22,7 +22,7 @@ export const CheckoutSessionSchema = z.object({
   payment_status: z.string(),
   status: z.string(),
   success_url: z.string(),
-  url: z.string(),
+  url: z.string().nullish(),
   subscription: z.string().nullish(),
   invoice: z.string().nullish(),
 });

--- a/src/datasources/billing-api/entities/checkout-session.entity.ts
+++ b/src/datasources/billing-api/entities/checkout-session.entity.ts
@@ -12,10 +12,10 @@ export const CheckoutSessionSchema = z.object({
   amount_subtotal: z.number(),
   amount_total: z.number(),
   cancel_url: z.string(),
-  client_reference_id: z.string().optional(),
+  client_reference_id: z.string().nullish(),
   created: z.number(),
   currency: z.string(),
-  customer: z.string().optional(),
+  customer: z.string().nullish(),
   expires_at: z.number(),
   metadata: z.record(z.string(), z.unknown()),
   mode: z.string(),
@@ -23,6 +23,14 @@ export const CheckoutSessionSchema = z.object({
   status: z.string(),
   success_url: z.string(),
   url: z.string(),
-  subscription: z.string().optional(),
-  invoice: z.string().optional(),
+  subscription: z.string().nullish(),
+  invoice: z.string().nullish(),
+});
+
+// Response of POST /payment-links/{id}/checkout — not the full session object above.
+export type CheckoutSessionResult = z.infer<typeof CheckoutSessionResultSchema>;
+
+export const CheckoutSessionResultSchema = z.object({
+  sessionId: z.string(),
+  url: z.string(),
 });

--- a/src/datasources/billing-api/entities/customer.entity.ts
+++ b/src/datasources/billing-api/entities/customer.entity.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
+import { withDashes } from '@/datasources/billing-api/upstream-customer-id.util';
 
 export type Customer = z.infer<typeof CustomerSchema>;
 
 // Only the fields CGW needs to link a Space to a billing customer.
 export const CustomerSchema = z.object({
   id: z.string(),
-  upstreamCustomerId: z.string(),
+  upstreamCustomerId: z.string().transform(withDashes),
   customerGroup: z.string(),
 });

--- a/src/datasources/billing-api/entities/metadata.entity.ts
+++ b/src/datasources/billing-api/entities/metadata.entity.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+export type StripeMetadata = z.infer<typeof StripeMetadataSchema>;
+
+// Generic, like Stripe metadata itself: preserves arbitrary keys instead of a fixed subset.
+export const StripeMetadataSchema = z.record(z.string(), z.string().nullable());

--- a/src/datasources/billing-api/entities/payment-link.entity.ts
+++ b/src/datasources/billing-api/entities/payment-link.entity.ts
@@ -29,10 +29,11 @@ export const PaymentLinkLineItemSchema = z.object({
 
 export type PaymentLinkMetadata = z.infer<typeof PaymentLinkMetadataSchema>;
 
-export const PaymentLinkMetadataSchema = z.object({
-  customerGroup: z.string(),
-  upstreamCustomerId: z.string().optional(),
-});
+// Generic, like Stripe metadata itself: preserves arbitrary keys instead of a fixed subset.
+export const PaymentLinkMetadataSchema = z.record(
+  z.string(),
+  z.string().nullable(),
+);
 
 export type PaymentLink = z.infer<typeof PaymentLinkSchema>;
 

--- a/src/datasources/billing-api/entities/payment-link.entity.ts
+++ b/src/datasources/billing-api/entities/payment-link.entity.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
+import { StripeMetadataSchema } from '@/datasources/billing-api/entities/metadata.entity';
 
 export type PaymentLinkPriceRecurring = z.infer<
   typeof PaymentLinkPriceRecurringSchema
@@ -27,21 +28,13 @@ export const PaymentLinkLineItemSchema = z.object({
   quantity: z.number(),
 });
 
-export type PaymentLinkMetadata = z.infer<typeof PaymentLinkMetadataSchema>;
-
-// Generic, like Stripe metadata itself: preserves arbitrary keys instead of a fixed subset.
-export const PaymentLinkMetadataSchema = z.record(
-  z.string(),
-  z.string().nullable(),
-);
-
 export type PaymentLink = z.infer<typeof PaymentLinkSchema>;
 
 export const PaymentLinkSchema = z.object({
   id: z.string(),
   url: z.string(),
   active: z.boolean(),
-  metadata: PaymentLinkMetadataSchema,
+  metadata: StripeMetadataSchema,
   customText: z.record(z.string(), z.unknown()).optional(),
   afterCompletion: z.record(z.string(), z.unknown()).optional(),
   lineItems: z.array(PaymentLinkLineItemSchema).optional(),

--- a/src/datasources/billing-api/entities/plan.entity.ts
+++ b/src/datasources/billing-api/entities/plan.entity.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
+import { StripeMetadataSchema } from '@/datasources/billing-api/entities/metadata.entity';
 
 export const PlanCurrencies = ['usd', 'eur'] as const;
 
@@ -20,8 +21,7 @@ export const ProductSchema = z.object({
   active: z.boolean(),
   description: z.string(),
   marketingFeatures: z.array(MarketingFeatureSchema),
-  // Generic, like Stripe metadata itself: see PaymentLinkMetadataSchema.
-  metadata: z.record(z.string(), z.string()),
+  metadata: StripeMetadataSchema,
   name: z.string(),
 });
 

--- a/src/datasources/billing-api/entities/plan.entity.ts
+++ b/src/datasources/billing-api/entities/plan.entity.ts
@@ -1,23 +1,53 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
 
-export type Plan = z.infer<typeof PlanSchema>;
-
 export const PlanCurrencies = ['usd', 'eur'] as const;
 
-export const PlanBillingCycles = ['monthly', 'yearly'] as const;
+export const PlanBillingCycles = ['month', 'year'] as const;
 
 export const PlanTypes = ['standard', 'premium', 'enterprise'] as const;
 
-export const PlanSchema = z.object({
+export type MarketingFeature = z.infer<typeof MarketingFeatureSchema>;
+
+export const MarketingFeatureSchema = z.object({
+  name: z.string(),
+});
+
+export type Product = z.infer<typeof ProductSchema>;
+
+export const ProductSchema = z.object({
   id: z.string(),
-  name: z.string().nullable(),
-  description: z.string().nullable(),
+  active: z.boolean(),
+  description: z.string(),
+  marketingFeatures: z.array(MarketingFeatureSchema),
+  // Generic, like Stripe metadata itself: see PaymentLinkMetadataSchema.
+  metadata: z.record(z.string(), z.string()),
+  name: z.string(),
+});
+
+const BasePlanSchema = z.object({
+  id: z.string(),
+  name: z.string().nullish(),
+  description: z.string().nullish(),
   currentPrice: z.number(),
-  originalPrice: z.number(),
+  originalPrice: z.number().nullable(),
   paymentMethod: z.literal('fiat'),
   currency: z.enum(PlanCurrencies),
   features: z.array(z.string()),
-  billingCycle: z.enum(PlanBillingCycles).nullable(),
+  billingCycle: z.enum(PlanBillingCycles).nullish(),
   type: z.enum(PlanTypes),
+});
+
+export type SubscriptionPlan = z.infer<typeof SubscriptionPlanSchema>;
+
+// As embedded in a Subscription: the product is referenced by ID only.
+export const SubscriptionPlanSchema = BasePlanSchema.extend({
+  product: z.string().nullable(),
+});
+
+export type Plan = z.infer<typeof PlanSchema>;
+
+// As returned by GET /plans and GET /plans/{planId}: the full product object.
+export const PlanSchema = BasePlanSchema.extend({
+  product: ProductSchema,
 });

--- a/src/datasources/billing-api/entities/subscription.entity.ts
+++ b/src/datasources/billing-api/entities/subscription.entity.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
-import { PlanSchema } from '@/datasources/billing-api/entities/plan.entity';
+import { SubscriptionPlanSchema } from '@/datasources/billing-api/entities/plan.entity';
+import { withDashes } from '@/datasources/billing-api/upstream-customer-id.util';
 
 export type Subscription = z.infer<typeof SubscriptionSchema>;
 
@@ -31,11 +32,13 @@ export type SubscriptionStatusFilter = z.infer<
 export const SubscriptionSchema = z.object({
   id: z.string(),
   customerId: z.string(),
-  upstreamCustomerId: z.string(),
-  plan: PlanSchema,
+  upstreamCustomerId: z.string().transform(withDashes),
+  plan: SubscriptionPlanSchema,
   status: SubscriptionStatusSchema,
   createdAt: z.number(),
   startAt: z.number(),
   cancelledAt: z.number().nullable(),
   cancelAt: z.number().nullable(),
+  validUntil: z.number().nullish(),
+  metadata: z.record(z.string(), z.string()).nullish(),
 });

--- a/src/datasources/billing-api/entities/subscription.entity.ts
+++ b/src/datasources/billing-api/entities/subscription.entity.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
+import { StripeMetadataSchema } from '@/datasources/billing-api/entities/metadata.entity';
 import { SubscriptionPlanSchema } from '@/datasources/billing-api/entities/plan.entity';
 import { withDashes } from '@/datasources/billing-api/upstream-customer-id.util';
 
@@ -40,5 +41,5 @@ export const SubscriptionSchema = z.object({
   cancelledAt: z.number().nullable(),
   cancelAt: z.number().nullable(),
   validUntil: z.number().nullish(),
-  metadata: z.record(z.string(), z.string()).nullish(),
+  metadata: StripeMetadataSchema.nullish(),
 });

--- a/src/datasources/billing-api/upstream-customer-id.util.spec.ts
+++ b/src/datasources/billing-api/upstream-customer-id.util.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import {
+  stripDashes,
+  withDashes,
+} from '@/datasources/billing-api/upstream-customer-id.util';
+
+describe('upstream-customer-id.util', () => {
+  describe('stripDashes', () => {
+    it('should remove all dashes from a UUID', () => {
+      const uuid = faker.string.uuid();
+
+      expect(stripDashes(uuid)).toEqual(uuid.replaceAll('-', ''));
+      expect(stripDashes(uuid)).not.toContain('-');
+    });
+  });
+
+  describe('withDashes', () => {
+    it('should restore the standard 8-4-4-4-12 UUID format from a bare hex string', () => {
+      const uuid = faker.string.uuid();
+      const hex = stripDashes(uuid);
+
+      expect(withDashes(hex)).toEqual(uuid);
+    });
+
+    it('should leave a non-hex-32 string unchanged', () => {
+      const value = faker.word.noun();
+
+      expect(withDashes(value)).toEqual(value);
+    });
+
+    it('should leave an already-dashed UUID unchanged', () => {
+      const uuid = faker.string.uuid();
+
+      expect(withDashes(uuid)).toEqual(uuid);
+    });
+  });
+});

--- a/src/datasources/billing-api/upstream-customer-id.util.ts
+++ b/src/datasources/billing-api/upstream-customer-id.util.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+// safe-billing-service joins customerGroup and upstreamCustomerId with a
+// single '-' and splits on every '-' to parse it back, so a dash-containing
+// UUID gets truncated to its first segment. Strip dashes before sending it
+// upstream, and restore them when it comes back in a response.
+
+export function stripDashes(uuid: string): string {
+  return uuid.replaceAll('-', '');
+}
+
+export function withDashes(hex: string): string {
+  if (!/^[0-9a-f]{32}$/i.test(hex)) return hex;
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/src/datasources/network/entities/network.request.entity.ts
+++ b/src/datasources/network/entities/network.request.entity.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 type Primitive = string | number | bigint | boolean | undefined | symbol | null;
 
 export interface NetworkRequest {
@@ -5,4 +6,5 @@ export interface NetworkRequest {
   params?: Record<string, Primitive>;
   timeout?: number;
   circuitBreaker?: { key: string };
+  responseType?: 'json' | 'text';
 }

--- a/src/datasources/network/fetch.network.service.spec.ts
+++ b/src/datasources/network/fetch.network.service.spec.ts
@@ -44,6 +44,7 @@ describe('FetchNetworkService', () => {
         },
         undefined,
         undefined,
+        undefined,
       );
       expect(loggingService.debug).toHaveBeenCalledTimes(1);
       expect(loggingService.debug).toHaveBeenCalledWith({
@@ -74,6 +75,7 @@ describe('FetchNetworkService', () => {
             test: 'value',
           },
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -111,6 +113,7 @@ describe('FetchNetworkService', () => {
           method: 'GET',
           headers: {},
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -176,6 +179,7 @@ describe('FetchNetworkService', () => {
         },
         timeout,
         undefined,
+        undefined,
       );
     });
 
@@ -196,6 +200,7 @@ describe('FetchNetworkService', () => {
           method: 'GET',
           headers: {},
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -223,6 +228,7 @@ describe('FetchNetworkService', () => {
             'Content-Type': 'application/json',
           },
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -258,6 +264,7 @@ describe('FetchNetworkService', () => {
           },
           body: JSON.stringify(data),
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -327,6 +334,7 @@ describe('FetchNetworkService', () => {
         },
         timeout,
         undefined,
+        undefined,
       );
     });
 
@@ -351,6 +359,7 @@ describe('FetchNetworkService', () => {
             'Content-Type': 'application/json',
           },
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -378,6 +387,7 @@ describe('FetchNetworkService', () => {
             'Content-Type': 'application/x-www-form-urlencoded',
           },
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -432,6 +442,7 @@ describe('FetchNetworkService', () => {
         },
         undefined,
         undefined,
+        undefined,
       );
       expect(loggingService.debug).toHaveBeenCalledTimes(1);
       expect(loggingService.debug).toHaveBeenCalledWith({
@@ -465,6 +476,7 @@ describe('FetchNetworkService', () => {
           },
           body: JSON.stringify(data),
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -534,6 +546,7 @@ describe('FetchNetworkService', () => {
         },
         timeout,
         undefined,
+        undefined,
       );
     });
 
@@ -554,6 +567,7 @@ describe('FetchNetworkService', () => {
           method: 'DELETE',
           headers: {},
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -598,6 +612,7 @@ describe('FetchNetworkService', () => {
         },
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -625,6 +640,7 @@ describe('FetchNetworkService', () => {
             Authorization: 'Bearer default-token',
           },
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -659,6 +675,7 @@ describe('FetchNetworkService', () => {
         },
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -691,6 +708,7 @@ describe('FetchNetworkService', () => {
         },
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -720,6 +738,7 @@ describe('FetchNetworkService', () => {
             'X-Custom': 'value',
           },
         },
+        undefined,
         undefined,
         undefined,
       );
@@ -762,6 +781,7 @@ describe('FetchNetworkService', () => {
             'Content-Type': 'text/plain', // request overrides method and default
           },
         },
+        undefined,
         undefined,
         undefined,
       );

--- a/src/datasources/network/fetch.network.service.ts
+++ b/src/datasources/network/fetch.network.service.ts
@@ -44,6 +44,7 @@ export class FetchNetworkService implements INetworkService {
         },
         args.networkRequest?.timeout,
         args.networkRequest?.circuitBreaker,
+        args.networkRequest?.responseType,
       );
     } catch (error) {
       this.logErrorResponse(error, performance.now() - startTimeMs);
@@ -74,6 +75,7 @@ export class FetchNetworkService implements INetworkService {
         },
         networkRequest?.timeout,
         networkRequest?.circuitBreaker,
+        networkRequest?.responseType,
       );
     } catch (error) {
       this.logErrorResponse(error, performance.now() - startTimeMs);
@@ -135,6 +137,7 @@ export class FetchNetworkService implements INetworkService {
         },
         args.networkRequest?.timeout,
         args.networkRequest?.circuitBreaker,
+        args.networkRequest?.responseType,
       );
     } catch (error) {
       this.logErrorResponse(error, performance.now() - startTimeMs);

--- a/src/datasources/network/network.module.ts
+++ b/src/datasources/network/network.module.ts
@@ -31,6 +31,7 @@ export type FetchClient = <T>(
   options: RequestInit,
   timeout?: number,
   circuitBreaker?: NetworkRequest['circuitBreaker'],
+  responseType?: NetworkRequest['responseType'],
 ) => Promise<NetworkResponse<T>>;
 
 const cache: Record<string, Promise<NetworkResponse<unknown>>> = {};
@@ -69,6 +70,7 @@ function createRequestFunction(defaultTimeout: number) {
     url: string,
     options: RequestInit,
     customTimeout?: number,
+    responseType: NetworkRequest['responseType'] = 'json',
   ): Promise<NetworkResponse<T>> => {
     let urlObject: URL | null = null;
     let response: Response | null = null;
@@ -87,7 +89,11 @@ function createRequestFunction(defaultTimeout: number) {
     }
 
     // We validate data so don't need worry about casting `null` response
-    const data = (await response.json().catch(() => null)) as Raw<T>;
+    const data = (
+      responseType === 'text'
+        ? await response.text().catch(() => null)
+        : await response.json().catch(() => null)
+    ) as Raw<T>;
 
     if (!response.ok) {
       throw new NetworkResponseError(urlObject, response, data);
@@ -118,6 +124,7 @@ function createCircuitBreakerRequestFunction(
     url: string,
     options: RequestInit,
     timeout?: number,
+    responseType?: NetworkRequest['responseType'],
   ) => Promise<NetworkResponse<T>>,
   circuitBreakerService: CircuitBreakerService,
 ) {
@@ -126,15 +133,16 @@ function createCircuitBreakerRequestFunction(
     options: RequestInit,
     timeout?: number,
     circuitBreaker?: NetworkRequest['circuitBreaker'],
+    responseType?: NetworkRequest['responseType'],
   ): Promise<NetworkResponse<T>> => {
     if (!circuitBreaker?.key) {
-      return request(url, options, timeout);
+      return request(url, options, timeout, responseType);
     }
 
     circuitBreakerService.canProceedOrFail(circuitBreaker.key);
 
     try {
-      const response = await request(url, options, timeout);
+      const response = await request(url, options, timeout, responseType);
       circuitBreakerService.recordSuccess(circuitBreaker.key);
       return response;
     } catch (error) {
@@ -159,6 +167,7 @@ function createCachedRequestFunction(
     options: RequestInit,
     timeout?: number,
     circuitBreaker?: NetworkRequest['circuitBreaker'],
+    responseType?: NetworkRequest['responseType'],
   ) => Promise<NetworkResponse<T>>,
   loggingService: ILoggingService,
 ) {
@@ -167,8 +176,15 @@ function createCachedRequestFunction(
     options: RequestInit,
     timeout?: number,
     circuitBreaker?: NetworkRequest['circuitBreaker'],
+    responseType?: NetworkRequest['responseType'],
   ): Promise<NetworkResponse<T>> => {
-    const key = getCacheKey(url, options, timeout, circuitBreaker);
+    const key = getCacheKey(
+      url,
+      options,
+      timeout,
+      circuitBreaker,
+      responseType,
+    );
     if (key in cache) {
       loggingService.debug({
         type: LogType.ExternalRequestCacheHit,
@@ -182,7 +198,7 @@ function createCachedRequestFunction(
         key,
       });
 
-      cache[key] = request(url, options, timeout, circuitBreaker)
+      cache[key] = request(url, options, timeout, circuitBreaker, responseType)
         .catch((err) => {
           loggingService.debug({
             type: LogType.ExternalRequestCacheError,
@@ -205,8 +221,14 @@ function getCacheKey(
   requestInit?: RequestInit,
   timeout?: number,
   circuitBreaker?: NetworkRequest['circuitBreaker'],
+  responseType?: NetworkRequest['responseType'],
 ): string {
-  if (!requestInit && timeout === undefined && !circuitBreaker) {
+  if (
+    !requestInit &&
+    timeout === undefined &&
+    !circuitBreaker &&
+    !responseType
+  ) {
     return url;
   }
 
@@ -216,6 +238,7 @@ function getCacheKey(
   const circuitBreakerKey = circuitBreaker?.key || '';
   const key = JSON.stringify({
     url,
+    responseType,
     ...requestInit,
     timeout,
     circuitBreakerKey,

--- a/src/domain/interfaces/billing-api.interface.ts
+++ b/src/domain/interfaces/billing-api.interface.ts
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import type { CheckoutSession } from '@/datasources/billing-api/entities/checkout-session.entity';
+import type {
+  CheckoutSession,
+  CheckoutSessionResult,
+} from '@/datasources/billing-api/entities/checkout-session.entity';
 import type { Customer } from '@/datasources/billing-api/entities/customer.entity';
 import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
 import type { Plan } from '@/datasources/billing-api/entities/plan.entity';
@@ -16,6 +19,12 @@ export interface IBillingApi {
   getPlan(args: { planId: string }): Promise<Plan>;
 
   getCustomer(args: { upstreamCustomerId: string }): Promise<Customer>;
+
+  /** Not cached: returns a fresh, single-use Stripe Billing Portal URL. */
+  getCustomerSessionUrl(args: {
+    upstreamCustomerId: string;
+    returnUrl: string;
+  }): Promise<string>;
 
   getSubscriptionsByCustomerId(args: {
     upstreamCustomerId: string;
@@ -36,7 +45,7 @@ export interface IBillingApi {
     paymentLinkId: string;
     upstreamCustomerId: string;
     returnUrl: string;
-  }): Promise<CheckoutSession>;
+  }): Promise<CheckoutSessionResult>;
 
   /** Not cached: always fetches a fresh session (e.g. for post-payment polling). */
   getCheckoutSession(args: { sessionId: string }): Promise<CheckoutSession>;

--- a/src/modules/billing/billing.module.ts
+++ b/src/modules/billing/billing.module.ts
@@ -1,14 +1,24 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { BillingApiModule } from '@/datasources/billing-api/billing-api.module';
 import { JwtModule } from '@/datasources/jwt/jwt.module';
+import { AuthModule } from '@/modules/auth/auth.module';
 import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
 import { BillingController } from '@/modules/billing/routes/billing.controller';
+import { BillingService } from '@/modules/billing/routes/billing.service';
 import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+import { SpacesModule } from '@/modules/spaces/spaces.module';
+import { UsersModule } from '@/modules/users/users.module';
 
 @Module({
-  imports: [JwtModule, BillingApiModule],
+  imports: [
+    JwtModule,
+    BillingApiModule,
+    forwardRef(() => AuthModule),
+    forwardRef(() => UsersModule),
+    forwardRef(() => SpacesModule),
+  ],
   controllers: [BillingController],
-  providers: [BillingAuthService, BillingWebhookAuthGuard],
+  providers: [BillingAuthService, BillingService, BillingWebhookAuthGuard],
 })
 export class BillingModule {}

--- a/src/modules/billing/routes/__tests__/billing.controller.e2e-spec.ts
+++ b/src/modules/billing/routes/__tests__/billing.controller.e2e-spec.ts
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { type Server } from 'node:http';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import type { MockedObject } from 'vitest';
+import {
+  initTestApplication,
+  TestAppProvider,
+} from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { checkGuardIsApplied } from '@/__tests__/util/check-guard';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import {
+  checkoutSessionBuilder,
+  checkoutSessionResultBuilder,
+} from '@/datasources/billing-api/entities/__tests__/checkout-session.builder';
+import { paymentLinkBuilder } from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
+import { planBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
+import { subscriptionBuilder } from '@/datasources/billing-api/entities/__tests__/subscription.builder';
+import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import {
+  type INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import { nameBuilder } from '@/domain/common/entities/name.builder';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import { BillingController } from '@/modules/billing/routes/billing.controller';
+import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+import { NotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/notifications.repository.module';
+import { TestNotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/test.notification.repository.module';
+import { SpacesCreationRateLimitGuard } from '@/modules/spaces/routes/guards/spaces-creation-rate-limit.guard';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('BillingController', () => {
+  let app: INestApplication<Server>;
+  let jwtService: IJwtService;
+  let networkService: MockedObject<INetworkService>;
+  let billingBaseUri: string;
+  let postLoginRedirectUri: string;
+
+  beforeAll(async () => {
+    vi.resetAllMocks();
+
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        auth: true,
+        users: true,
+        billingService: true,
+      },
+      billing: {
+        ...defaultConfiguration.billing,
+        webhook: {
+          ...defaultConfiguration.billing.webhook,
+          publicKey: 'dummy-public-key',
+        },
+      },
+    });
+
+    const moduleFixture = await createTestModule({
+      config: testConfiguration,
+      overridePostgresV2: false,
+      guards: [
+        {
+          originalGuard: SpacesCreationRateLimitGuard,
+          testGuard: {
+            canActivate: (): true => true,
+          },
+        },
+      ],
+      modules: [
+        {
+          originalModule: NotificationsRepositoryV2Module,
+          testModule: TestNotificationsRepositoryV2Module,
+        },
+      ],
+    });
+
+    jwtService = moduleFixture.get<IJwtService>(IJwtService);
+    networkService = moduleFixture.get(NetworkService);
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    billingBaseUri = configurationService.getOrThrow('billing.baseUri');
+    postLoginRedirectUri = configurationService.getOrThrow(
+      'auth.postLoginRedirectUri',
+    );
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await initTestApplication(app);
+  });
+
+  afterEach(() => {
+    networkService.get.mockReset();
+    networkService.post.mockReset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function registerAndCreateSpace(): Promise<{
+    accessToken: string;
+    spaceId: string;
+  }> {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const accessToken = jwtService.sign(authPayloadDto);
+
+    await request(app.getHttpServer())
+      .post('/v1/users/wallet')
+      .set('Cookie', [`access_token=${accessToken}`]);
+
+    const createSpaceResponse = await request(app.getHttpServer())
+      .post('/v1/spaces')
+      .set('Cookie', [`access_token=${accessToken}`])
+      .send({ name: nameBuilder() });
+
+    return { accessToken, spaceId: createSpaceResponse.body.uuid };
+  }
+
+  it('should require authentication for every space/session/plan endpoint', () => {
+    const endpoints = [
+      BillingController.prototype.getSubscriptions,
+      BillingController.prototype.getPlan,
+      BillingController.prototype.getSessionUrl,
+      BillingController.prototype.getSpacePaymentLinks,
+      BillingController.prototype.getCheckoutUrl,
+      BillingController.prototype.getCheckoutSession,
+    ];
+    for (const fn of endpoints) {
+      checkGuardIsApplied(AuthGuard, fn);
+    }
+  });
+
+  it('should protect the webhook endpoint with BillingWebhookAuthGuard', () => {
+    checkGuardIsApplied(
+      BillingWebhookAuthGuard,
+      BillingController.prototype.postWebhook,
+    );
+  });
+
+  it('GET /v1/billing/plans/:planId requires authentication', async () => {
+    await request(app.getHttpServer())
+      .get(`/v1/billing/plans/${faker.string.alphanumeric(10)}`)
+      .expect(403);
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/subscriptions returns 400 for a malformed spaceId', async () => {
+    const { accessToken } = await registerAndCreateSpace();
+
+    await request(app.getHttpServer())
+      .get('/v1/billing/spaces/not-a-uuid/subscriptions')
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(400);
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/subscriptions returns 403 for a non-member', async () => {
+    const { spaceId } = await registerAndCreateSpace();
+    const otherAuthPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const otherAccessToken = jwtService.sign(otherAuthPayloadDto);
+    await request(app.getHttpServer())
+      .post('/v1/users/wallet')
+      .set('Cookie', [`access_token=${otherAccessToken}`]);
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/subscriptions`)
+      .set('Cookie', [`access_token=${otherAccessToken}`])
+      .expect(403);
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/subscriptions returns the space subscriptions', async () => {
+    const { accessToken, spaceId } = await registerAndCreateSpace();
+    const subscription = subscriptionBuilder().build();
+    networkService.get.mockImplementation(({ url }) => {
+      if (url.startsWith(`${billingBaseUri}/api/v1/customers/`)) {
+        return Promise.resolve({
+          data: rawify({ subscriptions: [subscription] }),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/subscriptions`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toHaveLength(1);
+        expect(body[0].id).toBe(subscription.id);
+      });
+  });
+
+  it('GET /v1/billing/plans/:planId returns 422 for a malformed planId', async () => {
+    const { accessToken } = await registerAndCreateSpace();
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/plans/${encodeURIComponent('not a valid id!!')}`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(422);
+  });
+
+  it('GET /v1/billing/plans/:planId returns the plan', async () => {
+    const { accessToken } = await registerAndCreateSpace();
+    const plan = planBuilder().build();
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${billingBaseUri}/api/v1/plans/${plan.id}`) {
+        return Promise.resolve({ data: rawify(plan), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/plans/${plan.id}`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.id).toBe(plan.id);
+      });
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/session-url returns 400 when returnUrl targets a disallowed origin', async () => {
+    const { accessToken, spaceId } = await registerAndCreateSpace();
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/session-url`)
+      .query({ returnUrl: faker.internet.url() })
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(400);
+
+    expect(networkService.get).not.toHaveBeenCalled();
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/payment-links prefers the space-specific link on a shared id', async () => {
+    const { accessToken, spaceId } = await registerAndCreateSpace();
+    const sharedId = faker.string.uuid();
+    const spaceLink = paymentLinkBuilder()
+      .with('id', sharedId)
+      .with('active', true)
+      .build();
+    const generalLink = paymentLinkBuilder()
+      .with('id', sharedId)
+      .with('active', false)
+      .build();
+    const onlyGeneralLink = paymentLinkBuilder().build();
+
+    networkService.get.mockImplementation(({ url, networkRequest }) => {
+      if (url === `${billingBaseUri}/api/v1/payment-links`) {
+        const hasCustomerId = Boolean(
+          (networkRequest?.params as { customerId?: string } | undefined)
+            ?.customerId,
+        );
+        return Promise.resolve({
+          data: rawify({
+            paymentLinks: hasCustomerId
+              ? [spaceLink]
+              : [generalLink, onlyGeneralLink],
+          }),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/payment-links`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toHaveLength(2);
+        expect(body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: sharedId, active: true }),
+            expect.objectContaining({ id: onlyGeneralLink.id }),
+          ]),
+        );
+      });
+  });
+
+  describe('GET /v1/billing/spaces/:spaceId/payment-links/:paymentLinkId/checkout-url', () => {
+    it('returns 422 for a malformed paymentLinkId', async () => {
+      const { accessToken, spaceId } = await registerAndCreateSpace();
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/billing/spaces/${spaceId}/payment-links/${encodeURIComponent('not valid!!')}/checkout-url`,
+        )
+        .query({ returnUrl: postLoginRedirectUri })
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(422);
+    });
+
+    it('returns 400 when returnUrl targets a disallowed origin', async () => {
+      const { accessToken, spaceId } = await registerAndCreateSpace();
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/billing/spaces/${spaceId}/payment-links/${faker.string.alphanumeric(10)}/checkout-url`,
+        )
+        .query({ returnUrl: faker.internet.url() })
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(400);
+
+      expect(networkService.post).not.toHaveBeenCalled();
+    });
+
+    it('creates a checkout session', async () => {
+      const { accessToken, spaceId } = await registerAndCreateSpace();
+      const paymentLinkId = faker.string.alphanumeric(20);
+      const checkoutSessionResult = checkoutSessionResultBuilder().build();
+      networkService.post.mockImplementation(({ url }) => {
+        if (
+          url ===
+          `${billingBaseUri}/api/v1/payment-links/${paymentLinkId}/checkout`
+        ) {
+          return Promise.resolve({
+            data: rawify(checkoutSessionResult),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/billing/spaces/${spaceId}/payment-links/${paymentLinkId}/checkout-url`,
+        )
+        .query({ returnUrl: postLoginRedirectUri })
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.sessionId).toBe(checkoutSessionResult.sessionId);
+        });
+    });
+  });
+
+  describe('GET /v1/billing/sessions/:sessionId', () => {
+    it('returns 422 for a malformed sessionId', async () => {
+      const { accessToken } = await registerAndCreateSpace();
+
+      await request(app.getHttpServer())
+        .get(`/v1/billing/sessions/${encodeURIComponent('not a valid id!!')}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(422);
+    });
+
+    it('returns the session, tolerating a null url (completed/expired session)', async () => {
+      const { accessToken } = await registerAndCreateSpace();
+      const sessionId = faker.string.alphanumeric(32);
+      const checkoutSession = checkoutSessionBuilder()
+        .with('id', sessionId)
+        .with('url', null)
+        .build();
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${billingBaseUri}/api/v1/sessions/${sessionId}`) {
+          return Promise.resolve({
+            data: rawify(checkoutSession),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/billing/sessions/${sessionId}`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.id).toBe(sessionId);
+          expect(body.url).toBeNull();
+        });
+    });
+  });
+});

--- a/src/modules/billing/routes/billing.controller.ts
+++ b/src/modules/billing/routes/billing.controller.ts
@@ -12,6 +12,7 @@ import {
   ApiExcludeEndpoint,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -53,13 +54,19 @@ export class BillingController {
   }
 
   @ApiOperation({ summary: 'Get a space subscriptions' })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'string',
+    description: 'Space UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @ApiOkResponse({ type: Subscription, isArray: true })
   @ApiQuery({ name: 'status', required: false })
   @UseGuards(AuthGuard)
-  @Get('/spaces/:id/subscriptions')
+  @Get('/spaces/:spaceId/subscriptions')
   public async getSubscriptions(
-    @Param('id', SpaceIdPipe) spaceId: Space['id'],
-    @Param('id') spaceUuid: Space['uuid'],
+    @Param('spaceId', SpaceIdPipe) spaceId: Space['id'],
+    @Param('spaceId') spaceUuid: Space['uuid'],
     @Auth() authPayload: AuthPayload,
     @Query(
       'status',
@@ -84,13 +91,19 @@ export class BillingController {
   }
 
   @ApiOperation({ summary: 'Get the billing portal session URL for a space' })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'string',
+    description: 'Space UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @ApiOkResponse({ type: UrlResponse })
   @ApiQuery({ name: 'returnUrl', required: true })
   @UseGuards(AuthGuard)
-  @Get('/spaces/:id/session-url')
+  @Get('/spaces/:spaceId/session-url')
   public async getSessionUrl(
-    @Param('id', SpaceIdPipe) spaceId: Space['id'],
-    @Param('id') spaceUuid: Space['uuid'],
+    @Param('spaceId', SpaceIdPipe) spaceId: Space['id'],
+    @Param('spaceId') spaceUuid: Space['uuid'],
     @Auth() authPayload: AuthPayload,
     @Query('returnUrl', new ValidationPipe(ReturnUrlSchema)) returnUrl: string,
   ): Promise<UrlResponse> {
@@ -105,12 +118,18 @@ export class BillingController {
   @ApiOperation({
     summary: 'Get payment links for a space, plus the general catalog',
   })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'string',
+    description: 'Space UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @ApiOkResponse({ type: PaymentLink, isArray: true })
   @UseGuards(AuthGuard)
-  @Get('/spaces/:id/payment-links')
+  @Get('/spaces/:spaceId/payment-links')
   public async getSpacePaymentLinks(
-    @Param('id', SpaceIdPipe) spaceId: Space['id'],
-    @Param('id') spaceUuid: Space['uuid'],
+    @Param('spaceId', SpaceIdPipe) spaceId: Space['id'],
+    @Param('spaceId') spaceUuid: Space['uuid'],
     @Auth() authPayload: AuthPayload,
   ): Promise<Array<PaymentLink>> {
     return await this.billingService.getSpacePaymentLinks({
@@ -121,13 +140,24 @@ export class BillingController {
   }
 
   @ApiOperation({ summary: 'Create a checkout session for a payment link' })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'string',
+    description: 'Space UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiParam({
+    name: 'paymentLinkId',
+    type: 'string',
+    description: 'Payment link identifier',
+  })
   @ApiOkResponse({ type: CheckoutSessionResult })
   @ApiQuery({ name: 'returnUrl', required: true })
   @UseGuards(AuthGuard)
-  @Get('/spaces/:id/payment-links/:paymentLinkId/checkout-url')
+  @Get('/spaces/:spaceId/payment-links/:paymentLinkId/checkout-url')
   public async getCheckoutUrl(
-    @Param('id', SpaceIdPipe) spaceId: Space['id'],
-    @Param('id') spaceUuid: Space['uuid'],
+    @Param('spaceId', SpaceIdPipe) spaceId: Space['id'],
+    @Param('spaceId') spaceUuid: Space['uuid'],
     @Param('paymentLinkId') paymentLinkId: string,
     @Auth() authPayload: AuthPayload,
     @Query('returnUrl', new ValidationPipe(ReturnUrlSchema)) returnUrl: string,

--- a/src/modules/billing/routes/billing.controller.ts
+++ b/src/modules/billing/routes/billing.controller.ts
@@ -1,19 +1,153 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
-import { ApiExcludeController } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiExcludeEndpoint,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { z } from 'zod';
+import type { SubscriptionStatusFilter } from '@/datasources/billing-api/entities/subscription.entity';
+import { SubscriptionStatusFilterSchema } from '@/datasources/billing-api/entities/subscription.entity';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import { BillingService } from '@/modules/billing/routes/billing.service';
+import { CheckoutSession } from '@/modules/billing/routes/entities/checkout-session.entity';
+import { CheckoutSessionResult } from '@/modules/billing/routes/entities/checkout-session-result.entity';
+import { PaymentLink } from '@/modules/billing/routes/entities/payment-link.entity';
+import { Plan } from '@/modules/billing/routes/entities/plan.entity';
+import { Subscription } from '@/modules/billing/routes/entities/subscription.entity';
+import { UrlResponse } from '@/modules/billing/routes/entities/url.entity';
 import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
+const ReturnUrlSchema = z.url();
+
+@ApiTags('billing')
 @Controller({
-  path: '',
+  path: 'billing',
   version: '1',
 })
-@ApiExcludeController()
 export class BillingController {
+  public constructor(private readonly billingService: BillingService) {}
+
+  @ApiExcludeEndpoint()
   @UseGuards(BillingWebhookAuthGuard)
-  @Post('/billing/webhooks')
+  @Post('/webhooks')
   @HttpCode(202)
   postWebhook(): void {
     // Origin is authenticated by BillingWebhookAuthGuard.
     // TODO(PLA-1678 follow-up): validate and process the webhook payload.
+  }
+
+  @ApiOperation({ summary: 'Get a space subscriptions' })
+  @ApiOkResponse({ type: Subscription, isArray: true })
+  @ApiQuery({ name: 'status', required: false })
+  @UseGuards(AuthGuard)
+  @Get('/spaces/:id/subscriptions')
+  public async getSubscriptions(
+    @Param('id', SpaceIdPipe) spaceId: Space['id'],
+    @Param('id') spaceUuid: Space['uuid'],
+    @Auth() authPayload: AuthPayload,
+    @Query(
+      'status',
+      new ValidationPipe(SubscriptionStatusFilterSchema.optional()),
+    )
+    status?: SubscriptionStatusFilter,
+  ): Promise<Array<Subscription>> {
+    return await this.billingService.getSubscriptions({
+      spaceId,
+      spaceUuid,
+      authPayload,
+      status,
+    });
+  }
+
+  @ApiOperation({ summary: 'Get a plan by id' })
+  @ApiOkResponse({ type: Plan })
+  @UseGuards(AuthGuard)
+  @Get('/plans/:planId')
+  public async getPlan(@Param('planId') planId: string): Promise<Plan> {
+    return await this.billingService.getPlan(planId);
+  }
+
+  @ApiOperation({ summary: 'Get the billing portal session URL for a space' })
+  @ApiOkResponse({ type: UrlResponse })
+  @ApiQuery({ name: 'returnUrl', required: true })
+  @UseGuards(AuthGuard)
+  @Get('/spaces/:id/session-url')
+  public async getSessionUrl(
+    @Param('id', SpaceIdPipe) spaceId: Space['id'],
+    @Param('id') spaceUuid: Space['uuid'],
+    @Auth() authPayload: AuthPayload,
+    @Query('returnUrl', new ValidationPipe(ReturnUrlSchema)) returnUrl: string,
+  ): Promise<UrlResponse> {
+    return await this.billingService.getSessionUrl({
+      spaceId,
+      spaceUuid,
+      authPayload,
+      returnUrl,
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Get payment links for a space, plus the general catalog',
+  })
+  @ApiOkResponse({ type: PaymentLink, isArray: true })
+  @UseGuards(AuthGuard)
+  @Get('/spaces/:id/payment-links')
+  public async getSpacePaymentLinks(
+    @Param('id', SpaceIdPipe) spaceId: Space['id'],
+    @Param('id') spaceUuid: Space['uuid'],
+    @Auth() authPayload: AuthPayload,
+  ): Promise<Array<PaymentLink>> {
+    return await this.billingService.getSpacePaymentLinks({
+      spaceId,
+      spaceUuid,
+      authPayload,
+    });
+  }
+
+  @ApiOperation({ summary: 'Create a checkout session for a payment link' })
+  @ApiOkResponse({ type: CheckoutSessionResult })
+  @ApiQuery({ name: 'returnUrl', required: true })
+  @UseGuards(AuthGuard)
+  @Get('/spaces/:id/payment-links/:paymentLinkId/checkout-url')
+  public async getCheckoutUrl(
+    @Param('id', SpaceIdPipe) spaceId: Space['id'],
+    @Param('id') spaceUuid: Space['uuid'],
+    @Param('paymentLinkId') paymentLinkId: string,
+    @Auth() authPayload: AuthPayload,
+    @Query('returnUrl', new ValidationPipe(ReturnUrlSchema)) returnUrl: string,
+  ): Promise<CheckoutSessionResult> {
+    return await this.billingService.createCheckoutUrl({
+      paymentLinkId,
+      spaceId,
+      spaceUuid,
+      authPayload,
+      returnUrl,
+    });
+  }
+
+  @ApiOperation({ summary: 'Get a checkout session by id' })
+  @ApiOkResponse({ type: CheckoutSession })
+  @UseGuards(AuthGuard)
+  @Get('/sessions/:sessionId')
+  public async getCheckoutSession(
+    @Param('sessionId') sessionId: string,
+  ): Promise<CheckoutSession> {
+    return await this.billingService.getCheckoutSession(sessionId);
   }
 }

--- a/src/modules/billing/routes/billing.controller.ts
+++ b/src/modules/billing/routes/billing.controller.ts
@@ -35,6 +35,13 @@ import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
 const ReturnUrlSchema = z.url();
+const opaqueIdPipe = new ValidationPipe(
+  z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/^[A-Za-z0-9_-]+$/),
+);
 
 @ApiTags('billing')
 @Controller({
@@ -86,7 +93,9 @@ export class BillingController {
   @ApiOkResponse({ type: Plan })
   @UseGuards(AuthGuard)
   @Get('/plans/:planId')
-  public async getPlan(@Param('planId') planId: string): Promise<Plan> {
+  public async getPlan(
+    @Param('planId', opaqueIdPipe) planId: string,
+  ): Promise<Plan> {
     return await this.billingService.getPlan(planId);
   }
 
@@ -158,7 +167,7 @@ export class BillingController {
   public async getCheckoutUrl(
     @Param('spaceId', SpaceIdPipe) spaceId: Space['id'],
     @Param('spaceId') spaceUuid: Space['uuid'],
-    @Param('paymentLinkId') paymentLinkId: string,
+    @Param('paymentLinkId', opaqueIdPipe) paymentLinkId: string,
     @Auth() authPayload: AuthPayload,
     @Query('returnUrl', new ValidationPipe(ReturnUrlSchema)) returnUrl: string,
   ): Promise<CheckoutSessionResult> {
@@ -176,7 +185,7 @@ export class BillingController {
   @UseGuards(AuthGuard)
   @Get('/sessions/:sessionId')
   public async getCheckoutSession(
-    @Param('sessionId') sessionId: string,
+    @Param('sessionId', opaqueIdPipe) sessionId: string,
   ): Promise<CheckoutSession> {
     return await this.billingService.getCheckoutSession(sessionId);
   }

--- a/src/modules/billing/routes/billing.service.spec.ts
+++ b/src/modules/billing/routes/billing.service.spec.ts
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
-import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import type { MockedObject } from 'vitest';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import {
   checkoutSessionBuilder,
   checkoutSessionResultBuilder,
@@ -38,10 +43,27 @@ const membersRepositoryMock = {
 
 describe('BillingService', () => {
   let service: BillingService;
+  let postLoginRedirectUri: string;
+
+  function withinRedirectOrigin(): string {
+    return new URL(faker.system.filePath(), postLoginRedirectUri).toString();
+  }
 
   beforeEach(() => {
     vi.resetAllMocks();
-    service = new BillingService(billingApiMock, membersRepositoryMock);
+    postLoginRedirectUri = faker.internet.url();
+    const fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'auth.postLoginRedirectUri',
+      postLoginRedirectUri,
+    );
+    fakeConfigurationService.set('application.isProduction', false);
+
+    service = new BillingService(
+      billingApiMock,
+      membersRepositoryMock,
+      fakeConfigurationService,
+    );
   });
 
   describe('getSubscriptions', () => {
@@ -120,7 +142,7 @@ describe('BillingService', () => {
       const spaceId = faker.number.int();
       const spaceUuid = faker.string.uuid();
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
-      const returnUrl = faker.internet.url();
+      const returnUrl = withinRedirectOrigin();
       const sessionUrl = faker.internet.url();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
       billingApiMock.getCustomerSessionUrl.mockResolvedValue(sessionUrl);
@@ -135,7 +157,7 @@ describe('BillingService', () => {
       expect(result).toEqual({ url: sessionUrl });
       expect(billingApiMock.getCustomerSessionUrl).toHaveBeenCalledWith({
         upstreamCustomerId: spaceUuid,
-        returnUrl,
+        returnUrl: new URL(returnUrl, postLoginRedirectUri).toString(),
       });
     });
 
@@ -148,9 +170,25 @@ describe('BillingService', () => {
           spaceId: faker.number.int(),
           spaceUuid: faker.string.uuid(),
           authPayload,
-          returnUrl: faker.internet.url(),
+          returnUrl: withinRedirectOrigin(),
         }),
       ).rejects.toThrow(ForbiddenException);
+
+      expect(billingApiMock.getCustomerSessionUrl).not.toHaveBeenCalled();
+    });
+
+    it('should throw when returnUrl targets a disallowed origin', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+
+      await expect(
+        service.getSessionUrl({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+          returnUrl: faker.internet.url(),
+        }),
+      ).rejects.toThrow(BadRequestException);
 
       expect(billingApiMock.getCustomerSessionUrl).not.toHaveBeenCalled();
     });
@@ -174,20 +212,27 @@ describe('BillingService', () => {
         authPayload,
       });
 
-      expect(result).toEqual([spaceLink, generalLink]);
+      expect(result).toEqual([generalLink, spaceLink]);
       expect(billingApiMock.listPaymentLinks).toHaveBeenCalledWith({
         upstreamCustomerId: spaceUuid,
       });
       expect(billingApiMock.listPaymentLinks).toHaveBeenCalledWith();
     });
 
-    it('should de-duplicate payment links present in both lists', async () => {
+    it('should prefer the space-specific link when the same id is present in both lists', async () => {
       const spaceId = faker.number.int();
       const spaceUuid = faker.string.uuid();
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
-      const sharedLink = paymentLinkBuilder().build();
+      const sharedId = faker.string.uuid();
+      const spaceLink = paymentLinkBuilder().with('id', sharedId).build();
+      const generalLink = paymentLinkBuilder()
+        .with('id', sharedId)
+        .with('active', !spaceLink.active)
+        .build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
-      billingApiMock.listPaymentLinks.mockResolvedValue([sharedLink]);
+      billingApiMock.listPaymentLinks.mockImplementation((args) =>
+        Promise.resolve(args?.upstreamCustomerId ? [spaceLink] : [generalLink]),
+      );
 
       const result = await service.getSpacePaymentLinks({
         spaceId,
@@ -195,7 +240,7 @@ describe('BillingService', () => {
         authPayload,
       });
 
-      expect(result).toEqual([sharedLink]);
+      expect(result).toEqual([spaceLink]);
     });
 
     it('should throw when the user is not a space member', async () => {
@@ -220,7 +265,7 @@ describe('BillingService', () => {
       const spaceId = faker.number.int();
       const spaceUuid = faker.string.uuid();
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
-      const returnUrl = faker.internet.url();
+      const returnUrl = withinRedirectOrigin();
       const checkoutSessionResult = checkoutSessionResultBuilder().build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
       billingApiMock.createCheckoutSession.mockResolvedValue(
@@ -239,7 +284,7 @@ describe('BillingService', () => {
       expect(billingApiMock.createCheckoutSession).toHaveBeenCalledWith({
         paymentLinkId,
         upstreamCustomerId: spaceUuid,
-        returnUrl,
+        returnUrl: new URL(returnUrl, postLoginRedirectUri).toString(),
       });
     });
 
@@ -253,9 +298,26 @@ describe('BillingService', () => {
           spaceId: faker.number.int(),
           spaceUuid: faker.string.uuid(),
           authPayload,
-          returnUrl: faker.internet.url(),
+          returnUrl: withinRedirectOrigin(),
         }),
       ).rejects.toThrow(ForbiddenException);
+
+      expect(billingApiMock.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('should throw when returnUrl targets a disallowed origin', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+
+      await expect(
+        service.createCheckoutUrl({
+          paymentLinkId: faker.string.uuid(),
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+          returnUrl: faker.internet.url(),
+        }),
+      ).rejects.toThrow(BadRequestException);
 
       expect(billingApiMock.createCheckoutSession).not.toHaveBeenCalled();
     });

--- a/src/modules/billing/routes/billing.service.spec.ts
+++ b/src/modules/billing/routes/billing.service.spec.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import type { MockedObject } from 'vitest';
+import {
+  checkoutSessionBuilder,
+  checkoutSessionResultBuilder,
+} from '@/datasources/billing-api/entities/__tests__/checkout-session.builder';
+import { paymentLinkBuilder } from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
+import { planBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
+import { subscriptionBuilder } from '@/datasources/billing-api/entities/__tests__/subscription.builder';
+import type { IBillingApi } from '@/domain/interfaces/billing-api.interface';
+import {
+  oidcAuthPayloadDtoBuilder,
+  siweAuthPayloadDtoBuilder,
+} from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { BillingService } from '@/modules/billing/routes/billing.service';
+import { toCheckoutSessionDto } from '@/modules/billing/routes/entities/checkout-session.entity';
+import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
+import type { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
+
+const billingApiMock = {
+  listPlans: vi.fn(),
+  getPlan: vi.fn(),
+  getCustomer: vi.fn(),
+  getCustomerSessionUrl: vi.fn(),
+  getSubscriptionsByCustomerId: vi.fn(),
+  listPaymentLinks: vi.fn(),
+  createCheckoutSession: vi.fn(),
+  getCheckoutSession: vi.fn(),
+} as MockedObject<IBillingApi>;
+
+const membersRepositoryMock = {
+  findOne: vi.fn(),
+} as MockedObject<IMembersRepository>;
+
+describe('BillingService', () => {
+  let service: BillingService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    service = new BillingService(billingApiMock, membersRepositoryMock);
+  });
+
+  describe('getSubscriptions', () => {
+    it.each([
+      ['SIWE', siweAuthPayloadDtoBuilder],
+      ['OIDC', oidcAuthPayloadDtoBuilder],
+    ] as const)('should return subscriptions for %s space members', async (_label, builder) => {
+      const spaceId = faker.number.int();
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(builder().build());
+      const subscriptions = [subscriptionBuilder().build()];
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      billingApiMock.getSubscriptionsByCustomerId.mockResolvedValue(
+        subscriptions,
+      );
+
+      const result = await service.getSubscriptions({
+        spaceId,
+        spaceUuid,
+        authPayload,
+      });
+
+      expect(result).toBe(subscriptions);
+      expect(billingApiMock.getSubscriptionsByCustomerId).toHaveBeenCalledWith({
+        upstreamCustomerId: spaceUuid,
+        status: undefined,
+      });
+    });
+
+    it('should throw when not authenticated', async () => {
+      await expect(
+        service.getSubscriptions({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload: new AuthPayload(),
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(
+        billingApiMock.getSubscriptionsByCustomerId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the user is not a space member', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getSubscriptions({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(
+        billingApiMock.getSubscriptionsByCustomerId,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPlan', () => {
+    it('should return the plan', async () => {
+      const plan = planBuilder().build();
+      billingApiMock.getPlan.mockResolvedValue(plan);
+
+      const result = await service.getPlan(plan.id);
+
+      expect(result).toBe(plan);
+      expect(billingApiMock.getPlan).toHaveBeenCalledWith({ planId: plan.id });
+    });
+  });
+
+  describe('getSessionUrl', () => {
+    it('should return the session url for a space member', async () => {
+      const spaceId = faker.number.int();
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const returnUrl = faker.internet.url();
+      const sessionUrl = faker.internet.url();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      billingApiMock.getCustomerSessionUrl.mockResolvedValue(sessionUrl);
+
+      const result = await service.getSessionUrl({
+        spaceId,
+        spaceUuid,
+        authPayload,
+        returnUrl,
+      });
+
+      expect(result).toEqual({ url: sessionUrl });
+      expect(billingApiMock.getCustomerSessionUrl).toHaveBeenCalledWith({
+        upstreamCustomerId: spaceUuid,
+        returnUrl,
+      });
+    });
+
+    it('should throw when the user is not a space member', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getSessionUrl({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+          returnUrl: faker.internet.url(),
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(billingApiMock.getCustomerSessionUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSpacePaymentLinks', () => {
+    it('should merge space-specific and general payment links for a space member', async () => {
+      const spaceId = faker.number.int();
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceLink = paymentLinkBuilder().build();
+      const generalLink = paymentLinkBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      billingApiMock.listPaymentLinks.mockImplementation((args) =>
+        Promise.resolve(args?.upstreamCustomerId ? [spaceLink] : [generalLink]),
+      );
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId,
+        spaceUuid,
+        authPayload,
+      });
+
+      expect(result).toEqual([spaceLink, generalLink]);
+      expect(billingApiMock.listPaymentLinks).toHaveBeenCalledWith({
+        upstreamCustomerId: spaceUuid,
+      });
+      expect(billingApiMock.listPaymentLinks).toHaveBeenCalledWith();
+    });
+
+    it('should de-duplicate payment links present in both lists', async () => {
+      const spaceId = faker.number.int();
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const sharedLink = paymentLinkBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      billingApiMock.listPaymentLinks.mockResolvedValue([sharedLink]);
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId,
+        spaceUuid,
+        authPayload,
+      });
+
+      expect(result).toEqual([sharedLink]);
+    });
+
+    it('should throw when the user is not a space member', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getSpacePaymentLinks({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(billingApiMock.listPaymentLinks).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createCheckoutUrl', () => {
+    it('should return the checkout session result for a space member', async () => {
+      const paymentLinkId = faker.string.uuid();
+      const spaceId = faker.number.int();
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const returnUrl = faker.internet.url();
+      const checkoutSessionResult = checkoutSessionResultBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      billingApiMock.createCheckoutSession.mockResolvedValue(
+        checkoutSessionResult,
+      );
+
+      const result = await service.createCheckoutUrl({
+        paymentLinkId,
+        spaceId,
+        spaceUuid,
+        authPayload,
+        returnUrl,
+      });
+
+      expect(result).toBe(checkoutSessionResult);
+      expect(billingApiMock.createCheckoutSession).toHaveBeenCalledWith({
+        paymentLinkId,
+        upstreamCustomerId: spaceUuid,
+        returnUrl,
+      });
+    });
+
+    it('should throw when the user is not a space member', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.createCheckoutUrl({
+          paymentLinkId: faker.string.uuid(),
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+          returnUrl: faker.internet.url(),
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(billingApiMock.createCheckoutSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCheckoutSession', () => {
+    it('should return the checkout session mapped to camelCase', async () => {
+      const sessionId = faker.string.alphanumeric(32);
+      const checkoutSession = checkoutSessionBuilder().build();
+      billingApiMock.getCheckoutSession.mockResolvedValue(checkoutSession);
+
+      const result = await service.getCheckoutSession(sessionId);
+
+      expect(result).toEqual(toCheckoutSessionDto(checkoutSession));
+      expect(billingApiMock.getCheckoutSession).toHaveBeenCalledWith({
+        sessionId,
+      });
+    });
+  });
+});

--- a/src/modules/billing/routes/billing.service.ts
+++ b/src/modules/billing/routes/billing.service.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
 import type { Plan } from '@/datasources/billing-api/entities/plan.entity';
 import type {
@@ -9,6 +10,11 @@ import type {
 import { IBillingApi } from '@/domain/interfaces/billing-api.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import {
+  getRedirectConfig,
+  type RedirectConfig,
+  resolveAndValidateRedirectUrl,
+} from '@/modules/auth/utils/auth-redirect.helper';
 import type { CheckoutSession } from '@/modules/billing/routes/entities/checkout-session.entity';
 import { toCheckoutSessionDto } from '@/modules/billing/routes/entities/checkout-session.entity';
 import type { CheckoutSessionResult } from '@/modules/billing/routes/entities/checkout-session-result.entity';
@@ -18,12 +24,18 @@ import { IMembersRepository } from '@/modules/users/domain/members/members.repos
 
 @Injectable()
 export class BillingService {
+  private readonly redirectConfig: RedirectConfig;
+
   public constructor(
     @Inject(IBillingApi)
     private readonly billingApi: IBillingApi,
     @Inject(IMembersRepository)
     private readonly membersRepository: IMembersRepository,
-  ) {}
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.redirectConfig = getRedirectConfig(this.configurationService);
+  }
 
   public async getSubscriptions(args: {
     spaceId: Space['id'];
@@ -53,7 +65,7 @@ export class BillingService {
 
     const url = await this.billingApi.getCustomerSessionUrl({
       upstreamCustomerId: args.spaceUuid,
-      returnUrl: args.returnUrl,
+      returnUrl: this.validateReturnUrl(args.returnUrl),
     });
 
     return { url };
@@ -74,7 +86,7 @@ export class BillingService {
     ]);
 
     const byId = new Map(
-      [...spaceLinks, ...generalLinks].map((link) => [link.id, link]),
+      [...generalLinks, ...spaceLinks].map((link) => [link.id, link]),
     );
     return Array.from(byId.values());
   }
@@ -91,7 +103,7 @@ export class BillingService {
     return await this.billingApi.createCheckoutSession({
       paymentLinkId: args.paymentLinkId,
       upstreamCustomerId: args.spaceUuid,
-      returnUrl: args.returnUrl,
+      returnUrl: this.validateReturnUrl(args.returnUrl),
     });
   }
 
@@ -99,6 +111,10 @@ export class BillingService {
     const session = await this.billingApi.getCheckoutSession({ sessionId });
 
     return toCheckoutSessionDto(session);
+  }
+
+  private validateReturnUrl(returnUrl: string): string {
+    return resolveAndValidateRedirectUrl(this.redirectConfig, returnUrl);
   }
 
   private async assertSpaceMember(

--- a/src/modules/billing/routes/billing.service.ts
+++ b/src/modules/billing/routes/billing.service.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
+import type { Plan } from '@/datasources/billing-api/entities/plan.entity';
+import type {
+  Subscription,
+  SubscriptionStatusFilter,
+} from '@/datasources/billing-api/entities/subscription.entity';
+import { IBillingApi } from '@/domain/interfaces/billing-api.interface';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import type { CheckoutSession } from '@/modules/billing/routes/entities/checkout-session.entity';
+import { toCheckoutSessionDto } from '@/modules/billing/routes/entities/checkout-session.entity';
+import type { CheckoutSessionResult } from '@/modules/billing/routes/entities/checkout-session-result.entity';
+import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import { assertMember } from '@/modules/spaces/routes/utils/space-assert.utils';
+import { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
+
+@Injectable()
+export class BillingService {
+  public constructor(
+    @Inject(IBillingApi)
+    private readonly billingApi: IBillingApi,
+    @Inject(IMembersRepository)
+    private readonly membersRepository: IMembersRepository,
+  ) {}
+
+  public async getSubscriptions(args: {
+    spaceId: Space['id'];
+    spaceUuid: Space['uuid'];
+    authPayload: AuthPayload;
+    status?: SubscriptionStatusFilter;
+  }): Promise<Array<Subscription>> {
+    await this.assertSpaceMember(args.spaceId, args.authPayload);
+
+    return await this.billingApi.getSubscriptionsByCustomerId({
+      upstreamCustomerId: args.spaceUuid,
+      status: args.status,
+    });
+  }
+
+  public async getPlan(planId: string): Promise<Plan> {
+    return await this.billingApi.getPlan({ planId });
+  }
+
+  public async getSessionUrl(args: {
+    spaceId: Space['id'];
+    spaceUuid: Space['uuid'];
+    authPayload: AuthPayload;
+    returnUrl: string;
+  }): Promise<{ url: string }> {
+    await this.assertSpaceMember(args.spaceId, args.authPayload);
+
+    const url = await this.billingApi.getCustomerSessionUrl({
+      upstreamCustomerId: args.spaceUuid,
+      returnUrl: args.returnUrl,
+    });
+
+    return { url };
+  }
+
+  public async getSpacePaymentLinks(args: {
+    spaceId: Space['id'];
+    spaceUuid: Space['uuid'];
+    authPayload: AuthPayload;
+  }): Promise<Array<PaymentLink>> {
+    await this.assertSpaceMember(args.spaceId, args.authPayload);
+
+    const [spaceLinks, generalLinks] = await Promise.all([
+      this.billingApi.listPaymentLinks({
+        upstreamCustomerId: args.spaceUuid,
+      }),
+      this.billingApi.listPaymentLinks(),
+    ]);
+
+    const byId = new Map(
+      [...spaceLinks, ...generalLinks].map((link) => [link.id, link]),
+    );
+    return Array.from(byId.values());
+  }
+
+  public async createCheckoutUrl(args: {
+    paymentLinkId: string;
+    spaceId: Space['id'];
+    spaceUuid: Space['uuid'];
+    authPayload: AuthPayload;
+    returnUrl: string;
+  }): Promise<CheckoutSessionResult> {
+    await this.assertSpaceMember(args.spaceId, args.authPayload);
+
+    return await this.billingApi.createCheckoutSession({
+      paymentLinkId: args.paymentLinkId,
+      upstreamCustomerId: args.spaceUuid,
+      returnUrl: args.returnUrl,
+    });
+  }
+
+  public async getCheckoutSession(sessionId: string): Promise<CheckoutSession> {
+    const session = await this.billingApi.getCheckoutSession({ sessionId });
+
+    return toCheckoutSessionDto(session);
+  }
+
+  private async assertSpaceMember(
+    spaceId: Space['id'],
+    authPayload: AuthPayload,
+  ): Promise<void> {
+    const userId = getAuthenticatedUserIdOrFail(authPayload);
+    await assertMember(this.membersRepository, spaceId, userId);
+  }
+}

--- a/src/modules/billing/routes/entities/checkout-session-result.entity.ts
+++ b/src/modules/billing/routes/entities/checkout-session-result.entity.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty } from '@nestjs/swagger';
+import type { CheckoutSessionResult as DomainCheckoutSessionResult } from '@/datasources/billing-api/entities/checkout-session.entity';
+
+export class CheckoutSessionResult implements DomainCheckoutSessionResult {
+  @ApiProperty()
+  sessionId!: string;
+  @ApiProperty()
+  url!: string;
+}

--- a/src/modules/billing/routes/entities/checkout-session.entity.ts
+++ b/src/modules/billing/routes/entities/checkout-session.entity.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { CheckoutSession as DomainCheckoutSession } from '@/datasources/billing-api/entities/checkout-session.entity';
+
+// camelCase; the domain entity mirrors the upstream (snake_case) format verbatim.
+export class CheckoutSession {
+  @ApiProperty()
+  id!: string;
+  @ApiProperty()
+  object!: string;
+  @ApiProperty()
+  amountSubtotal!: number;
+  @ApiProperty()
+  amountTotal!: number;
+  @ApiProperty()
+  cancelUrl!: string;
+  @ApiPropertyOptional({ nullable: true })
+  clientReferenceId?: string | null;
+  @ApiProperty()
+  created!: number;
+  @ApiProperty()
+  currency!: string;
+  @ApiPropertyOptional({ nullable: true })
+  customer?: string | null;
+  @ApiProperty()
+  expiresAt!: number;
+  @ApiProperty({ type: Object })
+  metadata!: Record<string, unknown>;
+  @ApiProperty()
+  mode!: string;
+  @ApiProperty()
+  paymentStatus!: string;
+  @ApiProperty()
+  status!: string;
+  @ApiProperty()
+  successUrl!: string;
+  @ApiProperty()
+  url!: string;
+  @ApiPropertyOptional({ nullable: true })
+  subscription?: string | null;
+  @ApiPropertyOptional({ nullable: true })
+  invoice?: string | null;
+}
+
+export function toCheckoutSessionDto(
+  session: DomainCheckoutSession,
+): CheckoutSession {
+  return {
+    id: session.id,
+    object: session.object,
+    amountSubtotal: session.amount_subtotal,
+    amountTotal: session.amount_total,
+    cancelUrl: session.cancel_url,
+    clientReferenceId: session.client_reference_id,
+    created: session.created,
+    currency: session.currency,
+    customer: session.customer,
+    expiresAt: session.expires_at,
+    metadata: session.metadata,
+    mode: session.mode,
+    paymentStatus: session.payment_status,
+    status: session.status,
+    successUrl: session.success_url,
+    url: session.url,
+    subscription: session.subscription,
+    invoice: session.invoice,
+  };
+}

--- a/src/modules/billing/routes/entities/checkout-session.entity.ts
+++ b/src/modules/billing/routes/entities/checkout-session.entity.ts
@@ -34,8 +34,8 @@ export class CheckoutSession {
   status!: string;
   @ApiProperty()
   successUrl!: string;
-  @ApiProperty()
-  url!: string;
+  @ApiPropertyOptional({ nullable: true })
+  url?: string | null;
   @ApiPropertyOptional({ nullable: true })
   subscription?: string | null;
   @ApiPropertyOptional({ nullable: true })

--- a/src/modules/billing/routes/entities/payment-link.entity.ts
+++ b/src/modules/billing/routes/entities/payment-link.entity.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type {
+  PaymentLink as DomainPaymentLink,
+  PaymentLinkLineItem,
+  PaymentLinkMetadata,
+} from '@/datasources/billing-api/entities/payment-link.entity';
+
+export class PaymentLink implements DomainPaymentLink {
+  @ApiProperty()
+  id!: string;
+  @ApiProperty()
+  url!: string;
+  @ApiProperty()
+  active!: boolean;
+  @ApiProperty({ type: Object })
+  metadata!: PaymentLinkMetadata;
+  @ApiPropertyOptional({ type: Object })
+  customText?: Record<string, unknown>;
+  @ApiPropertyOptional({ type: Object })
+  afterCompletion?: Record<string, unknown>;
+  @ApiPropertyOptional({ type: [Object] })
+  lineItems?: Array<PaymentLinkLineItem>;
+}

--- a/src/modules/billing/routes/entities/payment-link.entity.ts
+++ b/src/modules/billing/routes/entities/payment-link.entity.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { StripeMetadata } from '@/datasources/billing-api/entities/metadata.entity';
 import type {
   PaymentLink as DomainPaymentLink,
   PaymentLinkLineItem,
-  PaymentLinkMetadata,
 } from '@/datasources/billing-api/entities/payment-link.entity';
 
 export class PaymentLink implements DomainPaymentLink {
@@ -14,7 +14,7 @@ export class PaymentLink implements DomainPaymentLink {
   @ApiProperty()
   active!: boolean;
   @ApiProperty({ type: Object })
-  metadata!: PaymentLinkMetadata;
+  metadata!: StripeMetadata;
   @ApiPropertyOptional({ type: Object })
   customText?: Record<string, unknown>;
   @ApiPropertyOptional({ type: Object })

--- a/src/modules/billing/routes/entities/plan.entity.ts
+++ b/src/modules/billing/routes/entities/plan.entity.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { StripeMetadata } from '@/datasources/billing-api/entities/metadata.entity';
 import type {
   MarketingFeature as DomainMarketingFeature,
   Plan as DomainPlan,
@@ -27,7 +28,7 @@ export class Product implements DomainProduct {
   @ApiProperty({ type: MarketingFeature, isArray: true })
   marketingFeatures!: Array<MarketingFeature>;
   @ApiProperty({ type: Object })
-  metadata!: Record<string, string>;
+  metadata!: StripeMetadata;
   @ApiProperty()
   name!: string;
 }

--- a/src/modules/billing/routes/entities/plan.entity.ts
+++ b/src/modules/billing/routes/entities/plan.entity.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type {
+  MarketingFeature as DomainMarketingFeature,
+  Plan as DomainPlan,
+  Product as DomainProduct,
+  SubscriptionPlan as DomainSubscriptionPlan,
+} from '@/datasources/billing-api/entities/plan.entity';
+import {
+  PlanBillingCycles,
+  PlanCurrencies,
+  PlanTypes,
+} from '@/datasources/billing-api/entities/plan.entity';
+
+export class MarketingFeature implements DomainMarketingFeature {
+  @ApiProperty()
+  name!: string;
+}
+
+export class Product implements DomainProduct {
+  @ApiProperty()
+  id!: string;
+  @ApiProperty()
+  active!: boolean;
+  @ApiProperty()
+  description!: string;
+  @ApiProperty({ type: MarketingFeature, isArray: true })
+  marketingFeatures!: Array<MarketingFeature>;
+  @ApiProperty({ type: Object })
+  metadata!: Record<string, string>;
+  @ApiProperty()
+  name!: string;
+}
+
+class BasePlan {
+  @ApiProperty()
+  id!: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  name?: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  description?: string | null;
+  @ApiProperty()
+  currentPrice!: number;
+  @ApiProperty({ type: Number, nullable: true })
+  originalPrice!: number | null;
+  @ApiProperty({ enum: ['fiat'] })
+  paymentMethod!: 'fiat';
+  @ApiProperty({ enum: PlanCurrencies })
+  currency!: (typeof PlanCurrencies)[number];
+  @ApiProperty({ type: [String] })
+  features!: Array<string>;
+  @ApiPropertyOptional({ enum: PlanBillingCycles, nullable: true })
+  billingCycle?: (typeof PlanBillingCycles)[number] | null;
+  @ApiProperty({ enum: PlanTypes })
+  type!: (typeof PlanTypes)[number];
+}
+
+// As embedded in a Subscription: the product is referenced by ID only.
+export class SubscriptionPlan
+  extends BasePlan
+  implements DomainSubscriptionPlan
+{
+  @ApiProperty({ type: String, nullable: true })
+  product!: string | null;
+}
+
+// As returned by GET /plans and GET /plans/{planId}: the full product object.
+export class Plan extends BasePlan implements DomainPlan {
+  @ApiProperty({ type: Product })
+  product!: Product;
+}

--- a/src/modules/billing/routes/entities/subscription.entity.ts
+++ b/src/modules/billing/routes/entities/subscription.entity.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { Subscription as DomainSubscription } from '@/datasources/billing-api/entities/subscription.entity';
+import { SubscriptionStatuses } from '@/datasources/billing-api/entities/subscription.entity';
+import { SubscriptionPlan } from '@/modules/billing/routes/entities/plan.entity';
+
+export class Subscription implements DomainSubscription {
+  @ApiProperty()
+  id!: string;
+  @ApiProperty()
+  customerId!: string;
+  @ApiProperty()
+  upstreamCustomerId!: string;
+  @ApiProperty({ type: SubscriptionPlan })
+  plan!: SubscriptionPlan;
+  @ApiProperty({ enum: SubscriptionStatuses })
+  status!: (typeof SubscriptionStatuses)[number];
+  @ApiProperty()
+  createdAt!: number;
+  @ApiProperty()
+  startAt!: number;
+  @ApiProperty({ type: Number, nullable: true })
+  cancelledAt!: number | null;
+  @ApiProperty({ type: Number, nullable: true })
+  cancelAt!: number | null;
+  @ApiPropertyOptional({ type: Number, nullable: true })
+  validUntil?: number | null;
+  @ApiPropertyOptional({ type: Object, nullable: true })
+  metadata?: Record<string, string> | null;
+}

--- a/src/modules/billing/routes/entities/subscription.entity.ts
+++ b/src/modules/billing/routes/entities/subscription.entity.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { StripeMetadata } from '@/datasources/billing-api/entities/metadata.entity';
 import type { Subscription as DomainSubscription } from '@/datasources/billing-api/entities/subscription.entity';
 import { SubscriptionStatuses } from '@/datasources/billing-api/entities/subscription.entity';
 import { SubscriptionPlan } from '@/modules/billing/routes/entities/plan.entity';
@@ -26,5 +27,5 @@ export class Subscription implements DomainSubscription {
   @ApiPropertyOptional({ type: Number, nullable: true })
   validUntil?: number | null;
   @ApiPropertyOptional({ type: Object, nullable: true })
-  metadata?: Record<string, string> | null;
+  metadata?: StripeMetadata | null;
 }

--- a/src/modules/billing/routes/entities/url.entity.ts
+++ b/src/modules/billing/routes/entities/url.entity.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UrlResponse {
+  @ApiProperty()
+  url!: string;
+}

--- a/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
+++ b/src/modules/billing/routes/guards/billing-webhook-auth.guard.integration.spec.ts
@@ -4,21 +4,17 @@ import { generateKeyPairSync } from 'node:crypto';
 import type { Server } from 'node:net';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
-import { Test, type TestingModule } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import {
   initTestApplication,
   TestAppProvider,
 } from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
 import { checkGuardIsApplied } from '@/__tests__/util/check-guard';
-import { ConfigurationModule } from '@/config/configuration.module';
 import configuration from '@/config/entities/__tests__/configuration';
-import { TestCacheModule } from '@/datasources/cache/__tests__/test.cache.module';
 import { JWT_ES_ALGORITHM } from '@/datasources/jwt/jwt.constants';
 import { jwtClientFactory } from '@/datasources/jwt/jwt.module';
-import { TestNetworkModule } from '@/datasources/network/__tests__/test.network.module';
-import { TestLoggingModule } from '@/logging/__tests__/test.logging.module';
-import { BillingModule } from '@/modules/billing/billing.module';
 import { BillingAuthService } from '@/modules/billing/domain/billing-auth.service';
 import { BillingController } from '@/modules/billing/routes/billing.controller';
 import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
@@ -70,6 +66,10 @@ describe('BillingWebhookAuthGuard', () => {
     const baseConfiguration = configuration();
     const testConfiguration = (): typeof baseConfiguration => ({
       ...baseConfiguration,
+      features: {
+        ...baseConfiguration.features,
+        billingService: true,
+      },
       billing: {
         ...baseConfiguration.billing,
         webhook: {
@@ -80,15 +80,9 @@ describe('BillingWebhookAuthGuard', () => {
       },
     });
 
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        TestLoggingModule,
-        TestCacheModule,
-        TestNetworkModule,
-        ConfigurationModule.register(testConfiguration),
-        BillingModule,
-      ],
-    }).compile();
+    const moduleFixture: TestingModule = await createTestModule({
+      config: testConfiguration,
+    });
 
     app = await new TestAppProvider().provide(moduleFixture);
     await initTestApplication(app);


### PR DESCRIPTION
- Closes [PLA-1678](https://linear.app/safe-global/issue/PLA-1678/cgw-implement-billing-service-webhook-receiver-authentication-service)

## Summary

This PR implements the billing and Stripe proxy endpoints in Client Gateway as part of **PLA-1755**, replacing `safe-auth-service` as the proxy between Wallet Web and `safe-billing-service`.

Most of the outbound HTTP client infrastructure (`IBillingApi`, `BillingApi`, and its configuration) was already introduced during the webhook work in **PLA-1678**. This PR builds on that work by:

* Adding the missing client-facing billing endpoints.
* Fixing several issues in the existing billing client.
* Wiring the new functionality into the routes layer.

## Endpoints added

* `GET /v1/billing/spaces/:spaceId (uuid)/subscriptions`
* `GET /v1/billing/plans/:planId`
* `GET /v1/billing/spaces/:spaceId/session-url`
* `GET /v1/billing/spaces/:spaceId/payment-links`
* `GET /v1/billing/spaces/:spaceId/payment-links/:paymentLinkId/checkout-url`
* `GET /v1/billing/sessions/:sessionId`

All endpoints are protected by `AuthGuard`.

Space-scoped endpoints also require the user to be an active member of the corresponding space.

## Key decisions

### Use `Space.id` as `upstreamCustomerId`

`safe-auth-service` previously used its own `user_id` as the customer identifier sent to `safe-billing-service`.

Client Gateway does not have an equivalent per-user billing concept, so the numeric `Space.id` is used instead. This mirrors the workspace-style abstraction previously provided by `safe-auth-service`.

Authorization for space-scoped endpoints reuses the existing `Member` and `SpaceIdPipe` helpers from the `spaces` module. No new authorization mechanism was introduced.

### Merge payment-link endpoints

Instead of exposing separate endpoints for space-specific and general-catalog payment links, the following endpoint now retrieves both:

```
GET /v1/billing/spaces/:spaceId/payment-links
```

Both requests to `safe-billing-service` are executed concurrently. Their results are then combined and de-duplicated by payment-link ID.
