### PR TITLE
ci: close the number-prefix gap in the arch-review gh allowlist

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -124,7 +124,10 @@ jobs:
             touches, is NOT a finding — only actual violations of the guides
             and failed Part 2 checks count.
           # The gh commands are pinned to the triggering PR's number so a
-          # prompt injection cannot redirect them at another PR.
+          # prompt injection cannot redirect them at another PR. `:*` is a
+          # string-prefix match, so each entry must end the number with a
+          # space-delimited token (or be an exact match) — a bare
+          # `gh pr comment 123:*` would also allow `gh pr comment 1234`.
           claude_args: |
             --model claude-opus-5
-            --allowedTools "Read,Grep,Glob,Bash(gh pr view ${{ github.event.issue.number || github.event.pull_request.number }}:*),Bash(gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }}:*),Bash(gh pr comment ${{ github.event.issue.number || github.event.pull_request.number }}:*)"
+            --allowedTools "Read,Grep,Glob,Bash(gh pr view ${{ github.event.issue.number || github.event.pull_request.number }} --json:*),Bash(gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }} --name-only),Bash(gh pr comment ${{ github.event.issue.number || github.event.pull_request.number }} --body:*)"


### PR DESCRIPTION
## Summary
  The Architecture Check workflow pins its allowed `gh` commands to the triggering PR's number, but the bare `<N>:*` entries are string-prefix matches: a pin to PR 123 also allowed `gh pr comment 1234`. Since the agent reads the (untrusted) PR diff, a successful prompt injection could have steered the verdict comment at any same-repo PR whose number string-extends the triggering one — defeating the pin's stated intent.
Each entry now bounds the number with the space-delimited token the prompt already mandates (`--json`, `--name-only`, `--body`), plus an exact match for the bare `gh pr diff <N>`, so the pin is number-exact and the "cannot redirect" comment in the workflow (and in docs/agents/agent-tooling.md) is accurate as written. Impact was low — worst case a bogus bot comment on a neighboring PR — but the fix is one line.
 
  ## Changes
  - `.github/workflows/architecture-check.yml` — bound each `allowedTools` `gh` entry with the trailing token the prompt instructs, and note in the comment why the trailing token is load-bearing