### PR TITLE
build(deps): bump tmp to 0.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,8 @@
   },
   "main": "main.ts",
   "repository": "https://github.com/5afe/safe-client-gateway-nest.git",
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.14.1",
+  "resolutions": {
+    "tmp": "0.2.7"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6332,13 +6332,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10/5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
-  languageName: node
-  linkType: hard
-
 "ox@npm:0.14.30":
   version: 0.14.30
   resolution: "ox@npm:0.14.30"
@@ -7668,12 +7661,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10/09c0abfd165cff29b32be42bc35e80b8c64727d97dedde6550022e88fa9fd39a084660415ed8e3ebaa2aca1ee142f86df8b31d4196d4f81c774a3a20fd4b6abf
+"tmp@npm:0.2.7":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 ## Summary
  
  Bumps the transitive `tmp` dependency from `0.0.33` to `0.2.7`.

  `tmp` is pulled in only via dev tooling (`@nestjs/cli` / `@angular-devkit/schematics-cli` → `@inquirer/prompts` → `@inquirer/editor` → `external-editor`), which requests the outdated `^0.0.33` range. Since that range can't resolve forward on its own, a `resolutions` override is added
  to `package.json` to pull the current release. This dedupes the tree onto a single `tmp@0.2.7` and drops the now-unneeded `os-tmpdir` sub-dependency.
  
  The bump is API-compatible: `external-editor` uses `tmp.tmpNameSync()`, which is unchanged in `0.2.7`.