### PR TITLE
fix: give KMS field encryption its own web identity token file env var

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -234,6 +234,12 @@
     "required": false
   },
   {
+    "name": "KMS_AWS_WEB_IDENTITY_TOKEN_FILE",
+    "description": "Path to the projected web identity token file used for AWS IRSA credentials for field encryption's KMS client, separate from AWS_WEB_IDENTITY_TOKEN_FILE so it doesn't implicitly assume another integration's role",
+    "defaultValue": "",
+    "required": false
+  },
+  {
     "name": "AWS_REGION",
     "description": "AWS region for resource deployment",
     "defaultValue": "dummy-region",

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -411,15 +411,28 @@ describe('Configuration validator', () => {
 
     it('should require KMS credentials when ENCRYPTION_ENABLED is true', () => {
       const config = omit(enabledConfiguration(), [
-        'AWS_WEB_IDENTITY_TOKEN_FILE',
+        'KMS_AWS_WEB_IDENTITY_TOKEN_FILE',
         'KMS_AWS_ACCESS_KEY_ID',
         'KMS_AWS_SECRET_ACCESS_KEY',
       ]);
       expect(() =>
         configurationValidator(config, RootConfigurationSchema),
       ).toThrow(
-        'Configuration is invalid: AWS_WEB_IDENTITY_TOKEN_FILE AWS credentials are required when ENCRYPTION_ENABLED is true',
+        'Configuration is invalid: KMS_AWS_WEB_IDENTITY_TOKEN_FILE AWS credentials are required when ENCRYPTION_ENABLED is true',
       );
+    });
+
+    it('should accept KMS credentials via the KMS-specific web identity token file', () => {
+      const config = omit(
+        {
+          ...enabledConfiguration(),
+          KMS_AWS_WEB_IDENTITY_TOKEN_FILE: `/var/run/secrets/${faker.string.alphanumeric(8)}/token`,
+        },
+        ['KMS_AWS_ACCESS_KEY_ID', 'KMS_AWS_SECRET_ACCESS_KEY'],
+      );
+      expect(() =>
+        configurationValidator(config, RootConfigurationSchema),
+      ).not.toThrow();
     });
   });
 

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -892,7 +892,7 @@ export default () => ({
       keyId: process.env.AWS_KMS_ENCRYPTION_KEY_ID,
       accessKeyId: process.env.KMS_AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.KMS_AWS_SECRET_ACCESS_KEY,
-      webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
+      webIdentityTokenFile: process.env.KMS_AWS_WEB_IDENTITY_TOKEN_FILE,
     },
   },
   staking: {

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -37,7 +37,7 @@ function validateFieldEncryptionConfig(
     ENCRYPTION_ENABLED?: string;
     ENCRYPTION_INDEX_KEY?: string;
     AWS_KMS_ENCRYPTION_KEY_ID?: string;
-    AWS_WEB_IDENTITY_TOKEN_FILE?: string;
+    KMS_AWS_WEB_IDENTITY_TOKEN_FILE?: string;
     KMS_AWS_ACCESS_KEY_ID?: string;
     KMS_AWS_SECRET_ACCESS_KEY?: string;
   },
@@ -64,15 +64,18 @@ function validateFieldEncryptionConfig(
   // pair, mirroring AwsKmsService's credential resolution. Dedicated
   // KMS_AWS_* keys (like SES_AWS_*/CSV_AWS_*) so enabling field encryption
   // doesn't silently repurpose the bare AWS_ACCESS_KEY_ID/SECRET_ACCESS_KEY
-  // credentials used by targeted messaging's S3 file storage.
+  // credentials used by targeted messaging's S3 file storage, and a
+  // KMS-specific web identity token file (rather than the shared
+  // AWS_WEB_IDENTITY_TOKEN_FILE) so configuring IRSA for SES doesn't
+  // implicitly make this client assume SES's role too.
   const hasStaticCredentials =
     !!config.KMS_AWS_ACCESS_KEY_ID && !!config.KMS_AWS_SECRET_ACCESS_KEY;
-  if (!(config.AWS_WEB_IDENTITY_TOKEN_FILE || hasStaticCredentials)) {
+  if (!(config.KMS_AWS_WEB_IDENTITY_TOKEN_FILE || hasStaticCredentials)) {
     ctx.addIssue({
       code: 'custom',
       message:
-        'AWS credentials are required when ENCRYPTION_ENABLED is true: set AWS_WEB_IDENTITY_TOKEN_FILE, or KMS_AWS_ACCESS_KEY_ID and KMS_AWS_SECRET_ACCESS_KEY',
-      path: ['AWS_WEB_IDENTITY_TOKEN_FILE'],
+        'AWS credentials are required when ENCRYPTION_ENABLED is true: set KMS_AWS_WEB_IDENTITY_TOKEN_FILE, or KMS_AWS_ACCESS_KEY_ID and KMS_AWS_SECRET_ACCESS_KEY',
+      path: ['KMS_AWS_WEB_IDENTITY_TOKEN_FILE'],
     });
   }
 }
@@ -124,6 +127,7 @@ export const RootConfigurationSchema = z
     AWS_WEB_IDENTITY_TOKEN_FILE: z.string().optional(),
     KMS_AWS_ACCESS_KEY_ID: z.string().optional(),
     KMS_AWS_SECRET_ACCESS_KEY: z.string().optional(),
+    KMS_AWS_WEB_IDENTITY_TOKEN_FILE: z.string().optional(),
     SES_AWS_ACCESS_KEY_ID: z.string().optional(),
     SES_AWS_SECRET_ACCESS_KEY: z.string().optional(),
     FF_SES_EMAIL: z.string().optional(),

--- a/src/datasources/common/utils/aws-credentials.utils.ts
+++ b/src/datasources/common/utils/aws-credentials.utils.ts
@@ -14,5 +14,7 @@ import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 export function resolveAwsCredentials(
   webIdentityTokenFile: string | undefined,
 ): ReturnType<typeof fromTokenFile> | undefined {
-  return webIdentityTokenFile ? fromTokenFile({ webIdentityTokenFile }) : undefined;
+  return webIdentityTokenFile
+    ? fromTokenFile({ webIdentityTokenFile })
+    : undefined;
 }

--- a/src/datasources/common/utils/aws-credentials.utils.ts
+++ b/src/datasources/common/utils/aws-credentials.utils.ts
@@ -14,5 +14,5 @@ import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 export function resolveAwsCredentials(
   webIdentityTokenFile: string | undefined,
 ): ReturnType<typeof fromTokenFile> | undefined {
-  return webIdentityTokenFile ? fromTokenFile() : undefined;
+  return webIdentityTokenFile ? fromTokenFile({ webIdentityTokenFile }) : undefined;
 }


### PR DESCRIPTION
## Summary

  AwsKmsService resolved IRSA credentials via AWS_WEB_IDENTITY_TOKEN_FILE, the same env var used by SES and the billing webhook signer, so enabling IRSA for one AWS integration silently made the KMS client assume that integration's role too. Field encryption's KMS client now reads a
  dedicated KMS_AWS_WEB_IDENTITY_TOKEN_FILE, and resolveAwsCredentials correctly passes the token file path into the AWS SDK instead of relying on it re-reading the ambient env var.

## Changes
- src/datasources/common/utils/aws-credentials.utils.ts: pass { webIdentityTokenFile } into fromTokenFile() instead of calling it with no arguments (previously it silently ignored the passed-in path and always re-read the ambient env var).
- src/config/entities/configuration.ts: encryption.kms.webIdentityTokenFile now sourced from KMS_AWS_WEB_IDENTITY_TOKEN_FILE instead of the shared AWS_WEB_IDENTITY_TOKEN_FILE.
- src/config/entities/schemas/configuration.schema.ts: schema and field-encryption validation updated to the new env var name.
- src/config/configuration.validator.spec.ts: updated/added coverage for the new var.
- .env.sample.json: documented KMS_AWS_WEB_IDENTITY_TOKEN_FILE.