### PR TITLE
build(deps): bump brace-expansion from 5.0.5 to 5.0.7

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,11 +3447,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
  - Bumps `brace-expansion` from 5.0.5 to 5.0.7 (transitive, via `@fastify/static` -> `glob` -> `minimatch`)
  - `yarn.lock` only; no `package.json` change needed since the existing range (`^5.0.5`) already permitted this version