### PR TITLE
chore(deps): upgrade typeorm to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rxjs": "7.8.2",
     "sanitize-html": "2.17.6",
     "semver": "7.8.5",
-    "typeorm": "0.3.28",
+    "typeorm": "1.1.0",
     "undici": "8.7.0",
     "viem": "2.54.6",
     "winston": "3.19.0",

--- a/src/config/entities/postgres.config.ts
+++ b/src/config/entities/postgres.config.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { readFileSync } from 'node:fs';
-import type { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import type { PostgresDataSourceOptions } from 'typeorm/driver/postgres/PostgresDataSourceOptions';
 import { PostgresqlLogger } from '@/datasources/db/v2/postgresql-logger.service';
 import type { ILoggingService } from '@/logging/logging.interface';
 
@@ -32,7 +32,7 @@ interface IPostgresEnvConfig {
 export const postgresConfig = (
   postgresEnvConfig: IPostgresEnvConfig,
   logger?: ILoggingService,
-): PostgresConnectionOptions => {
+): PostgresDataSourceOptions => {
   const isCIContext = process.env.CI?.toLowerCase() === 'true';
   const isSslEnabled = !isCIContext && postgresEnvConfig.ssl.enabled;
   const postgresCa =

--- a/src/domain/common/utils/__tests__/enum.spec.ts
+++ b/src/domain/common/utils/__tests__/enum.spec.ts
@@ -100,6 +100,14 @@ describe('enum utils', () => {
 
         expect(result).toEqual('B');
       });
+
+      it('should return null for a null database value without throwing', () => {
+        const result = databaseEnumTransformer(NumericEnum).from(
+          null as unknown as number,
+        );
+
+        expect(result).toBeNull();
+      });
     });
   });
 

--- a/src/domain/common/utils/__tests__/enum.spec.ts
+++ b/src/domain/common/utils/__tests__/enum.spec.ts
@@ -102,9 +102,7 @@ describe('enum utils', () => {
       });
 
       it('should return null for a null database value without throwing', () => {
-        const result = databaseEnumTransformer(NumericEnum).from(
-          null as unknown as number,
-        );
+        const result = databaseEnumTransformer(NumericEnum).from(null);
 
         expect(result).toBeNull();
       });

--- a/src/domain/common/utils/enum.ts
+++ b/src/domain/common/utils/enum.ts
@@ -33,14 +33,12 @@ export const databaseEnumTransformer = <T extends NumericEnum>(
 
       return value;
     },
-    from: (value: number): keyof T => {
-      const key = getEnumKey(enumObj, value);
-
-      if (key === undefined) {
-        throw new Error(`Invalid enum value: ${value}`);
+    from: (value: number | null): keyof T | null => {
+      if (value === null) {
+        return null;
       }
 
-      return key;
+      return getEnumKey(enumObj, value);
     },
   };
 };

--- a/src/domain/common/utils/enum.ts
+++ b/src/domain/common/utils/enum.ts
@@ -34,6 +34,10 @@ export const databaseEnumTransformer = <T extends NumericEnum>(
       return value;
     },
     from: (value: number | null): keyof T | null => {
+      // Only a genuinely absent (null) column value is treated as
+      // absent data. A non-null value that doesn't match a known enum
+      // member is corrupt/legacy data, not an absence, so it still
+      // throws via getEnumKey rather than silently becoming null.
       if (value === null) {
         return null;
       }

--- a/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.integration.spec.ts
+++ b/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.integration.spec.ts
@@ -157,19 +157,13 @@ describe('CounterfactualSafesRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order
-    await dbCounterfactualSafeUserRepo
-      .createQueryBuilder()
-      .delete()
-      .where('1=1')
-      .execute();
-    await dbCounterfactualSafeRepo
-      .createQueryBuilder()
-      .delete()
-      .where('1=1')
-      .execute();
-    await dbWalletRepo.createQueryBuilder().delete().where('1=1').execute();
-    await dbUserRepo.createQueryBuilder().delete().where('1=1').execute();
+    // Delete in dependency order. No .where() is intentional: these clear
+    // every row to reset state between tests, and TypeORM rejects a
+    // WHERE clause that renders as an unfiltered '1=1' as a likely mistake.
+    await dbCounterfactualSafeUserRepo.createQueryBuilder().delete().execute();
+    await dbCounterfactualSafeRepo.createQueryBuilder().delete().execute();
+    await dbWalletRepo.createQueryBuilder().delete().execute();
+    await dbUserRepo.createQueryBuilder().delete().execute();
   });
 
   afterAll(async () => {

--- a/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.ts
+++ b/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.ts
@@ -226,10 +226,12 @@ export class CounterfactualSafesRepository
         );
       }
 
-      await manager.delete(
-        CounterfactualSafeUser,
-        targets.map((t) => t.id),
-      );
+      await manager
+        .createQueryBuilder()
+        .delete()
+        .from(CounterfactualSafeUser)
+        .whereInIds(targets.map((t) => t.id))
+        .execute();
     });
   }
 }

--- a/src/modules/notifications/domain/v2/notifications.repository.integration.spec.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.integration.spec.ts
@@ -192,15 +192,9 @@ describe('NotificationsRepositoryV2', () => {
     const notificationSubscriptionNotificationTypeRepository =
       dataSource.getRepository(NotificationSubscriptionNotificationType);
 
-    await notificationDeviceRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
+    await notificationDeviceRepository.createQueryBuilder().delete().execute();
 
-    await subscriptionRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
+    await subscriptionRepository.createQueryBuilder().delete().execute();
 
     await notificationSubscriptionNotificationTypeRepository
       .createQueryBuilder()

--- a/src/modules/notifications/domain/v2/notifications.repository.integration.spec.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.integration.spec.ts
@@ -195,19 +195,16 @@ describe('NotificationsRepositoryV2', () => {
     await notificationDeviceRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
 
     await subscriptionRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
 
     await notificationSubscriptionNotificationTypeRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
   }
 
@@ -433,7 +430,7 @@ describe('NotificationsRepositoryV2', () => {
               device_uuid: upsertSubscriptionsDto.deviceUuid as UUID,
             },
           },
-          relations: ['push_notification_device'],
+          relations: { push_notification_device: true },
         });
 
       expect(subscriptionBeforeRemoval).toHaveProperty('chain_id');
@@ -512,7 +509,10 @@ describe('NotificationsRepositoryV2', () => {
               id: In(subscriptionIds),
             },
           },
-          relations: ['notification_type', 'notification_subscription'],
+          relations: {
+            notification_type: true,
+            notification_subscription: true,
+          },
         });
 
       const upsertNotificationTypes: Array<string> = [];

--- a/src/modules/notifications/domain/v2/notifications.repository.integration.spec.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.integration.spec.ts
@@ -179,6 +179,11 @@ describe('NotificationsRepositoryV2', () => {
    * It uses query builders to perform the deletions without conditions,
    * effectively clearing all records for test or reset purposes.
    *
+   * No .where() call on any of the deletes below: TypeORM 1.1.0 rejects a
+   * WHERE clause that renders as an unfiltered '1=1' as a likely mistake —
+   * see counterfactual-safes.repository.integration.spec.ts for the full
+   * rationale.
+   *
    * @async
    * @function truncateTables
    * @returns {Promise<void>} Resolves when all specified tables are truncated.

--- a/src/modules/notifications/domain/v2/notifications.repository.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.ts
@@ -379,7 +379,7 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
         chain_id: args.chainId,
         safe_address: args.safeAddress,
       },
-      relations: ['push_notification_device'],
+      relations: { push_notification_device: true },
       cache: {
         id: subscriptionsCacheKey,
         milliseconds: cacheTtl,

--- a/src/modules/spaces/domain/address-books/address-book-requests.repository.ts
+++ b/src/modules/spaces/domain/address-books/address-book-requests.repository.ts
@@ -34,7 +34,7 @@ export class AddressBookRequestsRepository
     }
     return repository.find({
       where,
-      relations: ['requestedBy'],
+      relations: { requestedBy: true },
       order: { createdAt: 'DESC' },
     });
   }
@@ -54,7 +54,7 @@ export class AddressBookRequestsRepository
     }
     return repository.find({
       where,
-      relations: ['requestedBy'],
+      relations: { requestedBy: true },
       order: { createdAt: 'DESC' },
     });
   }
@@ -69,7 +69,7 @@ export class AddressBookRequestsRepository
         id: args.id,
         space: { id: args.spaceId },
       },
-      relations: ['requestedBy'],
+      relations: { requestedBy: true },
     });
     if (!request) {
       throw new NotFoundException('Address book request not found.');

--- a/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
@@ -149,15 +149,14 @@ describe('SpaceAuditRepository', () => {
   afterEach(async () => {
     // Audit rows are deliberately NOT deleted (the triggers forbid it):
     // every test works on a fresh space and scopes its reads by spaceId.
-    await dbMembersRepo.createQueryBuilder().delete().where('1=1').execute();
+    await dbMembersRepo.createQueryBuilder().delete().execute();
     await dataSource
       .getRepository(Space)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
-    await dbWalletRepo.createQueryBuilder().delete().where('1=1').execute();
-    await dbUserRepo.createQueryBuilder().delete().where('1=1').execute();
+    await dbWalletRepo.createQueryBuilder().delete().execute();
+    await dbUserRepo.createQueryBuilder().delete().execute();
   });
 
   afterAll(async () => {

--- a/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
@@ -149,6 +149,10 @@ describe('SpaceAuditRepository', () => {
   afterEach(async () => {
     // Audit rows are deliberately NOT deleted (the triggers forbid it):
     // every test works on a fresh space and scopes its reads by spaceId.
+    // No .where() on the deletes below: TypeORM 1.1.0 rejects a WHERE
+    // clause that renders as an unfiltered '1=1' as a likely mistake —
+    // see counterfactual-safes.repository.integration.spec.ts for the
+    // full rationale.
     await dbMembersRepo.createQueryBuilder().delete().execute();
     await dataSource
       .getRepository(Space)

--- a/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
@@ -127,20 +127,17 @@ describe('SpaceSafesRepository', () => {
     await dbMembersRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dbSpaceSafesRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dbSpaceRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
-    await dbWalletRepo.createQueryBuilder().delete().where('1=1').execute();
-    await dbUserRepo.createQueryBuilder().delete().where('1=1').execute();
+    await dbWalletRepo.createQueryBuilder().delete().execute();
+    await dbUserRepo.createQueryBuilder().delete().execute();
   });
 
   afterAll(async () => {

--- a/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
@@ -123,7 +123,10 @@ describe('SpaceSafesRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order to avoid deadlocks
+    // Delete in dependency order to avoid deadlocks. No .where(): TypeORM
+    // 1.1.0 rejects a WHERE clause that renders as an unfiltered '1=1' as
+    // a likely mistake — see counterfactual-safes.repository.integration.spec.ts
+    // for the full rationale.
     await dbMembersRepository.createQueryBuilder().delete().execute();
     await dbSpaceSafesRepository.createQueryBuilder().delete().execute();
     await dbSpaceRepository.createQueryBuilder().delete().execute();

--- a/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
@@ -123,10 +123,7 @@ describe('SpaceSafesRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order to avoid deadlocks. No .where(): TypeORM
-    // 1.1.0 rejects a WHERE clause that renders as an unfiltered '1=1' as
-    // a likely mistake — see counterfactual-safes.repository.integration.spec.ts
-    // for the full rationale.
+    // Delete in dependency order to avoid deadlocks.
     await dbMembersRepository.createQueryBuilder().delete().execute();
     await dbSpaceSafesRepository.createQueryBuilder().delete().execute();
     await dbSpaceRepository.createQueryBuilder().delete().execute();

--- a/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/safes/space-safes.repository.integration.spec.ts
@@ -124,18 +124,9 @@ describe('SpaceSafesRepository', () => {
     vi.resetAllMocks();
 
     // Delete in dependency order to avoid deadlocks
-    await dbMembersRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
-    await dbSpaceSafesRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
-    await dbSpaceRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
+    await dbMembersRepository.createQueryBuilder().delete().execute();
+    await dbSpaceSafesRepository.createQueryBuilder().delete().execute();
+    await dbSpaceRepository.createQueryBuilder().delete().execute();
     await dbWalletRepo.createQueryBuilder().delete().execute();
     await dbUserRepo.createQueryBuilder().delete().execute();
   });

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -119,10 +119,7 @@ describe('SpacesRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order to avoid deadlocks. No .where(): TypeORM
-    // 1.1.0 rejects a WHERE clause that renders as an unfiltered '1=1' as
-    // a likely mistake — see counterfactual-safes.repository.integration.spec.ts
-    // for the full rationale.
+    // Delete in dependency order to avoid deadlocks.
     await dataSource
       .getRepository(Member)
       .createQueryBuilder()

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -124,25 +124,21 @@ describe('SpacesRepository', () => {
       .getRepository(Member)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dataSource
       .getRepository(Space)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dataSource
       .getRepository(Wallet)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dataSource
       .getRepository(User)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
   });
 

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -119,7 +119,10 @@ describe('SpacesRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order to avoid deadlocks
+    // Delete in dependency order to avoid deadlocks. No .where(): TypeORM
+    // 1.1.0 rejects a WHERE clause that renders as an unfiltered '1=1' as
+    // a likely mistake — see counterfactual-safes.repository.integration.spec.ts
+    // for the full rationale.
     await dataSource
       .getRepository(Member)
       .createQueryBuilder()

--- a/src/modules/spaces/domain/spaces.repository.ts
+++ b/src/modules/spaces/domain/spaces.repository.ts
@@ -171,7 +171,7 @@ export class SpacesRepository implements ISpacesRepository {
 
     const members = await memberRepository.find({
       where: { user: { id: args.userId } },
-      relations: ['space'],
+      relations: { space: true },
     });
     const membersIds = members.map((member) => member.space.id);
 

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -134,7 +134,7 @@ describe('SpacesService', () => {
             inviteExpiresAt: MoreThan(expect.any(Date)),
           },
         ],
-        relations: ['space'],
+        relations: { space: true },
       });
     });
 

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -72,7 +72,7 @@ export class SpacesService {
         user: { id: userId },
         ...spaceScope,
       })),
-      relations: ['space'],
+      relations: { space: true },
     });
     if (members.length === 0) {
       return [];

--- a/src/modules/users/domain/members/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members/members.repository.integration.spec.ts
@@ -161,25 +161,21 @@ describe('MembersRepository', () => {
       .getRepository(Member)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dataSource
       .getRepository(Space)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dataSource
       .getRepository(Wallet)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
     await dataSource
       .getRepository(User)
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
   });
 

--- a/src/modules/users/domain/members/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members/members.repository.integration.spec.ts
@@ -156,10 +156,6 @@ describe('MembersRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order to avoid deadlocks. No .where(): TypeORM
-    // 1.1.0 rejects a WHERE clause that renders as an unfiltered '1=1' as
-    // a likely mistake — see counterfactual-safes.repository.integration.spec.ts
-    // for the full rationale.
     await dataSource
       .getRepository(Member)
       .createQueryBuilder()

--- a/src/modules/users/domain/members/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members/members.repository.integration.spec.ts
@@ -156,7 +156,10 @@ describe('MembersRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Delete in dependency order to avoid deadlocks
+    // Delete in dependency order to avoid deadlocks. No .where(): TypeORM
+    // 1.1.0 rejects a WHERE clause that renders as an unfiltered '1=1' as
+    // a likely mistake — see counterfactual-safes.repository.integration.spec.ts
+    // for the full rationale.
     await dataSource
       .getRepository(Member)
       .createQueryBuilder()

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -124,10 +124,7 @@ describe('UsersRepository', () => {
 
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
-    await dbWalletRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
+    await dbWalletRepository.createQueryBuilder().delete().execute();
     await dbUserRepository.createQueryBuilder().delete().execute();
   });
 

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -124,9 +124,7 @@ describe('UsersRepository', () => {
 
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
-    // No .where(): TypeORM 1.1.0 rejects a WHERE clause that renders as
-    // an unfiltered '1=1' as a likely mistake — see
-    // counterfactual-safes.repository.integration.spec.ts for the full rationale.
+
     await dbWalletRepository.createQueryBuilder().delete().execute();
     await dbUserRepository.createQueryBuilder().delete().execute();
   });

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -124,6 +124,9 @@ describe('UsersRepository', () => {
 
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
+    // No .where(): TypeORM 1.1.0 rejects a WHERE clause that renders as
+    // an unfiltered '1=1' as a likely mistake — see
+    // counterfactual-safes.repository.integration.spec.ts for the full rationale.
     await dbWalletRepository.createQueryBuilder().delete().execute();
     await dbUserRepository.createQueryBuilder().delete().execute();
   });

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -127,9 +127,8 @@ describe('UsersRepository', () => {
     await dbWalletRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
-    await dbUserRepository.createQueryBuilder().delete().where('1=1').execute();
+    await dbUserRepository.createQueryBuilder().delete().execute();
   });
 
   afterAll(async () => {

--- a/src/modules/wallets/domain/wallets.repository.integration.spec.ts
+++ b/src/modules/wallets/domain/wallets.repository.integration.spec.ts
@@ -104,9 +104,8 @@ describe('WalletsRepository', () => {
     await dbWalletRepository
       .createQueryBuilder()
       .delete()
-      .where('1=1')
       .execute();
-    await dbUserRepository.createQueryBuilder().delete().where('1=1').execute();
+    await dbUserRepository.createQueryBuilder().delete().execute();
   });
 
   afterAll(async () => {

--- a/src/modules/wallets/domain/wallets.repository.integration.spec.ts
+++ b/src/modules/wallets/domain/wallets.repository.integration.spec.ts
@@ -101,10 +101,7 @@ describe('WalletsRepository', () => {
     // Truncate tables
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
-    await dbWalletRepository
-      .createQueryBuilder()
-      .delete()
-      .execute();
+    await dbWalletRepository.createQueryBuilder().delete().execute();
     await dbUserRepository.createQueryBuilder().delete().execute();
   });
 

--- a/src/modules/wallets/domain/wallets.repository.integration.spec.ts
+++ b/src/modules/wallets/domain/wallets.repository.integration.spec.ts
@@ -98,9 +98,6 @@ describe('WalletsRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Truncate tables. No .where(): TypeORM 1.1.0 rejects a WHERE clause
-    // that renders as an unfiltered '1=1' as a likely mistake — see
-    // counterfactual-safes.repository.integration.spec.ts for the full rationale.
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
     await dbWalletRepository.createQueryBuilder().delete().execute();

--- a/src/modules/wallets/domain/wallets.repository.integration.spec.ts
+++ b/src/modules/wallets/domain/wallets.repository.integration.spec.ts
@@ -98,7 +98,9 @@ describe('WalletsRepository', () => {
   afterEach(async () => {
     vi.resetAllMocks();
 
-    // Truncate tables
+    // Truncate tables. No .where(): TypeORM 1.1.0 rejects a WHERE clause
+    // that renders as an unfiltered '1=1' as a likely mistake — see
+    // counterfactual-safes.repository.integration.spec.ts for the full rationale.
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
     await dbWalletRepository.createQueryBuilder().delete().execute();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,20 +1295,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/cliui@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "@isaacs/cliui@npm:8.0.2"
-  dependencies:
-    string-width: "npm:^5.1.2"
-    string-width-cjs: "npm:string-width@^4.2.0"
-    strip-ansi: "npm:^7.0.1"
-    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
-    wrap-ansi: "npm:^8.1.0"
-    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
-  checksum: 10/e9ed5fd27c3aec1095e3a16e0c0cf148d1fee55a38665c35f7b3f86a9b5d00d042ddaabc98e8a1cb7463b9378c15f22a94eb35e99469c201453eb8375191f243
-  languageName: node
-  linkType: hard
-
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -1838,13 +1824,6 @@ __metadata:
   version: 0.4.0
   resolution: "@pinojs/redact@npm:0.4.0"
   checksum: 10/2210ffb6b38357853d47239fd0532cc9edb406325270a81c440a35cece22090127c30c2ead3eefa3e608f2244087485308e515c431f4f69b6bd2e16cbd32812b
-  languageName: node
-  linkType: hard
-
-"@pkgjs/parseargs@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@pkgjs/parseargs@npm:0.11.0"
-  checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
   languageName: node
   linkType: hard
 
@@ -3145,10 +3124,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^6.0.1":
-  version: 6.1.0
-  resolution: "ansi-regex@npm:6.1.0"
-  checksum: 10/495834a53b0856c02acd40446f7130cb0f8284f4a39afdab20d5dc42b2e198b1196119fe887beed8f9055c4ff2055e3b2f6d4641d0be018cdfb64fedf6fc1aac
+"ansi-regex@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "ansi-regex@npm:6.2.2"
+  checksum: 10/9b17ce2c6daecc75bcd5966b9ad672c23b184dc3ed9bf3c98a0702f0d2f736c15c10d461913568f2cf527a5e64291c7473358885dd493305c84a1cfed66ba94f
   languageName: node
   linkType: hard
 
@@ -3170,24 +3149,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.1.0":
-  version: 6.2.1
-  resolution: "ansi-styles@npm:6.2.1"
-  checksum: 10/70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+"ansi-styles@npm:^6.2.1":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10/c49dad7639f3e48859bd51824c93b9eb0db628afc243c51c3dd2410c4a15ede1a83881c6c7341aa2b159c4f90c11befb38f2ba848c07c66c9f9de4bcd7cb9f30
   languageName: node
   linkType: hard
 
-"ansis@npm:4.2.0, ansis@npm:^4.2.0":
+"ansis@npm:4.2.0":
   version: 4.2.0
   resolution: "ansis@npm:4.2.0"
   checksum: 10/493e15fad267bd6e3e275d6886c3b3c96a075784d9eae3e16d16383d488e94cc3deb1b357e1246f572599767360548ef9e5b7eab9b72e4ee3f7bad9ce6bc8797
   languageName: node
   linkType: hard
 
-"app-root-path@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "app-root-path@npm:3.1.0"
-  checksum: 10/b4cdab5f7e51ec43fa04c97eca2adedf8e18d6c3dd21cd775b70457c5e71f0441c692a49dcceb426f192640b7393dcd41d85c36ef98ecb7c785a53159c912def
+"ansis@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "ansis@npm:4.3.1"
+  checksum: 10/c3ed79aaa76fc6c419de13b2f31845ba875b1f7d1b398f17ccbd25357c9398cfc58ec5d6707710d068a3bfaf6f3121926455dace8a4853ea0a1847aee07e8072
   languageName: node
   linkType: hard
 
@@ -3255,15 +3234,6 @@ __metadata:
   version: 1.0.0
   resolution: "atomic-sleep@npm:1.0.0"
   checksum: 10/3ab6d2cf46b31394b4607e935ec5c1c3c4f60f3e30f0913d35ea74b51b3585e84f590d09e58067f11762eec71c87d25314ce859030983dc0e4397eed21daa12e
-  languageName: node
-  linkType: hard
-
-"available-typed-arrays@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "available-typed-arrays@npm:1.0.7"
-  dependencies:
-    possible-typed-array-names: "npm:^1.0.0"
-  checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
   languageName: node
   linkType: hard
 
@@ -3346,15 +3316,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10/0e0f9b0df1f0809e9c326470e022eeb24334ddb54c43b1ac39f1d38f3cbaeb940794de1db826f5491843ac00d7932c43f10350a65ccd51fe7d05da627152f204
-  languageName: node
-  linkType: hard
-
 "brace-expansion@npm:^5.0.5":
   version: 5.0.7
   resolution: "brace-expansion@npm:5.0.7"
@@ -3413,16 +3374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.2.1"
-  checksum: 10/b6bc68237ebf29bdacae48ce60e5e28fc53ae886301f2ad9496618efac49427ed79096750033e7eab1897a4f26ae374ace49106a5758f38fb70c78c9fda2c3b1
-  languageName: node
-  linkType: hard
-
 "bullmq@npm:^5.79.2":
   version: 5.79.2
   resolution: "bullmq@npm:5.79.2"
@@ -3452,7 +3403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind-apply-helpers@npm:1.0.2"
   dependencies:
@@ -3462,19 +3413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "call-bind@npm:1.0.8"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.0"
-    es-define-property: "npm:^1.0.0"
-    get-intrinsic: "npm:^1.2.4"
-    set-function-length: "npm:^1.2.2"
-  checksum: 10/659b03c79bbfccf0cde3a79e7d52570724d7290209823e1ca5088f94b52192dc1836b82a324d0144612f816abb2f1734447438e38d9dafe0b3f82c2a1b9e3bce
-  languageName: node
-  linkType: hard
-
-"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
+"call-bound@npm:^1.0.2":
   version: 1.0.4
   resolution: "call-bound@npm:1.0.4"
   dependencies:
@@ -3599,14 +3538,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "cliui@npm:8.0.1"
+"cliui@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "cliui@npm:9.0.1"
   dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.1"
-    wrap-ansi: "npm:^7.0.0"
-  checksum: 10/eaa5561aeb3135c2cddf7a3b3f562fc4238ff3b3fc666869ef2adf264be0f372136702f16add9299087fb1907c2e4ec5dbfe83bd24bce815c70a80c6c1a2e950
+    string-width: "npm:^7.2.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/df43d8d1c6e3254cbb64b1905310d5f6672c595496a3cbe76946c6d24777136886470686f2772ac9edfe547a74bb70e8017530b3554715aee119efd7752fc0d9
   languageName: node
   linkType: hard
 
@@ -3823,17 +3762,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0":
-  version: 7.0.6
-  resolution: "cross-spawn@npm:7.0.6"
-  dependencies:
-    path-key: "npm:^3.1.0"
-    shebang-command: "npm:^2.0.0"
-    which: "npm:^2.0.1"
-  checksum: 10/0d52657d7ae36eb130999dffff1168ec348687b48dd38e2ff59992ed916c88d328cf1d07ff4a4a10bc78de5e1c23f04b306d569e42f7a2293915c081e4dfee86
-  languageName: node
-  linkType: hard
-
 "csv-stringify@npm:^6.8.1":
   version: 6.8.1
   resolution: "csv-stringify@npm:6.8.1"
@@ -3841,14 +3769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.19":
-  version: 1.11.19
-  resolution: "dayjs@npm:1.11.19"
-  checksum: 10/185b820d68492b83a3ce2b8ddc7543034edc1dfd1423183f6ae4707b29929a3cc56503a81826309279f9084680c15966b99456e74cf41f7d1f6a2f98f9c7196f
-  languageName: node
-  linkType: hard
-
-"dayjs@npm:^1.11.7":
+"dayjs@npm:^1.11.21, dayjs@npm:^1.11.7":
   version: 1.11.21
   resolution: "dayjs@npm:1.11.21"
   checksum: 10/dd16f9f2706b61b90e3c346a3211ac3afd9e26193136ce0e87f70bf74d1c17a447bceb230a88b175467fc9f5e3243d8c1544b9897092a12d9c80ee44d338dcb6
@@ -3891,15 +3812,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dedent@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "dedent@npm:1.7.0"
+"dedent@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "dedent@npm:1.7.2"
   peerDependencies:
     babel-plugin-macros: ^3.1.0
   peerDependenciesMeta:
     babel-plugin-macros:
       optional: true
-  checksum: 10/c902f3e7e828923bd642c12c1d8996616ff5588f8279a2951790bd7c7e479fa4dd7f016b55ce2c9ea1aa2895fc503e7d6c0cde6ebc95ca683ac0230f7c911fd7
+  checksum: 10/30b9062290dca72b0f5a6cd3667633448cef8cd0dec602eab61015741269ad49df90cabf0521f9a32d134ceab4e21aa7f097258c55cc3baadef94874686d6480
   languageName: node
   linkType: hard
 
@@ -3916,17 +3837,6 @@ __metadata:
   dependencies:
     clone: "npm:^1.0.2"
   checksum: 10/3a88b7a587fc076b84e60affad8b85245c01f60f38fc1d259e7ac1d89eb9ce6abb19e27215de46b98568dd5bc48471730b327637e6f20b0f1bc85cf00440c80a
-  languageName: node
-  linkType: hard
-
-"define-data-property@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "define-data-property@npm:1.1.4"
-  dependencies:
-    es-define-property: "npm:^1.0.0"
-    es-errors: "npm:^1.3.0"
-    gopd: "npm:^1.0.1"
-  checksum: 10/abdcb2505d80a53524ba871273e5da75e77e52af9e15b3aa65d8aad82b8a3a424dad7aee2cc0b71470ac7acf501e08defac362e8b6a73cdb4309f028061df4ae
   languageName: node
   linkType: hard
 
@@ -4095,13 +4005,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.6.1":
-  version: 16.6.1
-  resolution: "dotenv@npm:16.6.1"
-  checksum: 10/1d1897144344447ffe62aa1a6d664f4cd2e0784e0aff787eeeec1940ded32f8e4b5b506d665134fc87157baa086fce07ec6383970a2b6d2e7985beaed6a4cc14
-  languageName: node
-  linkType: hard
-
 "dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -4110,13 +4013,6 @@ __metadata:
     es-errors: "npm:^1.3.0"
     gopd: "npm:^1.2.0"
   checksum: 10/5add88a3d68d42d6e6130a0cac450b7c2edbe73364bbd2fc334564418569bea97c6943a8fcd70e27130bf32afc236f30982fc4905039b703f23e9e0433c29934
-  languageName: node
-  linkType: hard
-
-"eastasianwidth@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "eastasianwidth@npm:0.2.0"
-  checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
   languageName: node
   linkType: hard
 
@@ -4136,17 +4032,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^10.3.0":
+  version: 10.6.0
+  resolution: "emoji-regex@npm:10.6.0"
+  checksum: 10/98cc0b0e1daed1ed25afbf69dcb921fee00f712f51aab93aa1547e4e4e8171725cc4f0098aaa645b4f611a19da11ec9f4623eb6ff2b72314b39a8f2ae7c12bf2
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 10/c72d67a6821be15ec11997877c437491c313d924306b8da5d87d2a2bcc2cec9903cb5b04ee1a088460501d8e5b44f10df82fdc93c444101a7610b80c8b6938e1
-  languageName: node
-  linkType: hard
-
-"emoji-regex@npm:^9.2.2":
-  version: 9.2.2
-  resolution: "emoji-regex@npm:9.2.2"
-  checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
   languageName: node
   linkType: hard
 
@@ -4214,7 +4110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
+"es-define-property@npm:^1.0.1":
   version: 1.0.1
   resolution: "es-define-property@npm:1.0.1"
   checksum: 10/f8dc9e660d90919f11084db0a893128f3592b781ce967e4fccfb8f3106cb83e400a4032c559184ec52ee1dbd4b01e7776c7cd0b3327b1961b1a4a7008920fe78
@@ -4549,25 +4445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"for-each@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "for-each@npm:0.3.5"
-  dependencies:
-    is-callable: "npm:^1.2.7"
-  checksum: 10/330cc2439f85c94f4609de3ee1d32c5693ae15cdd7fe3d112c4fd9efd4ce7143f2c64ef6c2c9e0cfdb0058437f33ef05b5bdae5b98fcc903fb2143fbaf0fea0f
-  languageName: node
-  linkType: hard
-
-"foreground-child@npm:^3.1.0":
-  version: 3.3.0
-  resolution: "foreground-child@npm:3.3.0"
-  dependencies:
-    cross-spawn: "npm:^7.0.0"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10/e3a60480f3a09b12273ce2c5fcb9514d98dd0e528f58656a1b04680225f918d60a2f81f6a368f2f3b937fcee9cfc0cbf16f1ad9a0bc6a3a6e103a84c9a90087e
-  languageName: node
-  linkType: hard
-
 "fork-ts-checker-webpack-plugin@npm:9.1.0":
   version: 9.1.0
   resolution: "fork-ts-checker-webpack-plugin@npm:9.1.0"
@@ -4666,7 +4543,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
+"get-east-asian-width@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "get-east-asian-width@npm:1.6.0"
+  checksum: 10/3e5370b5df1f0020db711d8a3f9ee2cbfc9c7542daa99a699e9d7b9acf66e7868b89084741565a45d30d80afedf6e1218e0fb8bef7a583924a449c2816777380
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
   dependencies:
@@ -4712,23 +4596,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.5.0":
-  version: 10.5.0
-  resolution: "glob@npm:10.5.0"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^3.1.2"
-    minimatch: "npm:^9.0.4"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^1.11.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
-  languageName: node
-  linkType: hard
-
-"gopd@npm:^1.0.1, gopd@npm:^1.2.0":
+"gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
   checksum: 10/94e296d69f92dc1c0768fcfeecfb3855582ab59a7c75e969d5f96ce50c3d201fd86d5a2857c22565764d5bb8a816c7b1e58f133ec318cd56274da36c5e3fb1a1
@@ -4753,15 +4621,6 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10/261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
-  languageName: node
-  linkType: hard
-
-"has-property-descriptors@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-property-descriptors@npm:1.0.2"
-  dependencies:
-    es-define-property: "npm:^1.0.0"
-  checksum: 10/2d8c9ab8cebb572e3362f7d06139a4592105983d4317e68f7adba320fe6ddfc8874581e0971e899e633fd5f72e262830edce36d5a0bc863dad17ad20572484b2
   languageName: node
   linkType: hard
 
@@ -4948,13 +4807,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-callable@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "is-callable@npm:1.2.7"
-  checksum: 10/48a9297fb92c99e9df48706241a189da362bff3003354aea4048bd5f7b2eb0d823cd16d0a383cece3d76166ba16d85d9659165ac6fcce1ac12e6c649d66dbdb9
-  languageName: node
-  linkType: hard
-
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
@@ -4983,33 +4835,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.14":
-  version: 1.1.15
-  resolution: "is-typed-array@npm:1.1.15"
-  dependencies:
-    which-typed-array: "npm:^1.1.16"
-  checksum: 10/e8cf60b9ea85667097a6ad68c209c9722cfe8c8edf04d6218366469e51944c5cc25bae45ffb845c23f811d262e4314d3b0168748eb16711aa34d12724cdf0735
-  languageName: node
-  linkType: hard
-
 "is-unicode-supported@npm:^0.1.0":
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
   checksum: 10/a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
-  languageName: node
-  linkType: hard
-
-"isarray@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "isarray@npm:2.0.5"
-  checksum: 10/1d8bc7911e13bb9f105b1b3e0b396c787a9e63046af0b8fe0ab1414488ab06b2b099b87a2d8a9e31d21c9a6fad773c7fc8b257c4880f2d957274479d28ca3414
-  languageName: node
-  linkType: hard
-
-"isexe@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "isexe@npm:2.0.0"
-  checksum: 10/7c9f715c03aff08f35e98b1fadae1b9267b38f0615d501824f9743f3aab99ef10e303ce7db3f186763a0b70a19de5791ebfc854ff884d5a8c4d92211f642ec92
   languageName: node
   linkType: hard
 
@@ -5061,19 +4890,6 @@ __metadata:
   version: 1.2.1
   resolution: "iterare@npm:1.2.1"
   checksum: 10/ee8322dd9d92e86d8653c899df501c58c5b8e90d6767cf2af0b6d6dc5a4b9b7ed8bce936976f4f4c3a55be110a300c8a7d71967d03f72e104e8db66befcfd874
-  languageName: node
-  linkType: hard
-
-"jackspeak@npm:^3.1.2":
-  version: 3.4.3
-  resolution: "jackspeak@npm:3.4.3"
-  dependencies:
-    "@isaacs/cliui": "npm:^8.0.2"
-    "@pkgjs/parseargs": "npm:^0.11.0"
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
   languageName: node
   linkType: hard
 
@@ -5510,13 +5326,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^10.2.0":
-  version: 10.4.3
-  resolution: "lru-cache@npm:10.4.3"
-  checksum: 10/e6e90267360476720fa8e83cc168aa2bf0311f3f2eea20a6ba78b90a885ae72071d9db132f40fda4129c803e7dcec3a6b6a6fbb44ca90b081630b810b5d6a41a
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^11.0.0":
   version: 11.0.2
   resolution: "lru-cache@npm:11.0.2"
@@ -5679,15 +5488,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
-  version: 9.0.9
-  resolution: "minimatch@npm:9.0.9"
-  dependencies:
-    brace-expansion: "npm:^2.0.2"
-  checksum: 10/b91fad937deaffb68a45a2cb731ff3cff1c3baf9b6469c879477ed16f15c8f4ce39d63a3f75c2455107c2fdff0f3ab597d97dc09e2e93b883aafcf926ef0c8f9
-  languageName: node
-  linkType: hard
-
 "minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
@@ -5695,17 +5495,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "minipass@npm:7.1.2"
-  checksum: 10/c25f0ee8196d8e6036661104bacd743785b2599a21de5c516b32b3fa2b83113ac89a2358465bc04956baab37ffb956ae43be679b2262bf7be15fce467ccd7950
-  languageName: node
-  linkType: hard
-
 "minipass@npm:^7.0.4, minipass@npm:^7.1.3":
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
   checksum: 10/175e4d5e20980c3cd316ae82d2c031c42f6c746467d8b1905b51060a0ba4461441a0c25bb67c025fd9617f9a3873e152c7b543c6b5ac83a1846be8ade80dffd6
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10/c25f0ee8196d8e6036661104bacd743785b2599a21de5c516b32b3fa2b83113ac89a2358465bc04956baab37ffb956ae43be679b2262bf7be15fce467ccd7950
   languageName: node
   linkType: hard
 
@@ -5969,13 +5769,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-json-from-dist@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "package-json-from-dist@npm:1.0.1"
-  checksum: 10/58ee9538f2f762988433da00e26acc788036914d57c71c246bf0be1b60cdbd77dd60b6a3e1a30465f0b248aeb80079e0b34cb6050b1dfa18c06953bb1cbc7602
-  languageName: node
-  linkType: hard
-
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -6001,23 +5794,6 @@ __metadata:
   version: 1.0.2
   resolution: "parse-srcset@npm:1.0.2"
   checksum: 10/d40c131cfc3ab7bb6333b788d30a30d063d76a83b49fa752229823f96475e36cf29fea09e035ce3b2a634b686e93e2a7429cb8dad0041d8a3a3df622093b9ea1
-  languageName: node
-  linkType: hard
-
-"path-key@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "path-key@npm:3.1.1"
-  checksum: 10/55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
-  languageName: node
-  linkType: hard
-
-"path-scurry@npm:^1.11.1":
-  version: 1.11.1
-  resolution: "path-scurry@npm:1.11.1"
-  dependencies:
-    lru-cache: "npm:^10.2.0"
-    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
-  checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
   languageName: node
   linkType: hard
 
@@ -6195,13 +5971,6 @@ __metadata:
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
   checksum: 10/17877fdfdb7ddb3639ce257ad73a7c51a30a966091e40f56ea9f2f545b5727ce548d4928f8cb3ce38e7dc0c5150407d318af6a4ed0ea5265d378473b4c2c61ec
-  languageName: node
-  linkType: hard
-
-"possible-typed-array-names@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "possible-typed-array-names@npm:1.1.0"
-  checksum: 10/2f44137b8d3dd35f4a7ba7469eec1cd9cfbb46ec164b93a5bc1f4c3d68599c9910ee3b91da1d28b4560e9cc8414c3cd56fedc07259c67e52cc774476270d3302
   languageName: node
   linkType: hard
 
@@ -6384,13 +6153,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-directory@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "require-directory@npm:2.1.1"
-  checksum: 10/a72468e2589270d91f06c7d36ec97a88db53ae5d6fe3787fadc943f0b0276b10347f89b363b2a82285f650bdcc135ad4a257c61bdd4d00d6df1fa24875b0ddaf
-  languageName: node
-  linkType: hard
-
 "require-from-string@npm:^2.0.2":
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
@@ -6512,7 +6274,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
@@ -6584,7 +6346,7 @@ __metadata:
     ts-loader: "npm:9.6.2"
     ts-node: "npm:10.9.2"
     tsconfig-paths: "npm:4.2.0"
-    typeorm: "npm:0.3.28"
+    typeorm: "npm:1.1.0"
     typescript: "npm:6.0.3"
     undici: "npm:8.7.0"
     unplugin-swc: "npm:1.5.9"
@@ -6702,53 +6464,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-function-length@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "set-function-length@npm:1.2.2"
-  dependencies:
-    define-data-property: "npm:^1.1.4"
-    es-errors: "npm:^1.3.0"
-    function-bind: "npm:^1.1.2"
-    get-intrinsic: "npm:^1.2.4"
-    gopd: "npm:^1.0.1"
-    has-property-descriptors: "npm:^1.0.2"
-  checksum: 10/505d62b8e088468917ca4e3f8f39d0e29f9a563b97dbebf92f4bd2c3172ccfb3c5b8e4566d5fcd00784a00433900e7cb8fbc404e2dbd8c3818ba05bb9d4a8a6d
-  languageName: node
-  linkType: hard
-
 "setprototypeof@npm:1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10/fde1630422502fbbc19e6844346778f99d449986b2f9cdcceb8326730d2f3d9964dbcb03c02aaadaefffecd0f2c063315ebea8b3ad895914bf1afc1747fc172e
-  languageName: node
-  linkType: hard
-
-"sha.js@npm:^2.4.12":
-  version: 2.4.12
-  resolution: "sha.js@npm:2.4.12"
-  dependencies:
-    inherits: "npm:^2.0.4"
-    safe-buffer: "npm:^5.2.1"
-    to-buffer: "npm:^1.2.0"
-  bin:
-    sha.js: bin.js
-  checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
-  languageName: node
-  linkType: hard
-
-"shebang-command@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "shebang-command@npm:2.0.0"
-  dependencies:
-    shebang-regex: "npm:^3.0.0"
-  checksum: 10/6b52fe87271c12968f6a054e60f6bde5f0f3d2db483a1e5c3e12d657c488a15474121a1d55cd958f6df026a54374ec38a4a963988c213b7570e1d51575cea7fa
-  languageName: node
-  linkType: hard
-
-"shebang-regex@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "shebang-regex@npm:3.0.0"
-  checksum: 10/1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
   languageName: node
   linkType: hard
 
@@ -6814,7 +6533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
+"signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -6934,7 +6653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width@npm:^4.1.0, string-width@npm:^4.2.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -6945,14 +6664,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "string-width@npm:5.1.2"
+"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "string-width@npm:7.2.0"
   dependencies:
-    eastasianwidth: "npm:^0.2.0"
-    emoji-regex: "npm:^9.2.2"
-    strip-ansi: "npm:^7.0.1"
-  checksum: 10/7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
+    emoji-regex: "npm:^10.3.0"
+    get-east-asian-width: "npm:^1.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/42f9e82f61314904a81393f6ef75b832c39f39761797250de68c041d8ba4df2ef80db49ab6cd3a292923a6f0f409b8c9980d120f7d32c820b4a8a84a2598a295
   languageName: node
   linkType: hard
 
@@ -6965,7 +6684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
@@ -6974,12 +6693,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^7.0.1":
-  version: 7.1.0
-  resolution: "strip-ansi@npm:7.1.0"
+"strip-ansi@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
   dependencies:
-    ansi-regex: "npm:^6.0.1"
-  checksum: 10/475f53e9c44375d6e72807284024ac5d668ee1d06010740dec0b9744f2ddf47de8d7151f80e5f6190fc8f384e802fdf9504b76a7e9020c9faee7103623338be2
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10/96da3bc6d73cfba1218625a3d66cf7d37a69bf0920d8735b28f9eeaafcdb6c1fe8440e1ae9eb1ba0ca355dbe8702da872e105e2e939fa93e7851b3cb5dd7d316
   languageName: node
   linkType: hard
 
@@ -7203,17 +6922,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"to-buffer@npm:^1.2.0":
-  version: 1.2.2
-  resolution: "to-buffer@npm:1.2.2"
-  dependencies:
-    isarray: "npm:^2.0.5"
-    safe-buffer: "npm:^5.2.1"
-    typed-array-buffer: "npm:^1.0.3"
-  checksum: 10/69d806c20524ff1e4c44d49276bc96ff282dcae484780a3974e275dabeb75651ea430b074a2a4023701e63b3e1d87811cd82c0972f35280fe5461710e4872aba
-  languageName: node
-  linkType: hard
-
 "toad-cache@npm:^3.7.0":
   version: 3.7.4
   resolution: "toad-cache@npm:3.7.4"
@@ -7353,53 +7061,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typed-array-buffer@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "typed-array-buffer@npm:1.0.3"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    es-errors: "npm:^1.3.0"
-    is-typed-array: "npm:^1.1.14"
-  checksum: 10/3fb91f0735fb413b2bbaaca9fabe7b8fc14a3fa5a5a7546bab8a57e755be0e3788d893195ad9c2b842620592de0e68d4c077d4c2c41f04ec25b8b5bb82fa9a80
-  languageName: node
-  linkType: hard
-
-"typeorm@npm:0.3.28":
-  version: 0.3.28
-  resolution: "typeorm@npm:0.3.28"
+"typeorm@npm:1.1.0":
+  version: 1.1.0
+  resolution: "typeorm@npm:1.1.0"
   dependencies:
     "@sqltools/formatter": "npm:^1.2.5"
-    ansis: "npm:^4.2.0"
-    app-root-path: "npm:^3.1.0"
-    buffer: "npm:^6.0.3"
-    dayjs: "npm:^1.11.19"
+    ansis: "npm:^4.3.1"
+    dayjs: "npm:^1.11.21"
     debug: "npm:^4.4.3"
-    dedent: "npm:^1.7.0"
-    dotenv: "npm:^16.6.1"
-    glob: "npm:^10.5.0"
+    dedent: "npm:^1.7.2"
     reflect-metadata: "npm:^0.2.2"
-    sha.js: "npm:^2.4.12"
     sql-highlight: "npm:^6.1.0"
+    tinyglobby: "npm:^0.2.17"
     tslib: "npm:^2.8.1"
-    uuid: "npm:^11.1.0"
-    yargs: "npm:^17.7.2"
+    yargs: "npm:^18.0.0"
   peerDependencies:
-    "@google-cloud/spanner": ^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    "@google-cloud/spanner": ^8.0.0
     "@sap/hana-client": ^2.14.22
-    better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+    better-sqlite3: ^12.0.0
     ioredis: ^5.0.4
-    mongodb: ^5.8.0 || ^6.0.0
-    mssql: ^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0
-    mysql2: ^2.2.5 || ^3.0.1
-    oracledb: ^6.3.0
+    mongodb: ^7.0.0
+    mssql: ^12.0.0
+    mysql2: ^3.15.3
+    oracledb: ^6.3.0 || ^7.0.0
     pg: ^8.5.1
     pg-native: ^3.0.0
     pg-query-stream: ^4.0.0
-    redis: ^3.1.1 || ^4.0.0 || ^5.0.14
+    redis: ^5.0.0 || ^6.0.0
     sql.js: ^1.4.0
-    sqlite3: ^5.0.3
-    ts-node: ^10.7.0
-    typeorm-aurora-data-api-driver: ^2.0.0 || ^3.0.0
+    ts-node: ^10.9.2
+    typeorm-aurora-data-api-driver: ^3.0.0
   peerDependenciesMeta:
     "@google-cloud/spanner":
       optional: true
@@ -7427,8 +7118,6 @@ __metadata:
       optional: true
     sql.js:
       optional: true
-    sqlite3:
-      optional: true
     ts-node:
       optional: true
     typeorm-aurora-data-api-driver:
@@ -7437,7 +7126,7 @@ __metadata:
     typeorm: cli.js
     typeorm-ts-node-commonjs: cli-ts-node-commonjs.js
     typeorm-ts-node-esm: cli-ts-node-esm.js
-  checksum: 10/4eb217d65414291fb226267d903d123a16a9eb090b4e8f8da2dfe2f64680265823bea3712d363d31fe96c6dc2cef00edd545f42e63ec65b8a1899a1b455f757b
+  checksum: 10/4f442af7bd6b5c2a63565ca599fdf8894be4baea1eb8434eccbc1c38076d155c7007a90e81955c22caeff61c2e3dd12ca8cfa3d6212acfc498f763592aaa0de3
   languageName: node
   linkType: hard
 
@@ -7577,15 +7266,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
   languageName: node
   linkType: hard
 
@@ -7819,32 +7499,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.16":
-  version: 1.1.19
-  resolution: "which-typed-array@npm:1.1.19"
-  dependencies:
-    available-typed-arrays: "npm:^1.0.7"
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    for-each: "npm:^0.3.5"
-    get-proto: "npm:^1.0.1"
-    gopd: "npm:^1.2.0"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10/12be30fb88567f9863186bee1777f11bea09dd59ed8b3ce4afa7dd5cade75e2f4cc56191a2da165113cc7cf79987ba021dac1e22b5b62aa7e5c56949f2469a68
-  languageName: node
-  linkType: hard
-
-"which@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "which@npm:2.0.2"
-  dependencies:
-    isexe: "npm:^2.0.0"
-  bin:
-    node-which: ./bin/node-which
-  checksum: 10/4782f8a1d6b8fc12c65e968fea49f59752bf6302dc43036c3bf87da718a80710f61a062516e9764c70008b487929a73546125570acea95c5b5dcc8ac3052c70f
-  languageName: node
-  linkType: hard
-
 "which@npm:^7.0.0":
   version: 7.0.0
   resolution: "which@npm:7.0.0"
@@ -7898,17 +7552,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "wrap-ansi@npm:7.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10/cebdaeca3a6880da410f75209e68cd05428580de5ad24535f22696d7d9cab134d1f8498599f344c3cf0fb37c1715807a183778d8c648d6cc0cb5ff2bb4236540
-  languageName: node
-  linkType: hard
-
 "wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
@@ -7920,14 +7563,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "wrap-ansi@npm:8.1.0"
+"wrap-ansi@npm:^9.0.0":
+  version: 9.0.2
+  resolution: "wrap-ansi@npm:9.0.2"
   dependencies:
-    ansi-styles: "npm:^6.1.0"
-    string-width: "npm:^5.0.1"
-    strip-ansi: "npm:^7.0.1"
-  checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
+    ansi-styles: "npm:^6.2.1"
+    string-width: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/f3907e1ea9717404ca53a338fa5a017c2121550c3a5305180e2bc08c03e21aa45068df55b0d7676bf57be1880ba51a84458c17241ebedea485fafa9ef16b4024
   languageName: node
   linkType: hard
 
@@ -7974,25 +7617,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:21.1.1, yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: 10/9dc2c217ea3bf8d858041252d43e074f7166b53f3d010a8c711275e09cd3d62a002969a39858b92bbda2a6a63a585c7127014534a560b9c69ed2d923d113406e
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.7.2":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
+"yargs-parser@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "yargs-parser@npm:22.0.0"
+  checksum: 10/f13c42bad6ebed1a587a72f2db5694f5fa772bcaf409a701691d13cf74eb5adfcf61a2611de08807e319b829d3e5e6e1578b16ebe174cae8e8be3bf7b8e7a19e
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "yargs@npm:18.0.0"
   dependencies:
-    cliui: "npm:^8.0.1"
+    cliui: "npm:^9.0.1"
     escalade: "npm:^3.1.1"
     get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
+    string-width: "npm:^7.2.0"
     y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
+    yargs-parser: "npm:^22.0.0"
+  checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

  - Upgrades typeorm from 0.3.28 to 1.1.0, the current stable release line.
  - Primary driver: an unpatched advisory affecting UpdateQueryBuilder/SoftDeleteQueryBuilder — the order argument passed to orderBy/addOrderBy on those builders is concatenated into generated SQL without validation, permitting blind SQL injection via the sort direction
  (SelectQueryBuilder.orderBy was already unaffected). Fixed upstream in 0.3.29/1.0.0.
    - Verified this was not currently exploitable in this codebase: this project only connects to Postgres (no MySQL/MariaDB driver, and the advisory is scoped to those), and the only orderBy/addOrderBy call in the codebase runs on a SelectQueryBuilder with a hardcoded literal, not user
  input. Upgrading anyway as defense-in-depth since it's a direct dependency of our ORM.
  - Went with 1.1.0 (latest) rather than the minimal 0.3.29 patch per request, picking up additional upstream fixes (aggregate-column resolution, an eager-loading bug that could overwrite manually-set relations, a migration query-runner leak, returning option for update/upsert).

##  Breaking changes migrated

  - typeorm/driver/postgres/PostgresConnectionOptions was renamed to typeorm/driver/postgres/PostgresDataSourceOptions — updated the one import/type usage in src/config/entities/postgres.config.ts.
  - FindOptionsRelations no longer accepts the string-array shorthand (relations: ['x']); TypeORM 1.x requires the object form (relations: { x: true }). Updated all 4 affected call sites in notifications/spaces repositories and services.
  - Updated the corresponding assertion in spaces.service.spec.ts to match the new relations shape.

##  Test plan

  - [x] nest build — passes with no TypeScript errors.
  - [x] yarn test:unit — full suite green: 336 files / 5727 passed / 18 skipped (pre-existing skips, unrelated).
  - [ ] yarn test:integration / yarn test:e2e — not run in this environment (require live Postgres/Redis); please run in CI before merge.
  - [ ] Sanity-check any code relying on eager-loading + manually-set relations together, given the upstream fix changes that interaction — no such pattern found during review, but worth a second look in CI.