### PR TITLE
ci: move the arch-review concurrency group to the job level

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -12,10 +12,6 @@ on:
   pull_request_review_comment:
     types: [created]
 
-concurrency:
-  group: architecture-check-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true
-
 # GITHUB_TOKEN is only used by the checkout step; the review agent's gh
 # commands (pr view/diff/comment) run with the Claude GitHub App installation
 # token obtained via the OIDC exchange, so no pull-requests/issues scopes are
@@ -49,6 +45,14 @@ jobs:
           github.event.comment.author_association == 'OWNER'
         )
       )
+    # Job-level, not workflow-level: the verdict comment the agent posts is
+    # itself an issue_comment event, and a workflow-level group is entered
+    # before the `if` guard runs — so the bot-triggered run would cancel the
+    # in-progress review it was spawned by. A skipped job never enters a
+    # job-level group.
+    concurrency:
+      group: architecture-check-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
Every successful Architecture Check run ends marked "cancelled" (e.g. run 31180955615). The review agent posts its verdict comment with the Claude GitHub App token, so the comment fires a new `issue_comment` run of the same workflow. A workflow-level concurrency group is entered before the job-level `if` guard is evaluated, so that bot-triggered run cancels the in-progress review that spawned it and is then skipped by the guard. A job skipped by its `if` guard never enters a job-level concurrency group, so the group moves into the job — the placement claude-code-review.yml already uses. Behavior on a genuine re-trigger is unchanged: a new `@claude arch-review` comment still cancels the stale in progress run.

## Changes
- `.github/workflows/architecture-check.yml` — move the `concurrency` block from the workflow level into the `architecture-check` job