### PR TITLE
chore: lower log level of high-volume non-actionable logs

### DIFF
--- a/src/modules/data-decoder/domain/v2/data-decoder.repository.ts
+++ b/src/modules/data-decoder/domain/v2/data-decoder.repository.ts
@@ -48,7 +48,10 @@ export class DataDecoderRepository implements IDataDecoderRepository {
         to: this.getDataDecodedTo(args.transaction),
       });
     } catch (e) {
-      this.loggingService.warn(
+      // Undecodable data is expected and not actionable, so this is logged at
+      // debug level to keep it out of indexed logs. APM traces cover the
+      // failing Decoder calls when they need investigating.
+      this.loggingService.debug(
         `Error decoding transaction data: ${asError(e).message}`,
       );
       return null;

--- a/src/modules/notifications/domain/push/push-notification.service.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.spec.ts
@@ -47,6 +47,7 @@ const mockJobQueueService = vi.mocked({
 
 const mockLoggingService = vi.mocked({
   info: vi.fn(),
+  debug: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
 } as MockedObject<ILoggingService>);
@@ -190,7 +191,7 @@ describe('PushNotificationService (Unit)', () => {
         mockNotificationsRepository.getSubscribersBySafe,
       ).not.toHaveBeenCalled();
       expect(mockJobQueueService.addJob).not.toHaveBeenCalled();
-      expect(mockLoggingService.info).toHaveBeenCalledWith({
+      expect(mockLoggingService.debug).toHaveBeenCalledWith({
         type: LogType.NotificationSpamTokenDropped,
         eventType: event.type,
         chainId: event.chainId,
@@ -239,7 +240,7 @@ describe('PushNotificationService (Unit)', () => {
       expect(
         mockNotificationsRepository.getSubscribersBySafe,
       ).toHaveBeenCalled();
-      expect(mockLoggingService.info).not.toHaveBeenCalledWith(
+      expect(mockLoggingService.debug).not.toHaveBeenCalledWith(
         expect.objectContaining({
           type: LogType.NotificationSpamTokenDropped,
         }),
@@ -647,13 +648,13 @@ describe('PushNotificationService (Unit)', () => {
 
       await service.processEvent(event);
 
-      const deliveryQueuedCalls = mockLoggingService.info.mock.calls.filter(
+      const deliveryQueuedCalls = mockLoggingService.debug.mock.calls.filter(
         (call) =>
           (call[0] as Record<string, unknown>).type ===
           LogType.NotificationDeliveryQueued,
       );
       expect(deliveryQueuedCalls).toHaveLength(2);
-      expect(mockLoggingService.info).toHaveBeenCalledWith(
+      expect(mockLoggingService.debug).toHaveBeenCalledWith(
         expect.objectContaining({
           type: LogType.NotificationDeliveryQueued,
           chainId: event.chainId,
@@ -681,7 +682,7 @@ describe('PushNotificationService (Unit)', () => {
 
       await service.processEvent(event);
 
-      expect(mockLoggingService.info).toHaveBeenCalledWith(
+      expect(mockLoggingService.debug).toHaveBeenCalledWith(
         expect.objectContaining({
           type: LogType.NotificationEventProcessed,
           eventType: event.type,
@@ -699,7 +700,7 @@ describe('PushNotificationService (Unit)', () => {
 
       await service.processEvent(event);
 
-      expect(mockLoggingService.info).toHaveBeenCalledWith(
+      expect(mockLoggingService.debug).toHaveBeenCalledWith(
         expect.objectContaining({
           type: LogType.NotificationEventProcessed,
           deliveryJobCount: 0,
@@ -733,7 +734,7 @@ describe('PushNotificationService (Unit)', () => {
 
       await service.processDelivery(data);
 
-      expect(mockLoggingService.info).toHaveBeenCalledWith({
+      expect(mockLoggingService.debug).toHaveBeenCalledWith({
         type: LogType.NotificationSent,
         chainId: data.chainId,
         safeAddress: data.safeAddress,

--- a/src/modules/notifications/domain/push/push-notification.service.ts
+++ b/src/modules/notifications/domain/push/push-notification.service.ts
@@ -90,7 +90,7 @@ export class PushNotificationService implements IPushNotificationService {
 
     // Drop transfers the Transaction Service flagged as untrusted.
     if (event.type === TransactionEventType.INCOMING_TOKEN && !event.trusted) {
-      this.loggingService.info({
+      this.loggingService.debug({
         type: LogType.NotificationSpamTokenDropped,
         eventType: event.type,
         chainId: event.chainId,
@@ -136,7 +136,7 @@ export class PushNotificationService implements IPushNotificationService {
                 notificationType: notification.type,
               },
             );
-            this.loggingService.info({
+            this.loggingService.debug({
               type: LogType.NotificationDeliveryQueued,
               chainId: notification.chainId,
               safeAddress: notification.address,
@@ -157,7 +157,7 @@ export class PushNotificationService implements IPushNotificationService {
       )
     ).reduce((sum, n) => sum + n, 0);
 
-    this.loggingService.info({
+    this.loggingService.debug({
       type: LogType.NotificationEventProcessed,
       eventType: event.type,
       chainId: event.chainId,
@@ -183,7 +183,7 @@ export class PushNotificationService implements IPushNotificationService {
       deviceUuid: data.deviceUuid,
       notification: data.notification,
     });
-    this.loggingService.info({
+    this.loggingService.debug({
       type: LogType.NotificationSent,
       chainId: data.chainId,
       safeAddress: data.safeAddress,

--- a/src/modules/transactions/routes/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/transfers/transfer-info.mapper.spec.ts
@@ -41,6 +41,7 @@ const tokenRepository = vi.mocked({
 
 const mockLoggingService = vi.mocked({
   warn: vi.fn(),
+  debug: vi.fn(),
 } as MockedObject<ILoggingService>);
 
 describe('Transfer Info mapper (Unit)', () => {

--- a/src/modules/transactions/routes/mappers/transfers/transfer-info.mapper.ts
+++ b/src/modules/transactions/routes/mappers/transfers/transfer-info.mapper.ts
@@ -97,7 +97,7 @@ export class TransferInfoMapper {
       return await this.swapTransferInfoMapper.mapSwapTransferInfo(args);
     } catch (error) {
       // There were either issues mapping the swap transfer or it is a "normal" transfer
-      this.loggingService.warn(error);
+      this.loggingService.debug(error);
       return null;
     }
   }

--- a/src/modules/transactions/routes/mappers/transfers/transfer.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/transfers/transfer.mapper.spec.ts
@@ -47,6 +47,7 @@ const swapTransferInfoMapper = vi.mocked({
 
 const mockLoggingService = vi.mocked({
   warn: vi.fn(),
+  debug: vi.fn(),
 } as MockedObject<ILoggingService>);
 
 describe('Transfer mapper (Unit)', () => {


### PR DESCRIPTION
Reduces indexed log volume. CGW is the top log indexer at ~20M events/day and these are the largest non-actionable contributors.

Notifications (~5M events/day) - info to debug:
- `NOTIFICATION_EVENT_PROCESSED`
- `NOTIFICATION_DELIVERY_QUEUED`
- `NOTIFICATION_SENT`
- `NOTIFICATION_SPAM_TOKEN_DROPPED`

NotificationError is left at warn as it is actionable.

Noisy warns (~3M events/day, 94% of all CGW warns) - warn to debug:
- "Error decoding transaction data" - undecodable data is expected; the failing Decoder calls are already errored spans in APM.
- "Neither sender nor receiver are settlement contract" - fires on the normal path for every non-swap transfer, several times per request.

Note the second is a catch-all, so "Transfer not found in order", "Unsupported App" and swap token-fetch failures move to debug with it. Those are the remaining ~6% of CGW warns.

## Summary

## Changes
