### PR TITLE
build(deps): bump @safe-global/safe-deployments to 1.37.62

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,3 +13,8 @@ yarnPath: .yarn/releases/yarn-4.14.1.cjs
 enableHardenedMode: true
 
 npmMinimalAgeGate: 10080 # minutes (7 days)
+
+# Exact in-house packages exempt from the age gate (deliberately not '@safe-global/*')
+npmPreapprovedPackages:
+  - '@safe-global/safe-deployments'
+  - '@safe-global/safe-modules-deployments'

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@nestjs/serve-static": "5.0.5",
     "@nestjs/swagger": "11.4.6",
     "@nestjs/typeorm": "11.0.3",
-    "@safe-global/safe-deployments": "1.37.58",
+    "@safe-global/safe-deployments": "1.37.62",
     "@safe-global/safe-modules-deployments": "3.0.8",
     "amqp-connection-manager": "5.0.0",
     "amqplib": "2.0.1",

--- a/src/__tests__/deployments.helper.spec.ts
+++ b/src/__tests__/deployments.helper.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 
 describe('Deployments helper', () => {
@@ -9,7 +10,7 @@ describe('Deployments helper', () => {
       );
 
       expect(versions).toStrictEqual({
-        '100': ['1.3.0', '1.4.1'],
+        '100': ['1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -21,7 +22,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.3.0', '1.4.1'],
+        '100': ['1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -45,7 +46,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.1.1', '1.3.0', '1.4.1'],
+        '100': ['1.1.1', '1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -57,7 +58,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.3.0', '1.4.1'],
+        '100': ['1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -69,7 +70,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1'],
+        '100': ['1.0.0', '1.1.1', '1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -81,7 +82,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1'],
+        '100': ['1.0.0', '1.1.1', '1.2.0', '1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -93,7 +94,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.3.0', '1.4.1'],
+        '100': ['1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -105,7 +106,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.4.1'],
+        '100': ['1.4.1', '1.5.0'],
         '11155111': ['1.4.1', '1.5.0'],
       });
     });
@@ -129,7 +130,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.4.1'],
+        '100': ['1.4.1', '1.5.0'],
         '11155111': ['1.4.1', '1.5.0'],
       });
     });
@@ -141,7 +142,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.3.0', '1.4.1'],
+        '100': ['1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });
@@ -153,7 +154,7 @@ describe('Deployments helper', () => {
       ]);
 
       expect(versions).toStrictEqual({
-        '100': ['1.3.0', '1.4.1'],
+        '100': ['1.3.0', '1.4.1', '1.5.0'],
         '11155111': ['1.3.0', '1.4.1', '1.5.0'],
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,12 +2012,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:1.37.58":
-  version: 1.37.58
-  resolution: "@safe-global/safe-deployments@npm:1.37.58"
+"@safe-global/safe-deployments@npm:1.37.62":
+  version: 1.37.62
+  resolution: "@safe-global/safe-deployments@npm:1.37.62"
   dependencies:
     semver: "npm:^7.6.2"
-  checksum: 10/2e2d895530e3eb60ababfd75634420df28ffaa8c166eaa0de027101348469aedf5b95efe20729500bd7d89cf1220119eb69f2d812510a33f218c386a7d787c90
+  checksum: 10/3a3f8128c0fe0e658b40f9462119159d9c335da4449199d622722f219fac0cc82cf50d2c3a399bbbcc04aa9639bc69418ad9bcb3636efb32b28e1e0183bf1a51
   languageName: node
   linkType: hard
 
@@ -6288,7 +6288,7 @@ __metadata:
     "@nestjs/swagger": "npm:11.4.6"
     "@nestjs/testing": "npm:11.1.28"
     "@nestjs/typeorm": "npm:11.0.3"
-    "@safe-global/safe-deployments": "npm:1.37.58"
+    "@safe-global/safe-deployments": "npm:1.37.62"
     "@safe-global/safe-modules-deployments": "npm:3.0.8"
     "@smithy/util-stream": "npm:4.7.16"
     "@swc/core": "npm:1.15.43"


### PR DESCRIPTION
## Summary

Bump the exact pin from 1.37.58 to 1.37.62, growing v1.5.0 deployment
coverage from 86 to 120 chains (adds Gnosis, Polygon, Arbitrum, Optimism,
Avalanche, zkSync Era, Linea, Mantle, among others). Part of the Safe 1.5.0
rollout (WA-2936).

This adds an `npmPreapprovedPackages` entry to `.yarnrc.yml`: 1.37.62 was
published inside the 7-day `npmMinimalAgeGate` window, so the pin is not
installable without an exemption. The list deliberately names the two
in-house packages this service consumes instead of `'@safe-global/*'`, so a
compromised org publish token gains no instant path into CI for every
package under the scope.

## Changes

- `package.json` / `yarn.lock` — `@safe-global/safe-deployments` 1.37.58 → 1.37.62
- `.yarnrc.yml` — age-gate exemption for the two in-house packages we consume
- `src/__tests__/deployments.helper.spec.ts` — per-chain version fixtures gain 1.5.0 on Gnosis (data change from the bump), plus the SPDX header the pre-commit hook requires on touched files
