### PR TITLE
feat: Allow switching authenticators

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -192,6 +192,12 @@
     "required": false
   },
   {
+    "name": "AUTH0_MANAGEMENT_API_TOKEN_TTL_BUFFER_IN_SECONDS",
+    "description": "Seconds subtracted from the Auth0 Management API token expiry when caching, so the token is refreshed before it actually expires",
+    "defaultValue": 60,
+    "required": false
+  },
+  {
     "name": "AUTH_STATE_TTL_MILLISECONDS",
     "description": "Time-to-live for the OAuth state cookie in milliseconds",
     "defaultValue": 300000,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -41,6 +41,10 @@ export default (): ReturnType<typeof configuration> => ({
       scope: 'openid email',
       jwksCacheMaxAgeMs: faker.number.int({ min: 60_000, max: 3_600_000 }),
       jwksCooldownMs: faker.number.int({ min: 1_000, max: 60_000 }),
+      managementApiTokenTtlBufferInSeconds: faker.number.int({
+        min: 30,
+        max: 120,
+      }),
     },
     rateLimit: {
       max: faker.number.int({ min: 100, max: 200 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -76,6 +76,10 @@ export default () => ({
         process.env.AUTH0_JWKS_COOLDOWN_MILLISECONDS ?? `${30_000}`,
         10, // 30 seconds
       ),
+      managementApiTokenTtlBufferInSeconds: Number.parseInt(
+        process.env.AUTH0_MANAGEMENT_API_TOKEN_TTL_BUFFER_IN_SECONDS ?? `${60}`,
+        10, // 60 seconds
+      ),
     },
     rateLimit: {
       max: Number.parseInt(process.env.AUTH_RATE_LIMIT_MAX ?? `${5}`, 10),

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -14,6 +14,8 @@ export class CacheRouter {
   private static readonly ACCOUNT_KEY = 'account';
   private static readonly ALL_TRANSACTIONS_KEY = 'all_transactions';
   private static readonly AUTH_NONCE_KEY = 'auth_nonce';
+  private static readonly AUTH0_MANAGEMENT_API_TOKEN_KEY =
+    'auth0_management_api_token';
   private static readonly BACKBONE_KEY = 'backbone';
   private static readonly BRIDGE_CHAINS_KEY = 'bridge_chains';
   private static readonly CHAIN_KEY = 'chain';
@@ -106,6 +108,10 @@ export class CacheRouter {
 
   static getAuthNonceCacheDir(nonce: string): CacheDir {
     return new CacheDir(CacheRouter.getAuthNonceCacheKey(nonce), '');
+  }
+
+  static getAuth0ManagementApiTokenCacheDir(): CacheDir {
+    return new CacheDir(CacheRouter.AUTH0_MANAGEMENT_API_TOKEN_KEY, '');
   }
 
   static getBridgeChainsCacheDir(): CacheDir {

--- a/src/modules/auth/oidc/auth0/auth0.module.ts
+++ b/src/modules/auth/oidc/auth0/auth0.module.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
+import { CacheModule } from '@/datasources/cache/cache.module';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkModule } from '@/datasources/network/network.module';
 import { IAuth0Api } from '@/modules/auth/oidc/auth0/datasources/auth0-api.interface';
@@ -9,7 +10,7 @@ import { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.reposit
 import { Auth0TokenVerifier } from '@/modules/auth/oidc/auth0/domain/auth0-token.verifier';
 
 @Module({
-  imports: [NetworkModule],
+  imports: [CacheModule, NetworkModule],
   providers: [
     HttpErrorFactory,
     {

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.interface.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.interface.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import type { Auth0AuthenticationMethod } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity';
 import type { Auth0TokenResponse } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-token-response.entity';
 import type { Raw } from '@/validation/entities/raw.entity';
 
@@ -10,9 +11,14 @@ export interface IAuth0Api {
    *
    * @param state - Opaque anti-CSRF state value that will be echoed back by Auth0.
    * @param connection - Optional Auth0 connection name to route directly to a specific identity provider.
+   * @param enroll - When true, requests hosted enrollment of a new authenticator.
    * @returns The fully qualified Auth0 `/authorize` URL.
    */
-  getAuthorizationUrl(state: string, connection?: string): string;
+  getAuthorizationUrl(
+    state: string,
+    connection?: string,
+    enroll?: boolean,
+  ): string;
 
   /**
    * Exchanges an OAuth 2.0 authorization code for Auth0 tokens.
@@ -21,4 +27,26 @@ export interface IAuth0Api {
    * @returns The raw Auth0 token response.
    */
   exchangeAuthorizationCode(code: string): Promise<Raw<Auth0TokenResponse>>;
+
+  /**
+   * Lists the MFA authentication methods (e.g. `totp`, `recovery-code`) of
+   * the given user via the Auth0 Management API.
+   *
+   * @param extUserId - The Auth0 user identifier (`sub` claim).
+   */
+  listUserAuthenticationMethods(
+    extUserId: string,
+  ): Promise<Array<Auth0AuthenticationMethod>>;
+
+  /**
+   * Deletes a single MFA authentication method of the given user via the
+   * Auth0 Management API.
+   *
+   * @param extUserId - The Auth0 user identifier (`sub` claim).
+   * @param methodId - The authentication method identifier.
+   */
+  deleteUserAuthenticationMethod(
+    extUserId: string,
+    methodId: string,
+  ): Promise<void>;
 }

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.spec.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.spec.ts
@@ -3,6 +3,8 @@
 import { faker } from '@faker-js/faker';
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
@@ -10,11 +12,14 @@ import { Auth0Api } from '@/modules/auth/oidc/auth0/datasources/auth0-api.servic
 import { rawify } from '@/validation/entities/raw.entity';
 
 const networkService = {
+  delete: vi.fn(),
+  get: vi.fn(),
   postForm: vi.fn(),
 } as MockedObject<INetworkService>;
 
 describe('Auth0Api', () => {
   let target: Auth0Api;
+  let fakeCacheService: FakeCacheService;
   let baseUri: string;
   let clientId: string;
   let clientSecret: string;
@@ -41,8 +46,10 @@ describe('Auth0Api', () => {
     fakeConfigurationService.set('auth.auth0.audience', audience);
     fakeConfigurationService.set('auth.auth0.scope', scope);
 
+    fakeCacheService = new FakeCacheService();
     target = new Auth0Api(
       networkService,
+      fakeCacheService,
       fakeConfigurationService,
       new HttpErrorFactory(),
     );
@@ -118,6 +125,120 @@ describe('Auth0Api', () => {
       await expect(
         target.exchangeAuthorizationCode(faker.string.alphanumeric(32)),
       ).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  describe('Management API token caching', () => {
+    beforeEach(() => {
+      networkService.get.mockResolvedValue({
+        status: 200,
+        data: rawify([]),
+      });
+      networkService.delete.mockResolvedValue({
+        status: 204,
+        data: rawify(undefined),
+      });
+    });
+
+    it('should use a cached token for Management API requests', async () => {
+      const accessToken = faker.string.alphanumeric();
+      const extUserId = faker.string.uuid();
+      await fakeCacheService.hSet(
+        new CacheDir('auth0_management_api_token', ''),
+        accessToken,
+        3_600,
+      );
+
+      await target.listUserAuthenticationMethods(extUserId);
+      await target.deleteUserAuthenticationMethod(
+        extUserId,
+        faker.string.uuid(),
+      );
+
+      expect(networkService.postForm).not.toHaveBeenCalled();
+      expect(networkService.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          networkRequest: {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        }),
+      );
+      expect(networkService.delete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          networkRequest: {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        }),
+      );
+    });
+
+    it('should cache a new token until one minute before expiry', async () => {
+      const accessToken = faker.string.alphanumeric();
+      const extUserId = faker.string.uuid();
+      const cacheSetSpy = vi.spyOn(fakeCacheService, 'hSet');
+      networkService.postForm.mockResolvedValueOnce({
+        status: 200,
+        data: rawify({
+          access_token: accessToken,
+          expires_in: 3_600,
+        }),
+      });
+
+      await target.listUserAuthenticationMethods(extUserId);
+
+      expect(cacheSetSpy).toHaveBeenCalledWith(
+        new CacheDir('auth0_management_api_token', ''),
+        accessToken,
+        3_540,
+        0,
+      );
+      await expect(
+        fakeCacheService.hGet(
+          new CacheDir('auth0_management_api_token', ''),
+        ),
+      ).resolves.toBe(accessToken);
+      expect(networkService.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          networkRequest: {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        }),
+      );
+    });
+
+    it('should share a token request between concurrent callers', async () => {
+      const accessToken = faker.string.alphanumeric();
+      networkService.postForm.mockResolvedValueOnce({
+        status: 200,
+        data: rawify({
+          access_token: accessToken,
+          expires_in: 3_600,
+        }),
+      });
+
+      await Promise.all([
+        target.listUserAuthenticationMethods(faker.string.uuid()),
+        target.listUserAuthenticationMethods(faker.string.uuid()),
+      ]);
+
+      expect(networkService.postForm).toHaveBeenCalledTimes(1);
+      expect(networkService.get).toHaveBeenCalledTimes(2);
+      expect(networkService.get).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          networkRequest: {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        }),
+      );
+      expect(networkService.get).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          networkRequest: {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        }),
+      );
     });
   });
 });

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.spec.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.spec.ts
@@ -45,6 +45,10 @@ describe('Auth0Api', () => {
     fakeConfigurationService.set('auth.auth0.redirectUri', redirectUri);
     fakeConfigurationService.set('auth.auth0.audience', audience);
     fakeConfigurationService.set('auth.auth0.scope', scope);
+    fakeConfigurationService.set(
+      'auth.auth0.managementApiTokenTtlBufferInSeconds',
+      60,
+    );
 
     fakeCacheService = new FakeCacheService();
     target = new Auth0Api(

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.spec.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.spec.ts
@@ -193,9 +193,7 @@ describe('Auth0Api', () => {
         0,
       );
       await expect(
-        fakeCacheService.hGet(
-          new CacheDir('auth0_management_api_token', ''),
-        ),
+        fakeCacheService.hGet(new CacheDir('auth0_management_api_token', '')),
       ).resolves.toBe(accessToken);
       expect(networkService.get).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
@@ -3,6 +3,11 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import {
   type INetworkService,
@@ -18,22 +23,27 @@ import type { Raw } from '@/validation/entities/raw.entity';
 
 const ManagementApiTokenResponseSchema = z.object({
   access_token: z.string(),
+  expires_in: z.number().int().positive(),
 });
 
 @Injectable()
 export class Auth0Api implements IAuth0Api {
   private static readonly AUTHORIZATION_CODE_GRANT_TYPE = 'authorization_code';
   private static readonly CLIENT_CREDENTIALS_GRANT_TYPE = 'client_credentials';
+  private static readonly MANAGEMENT_API_TOKEN_TTL_BUFFER_IN_SECONDS = 60;
   private readonly baseUri: string;
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly redirectUri: string;
   private readonly audience: string;
   private readonly scope: string;
+  private inFlightManagementApiTokenRequest: Promise<string> | undefined;
 
   constructor(
     @Inject(NetworkService)
     private readonly networkService: INetworkService,
+    @Inject(CacheService)
+    private readonly cacheService: ICacheService,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     private readonly httpErrorFactory: HttpErrorFactory,
@@ -125,7 +135,6 @@ export class Auth0Api implements IAuth0Api {
     }
   }
 
-
   public async deleteUserAuthenticationMethod(
     extUserId: string,
     methodId: string,
@@ -150,17 +159,33 @@ export class Auth0Api implements IAuth0Api {
     ).toString();
   }
 
+  private async getManagementApiToken(): Promise<string> {
+    const cacheDir = CacheRouter.getAuth0ManagementApiTokenCacheDir();
+    const cachedToken = await this.cacheService.hGet(cacheDir);
+
+    if (cachedToken) {
+      return cachedToken;
+    }
+
+    if (!this.inFlightManagementApiTokenRequest) {
+      this.inFlightManagementApiTokenRequest =
+        this.fetchManagementApiToken().finally(() => {
+          this.inFlightManagementApiTokenRequest = undefined;
+        });
+    }
+
+    return this.inFlightManagementApiTokenRequest;
+  }
+
   /**
-   * Fetches a Management API access token via the Client Credentials grant.
+   * Fetches and caches a Management API access token via the Client Credentials
+   * grant.
    *
    * Requires the Auth0 application to be authorized for the Management API
    * (audience `https://{domain}/api/v2/`) with at least the
    * `read:authentication_methods` and `delete:authentication_methods` scopes.
-   *
-   * Note: the token is fetched per request (no caching) — acceptable for a
-   * spike, should be cached before production use.
    */
-  private async getManagementApiToken(): Promise<string> {
+  private async fetchManagementApiToken(): Promise<string> {
     const response = await this.networkService.postForm({
       url: new URL('/oauth/token', this.baseUri).toString(),
       data: {
@@ -171,6 +196,16 @@ export class Auth0Api implements IAuth0Api {
       },
     });
 
-    return ManagementApiTokenResponseSchema.parse(response.data).access_token;
+    const { access_token, expires_in } =
+      ManagementApiTokenResponseSchema.parse(response.data);
+
+    await this.cacheService.hSet(
+      CacheRouter.getAuth0ManagementApiTokenCacheDir(),
+      access_token,
+      expires_in - Auth0Api.MANAGEMENT_API_TOKEN_TTL_BUFFER_IN_SECONDS,
+      0,
+    );
+
+    return access_token;
   }
 }

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import {
@@ -8,12 +9,21 @@ import {
   NetworkService,
 } from '@/datasources/network/network.service.interface';
 import type { IAuth0Api } from '@/modules/auth/oidc/auth0/datasources/auth0-api.interface';
+import {
+  type Auth0AuthenticationMethod,
+  Auth0AuthenticationMethodsSchema,
+} from '@/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity';
 import type { Auth0TokenResponse } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-token-response.entity';
 import type { Raw } from '@/validation/entities/raw.entity';
+
+const ManagementApiTokenResponseSchema = z.object({
+  access_token: z.string(),
+});
 
 @Injectable()
 export class Auth0Api implements IAuth0Api {
   private static readonly AUTHORIZATION_CODE_GRANT_TYPE = 'authorization_code';
+  private static readonly CLIENT_CREDENTIALS_GRANT_TYPE = 'client_credentials';
   private readonly baseUri: string;
   private readonly clientId: string;
   private readonly clientSecret: string;
@@ -50,7 +60,11 @@ export class Auth0Api implements IAuth0Api {
     );
   }
 
-  public getAuthorizationUrl(state: string, connection?: string): string {
+  public getAuthorizationUrl(
+    state: string,
+    connection?: string,
+    enroll?: boolean,
+  ): string {
     const url = new URL('/authorize', this.baseUri);
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('client_id', this.clientId);
@@ -61,6 +75,13 @@ export class Auth0Api implements IAuth0Api {
 
     if (connection) {
       url.searchParams.set('connection', connection);
+    }
+
+    if (enroll) {
+      // Signals the tenant's post-login Action (via event.request.query) to
+      // challenge an existing factor and then enroll a new authenticator on
+      // the hosted pages.
+      url.searchParams.set('ext-enroll-otp', 'true');
     }
 
     return url.toString();
@@ -85,5 +106,71 @@ export class Auth0Api implements IAuth0Api {
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
+  }
+
+  public async listUserAuthenticationMethods(
+    extUserId: string,
+  ): Promise<Array<Auth0AuthenticationMethod>> {
+    try {
+      const accessToken = await this.getManagementApiToken();
+      const response = await this.networkService.get({
+        url: this.getAuthenticationMethodsUrl(extUserId),
+        networkRequest: {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      });
+      return Auth0AuthenticationMethodsSchema.parse(response.data);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+
+  public async deleteUserAuthenticationMethod(
+    extUserId: string,
+    methodId: string,
+  ): Promise<void> {
+    try {
+      const accessToken = await this.getManagementApiToken();
+      await this.networkService.delete({
+        url: `${this.getAuthenticationMethodsUrl(extUserId)}/${encodeURIComponent(methodId)}`,
+        networkRequest: {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  private getAuthenticationMethodsUrl(extUserId: string): string {
+    return new URL(
+      `/api/v2/users/${encodeURIComponent(extUserId)}/authentication-methods`,
+      this.baseUri,
+    ).toString();
+  }
+
+  /**
+   * Fetches a Management API access token via the Client Credentials grant.
+   *
+   * Requires the Auth0 application to be authorized for the Management API
+   * (audience `https://{domain}/api/v2/`) with at least the
+   * `read:authentication_methods` and `delete:authentication_methods` scopes.
+   *
+   * Note: the token is fetched per request (no caching) — acceptable for a
+   * spike, should be cached before production use.
+   */
+  private async getManagementApiToken(): Promise<string> {
+    const response = await this.networkService.postForm({
+      url: new URL('/oauth/token', this.baseUri).toString(),
+      data: {
+        grant_type: Auth0Api.CLIENT_CREDENTIALS_GRANT_TYPE,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        audience: new URL('/api/v2/', this.baseUri).toString(),
+      },
+    });
+
+    return ManagementApiTokenResponseSchema.parse(response.data).access_token;
   }
 }

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
@@ -30,13 +30,13 @@ const ManagementApiTokenResponseSchema = z.object({
 export class Auth0Api implements IAuth0Api {
   private static readonly AUTHORIZATION_CODE_GRANT_TYPE = 'authorization_code';
   private static readonly CLIENT_CREDENTIALS_GRANT_TYPE = 'client_credentials';
-  private static readonly MANAGEMENT_API_TOKEN_TTL_BUFFER_IN_SECONDS = 60;
   private readonly baseUri: string;
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly redirectUri: string;
   private readonly audience: string;
   private readonly scope: string;
+  private readonly managementApiTokenTtlBufferInSeconds: number;
   private inFlightManagementApiTokenRequest: Promise<string> | undefined;
 
   constructor(
@@ -68,6 +68,10 @@ export class Auth0Api implements IAuth0Api {
     this.scope = this.configurationService.getOrThrow<string>(
       `${prefix}.scope`,
     );
+    this.managementApiTokenTtlBufferInSeconds =
+      this.configurationService.getOrThrow<number>(
+        `${prefix}.managementApiTokenTtlBufferInSeconds`,
+      );
   }
 
   public getAuthorizationUrl(
@@ -203,7 +207,7 @@ export class Auth0Api implements IAuth0Api {
     await this.cacheService.hSet(
       CacheRouter.getAuth0ManagementApiTokenCacheDir(),
       access_token,
-      expires_in - Auth0Api.MANAGEMENT_API_TOKEN_TTL_BUFFER_IN_SECONDS,
+      expires_in - this.managementApiTokenTtlBufferInSeconds,
       0,
     );
 

--- a/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
+++ b/src/modules/auth/oidc/auth0/datasources/auth0-api.service.ts
@@ -196,8 +196,9 @@ export class Auth0Api implements IAuth0Api {
       },
     });
 
-    const { access_token, expires_in } =
-      ManagementApiTokenResponseSchema.parse(response.data);
+    const { access_token, expires_in } = ManagementApiTokenResponseSchema.parse(
+      response.data,
+    );
 
     await this.cacheService.hSet(
       CacheRouter.getAuth0ManagementApiTokenCacheDir(),

--- a/src/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity.ts
+++ b/src/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+// https://auth0.com/docs/api/management/v2/users/get-authentication-methods
+export const Auth0AuthenticationMethodSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  name: z.string().optional(),
+  created_at: z.string().optional(),
+});
+
+export const Auth0AuthenticationMethodsSchema = z.array(
+  Auth0AuthenticationMethodSchema,
+);
+
+export type Auth0AuthenticationMethod = z.infer<
+  typeof Auth0AuthenticationMethodSchema
+>;
+
+export const TOTP_AUTHENTICATION_METHOD_TYPE = 'totp';

--- a/src/modules/auth/oidc/auth0/datasources/entities/auth0-otp-association.entity.ts
+++ b/src/modules/auth/oidc/auth0/datasources/entities/auth0-otp-association.entity.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+/**
+ * Response of the MFA API `POST /mfa/associate` call for an `otp`
+ * authenticator: the provider-generated secret and its `otpauth://` URI,
+ * rendered client-side as a QR code.
+ */
+export const Auth0OtpAssociationSchema = z.object({
+  authenticator_type: z.literal('otp'),
+  secret: z.string().min(1),
+  barcode_uri: z.string().min(1),
+});
+
+export type Auth0OtpAssociation = z.infer<typeof Auth0OtpAssociationSchema>;

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.interface.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.interface.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import type { Auth0AuthenticationMethod } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity';
 import type { Auth0Token } from '@/modules/auth/oidc/auth0/domain/entities/auth0-token.entity';
 
 export const IAuth0Repository = Symbol('IAuth0Repository');
@@ -9,9 +10,14 @@ export interface IAuth0Repository {
    *
    * @param state - Opaque anti-CSRF state value that will be echoed back by Auth0.
    * @param connection - Optional OIDC connection name to route directly to a specific identity provider.
+   * @param enroll - When true, requests hosted enrollment of a new authenticator.
    * @returns The fully qualified Auth0 `/authorize` URL.
    */
-  getAuthorizationUrl(state: string, connection?: string): string;
+  getAuthorizationUrl(
+    state: string,
+    connection?: string,
+    enroll?: boolean,
+  ): string;
 
   /**
    * Authenticates an Auth0 authorization code and returns the verified token claims.
@@ -20,4 +26,25 @@ export interface IAuth0Repository {
    * @returns The decoded Auth0 token with claims.
    */
   authenticateWithAuthorizationCode(code: string): Promise<Auth0Token>;
+
+  /**
+   * Lists the MFA authentication methods (e.g. `totp`, `recovery-code`) of
+   * the given Auth0 user.
+   *
+   * @param extUserId - The Auth0 user identifier (`sub` claim).
+   */
+  listUserAuthenticationMethods(
+    extUserId: string,
+  ): Promise<Array<Auth0AuthenticationMethod>>;
+
+  /**
+   * Deletes a single MFA authentication method of the given Auth0 user.
+   *
+   * @param extUserId - The Auth0 user identifier (`sub` claim).
+   * @param methodId - The authentication method identifier.
+   */
+  deleteUserAuthenticationMethod(
+    extUserId: string,
+    methodId: string,
+  ): Promise<void>;
 }

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
@@ -38,6 +38,7 @@ describe('Auth0Repository', () => {
       expect(auth0ApiMock.getAuthorizationUrl).toHaveBeenCalledWith(
         state,
         undefined,
+        undefined,
       );
     });
 
@@ -52,6 +53,22 @@ describe('Auth0Repository', () => {
       expect(auth0ApiMock.getAuthorizationUrl).toHaveBeenCalledWith(
         state,
         'google-oauth2',
+        undefined,
+      );
+    });
+
+    it('should pass enroll through to the Auth0 API', () => {
+      const state = faker.string.alphanumeric(32);
+      const expectedUrl = faker.internet.url();
+      auth0ApiMock.getAuthorizationUrl.mockReturnValue(expectedUrl);
+
+      const result = target.getAuthorizationUrl(state, 'google-oauth2', true);
+
+      expect(result).toBe(expectedUrl);
+      expect(auth0ApiMock.getAuthorizationUrl).toHaveBeenCalledWith(
+        state,
+        'google-oauth2',
+        true,
       );
     });
   });

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.ts
@@ -2,6 +2,7 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import { IAuth0Api } from '@/modules/auth/oidc/auth0/datasources/auth0-api.interface';
+import type { Auth0AuthenticationMethod } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity';
 import { Auth0TokenResponseSchema } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-token-response.entity';
 import type { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository.interface';
 import { Auth0TokenVerifier } from '@/modules/auth/oidc/auth0/domain/auth0-token.verifier';
@@ -15,8 +16,12 @@ export class Auth0Repository implements IAuth0Repository {
     private readonly auth0TokenVerifier: Auth0TokenVerifier,
   ) {}
 
-  public getAuthorizationUrl(state: string, connection?: string): string {
-    return this.auth0Api.getAuthorizationUrl(state, connection);
+  public getAuthorizationUrl(
+    state: string,
+    connection?: string,
+    enroll?: boolean,
+  ): string {
+    return this.auth0Api.getAuthorizationUrl(state, connection, enroll);
   }
 
   public async authenticateWithAuthorizationCode(
@@ -25,5 +30,18 @@ export class Auth0Repository implements IAuth0Repository {
     const response = await this.auth0Api.exchangeAuthorizationCode(code);
     const { id_token } = Auth0TokenResponseSchema.parse(response);
     return this.auth0TokenVerifier.verifyAndDecode(id_token);
+  }
+
+  public async listUserAuthenticationMethods(
+    extUserId: string,
+  ): Promise<Array<Auth0AuthenticationMethod>> {
+    return await this.auth0Api.listUserAuthenticationMethods(extUserId);
+  }
+
+  public async deleteUserAuthenticationMethod(
+    extUserId: string,
+    methodId: string,
+  ): Promise<void> {
+    await this.auth0Api.deleteUserAuthenticationMethod(extUserId, methodId);
   }
 }

--- a/src/modules/auth/oidc/routes/entities/authenticator.entity.ts
+++ b/src/modules/auth/oidc/routes/entities/authenticator.entity.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class Authenticator {
+  @ApiProperty({
+    description: 'Auth0 authentication method identifier (e.g. totp|...)',
+  })
+  id!: string;
+
+  @ApiProperty({ description: 'Authentication method type (e.g. totp)' })
+  type!: string;
+
+  @ApiPropertyOptional({ description: 'User-visible authenticator name' })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'ISO 8601 timestamp of when the method was enrolled',
+  })
+  createdAt?: string;
+}

--- a/src/modules/auth/oidc/routes/entities/mfa-enrollment-session.entity.ts
+++ b/src/modules/auth/oidc/routes/entities/mfa-enrollment-session.entity.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+/**
+ * Server-side, short-lived record of an in-flight authenticator enrollment:
+ * the MFA API access token obtained via the authorization round-trip and —
+ * once `associate` ran — the ids of the authenticator methods it supersedes.
+ * Never leaves the cache; deleted on completion or expiry.
+ */
+export const MfaEnrollmentSessionSchema = z.object({
+  mfaApiToken: z.string().min(1),
+  supersededIds: z.array(z.string().min(1)).optional(),
+});
+
+export type MfaEnrollmentSession = z.infer<typeof MfaEnrollmentSessionSchema>;

--- a/src/modules/auth/oidc/routes/entities/oidc-state.entity.ts
+++ b/src/modules/auth/oidc/routes/entities/oidc-state.entity.ts
@@ -4,6 +4,10 @@ import { z } from 'zod';
 export const OidcStateSchema = z.object({
   csrf: z.hex().length(64),
   redirectUrl: z.string().min(1).max(2048).optional(),
+  // Marks an authenticator-enrollment round-trip: the provider challenges an
+  // existing factor and enrolls a new authenticator; the callback then
+  // removes superseded ones.
+  enroll: z.boolean().optional(),
 });
 
 export type OidcState = z.infer<typeof OidcStateSchema>;

--- a/src/modules/auth/oidc/routes/entities/otp-code.entity.ts
+++ b/src/modules/auth/oidc/routes/entities/otp-code.entity.ts
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+/** Six-digit one-time password produced by an authenticator app. */
+export const OtpCodeSchema = z.string().regex(/^\d{6}$/);

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.ts
@@ -10,21 +10,30 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiForbiddenResponse,
   ApiFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import type { FastifyReply } from 'fastify';
+import { z } from 'zod';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import {
   type OidcConnection,
   OidcConnectionSchema,
 } from '@/modules/auth/oidc/routes/entities/oidc-connection.entity';
 import { OidcAuthRateLimitGuard } from '@/modules/auth/oidc/routes/guards/oidc-auth-rate-limit.guard';
-import { OidcAuthService } from '@/modules/auth/oidc/routes/oidc-auth.service';
+import {
+  type Authenticator,
+  OidcAuthService,
+} from '@/modules/auth/oidc/routes/oidc-auth.service';
+import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
 import {
   ACCESS_TOKEN_COOKIE_NAME,
   getClearCookieOptions,
@@ -87,6 +96,13 @@ export class OidcAuthController {
     description:
       'OIDC connection name to route to a specific identity provider.',
   })
+  @ApiQuery({
+    name: 'enroll',
+    required: false,
+    type: Boolean,
+    description:
+      'When true, requests hosted enrollment of a new authenticator: the provider challenges an existing factor, then walks the user through enrolling the new one.',
+  })
   @ApiFoundResponse({
     description: 'Redirect to OIDC authorize endpoint',
   })
@@ -98,11 +114,14 @@ export class OidcAuthController {
     redirectUrl?: string,
     @Query('connection', new ValidationPipe(OidcConnectionSchema.optional()))
     connection?: OidcConnection,
+    @Query('enroll', new ValidationPipe(z.literal('true').optional()))
+    enroll?: 'true',
   ): void {
     const { authorizationUrl, state, stateMaxAge } =
       this.oidcAuthService.createOidcAuthorizationRequest(
         redirectUrl,
         connection,
+        enroll === 'true',
       );
 
     res.setCookie(
@@ -203,8 +222,18 @@ export class OidcAuthController {
     }
 
     try {
-      const { accessToken, maxAge } =
+      const { accessToken, maxAge, userId } =
         await this.oidcAuthService.authenticateWithOidc(code);
+
+      if (this.oidcAuthService.isEnrollmentState(state)) {
+        try {
+          await this.oidcAuthService.cleanupSupersededAuthenticators(userId);
+        } catch (cleanupError) {
+          this.loggingService.warn(
+            `Auth callback: superseded authenticator cleanup failed: ${asError(cleanupError).message}`,
+          );
+        }
+      }
 
       res.setCookie(
         ACCESS_TOKEN_COOKIE_NAME,
@@ -222,6 +251,22 @@ export class OidcAuthController {
         302,
       );
     }
+  }
+
+  @ApiOperation({
+    summary: 'List MFA authenticators',
+    description:
+      'Lists the MFA authentication methods of the authenticated user for the self-service authenticator ' +
+      'management UI.',
+  })
+  @ApiOkResponse({ description: 'MFA authentication methods' })
+  @ApiForbiddenResponse({ description: 'Not authenticated' })
+  @UseGuards(AuthGuard)
+  @Get('oidc/mfa/authenticators')
+  async listAuthenticators(
+    @Auth() authPayload: AuthPayload,
+  ): Promise<Array<Authenticator>> {
+    return await this.oidcAuthService.listAuthenticators(authPayload);
   }
 
   /**

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.ts
@@ -27,11 +27,9 @@ import {
   type OidcConnection,
   OidcConnectionSchema,
 } from '@/modules/auth/oidc/routes/entities/oidc-connection.entity';
+import { Authenticator } from '@/modules/auth/oidc/routes/entities/authenticator.entity';
 import { OidcAuthRateLimitGuard } from '@/modules/auth/oidc/routes/guards/oidc-auth-rate-limit.guard';
-import {
-  type Authenticator,
-  OidcAuthService,
-} from '@/modules/auth/oidc/routes/oidc-auth.service';
+import { OidcAuthService } from '@/modules/auth/oidc/routes/oidc-auth.service';
 import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
 import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
 import {
@@ -259,7 +257,11 @@ export class OidcAuthController {
       'Lists the MFA authentication methods of the authenticated user for the self-service authenticator ' +
       'management UI.',
   })
-  @ApiOkResponse({ description: 'MFA authentication methods' })
+  @ApiOkResponse({
+    description: 'MFA authentication methods',
+    type: Authenticator,
+    isArray: true,
+  })
   @ApiForbiddenResponse({ description: 'Not authenticated' })
   @UseGuards(AuthGuard)
   @Get('oidc/mfa/authenticators')

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.ts
@@ -23,11 +23,11 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Authenticator } from '@/modules/auth/oidc/routes/entities/authenticator.entity';
 import {
   type OidcConnection,
   OidcConnectionSchema,
 } from '@/modules/auth/oidc/routes/entities/oidc-connection.entity';
-import { Authenticator } from '@/modules/auth/oidc/routes/entities/authenticator.entity';
 import { OidcAuthRateLimitGuard } from '@/modules/auth/oidc/routes/guards/oidc-auth-rate-limit.guard';
 import { OidcAuthService } from '@/modules/auth/oidc/routes/oidc-auth.service';
 import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';

--- a/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
@@ -791,6 +791,32 @@ describe('OidcAuthService', () => {
           auth0RepositoryMock.deleteUserAuthenticationMethod,
         ).not.toHaveBeenCalled();
       });
+
+      it('should abort cleanup when a TOTP created_at is missing', async () => {
+        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
+          {
+            id: 'totp|dated',
+            type: 'totp',
+            created_at: '2026-07-01T10:00:00.000Z',
+          },
+          {
+            id: 'totp|missing-created-at',
+            type: 'totp',
+          },
+          recoveryMethod,
+        ]);
+
+        await expect(
+          target.cleanupSupersededAuthenticators(
+            Number(authPayload.getUserId()),
+          ),
+        ).rejects.toThrow(
+          'Cannot clean up TOTP authentication methods without created_at',
+        );
+        expect(
+          auth0RepositoryMock.deleteUserAuthenticationMethod,
+        ).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
@@ -9,7 +9,10 @@ import {
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import type { IAuthRepository } from '@/modules/auth/domain/auth.repository.interface';
-import { AuthMethod } from '@/modules/auth/domain/entities/auth-payload.entity';
+import {
+  AuthMethod,
+  AuthPayload,
+} from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository.interface';
 import { OidcAuthService } from '@/modules/auth/oidc/routes/oidc-auth.service';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -23,11 +26,15 @@ const authRepositoryMock = {
 
 const usersRepositoryMock = {
   findOrCreateByExtUserIdAndEmail: vi.fn(),
+  findOneOrFail: vi.fn(),
+  findEmailById: vi.fn(),
 } as MockedObject<IUsersRepository>;
 
 const auth0RepositoryMock = {
   getAuthorizationUrl: vi.fn(),
   authenticateWithAuthorizationCode: vi.fn(),
+  listUserAuthenticationMethods: vi.fn(),
+  deleteUserAuthenticationMethod: vi.fn(),
 } as MockedObject<IAuth0Repository>;
 
 describe('OidcAuthService', () => {
@@ -102,10 +109,10 @@ describe('OidcAuthService', () => {
 
       expect(result).toEqual(expect.objectContaining({ accessToken }));
       expect(authRepositoryMock.signToken).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           auth_method: AuthMethod.Oidc,
           sub: userId.toString(),
-        },
+        }),
         {
           nbf,
           exp,
@@ -149,10 +156,10 @@ describe('OidcAuthService', () => {
 
       expect(result).toEqual(expect.objectContaining({ accessToken }));
       expect(authRepositoryMock.signToken).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           auth_method: AuthMethod.Oidc,
           sub: userId.toString(),
-        },
+        }),
         {
           nbf: undefined,
           exp: maxExpiration,
@@ -405,8 +412,10 @@ describe('OidcAuthService', () => {
       );
       expect(decoded.csrf).toHaveLength(64); // 32 bytes hex-encoded
       expect(decoded.redirectUrl).toBeUndefined();
+      expect(decoded.enroll).toBeUndefined();
       expect(auth0RepositoryMock.getAuthorizationUrl).toHaveBeenCalledWith(
         result.state,
+        undefined,
         undefined,
       );
     });
@@ -424,6 +433,7 @@ describe('OidcAuthService', () => {
       expect(auth0RepositoryMock.getAuthorizationUrl).toHaveBeenCalledWith(
         result.state,
         'google-oauth2',
+        undefined,
       );
     });
 
@@ -661,6 +671,126 @@ describe('OidcAuthService', () => {
       expect(() => target.getPostLoginRedirectUri('not-valid-base64!')).toThrow(
         UnauthorizedException,
       );
+    });
+  });
+  describe('MFA switch', () => {
+    const authPayload = new AuthPayload({
+      auth_method: AuthMethod.Oidc,
+      sub: faker.number.int().toString(),
+    });
+    const extUserId = `auth0|${faker.string.uuid()}`;
+    const totpMethod = { id: `totp|${faker.string.uuid()}`, type: 'totp' };
+    const recoveryMethod = {
+      id: `recovery-code|${faker.string.uuid()}`,
+      type: 'recovery-code',
+    };
+
+    beforeEach(() => {
+      usersRepositoryMock.findOneOrFail.mockResolvedValue({
+        extUserId,
+      } as Awaited<ReturnType<IUsersRepository['findOneOrFail']>>);
+    });
+
+    describe('listAuthenticators', () => {
+      it('should map the Auth0 authentication methods', async () => {
+        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
+          totpMethod,
+          recoveryMethod,
+        ]);
+
+        await expect(target.listAuthenticators(authPayload)).resolves.toEqual([
+          expect.objectContaining({ id: totpMethod.id, type: 'totp' }),
+          expect.objectContaining({
+            id: recoveryMethod.id,
+            type: 'recovery-code',
+          }),
+        ]);
+      });
+
+      it('should reject users without a linked OIDC identity', async () => {
+        usersRepositoryMock.findOneOrFail.mockResolvedValue({
+          extUserId: null,
+        } as Awaited<ReturnType<IUsersRepository['findOneOrFail']>>);
+
+        await expect(target.listAuthenticators(authPayload)).rejects.toThrow(
+          new UnauthorizedException('User is not linked to an OIDC identity'),
+        );
+      });
+    });
+
+    describe('deleteAuthenticator', () => {
+      it('should delete a TOTP enrollment', async () => {
+        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
+          totpMethod,
+          recoveryMethod,
+        ]);
+
+        await target.deleteAuthenticator(authPayload, totpMethod.id);
+
+        expect(
+          auth0RepositoryMock.deleteUserAuthenticationMethod,
+        ).toHaveBeenCalledWith(extUserId, totpMethod.id);
+      });
+
+      it('should refuse to delete the recovery code', async () => {
+        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
+          totpMethod,
+          recoveryMethod,
+        ]);
+
+        await expect(
+          target.deleteAuthenticator(authPayload, recoveryMethod.id),
+        ).rejects.toThrow(new BadRequestException('Unknown authenticator'));
+        expect(
+          auth0RepositoryMock.deleteUserAuthenticationMethod,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('cleanupSupersededAuthenticators', () => {
+      it('should delete all TOTP enrollments except the newest', async () => {
+        const oldMethod = {
+          id: 'totp|old',
+          type: 'totp',
+          created_at: '2026-07-01T10:00:00.000Z',
+        };
+        const newMethod = {
+          id: 'totp|new',
+          type: 'totp',
+          created_at: '2026-07-17T10:00:00.000Z',
+        };
+        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
+          newMethod,
+          oldMethod,
+          recoveryMethod,
+        ]);
+
+        await target.cleanupSupersededAuthenticators(
+          Number(authPayload.getUserId()),
+        );
+
+        expect(
+          auth0RepositoryMock.deleteUserAuthenticationMethod,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          auth0RepositoryMock.deleteUserAuthenticationMethod,
+        ).toHaveBeenCalledWith(extUserId, oldMethod.id);
+      });
+
+      it('should not delete anything when a single TOTP enrollment exists', async () => {
+        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
+          totpMethod,
+          recoveryMethod,
+        ]);
+
+        await target.cleanupSupersededAuthenticators(
+          Number(authPayload.getUserId()),
+        );
+
+        expect(
+          auth0RepositoryMock.deleteUserAuthenticationMethod,
+        ).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
@@ -718,35 +718,6 @@ describe('OidcAuthService', () => {
       });
     });
 
-    describe('deleteAuthenticator', () => {
-      it('should delete a TOTP enrollment', async () => {
-        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
-          totpMethod,
-          recoveryMethod,
-        ]);
-
-        await target.deleteAuthenticator(authPayload, totpMethod.id);
-
-        expect(
-          auth0RepositoryMock.deleteUserAuthenticationMethod,
-        ).toHaveBeenCalledWith(extUserId, totpMethod.id);
-      });
-
-      it('should refuse to delete the recovery code', async () => {
-        auth0RepositoryMock.listUserAuthenticationMethods.mockResolvedValue([
-          totpMethod,
-          recoveryMethod,
-        ]);
-
-        await expect(
-          target.deleteAuthenticator(authPayload, recoveryMethod.id),
-        ).rejects.toThrow(new BadRequestException('Unknown authenticator'));
-        expect(
-          auth0RepositoryMock.deleteUserAuthenticationMethod,
-        ).not.toHaveBeenCalled();
-      });
-    });
-
     describe('cleanupSupersededAuthenticators', () => {
       it('should delete all TOTP enrollments except the newest', async () => {
         const oldMethod = {

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -4,7 +4,11 @@ import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { getSecondsUntil } from '@/domain/common/utils/time';
 import { IAuthRepository } from '@/modules/auth/domain/auth.repository.interface';
-import { AuthMethod } from '@/modules/auth/domain/entities/auth-payload.entity';
+import {
+  AuthMethod,
+  type AuthPayload,
+} from '@/modules/auth/domain/entities/auth-payload.entity';
+import { TOTP_AUTHENTICATION_METHOD_TYPE } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity';
 import { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository.interface';
 import type { OidcConnection } from '@/modules/auth/oidc/routes/entities/oidc-connection.entity';
 import {
@@ -25,6 +29,14 @@ import { IUsersRepository } from '@/modules/users/domain/users.repository.interf
 type OidcAuthTokenResponse = {
   accessToken: string;
   maxAge: number | undefined;
+  userId: number;
+};
+
+export type Authenticator = {
+  id: string;
+  type: string;
+  name?: string;
+  createdAt?: string;
 };
 
 @Injectable()
@@ -49,6 +61,14 @@ export class OidcAuthService {
     this.stateTtlMs =
       this.configurationService.getOrThrow<number>('auth.stateTtlMs');
     this.redirectConfig = getRedirectConfig(this.configurationService);
+  }
+
+  /**
+   * Whether the given state payload marks an authenticator-enrollment
+   * round-trip.
+   */
+  public isEnrollmentState(state: string): boolean {
+    return this.decodeState(state).enroll === true;
   }
 
   public async authenticateWithOidc(
@@ -101,7 +121,70 @@ export class OidcAuthService {
     return {
       accessToken,
       maxAge: getSecondsUntil(exp),
+      userId,
     };
+  }
+
+  /**
+   * Lists the MFA authentication methods of the authenticated user, for the
+   * self-service authenticator management UI (Auth0's recommended flow for
+   * factor replacement).
+   */
+  public async listAuthenticators(
+    authPayload: AuthPayload,
+  ): Promise<Array<Authenticator>> {
+    const extUserId = await this.getExtUserId(authPayload);
+    const methods =
+      await this.auth0Repository.listUserAuthenticationMethods(extUserId);
+
+    return methods.map((method) => ({
+      id: method.id,
+      type: method.type,
+      name: method.name,
+      createdAt: method.created_at,
+    }));
+  }
+
+  /**
+   * Removes authenticator (TOTP) enrollments superseded by a hosted
+   * enrollment round-trip: every TOTP method except the most recently
+   * created one. The recovery code is untouched.
+   */
+  public async cleanupSupersededAuthenticators(userId: number): Promise<void> {
+    const user = await this.usersRepository.findOneOrFail({ id: userId });
+    if (!user.extUserId) {
+      return;
+    }
+
+    const methods = await this.auth0Repository.listUserAuthenticationMethods(
+      user.extUserId,
+    );
+    const totpMethods = methods
+      .filter((method) => method.type === TOTP_AUTHENTICATION_METHOD_TYPE)
+      .sort(
+        (a, b) =>
+          new Date(a.created_at ?? 0).getTime() -
+          new Date(b.created_at ?? 0).getTime(),
+      );
+
+    for (const method of totpMethods.slice(0, -1)) {
+      await this.auth0Repository.deleteUserAuthenticationMethod(
+        user.extUserId,
+        method.id,
+      );
+    }
+  }
+
+  private async getExtUserId(authPayload: AuthPayload): Promise<string> {
+    const user = await this.usersRepository.findOneOrFail({
+      id: Number(authPayload.getUserId()),
+    });
+
+    if (!user.extUserId) {
+      throw new UnauthorizedException('User is not linked to an OIDC identity');
+    }
+
+    return user.extUserId;
   }
 
   /**
@@ -114,12 +197,17 @@ export class OidcAuthService {
    *   same-origin as the configured {@link postLoginRedirectUri}.
    * @param connection - Optional OIDC connection name to route directly
    *   to a specific identity provider.
+   * @param enroll - When true, requests hosted enrollment of a new
+   *   authenticator: the provider challenges an existing factor, then walks
+   *   the user through enrolling the new one; the callback removes
+   *   superseded enrollments.
    * @returns The OIDC authorization URL, the encoded state, and its TTL.
    * @throws {BadRequestException} If {@link redirectUrl} is not same-origin.
    */
   public createOidcAuthorizationRequest(
     redirectUrl?: string,
     connection?: OidcConnection,
+    enroll?: boolean,
   ): {
     authorizationUrl: string;
     state: string;
@@ -132,6 +220,7 @@ export class OidcAuthService {
     const statePayload = {
       csrf: randomBytes(32).toString('hex'),
       redirectUrl: resolvedRedirectUrl,
+      enroll: enroll || undefined,
     };
 
     const state = Buffer.from(JSON.stringify(statePayload)).toString(
@@ -142,6 +231,7 @@ export class OidcAuthService {
       authorizationUrl: this.auth0Repository.getAuthorizationUrl(
         state,
         connection,
+        enroll,
       ),
       state,
       stateMaxAge: this.stateTtlMs,

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -129,6 +129,10 @@ export class OidcAuthService {
    * Lists the MFA authentication methods of the authenticated user, for the
    * self-service authenticator management UI (Auth0's recommended flow for
    * factor replacement).
+   *
+   * Security invariant: the Auth0 user ID must always be resolved from the
+   * authenticated gateway payload. Never accept a local or Auth0 user ID from
+   * request input here, as the Management API token has tenant-wide access.
    */
   public async listAuthenticators(
     authPayload: AuthPayload,
@@ -149,6 +153,10 @@ export class OidcAuthService {
    * Removes authenticator (TOTP) enrollments superseded by a hosted
    * enrollment round-trip: every TOTP method except the most recently
    * created one. The recovery code is untouched.
+   *
+   * Security invariant: {@link userId} must come from the verified OIDC
+   * callback result, never from request input. Authentication method IDs must
+   * likewise come from Auth0's response for that resolved user.
    */
   public async cleanupSupersededAuthenticators(userId: number): Promise<void> {
     const user = await this.usersRepository.findOneOrFail({ id: userId });

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -167,13 +167,25 @@ export class OidcAuthService {
     const methods = await this.auth0Repository.listUserAuthenticationMethods(
       user.extUserId,
     );
-    const totpMethods = methods
-      .filter((method) => method.type === TOTP_AUTHENTICATION_METHOD_TYPE)
-      .sort(
-        (a, b) =>
-          new Date(a.created_at ?? 0).getTime() -
-          new Date(b.created_at ?? 0).getTime(),
+    const totpMethods = methods.filter(
+      (method) => method.type === TOTP_AUTHENTICATION_METHOD_TYPE,
+    );
+
+    if (totpMethods.length <= 1) {
+      return;
+    }
+
+    if (totpMethods.some((method) => !method.created_at)) {
+      throw new Error(
+        'Cannot clean up TOTP authentication methods without created_at',
       );
+    }
+
+    totpMethods.sort(
+      (a, b) =>
+        Date.parse(a.created_at as string) -
+        Date.parse(b.created_at as string),
+    );
 
     for (const method of totpMethods.slice(0, -1)) {
       await this.auth0Repository.deleteUserAuthenticationMethod(

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { TOTP_AUTHENTICATION_METHOD_TYPE } from '@/modules/auth/oidc/auth0/datasources/entities/auth0-authentication-method.entity';
 import { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository.interface';
+import type { Authenticator } from '@/modules/auth/oidc/routes/entities/authenticator.entity';
 import type { OidcConnection } from '@/modules/auth/oidc/routes/entities/oidc-connection.entity';
 import {
   type OidcState,
@@ -32,12 +33,6 @@ type OidcAuthTokenResponse = {
   userId: number;
 };
 
-export type Authenticator = {
-  id: string;
-  type: string;
-  name?: string;
-  createdAt?: string;
-};
 
 @Injectable()
 export class OidcAuthService {

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -183,8 +183,7 @@ export class OidcAuthService {
 
     totpMethods.sort(
       (a, b) =>
-        Date.parse(a.created_at as string) -
-        Date.parse(b.created_at as string),
+        Date.parse(a.created_at as string) - Date.parse(b.created_at as string),
     );
 
     for (const method of totpMethods.slice(0, -1)) {

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -33,7 +33,6 @@ type OidcAuthTokenResponse = {
   userId: number;
 };
 
-
 @Injectable()
 export class OidcAuthService {
   private readonly maxValidityPeriodInSeconds: number;


### PR DESCRIPTION
fixes WA-2850 

 ## Summary

  Allows a signed-in OIDC user to switch their TOTP authenticator (e.g. moving to a new phone) without support intervention. Demo: [Linear project update](https://linear.app/safe-global/project/workspace-2fa-26155ec54c2d/activity#project-update-5d3c5ad7).

  Flow: the frontend starts a re-enrollment via `GET /v1/auth/oidc/authorize?enroll=true`. The Auth0 post-login Action (`ext-enroll-otp`, deployed via terraform-auth0-module) challenges the user with a **recovery code**, then forces enrollment of a **new TOTP**. On the callback, CGW deletes the superseded TOTP method(s), keeping only the newest, so the account never ends up with stale authenticators.

  ```mermaid
  sequenceDiagram
    participant W as Web app
    participant C as CGW
    participant A as Auth0
    W->>C: GET /oidc/authorize?enroll=true
    C->>A: /authorize (enroll marked in state)
    A->>A: recovery-code challenge and new TOTP enrollment (Action)
    A->>C: /oidc/callback (code)
    C->>A: exchange code, verify ID token
    C->>A: Management API - list methods, delete superseded TOTPs
    C->>W: session cookie and redirect
  ```

  ## Changes

  - `GET /v1/auth/oidc/authorize` accepts `enroll=true`, carried through the OAuth `state`
  - `GET /v1/auth/oidc/mfa/authenticators` lists the user's authentication methods
  - `cleanupSupersededAuthenticators`: after an enroll round-trip, deletes all TOTP methods except the newest; aborts (no deletions) if any method lacks `created_at`
  - Auth0 Management API client (list/delete authentication methods) with the token cached in Redis until shortly before expiry
  - Unit + integration tests for the above

  ## Deployment

  Deploy together with [terraform-auth0 PR #21](https://github.com/safe-global/terraform-auth0-module/pull/21) (Action + Management API scopes + tenant flag) — CGW's enroll flow fails closed without it. [Frontend PR #8320](https://github.com/safe-global/safe-wallet-monorepo/pull/8320) can ship later.

  Rollback: revert CGW; the tenant config is backwards-compatible with the previous build.

  ## How to test

If you want to test this by click through on your local machine you'll have to create a separate account/tenant on auth0, use the terraform-auth0-module to clone the company config, get a Google Cloud key, and then, if you manage to put the right env vars, you should be able to locally test this. I'm happy to help you setting this up.
