### PR TITLE
fix: annotate UserWallet.address as string in OpenAPI schema

### DIFF
--- a/src/modules/users/routes/entities/user-with-wallets.entity.ts
+++ b/src/modules/users/routes/entities/user-with-wallets.entity.ts
@@ -8,7 +8,7 @@ class UserWallet implements Pick<Wallet, 'id' | 'address'> {
   @ApiProperty()
   id!: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: String })
   address!: Wallet['address'];
 }
 


### PR DESCRIPTION
## Summary

After #3245 retyped the `UserWallet.address` field from `Address` to `Wallet['address']`, the generated OpenAPI spec started emitting `type: object` for this field instead of `type: string`. This broke the frontend's CGW type regeneration (`@safe-global/store`), which produced `address: object` and failed web type-check in the `spaces` feature.

Since this project does not enable the `@nestjs/swagger` CLI plugin (`nest-cli.json` has no `plugins`), `@ApiProperty()` without an explicit `type` infers the schema type from `emitDecoratorMetadata` reflection. The reflector cannot resolve the indexed-access type `Wallet['address']` and falls back to `Object` → `type: object`. The previous `Address` (a `` `0x${string}` `` template-literal alias) resolved to `String`, which is why the change was silent.

The underlying value is unchanged — the endpoint still returns a plain string.

## Changes

- Add an explicit `type: String` to the `@ApiProperty()` decorator on `UserWallet.address`, so the OpenAPI spec emits `type: string`. This matches the established convention already used for other address fields that reference an indexed-access type (e.g. `targeted-safe.entity.ts`, `counterfactual-safe.dto.entity.ts`, `space-address-book.dto.entity.ts`).