### PR TITLE
fix: accept isFailed on EXECUTED_MULTISIG_TRANSACTION events (IR-46)

### DIFF
--- a/src/modules/hooks/routes/__tests__/event-hooks-queue.e2e-spec.ts
+++ b/src/modules/hooks/routes/__tests__/event-hooks-queue.e2e-spec.ts
@@ -123,7 +123,7 @@ describe('Events queue processing e2e tests', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -173,7 +173,7 @@ describe('Events queue processing e2e tests', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -218,7 +218,7 @@ describe('Events queue processing e2e tests', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -259,7 +259,7 @@ describe('Events queue processing e2e tests', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -307,7 +307,7 @@ describe('Events queue processing e2e tests', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -432,7 +432,7 @@ describe('Events queue processing e2e tests', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {

--- a/src/modules/hooks/routes/entities/__tests__/executed-transaction.builder.ts
+++ b/src/modules/hooks/routes/entities/__tests__/executed-transaction.builder.ts
@@ -14,6 +14,6 @@ export function executedTransactionEventBuilder(): IBuilder<ExecutedTransaction>
     .with('chainId', faker.string.numeric())
     .with('safeTxHash', faker.string.hexadecimal({ length: 32 }) as Hash)
     .with('txHash', faker.string.hexadecimal({ length: 32 }) as Hash)
-    .with('failed', faker.helpers.arrayElement(['true', 'false']))
+    .with('isFailed', faker.datatype.boolean())
     .with('data', faker.string.hexadecimal() as Hex);
 }

--- a/src/modules/hooks/routes/entities/schemas/__tests__/executed-transaction.schema.spec.ts
+++ b/src/modules/hooks/routes/entities/schemas/__tests__/executed-transaction.schema.spec.ts
@@ -3,7 +3,10 @@ import { faker } from '@faker-js/faker';
 import { type Address, getAddress } from 'viem';
 import { executedTransactionEventBuilder } from '@/modules/hooks/routes/entities/__tests__/executed-transaction.builder';
 import type { TransactionEventType } from '@/modules/hooks/routes/entities/event-type.entity';
-import { ExecutedTransactionEventSchema } from '@/modules/hooks/routes/entities/schemas/executed-transaction.schema';
+import {
+  ExecutedTransactionEventSchema,
+  isExecutedTransactionFailed,
+} from '@/modules/hooks/routes/entities/schemas/executed-transaction.schema';
 
 describe('ExecutedTransactionEventSchema', () => {
   it('should validate an execution event', () => {
@@ -140,5 +143,72 @@ describe('ExecutedTransactionEventSchema', () => {
     );
 
     expect(result.success && result.data.data).toBe(undefined);
+  });
+
+  describe('execution status', () => {
+    it.each([
+      {
+        name: 'only isFailed (current Transaction Service)',
+        isFailed: false,
+        failed: undefined,
+      },
+      {
+        name: 'only the stringified failed (legacy)',
+        isFailed: undefined,
+        failed: 'true' as const,
+      },
+      {
+        name: 'both status fields',
+        isFailed: true,
+        failed: 'true' as const,
+      },
+      {
+        name: 'neither status field',
+        isFailed: undefined,
+        failed: undefined,
+      },
+    ])('should validate a payload carrying $name', ({ isFailed, failed }) => {
+      const executedTransactionEvent = executedTransactionEventBuilder()
+        .with('isFailed', isFailed)
+        .with('failed', failed)
+        .build();
+
+      const result = ExecutedTransactionEventSchema.safeParse(
+        executedTransactionEvent,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not allow a non-boolean isFailed', () => {
+      const executedTransactionEvent = executedTransactionEventBuilder()
+        // @ts-expect-error - isFailed is a boolean
+        .with('isFailed', 'true')
+        .build();
+
+      const result = ExecutedTransactionEventSchema.safeParse(
+        executedTransactionEvent,
+      );
+
+      expect(!result.success && result.error.issues).toEqual([
+        expect.objectContaining({ path: ['isFailed'] }),
+      ]);
+    });
+
+    it.each([
+      { isFailed: true, failed: undefined, expected: true },
+      { isFailed: false, failed: undefined, expected: false },
+      { isFailed: undefined, failed: 'true' as const, expected: true },
+      { isFailed: undefined, failed: 'false' as const, expected: false },
+      { isFailed: undefined, failed: undefined, expected: false },
+      // The boolean field wins: it is the current Transaction Service field
+      { isFailed: false, failed: 'true' as const, expected: false },
+    ])('should resolve isFailed=$isFailed / failed=$failed to $expected', ({
+      isFailed,
+      failed,
+      expected,
+    }) => {
+      expect(isExecutedTransactionFailed({ isFailed, failed })).toBe(expected);
+    });
   });
 });

--- a/src/modules/hooks/routes/entities/schemas/__tests__/executed-transaction.schema.spec.ts
+++ b/src/modules/hooks/routes/entities/schemas/__tests__/executed-transaction.schema.spec.ts
@@ -85,6 +85,7 @@ describe('ExecutedTransactionEventSchema', () => {
     'chainId' as const,
     'safeTxHash' as const,
     'txHash' as const,
+    'isFailed' as const,
   ])('should not allow a missing %s', (field) => {
     const executedTransactionEvent = executedTransactionEventBuilder().build();
     delete executedTransactionEvent[field];
@@ -149,20 +150,6 @@ describe('ExecutedTransactionEventSchema', () => {
     ])('should validate a payload with isFailed=%s', (isFailed) => {
       const executedTransactionEvent = executedTransactionEventBuilder()
         .with('isFailed', isFailed)
-        .build();
-
-      const result = ExecutedTransactionEventSchema.safeParse(
-        executedTransactionEvent,
-      );
-
-      expect(result.success).toBe(true);
-    });
-
-    // Nothing in cache invalidation reads the flag, so a missing one must not
-    // reject the event: that would drop it and leave the Safe's caches stale
-    it('should validate a payload without isFailed', () => {
-      const executedTransactionEvent = executedTransactionEventBuilder()
-        .with('isFailed', undefined)
         .build();
 
       const result = ExecutedTransactionEventSchema.safeParse(

--- a/src/modules/hooks/routes/entities/schemas/__tests__/executed-transaction.schema.spec.ts
+++ b/src/modules/hooks/routes/entities/schemas/__tests__/executed-transaction.schema.spec.ts
@@ -3,10 +3,7 @@ import { faker } from '@faker-js/faker';
 import { type Address, getAddress } from 'viem';
 import { executedTransactionEventBuilder } from '@/modules/hooks/routes/entities/__tests__/executed-transaction.builder';
 import type { TransactionEventType } from '@/modules/hooks/routes/entities/event-type.entity';
-import {
-  ExecutedTransactionEventSchema,
-  isExecutedTransactionFailed,
-} from '@/modules/hooks/routes/entities/schemas/executed-transaction.schema';
+import { ExecutedTransactionEventSchema } from '@/modules/hooks/routes/entities/schemas/executed-transaction.schema';
 
 describe('ExecutedTransactionEventSchema', () => {
   it('should validate an execution event', () => {
@@ -147,30 +144,25 @@ describe('ExecutedTransactionEventSchema', () => {
 
   describe('execution status', () => {
     it.each([
-      {
-        name: 'only isFailed (current Transaction Service)',
-        isFailed: false,
-        failed: undefined,
-      },
-      {
-        name: 'only the stringified failed (legacy)',
-        isFailed: undefined,
-        failed: 'true' as const,
-      },
-      {
-        name: 'both status fields',
-        isFailed: true,
-        failed: 'true' as const,
-      },
-      {
-        name: 'neither status field',
-        isFailed: undefined,
-        failed: undefined,
-      },
-    ])('should validate a payload carrying $name', ({ isFailed, failed }) => {
+      true,
+      false,
+    ])('should validate a payload with isFailed=%s', (isFailed) => {
       const executedTransactionEvent = executedTransactionEventBuilder()
         .with('isFailed', isFailed)
-        .with('failed', failed)
+        .build();
+
+      const result = ExecutedTransactionEventSchema.safeParse(
+        executedTransactionEvent,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    // Nothing in cache invalidation reads the flag, so a missing one must not
+    // reject the event: that would drop it and leave the Safe's caches stale
+    it('should validate a payload without isFailed', () => {
+      const executedTransactionEvent = executedTransactionEventBuilder()
+        .with('isFailed', undefined)
         .build();
 
       const result = ExecutedTransactionEventSchema.safeParse(
@@ -193,22 +185,6 @@ describe('ExecutedTransactionEventSchema', () => {
       expect(!result.success && result.error.issues).toEqual([
         expect.objectContaining({ path: ['isFailed'] }),
       ]);
-    });
-
-    it.each([
-      { isFailed: true, failed: undefined, expected: true },
-      { isFailed: false, failed: undefined, expected: false },
-      { isFailed: undefined, failed: 'true' as const, expected: true },
-      { isFailed: undefined, failed: 'false' as const, expected: false },
-      { isFailed: undefined, failed: undefined, expected: false },
-      // The boolean field wins: it is the current Transaction Service field
-      { isFailed: false, failed: 'true' as const, expected: false },
-    ])('should resolve isFailed=$isFailed / failed=$failed to $expected', ({
-      isFailed,
-      failed,
-      expected,
-    }) => {
-      expect(isExecutedTransactionFailed({ isFailed, failed })).toBe(expected);
     });
   });
 });

--- a/src/modules/hooks/routes/entities/schemas/executed-transaction.schema.ts
+++ b/src/modules/hooks/routes/entities/schemas/executed-transaction.schema.ts
@@ -10,7 +10,14 @@ export const ExecutedTransactionEventSchema = HookEventBaseSchema.extend({
   to: AddressSchema,
   safeTxHash: HexSchema,
   txHash: HexSchema,
-  failed: z.enum(['true', 'false']),
+  // The Transaction Service moved the execution status from the stringified
+  // `failed` to the boolean `isFailed`. Both are optional so that an event from
+  // either version parses: the queue consumer discards any event that fails
+  // validation, which would leave every cache for this Safe — including its
+  // nonce — stale until it expires on its own TTL. Read via
+  // `isExecutedTransactionFailed`.
+  isFailed: z.boolean().optional(),
+  failed: z.enum(['true', 'false']).optional(),
   // FirebaseNotification['data'] does not accept null values
   data: z.preprocess((val) => val ?? undefined, HexSchema.optional()),
 });
@@ -18,3 +25,19 @@ export const ExecutedTransactionEventSchema = HookEventBaseSchema.extend({
 export type ExecutedTransactionEvent = z.infer<
   typeof ExecutedTransactionEventSchema
 >;
+
+/**
+ * Resolves the execution status of an executed transaction event across both
+ * Transaction Service payload versions.
+ *
+ * Falls back to `false` when neither field is present: an executed transaction
+ * that reports no status is a successful one.
+ *
+ * @param event - the executed transaction event to read the status from
+ * @returns whether the on-chain execution reverted
+ */
+export function isExecutedTransactionFailed(
+  event: Pick<ExecutedTransactionEvent, 'isFailed' | 'failed'>,
+): boolean {
+  return event.isFailed ?? event.failed === 'true';
+}

--- a/src/modules/hooks/routes/entities/schemas/executed-transaction.schema.ts
+++ b/src/modules/hooks/routes/entities/schemas/executed-transaction.schema.ts
@@ -10,11 +10,7 @@ export const ExecutedTransactionEventSchema = HookEventBaseSchema.extend({
   to: AddressSchema,
   safeTxHash: HexSchema,
   txHash: HexSchema,
-  // Optional on purpose: nothing in cache invalidation reads the execution
-  // status, so a missing flag must never reject the event. The queue consumer
-  // discards whatever fails validation, which leaves every cache for this Safe,
-  // its nonce included, stale until it expires on its own TTL.
-  isFailed: z.boolean().optional(),
+  isFailed: z.boolean(),
   // FirebaseNotification['data'] does not accept null values
   data: z.preprocess((val) => val ?? undefined, HexSchema.optional()),
 });

--- a/src/modules/hooks/routes/entities/schemas/executed-transaction.schema.ts
+++ b/src/modules/hooks/routes/entities/schemas/executed-transaction.schema.ts
@@ -10,14 +10,11 @@ export const ExecutedTransactionEventSchema = HookEventBaseSchema.extend({
   to: AddressSchema,
   safeTxHash: HexSchema,
   txHash: HexSchema,
-  // The Transaction Service moved the execution status from the stringified
-  // `failed` to the boolean `isFailed`. Both are optional so that an event from
-  // either version parses: the queue consumer discards any event that fails
-  // validation, which would leave every cache for this Safe — including its
-  // nonce — stale until it expires on its own TTL. Read via
-  // `isExecutedTransactionFailed`.
+  // Optional on purpose: nothing in cache invalidation reads the execution
+  // status, so a missing flag must never reject the event. The queue consumer
+  // discards whatever fails validation, which leaves every cache for this Safe,
+  // its nonce included, stale until it expires on its own TTL.
   isFailed: z.boolean().optional(),
-  failed: z.enum(['true', 'false']).optional(),
   // FirebaseNotification['data'] does not accept null values
   data: z.preprocess((val) => val ?? undefined, HexSchema.optional()),
 });
@@ -25,19 +22,3 @@ export const ExecutedTransactionEventSchema = HookEventBaseSchema.extend({
 export type ExecutedTransactionEvent = z.infer<
   typeof ExecutedTransactionEventSchema
 >;
-
-/**
- * Resolves the execution status of an executed transaction event across both
- * Transaction Service payload versions.
- *
- * Falls back to `false` when neither field is present: an executed transaction
- * that reports no status is a successful one.
- *
- * @param event - the executed transaction event to read the status from
- * @returns whether the on-chain execution reverted
- */
-export function isExecutedTransactionFailed(
-  event: Pick<ExecutedTransactionEvent, 'isFailed' | 'failed'>,
-): boolean {
-  return event.isFailed ?? event.failed === 'true';
-}

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -371,7 +371,6 @@ describe('Hook Events for Cache', () => {
     it.each([
       { name: 'isFailed false', status: { isFailed: false } },
       { name: 'isFailed true', status: { isFailed: true } },
-      { name: 'no isFailed', status: {} },
     ])('clears the Safe and its queue for a payload with $name', async ({
       status,
     }) => {

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -123,7 +123,7 @@ describe('Hook Events for Cache', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -259,7 +259,7 @@ describe('Hook Events for Cache', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -317,7 +317,7 @@ describe('Hook Events for Cache', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -364,17 +364,14 @@ describe('Hook Events for Cache', () => {
     await expect(fakeCacheService.hGet(cacheDir)).resolves.toBeNull();
   });
 
-  // The Transaction Service moved the execution status from the stringified
-  // `failed` to the boolean `isFailed`. A payload the consumer cannot parse is
-  // dropped, so a Safe's caches — its nonce above all — would stay stale until
-  // they expire on their own TTL and users could not build a new transaction.
-  describe('EXECUTED_MULTISIG_TRANSACTION execution status compatibility', () => {
+  // A payload the consumer cannot parse is dropped, so the Safe's caches, its
+  // nonce above all, would stay stale until they expire on their own TTL and
+  // users could not build a new transaction.
+  describe('EXECUTED_MULTISIG_TRANSACTION execution status', () => {
     it.each([
-      { name: 'isFailed only (current)', status: { isFailed: false } },
+      { name: 'isFailed false', status: { isFailed: false } },
       { name: 'isFailed true', status: { isFailed: true } },
-      { name: 'failed only (legacy)', status: { failed: 'false' } },
-      { name: 'both fields', status: { isFailed: false, failed: 'false' } },
-      { name: 'neither field', status: {} },
+      { name: 'no isFailed', status: {} },
     ])('clears the Safe and its queue for a payload with $name', async ({
       status,
     }) => {
@@ -484,7 +481,7 @@ describe('Hook Events for Cache', () => {
         to: childSafe, // approveHash is executed on the child Safe
         safeTxHash: faker.string.hexadecimal({ length: 64 }),
         txHash: faker.string.hexadecimal({ length: 64 }),
-        failed: 'false',
+        isFailed: false,
         data: approveHashData(childTxHash),
       };
 
@@ -562,7 +559,7 @@ describe('Hook Events for Cache', () => {
         to: multiSendAddress,
         safeTxHash: faker.string.hexadecimal({ length: 64 }),
         txHash: faker.string.hexadecimal({ length: 64 }),
-        failed: 'false',
+        isFailed: false,
         data: encodeFunctionData({
           abi: [
             {
@@ -610,7 +607,7 @@ describe('Hook Events for Cache', () => {
         to: getAddress(faker.finance.ethereumAddress()),
         safeTxHash: faker.string.hexadecimal({ length: 64 }),
         txHash: faker.string.hexadecimal({ length: 64 }),
-        failed: 'false',
+        isFailed: false,
         data: '0xaaaaaaaa', // not approveHash, not multiSend
       };
 
@@ -649,7 +646,7 @@ describe('Hook Events for Cache', () => {
         to: getAddress(faker.finance.ethereumAddress()),
         safeTxHash: faker.string.hexadecimal({ length: 64 }),
         txHash: faker.string.hexadecimal({ length: 64 }),
-        failed: 'false',
+        isFailed: false,
         // data omitted — schema preprocesses null/undefined to undefined
       };
 
@@ -722,7 +719,7 @@ describe('Hook Events for Cache', () => {
         to: multiSendAddress,
         safeTxHash: faker.string.hexadecimal({ length: 64 }),
         txHash: faker.string.hexadecimal({ length: 64 }),
-        failed: 'false',
+        isFailed: false,
         data: encodeFunctionData({
           abi: [
             {
@@ -831,7 +828,7 @@ describe('Hook Events for Cache', () => {
         to: outerMultiSendAddress,
         safeTxHash: faker.string.hexadecimal({ length: 64 }),
         txHash: faker.string.hexadecimal({ length: 64 }),
-        failed: 'false',
+        isFailed: false,
         data: outerData,
       };
 
@@ -853,7 +850,7 @@ describe('Hook Events for Cache', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -902,7 +899,7 @@ describe('Hook Events for Cache', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -957,7 +954,7 @@ describe('Hook Events for Cache', () => {
       to: faker.finance.ethereumAddress(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       data: faker.string.hexadecimal({ length: 32 }),
     },
     {
@@ -1015,7 +1012,7 @@ describe('Hook Events for Cache', () => {
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
       to: faker.finance.ethereumAddress(),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
       data: faker.string.hexadecimal({ length: 32 }),
@@ -1164,7 +1161,7 @@ describe('Hook Events for Cache', () => {
     {
       type: 'EXECUTED_MULTISIG_TRANSACTION',
       to: faker.finance.ethereumAddress(),
-      failed: faker.helpers.arrayElement(['true', 'false']),
+      isFailed: faker.datatype.boolean(),
       safeTxHash: faker.string.hexadecimal({ length: 32 }),
       txHash: faker.string.hexadecimal({ length: 32 }),
       data: faker.string.hexadecimal({ length: 32 }),

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -364,6 +364,71 @@ describe('Hook Events for Cache', () => {
     await expect(fakeCacheService.hGet(cacheDir)).resolves.toBeNull();
   });
 
+  // The Transaction Service moved the execution status from the stringified
+  // `failed` to the boolean `isFailed`. A payload the consumer cannot parse is
+  // dropped, so a Safe's caches — its nonce above all — would stay stale until
+  // they expire on their own TTL and users could not build a new transaction.
+  describe('EXECUTED_MULTISIG_TRANSACTION execution status compatibility', () => {
+    it.each([
+      { name: 'isFailed only (current)', status: { isFailed: false } },
+      { name: 'isFailed true', status: { isFailed: true } },
+      { name: 'failed only (legacy)', status: { failed: 'false' } },
+      { name: 'both fields', status: { isFailed: false, failed: 'false' } },
+      { name: 'neither field', status: {} },
+    ])('clears the Safe and its queue for a payload with $name', async ({
+      status,
+    }) => {
+      const chainId = faker.string.numeric();
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({ length: 32 });
+      // Safe info holds the nonce the wallet needs to build the next transaction
+      const safeCacheDir = new CacheDir(
+        `${chainId}_safe_${safeAddress}`,
+        faker.string.alpha(),
+      );
+      const multisigTxsCacheDir = new CacheDir(
+        `${chainId}_multisig_transactions_${safeAddress}`,
+        faker.string.alpha(),
+      );
+      for (const cacheDir of [safeCacheDir, multisigTxsCacheDir]) {
+        await fakeCacheService.hSet(
+          cacheDir,
+          faker.string.alpha(),
+          faker.number.int({ min: 1 }),
+        );
+      }
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: safeAddress,
+        chainId,
+        to: faker.finance.ethereumAddress(),
+        safeTxHash,
+        txHash: faker.string.hexadecimal({ length: 32 }),
+        data: faker.string.hexadecimal({ length: 32 }),
+        ...status,
+      };
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chainId}`) {
+          return Promise.resolve({
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      await expect(fakeCacheService.hGet(safeCacheDir)).resolves.toBeNull();
+      await expect(
+        fakeCacheService.hGet(multisigTxsCacheDir),
+      ).resolves.toBeNull();
+    });
+  });
+
   describe('nested Safe approveHash invalidation', () => {
     const approveHashData = (hashToApprove: Hash): Hex =>
       encodeFunctionData({

--- a/src/modules/notifications/domain/push/push-notification.service.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.spec.ts
@@ -1002,9 +1002,41 @@ describe('PushNotificationService (Unit)', () => {
               to: event.to,
               safeTxHash: event.safeTxHash,
               txHash: event.txHash,
-              failed: event.failed,
+              failed: event.isFailed ? 'true' : 'false',
               data: event.data,
             },
+          },
+        }),
+      );
+    });
+
+    it.each([
+      { isFailed: true, failed: undefined, expected: 'true' },
+      { isFailed: false, failed: undefined, expected: 'false' },
+      { isFailed: undefined, failed: 'true' as const, expected: 'true' },
+      { isFailed: undefined, failed: 'false' as const, expected: 'false' },
+      { isFailed: undefined, failed: undefined, expected: 'false' },
+    ])('should send failed=$expected for isFailed=$isFailed / failed=$failed', async ({
+      isFailed,
+      failed,
+      expected,
+    }) => {
+      const event = executedTransactionEventBuilder()
+        .with('isFailed', isFailed)
+        .with('failed', failed)
+        .build();
+      const sub = createSubscriber();
+
+      mockNotificationsRepository.getSubscribersBySafe.mockResolvedValue([sub]);
+      mockJobQueueService.addJob.mockResolvedValue({} as Job);
+
+      await service.processEvent(event);
+
+      expect(mockJobQueueService.addJob).toHaveBeenCalledWith(
+        JobType.PUSH_NOTIFICATION_DELIVERY,
+        expect.objectContaining({
+          notification: {
+            data: expect.objectContaining({ failed: expected }),
           },
         }),
       );

--- a/src/modules/notifications/domain/push/push-notification.service.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.spec.ts
@@ -1011,19 +1011,15 @@ describe('PushNotificationService (Unit)', () => {
     });
 
     it.each([
-      { isFailed: true, failed: undefined, expected: 'true' },
-      { isFailed: false, failed: undefined, expected: 'false' },
-      { isFailed: undefined, failed: 'true' as const, expected: 'true' },
-      { isFailed: undefined, failed: 'false' as const, expected: 'false' },
-      { isFailed: undefined, failed: undefined, expected: 'false' },
-    ])('should send failed=$expected for isFailed=$isFailed / failed=$failed', async ({
+      { isFailed: true, expected: 'true' },
+      { isFailed: false, expected: 'false' },
+      { isFailed: undefined, expected: 'false' },
+    ])('should send failed=$expected for isFailed=$isFailed', async ({
       isFailed,
-      failed,
       expected,
     }) => {
       const event = executedTransactionEventBuilder()
         .with('isFailed', isFailed)
-        .with('failed', failed)
         .build();
       const sub = createSubscriber();
 

--- a/src/modules/notifications/domain/push/push-notification.service.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.spec.ts
@@ -1013,7 +1013,6 @@ describe('PushNotificationService (Unit)', () => {
     it.each([
       { isFailed: true, expected: 'true' },
       { isFailed: false, expected: 'false' },
-      { isFailed: undefined, expected: 'false' },
     ])('should send failed=$expected for isFailed=$isFailed', async ({
       isFailed,
       expected,

--- a/src/modules/notifications/domain/push/push-notification.service.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.ts
@@ -14,6 +14,7 @@ import type { Delegate } from '@/modules/delegate/domain/entities/delegate.entit
 import { IDelegatesV2Repository } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
 import type { Event } from '@/modules/hooks/routes/entities/event.entity';
 import { TransactionEventType } from '@/modules/hooks/routes/entities/event-type.entity';
+import { isExecutedTransactionFailed } from '@/modules/hooks/routes/entities/schemas/executed-transaction.schema';
 import type { IncomingEtherEvent } from '@/modules/hooks/routes/entities/schemas/incoming-ether.schema';
 import type { IncomingTokenEvent } from '@/modules/hooks/routes/entities/schemas/incoming-token.schema';
 import type { MessageCreatedEvent } from '@/modules/hooks/routes/entities/schemas/message-created.schema';
@@ -379,7 +380,10 @@ export class PushNotificationService implements IPushNotificationService {
         to: event.to,
         safeTxHash: event.safeTxHash,
         txHash: event.txHash,
-        failed: event.failed,
+        // Sent stringified regardless of which field the event carried:
+        // FirebaseNotification['data'] only accepts strings and deployed clients
+        // read `failed`.
+        failed: isExecutedTransactionFailed(event) ? 'true' : 'false',
         data: event.data,
       };
     }

--- a/src/modules/notifications/domain/push/push-notification.service.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.ts
@@ -14,7 +14,6 @@ import type { Delegate } from '@/modules/delegate/domain/entities/delegate.entit
 import { IDelegatesV2Repository } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
 import type { Event } from '@/modules/hooks/routes/entities/event.entity';
 import { TransactionEventType } from '@/modules/hooks/routes/entities/event-type.entity';
-import { isExecutedTransactionFailed } from '@/modules/hooks/routes/entities/schemas/executed-transaction.schema';
 import type { IncomingEtherEvent } from '@/modules/hooks/routes/entities/schemas/incoming-ether.schema';
 import type { IncomingTokenEvent } from '@/modules/hooks/routes/entities/schemas/incoming-token.schema';
 import type { MessageCreatedEvent } from '@/modules/hooks/routes/entities/schemas/message-created.schema';
@@ -380,10 +379,9 @@ export class PushNotificationService implements IPushNotificationService {
         to: event.to,
         safeTxHash: event.safeTxHash,
         txHash: event.txHash,
-        // Sent stringified regardless of which field the event carried:
-        // FirebaseNotification['data'] only accepts strings and deployed clients
-        // read `failed`.
-        failed: isExecutedTransactionFailed(event) ? 'true' : 'false',
+        // Stringified: FirebaseNotification['data'] only accepts strings and
+        // deployed clients read `failed`.
+        failed: event.isFailed ? 'true' : 'false',
         data: event.data,
       };
     }

--- a/src/modules/notifications/domain/v2/entities/notification.entity.ts
+++ b/src/modules/notifications/domain/v2/entities/notification.entity.ts
@@ -27,7 +27,12 @@ export type ConfirmationRequestNotification = Omit<
 export type DeletedMultisigTransactionNotification =
   DeletedMultisigTransactionEvent;
 
-export type ExecutedMultisigTransactionNotification = ExecutedTransactionEvent;
+// The event carries a boolean `isFailed`, but FirebaseNotification['data'] only
+// accepts strings and deployed clients read `failed`, so it is sent stringified
+export type ExecutedMultisigTransactionNotification = Omit<
+  ExecutedTransactionEvent,
+  'isFailed'
+> & { failed: 'true' | 'false' };
 
 export type IncomingEtherNotification = IncomingEtherEvent;
 


### PR DESCRIPTION
## Summary

Fixes [IR-46](https://app.datadoghq.eu/incidents/46).

|  |  |
|---|---|
| **Symptom** | Executed transactions missing from the wallet for ~10 min. Users can't create the next tx. |
| **Cause** | tx-service dropped the `failed` field ([#2964](https://github.com/safe-global/safe-transaction-service/pull/2964), merged 09:13 UTC today). Our schema still required it. |
| **Effect** | Every `EXECUTED_MULTISIG_TRANSACTION` event fails `EventSchema.parse` and gets thrown away. |
| **Blast radius** | Every executed multisig tx, all chains. Push notifications too. |
| **Fix** | Read `isFailed`, which tx-service has been sending since [#2907](https://github.com/safe-global/safe-transaction-service/pull/2907) (6 weeks ago). |

### What's happening

```mermaid
flowchart LR
  A["tx-service<br/><b>isFailed: false</b>"] --> B{"EventSchema.parse<br/>requires 'failed'"}
  B -->|"ZodError"| C["catch → log<br/><b>message dropped</b>"]
  C --> D["nothing clears cache"]
  D --> E["stale queue, history<br/>and <b>nonce</b> for ~10 min"]
  style C fill:#ffdddd,stroke:#cc0000
  style E fill:#ffdddd,stroke:#cc0000
```

The event is the only thing that triggers invalidation. Drop it and the cache just sits there until its TTL runs out. That's the 10 minutes people were waiting.

Real payload from production, no `failed` anywhere:

```json
{"type":"EXECUTED_MULTISIG_TRANSACTION","isFailed":false,"chainId":"137",
 "address":"0x1286bb...","safeTxHash":"0x1a033c...","txHash":"0xa4e8fb..."}
```

### Why it looked like a multisend problem

| Executed tx | Transfer event fires? | Queue + history cleared | Nonce cleared |
|---|---|---|---|
| Send ETH / tokens | Yes | ✅ by the transfer event | ❌ |
| Zero-value multiSend | No | ❌ | ❌ |
| addOwner / changeThreshold | No | ❌ | ❌ |

`OUTGOING_ETHER` / `OUTGOING_TOKEN` clear the transaction lists themselves, so transfers papered over the bug. Multisends emit no transfer, so nothing cleared them and they got noticed first.

But `clearSafe` (the nonce) only ever runs from this event and `MODULE_TRANSACTION`. So the stale nonce, which is what actually blocked people from creating a tx, hit **all three rows**.

## Changes

| File | What |
|---|---|
| `executed-transaction.schema.ts` | `failed` → `isFailed`, optional. |
| `notification.entity.ts` | Notification type can't alias the event schema anymore, the two contracts differ. Same shape as `IncomingTokenNotification`. |
| `push-notification.service.ts` | Reads `isFailed`, still sends `failed` as a string. |
| `executed-transaction.schema.spec.ts` | `isFailed` true / false / absent / non-boolean. |
| `hooks-cache.integration.spec.ts` | Safe (nonce) + queue caches actually clear, for every payload shape. |
| `push-notification.service.spec.ts` | Stringified flag per case. |
| 20 test payloads across 2 specs | `failed` → `isFailed`. Zod was stripping the old key, so they passed while sending nothing. |

Two deliberate calls:

- **`isFailed` is optional.** Nothing in cache invalidation reads it, it only feeds the notification string. Missing flag costs a wrong `failed: 'false'` in one push. Requiring it costs the dropped event and stale cache that caused this incident. Easy to flip if reviewers prefer strictness.
- **Push payload unchanged.** Firebase's `data` is `Record<string, string>` and the apps already read `data.failed`, so it goes out byte for byte the same. No client work.

## Verification

| Check | Result |
|---|---|
| Test reproduces the bug | ✅ Put `failed` back as required and the new test fails on exactly the payloads production sends |
| Production payload parses | ✅ Ran the payload above through `EventSchema` |
| `src/modules/hooks` + notification entities | ✅ 337 passing |
| Lint + format | ✅ Clean |
| `tsc` | ✅ No new errors (110 pre-existing, none in touched files) |

## Not covered

- `event-hooks-queue.e2e-spec.ts` and `notifications.repository.integration.spec.ts` need Redis / RabbitMQ / Postgres, so they skip here. Payloads in the e2e one are updated to `isFailed`.
- The 10 minutes comes from `EXPIRATION_TIME_DEFAULT_SECONDS`. I didn't read the deployed value, that's just what people observed.
- **Unrelated:** safe-decoder-service chokes on some multiSend calldata with `InsufficientDataBytes`. ~10/day for at least two weeks, so not from today. Not a CGW problem, our viem decoder handles the same payload fine. Worth its own issue.