### PR TITLE
feat: recognise the 1.5.0 ExtensibleFallbackHandler as official

### DIFF
--- a/src/domain/common/utils/__tests__/deployments.spec.ts
+++ b/src/domain/common/utils/__tests__/deployments.spec.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { getAddress } from 'viem';
+import {
+  getExtensibleFallbackHandlerVersions,
+  getFallbackHandlerVersions,
+  getSafeToL2SetupVersions,
+  isExtensibleFallbackHandlerDeployed,
+  isFallbackHandlerDeployed,
+} from '@/domain/common/utils/deployments';
+
+// Canonical 1.5.0 deployment addresses (identical across all chains)
+const EXTENSIBLE_FALLBACK_HANDLER_150 = getAddress(
+  '0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3',
+);
+const COMPATIBILITY_FALLBACK_HANDLER_150 = getAddress(
+  '0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4',
+);
+const MAINNET_CHAIN_ID = '1';
+
+describe('deployments', () => {
+  describe('getFallbackHandlerVersions', () => {
+    it('should include all CompatibilityFallbackHandler versions', () => {
+      expect(getFallbackHandlerVersions()).toEqual(
+        expect.arrayContaining(['1.3.0', '1.4.1', '1.5.0']),
+      );
+    });
+  });
+
+  describe('getExtensibleFallbackHandlerVersions', () => {
+    it('should include 1.5.0, the version the ExtensibleFallbackHandler was introduced in', () => {
+      expect(getExtensibleFallbackHandlerVersions()).toEqual(
+        expect.arrayContaining(['1.5.0']),
+      );
+    });
+  });
+
+  describe('getSafeToL2SetupVersions', () => {
+    it('should include all SafeToL2Setup versions', () => {
+      expect(getSafeToL2SetupVersions()).toEqual(
+        expect.arrayContaining(['1.4.1', '1.5.0']),
+      );
+    });
+  });
+
+  describe('isExtensibleFallbackHandlerDeployed', () => {
+    it('should return true for the canonical ExtensibleFallbackHandler deployment', () => {
+      expect(
+        isExtensibleFallbackHandlerDeployed({
+          chainId: MAINNET_CHAIN_ID,
+          version: '1.5.0',
+          address: EXTENSIBLE_FALLBACK_HANDLER_150,
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false for the CompatibilityFallbackHandler deployment', () => {
+      expect(
+        isExtensibleFallbackHandlerDeployed({
+          chainId: MAINNET_CHAIN_ID,
+          version: '1.5.0',
+          address: COMPATIBILITY_FALLBACK_HANDLER_150,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false for versions preceding the ExtensibleFallbackHandler', () => {
+      expect(
+        isExtensibleFallbackHandlerDeployed({
+          chainId: MAINNET_CHAIN_ID,
+          version: '1.4.1',
+          address: EXTENSIBLE_FALLBACK_HANDLER_150,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isFallbackHandlerDeployed', () => {
+    it('should not recognize the ExtensibleFallbackHandler as a CompatibilityFallbackHandler', () => {
+      expect(
+        isFallbackHandlerDeployed({
+          chainId: MAINNET_CHAIN_ID,
+          version: '1.5.0',
+          address: EXTENSIBLE_FALLBACK_HANDLER_150,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import {
+  getExtensibleFallbackHandlerDeployments as _getExtensibleFallbackHandlerDeployments,
   getCompatibilityFallbackHandlerDeployments as _getFallbackHandlerDeployments,
   getMultiSendCallOnlyDeployments as _getMultiSendCallOnlyDeployments,
   getMultiSendDeployments as _getMultiSendDeployments,
@@ -10,7 +11,11 @@ import {
   getSafeToL2MigrationDeployments as _getSafeToL2MigrationDeployments,
   getSafeToL2SetupDeployments as _getSafeToL2SetupDeployments,
 } from '@safe-global/safe-deployments';
-import { _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS } from '@safe-global/safe-deployments/dist/deployments';
+import {
+  _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS,
+  _EXTENSIBLE_FALLBACK_HANDLER_DEPLOYMENTS,
+  _SAFE_TO_L2_SETUP_DEPLOYMENTS,
+} from '@safe-global/safe-deployments/dist/deployments';
 import { getSafeWebAuthnSignerFactoryDeployment } from '@safe-global/safe-modules-deployments';
 import { type Address, getAddress, type parseAbi } from 'viem';
 
@@ -26,6 +31,7 @@ type DeploymentGetter =
   | typeof _getMultiSendCallOnlyDeployments
   | typeof _getMultiSendDeployments
   | typeof _getFallbackHandlerDeployments
+  | typeof _getExtensibleFallbackHandlerDeployments
   | typeof _getSafeToL2SetupDeployments
   | typeof _getSafeToL2MigrationDeployments;
 
@@ -122,6 +128,20 @@ export function getFallbackHandlerDeployments(args: Filter): Array<Address> {
 }
 
 /**
+ * Returns a list of official ExtensibleFallbackHandler addresses based on given {@link Filter}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @param {string} args.version - the version to filter deployments by
+ *
+ * @returns {Array<Address>} - a list of checksummed ExtensibleFallbackHandler addresses
+ */
+export function getExtensibleFallbackHandlerDeployments(
+  args: Filter,
+): Array<Address> {
+  return formatDeployments(_getExtensibleFallbackHandlerDeployments, args);
+}
+
+/**
  * Returns a list of official SafeToL2Migration addresses based on given {@link Filter}.
  *
  * @param {string} args.chainId - the chain ID to filter deployments by
@@ -190,6 +210,30 @@ export function getFallbackHandlerVersions(): Array<string> {
   return _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS.map(
     (deployment) => deployment.version,
   );
+}
+
+/**
+ * Gets the list of ExtensibleFallbackHandler versions available in the safe-deployments package.
+ * Infers versions from the _EXTENSIBLE_FALLBACK_HANDLER_DEPLOYMENTS constant exported by the package.
+ * Note: ExtensibleFallbackHandler was introduced in Safe v1.5.0.
+ *
+ * @returns {Array<string>} - a list of extensible fallback handler versions in descending order
+ */
+export function getExtensibleFallbackHandlerVersions(): Array<string> {
+  return _EXTENSIBLE_FALLBACK_HANDLER_DEPLOYMENTS.map(
+    (deployment) => deployment.version,
+  );
+}
+
+/**
+ * Gets the list of SafeToL2Setup versions available in the safe-deployments package.
+ * Infers versions from the _SAFE_TO_L2_SETUP_DEPLOYMENTS constant exported by the package.
+ * Note: SafeToL2Setup was introduced in Safe v1.4.1.
+ *
+ * @returns {Array<string>} - a list of SafeToL2Setup versions in descending order
+ */
+export function getSafeToL2SetupVersions(): Array<string> {
+  return _SAFE_TO_L2_SETUP_DEPLOYMENTS.map((deployment) => deployment.version);
 }
 
 /**
@@ -264,6 +308,13 @@ export const isProxyFactoryDeployed = (
 export const isFallbackHandlerDeployed = (
   args: Filter & { address: Address },
 ): boolean => isDeployed(getFallbackHandlerDeployments, args);
+
+/**
+ * Checks if a given address is deployed as an ExtensibleFallbackHandler.
+ */
+export const isExtensibleFallbackHandlerDeployed = (
+  args: Filter & { address: Address },
+): boolean => isDeployed(getExtensibleFallbackHandlerDeployments, args);
 
 /**
  * The SafeWebAuthnSignerFactory contract version supported by the relay.

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -135,9 +135,7 @@ export function getFallbackHandlerDeployments(args: Filter): Array<Address> {
  *
  * @returns {Array<Address>} - a list of checksummed ExtensibleFallbackHandler addresses
  */
-export function getExtensibleFallbackHandlerDeployments(
-  args: Filter,
-): Array<Address> {
+function getExtensibleFallbackHandlerDeployments(args: Filter): Array<Address> {
   return formatDeployments(_getExtensibleFallbackHandlerDeployments, args);
 }
 

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -135,7 +135,9 @@ export function getFallbackHandlerDeployments(args: Filter): Array<Address> {
  *
  * @returns {Array<Address>} - a list of checksummed ExtensibleFallbackHandler addresses
  */
-function getExtensibleFallbackHandlerDeployments(args: Filter): Array<Address> {
+export function getExtensibleFallbackHandlerDeployments(
+  args: Filter,
+): Array<Address> {
   return formatDeployments(_getExtensibleFallbackHandlerDeployments, args);
 }
 

--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
@@ -1279,6 +1279,57 @@ describe('ContractAnalysisService', () => {
         expect(mockDataDecoderApi.getContracts).toHaveBeenCalledTimes(1);
       });
 
+      it('should omit FALLBACK_HANDLER when handler is the official ExtensibleFallbackHandler', async () => {
+        const extensibleHandler = getAddress(
+          '0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3',
+        );
+        const mainnetChainId = '1';
+
+        const mockContractPage = pageBuilder()
+          .with('count', 1)
+          .with('results', [
+            contractBuilder()
+              .with('address', contractAddress)
+              .with('abi', {
+                abiJson: [{ type: 'function', name: 'test' }],
+                abiHash: faker.string.hexadecimal() as Hex,
+                modified: faker.date.recent(),
+              })
+              .with('displayName', name)
+              .with('logoUrl', logoUrl)
+              .build(),
+          ])
+          .build();
+
+        mockDataDecoderApi.getContracts.mockResolvedValue(
+          rawify(mockContractPage),
+        );
+
+        const result = await service.verifyContract({
+          chainId: mainnetChainId,
+          contract: {
+            address: contractAddress,
+            isDelegateCall: false,
+            fallbackHandler: extensibleHandler,
+          },
+        });
+
+        expect(result).toEqual({
+          logoUrl,
+          name,
+          CONTRACT_VERIFICATION: [
+            {
+              severity: SEVERITY_MAPPING.VERIFIED,
+              type: 'VERIFIED',
+              title: TITLE_MAPPING.VERIFIED,
+              description: DESCRIPTION_MAPPING.VERIFIED({ name }),
+            },
+          ],
+        });
+
+        expect(mockDataDecoderApi.getContracts).toHaveBeenCalledTimes(1);
+      });
+
       it('should omit FALLBACK_HANDLER when handler address is undefined', async () => {
         const mockContractPage = pageBuilder()
           .with('count', 1)

--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
@@ -8,6 +8,7 @@ import type { IConfigurationService } from '@/config/configuration.service.inter
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import { LogType } from '@/domain/common/entities/log-type.entity';
+import { getExtensibleFallbackHandlerDeployments } from '@/domain/common/utils/deployments';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import type { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
 import type { ITransactionApi } from '@/domain/interfaces/transaction-api.interface';
@@ -1280,10 +1281,13 @@ describe('ContractAnalysisService', () => {
       });
 
       it('should omit FALLBACK_HANDLER when handler is the official ExtensibleFallbackHandler', async () => {
-        const extensibleHandler = getAddress(
-          '0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3',
-        );
         const mainnetChainId = '1';
+        const extensibleHandler = faker.helpers.arrayElement(
+          getExtensibleFallbackHandlerDeployments({
+            chainId: mainnetChainId,
+            version: '1.5.0',
+          }),
+        );
 
         const mockContractPage = pageBuilder()
           .with('count', 1)

--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
@@ -1280,7 +1280,7 @@ describe('ContractAnalysisService', () => {
         expect(mockDataDecoderApi.getContracts).toHaveBeenCalledTimes(1);
       });
 
-      it('should omit FALLBACK_HANDLER when handler is the official ExtensibleFallbackHandler', async () => {
+      it('should return VERIFIED when the handler is the official ExtensibleFallbackHandler', async () => {
         const mainnetChainId = '1';
         const extensibleHandler = faker.helpers.arrayElement(
           getExtensibleFallbackHandlerDeployments({

--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.ts
@@ -8,7 +8,9 @@ import {
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import {
+  getExtensibleFallbackHandlerVersions,
   getFallbackHandlerVersions,
+  isExtensibleFallbackHandlerDeployed,
   isFallbackHandlerDeployed,
 } from '@/domain/common/utils/deployments';
 import { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
@@ -444,8 +446,13 @@ export class ContractAnalysisService {
     address: Address,
     chainId: string,
   ): boolean {
-    return getFallbackHandlerVersions().some((version) =>
-      isFallbackHandlerDeployed({ chainId, version, address }),
+    return (
+      getFallbackHandlerVersions().some((version) =>
+        isFallbackHandlerDeployed({ chainId, version, address }),
+      ) ||
+      getExtensibleFallbackHandlerVersions().some((version) =>
+        isExtensibleFallbackHandlerDeployed({ chainId, version, address }),
+      )
     );
   }
 

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.spec.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.spec.ts
@@ -1749,6 +1749,62 @@ describe('RecipientAnalysisService', () => {
       );
     });
 
+    it('should not return INCOMPATIBLE_SAFE for a 1.5.0 Safe created with the ExtensibleFallbackHandler', async () => {
+      const targetChainId = '11155111'; // Sepolia has canonical 1.5.0 deployments
+      const mockTxInfo = createMockTxInfo(mockSafeAddress, targetChainId);
+
+      mockTransactionApiManager.getApi.mockImplementation((chainId) => {
+        if (chainId === mockChainId) {
+          return Promise.resolve({
+            ...mockTransactionApi,
+            getSafe: vi.fn().mockResolvedValue(mockSourceSafe),
+          });
+        }
+        return Promise.resolve({
+          ...mockTransactionApi,
+          getSafe: vi.fn().mockResolvedValue(null),
+        });
+      });
+
+      const v150CreationTransaction = {
+        ...createMockCreationTransaction([mockSafeAddress], 1),
+        masterCopy: '0xFf51A5898e281Db6DfC7855790607438dF2ca44b' as Address, // Safe 1.5.0
+        factoryAddress: '0x14F2982D601c9458F93bd70B218933A6f8165e7b' as Address, // SafeProxyFactory 1.5.0
+      };
+      v150CreationTransaction.dataDecoded!.parameters =
+        v150CreationTransaction.dataDecoded!.parameters!.map((parameter) => {
+          if (parameter.name === 'fallbackHandler') {
+            // ExtensibleFallbackHandler 1.5.0
+            return {
+              ...parameter,
+              value: '0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3',
+            };
+          }
+          if (parameter.name === 'to') {
+            return { ...parameter, value: zeroAddress };
+          }
+          return parameter;
+        });
+      mockTransactionsService.getCreationTransaction.mockResolvedValue(
+        v150CreationTransaction,
+      );
+
+      mockChainsRepository.isSupportedChain.mockResolvedValue(true);
+      mockChainsRepository.getChain.mockResolvedValue(
+        chainBuilder().with('chainId', targetChainId).with('l2', false).build(),
+      );
+
+      const result = await service.analyzeBridge({
+        chainId: mockChainId,
+        safeAddress: mockSafeAddress,
+        txInfo: mockTxInfo,
+      });
+
+      expect(result[mockSafeAddress]?.BRIDGE?.[0]?.type).toBe(
+        'MISSING_OWNERSHIP',
+      );
+    });
+
     it('should return INCOMPATIBLE_SAFE for a 1.5.0 Safe when the target chain only has 1.4.1 deployments', async () => {
       // Deployment lookups hit the real safe-deployments data, so the chain
       // cannot be fully random: pick any chain with 1.4.1 but no 1.5.0 ones.

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.spec.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.spec.ts
@@ -9,6 +9,11 @@ import { getVersionsByChainIdByDeploymentMap } from '@/__tests__/deployments.hel
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
 import { CacheRouter } from '@/datasources/cache/cache.router';
+import {
+  getExtensibleFallbackHandlerDeployments,
+  getProxyFactoryDeployments,
+  getSafeSingletonDeployments,
+} from '@/domain/common/utils/deployments';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import type { Page } from '@/domain/entities/page.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
@@ -1750,7 +1755,20 @@ describe('RecipientAnalysisService', () => {
     });
 
     it('should not return INCOMPATIBLE_SAFE for a 1.5.0 Safe created with the ExtensibleFallbackHandler', async () => {
-      const targetChainId = '11155111'; // Sepolia has canonical 1.5.0 deployments
+      // Deployment lookups hit the real safe-deployments data, so the chain
+      // cannot be fully random: pick any chain with canonical 1.5.0 deployments.
+      const versionsByChainId = getVersionsByChainIdByDeploymentMap();
+      const targetChainId = faker.helpers.arrayElement(
+        Object.keys(versionsByChainId.Safe).filter(
+          (chainId) =>
+            chainId !== mockChainId &&
+            !!versionsByChainId.Safe[chainId]?.includes('1.5.0') &&
+            !!versionsByChainId.ProxyFactory[chainId]?.includes('1.5.0') &&
+            !!versionsByChainId.ExtensibleFallbackHandler[chainId]?.includes(
+              '1.5.0',
+            ),
+        ),
+      );
       const mockTxInfo = createMockTxInfo(mockSafeAddress, targetChainId);
 
       mockTransactionApiManager.getApi.mockImplementation((chainId) => {
@@ -1768,16 +1786,31 @@ describe('RecipientAnalysisService', () => {
 
       const v150CreationTransaction = {
         ...createMockCreationTransaction([mockSafeAddress], 1),
-        masterCopy: '0xFf51A5898e281Db6DfC7855790607438dF2ca44b' as Address, // Safe 1.5.0
-        factoryAddress: '0x14F2982D601c9458F93bd70B218933A6f8165e7b' as Address, // SafeProxyFactory 1.5.0
+        masterCopy: faker.helpers.arrayElement(
+          getSafeSingletonDeployments({
+            chainId: targetChainId,
+            version: '1.5.0',
+          }),
+        ),
+        factoryAddress: faker.helpers.arrayElement(
+          getProxyFactoryDeployments({
+            chainId: targetChainId,
+            version: '1.5.0',
+          }),
+        ),
       };
+      const extensibleFallbackHandler = faker.helpers.arrayElement(
+        getExtensibleFallbackHandlerDeployments({
+          chainId: targetChainId,
+          version: '1.5.0',
+        }),
+      );
       v150CreationTransaction.dataDecoded!.parameters =
         v150CreationTransaction.dataDecoded!.parameters!.map((parameter) => {
           if (parameter.name === 'fallbackHandler') {
-            // ExtensibleFallbackHandler 1.5.0
             return {
               ...parameter,
-              value: '0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3',
+              value: extensibleFallbackHandler,
             };
           }
           if (parameter.name === 'to') {
@@ -1800,9 +1833,13 @@ describe('RecipientAnalysisService', () => {
         txInfo: mockTxInfo,
       });
 
-      expect(result[mockSafeAddress]?.BRIDGE?.[0]?.type).toBe(
-        'MISSING_OWNERSHIP',
+      const bridgeResultTypes = result[mockSafeAddress]?.BRIDGE?.map(
+        ({ type }) => type,
       );
+      expect(bridgeResultTypes).not.toContain('INCOMPATIBLE_SAFE');
+      // The compatible Safe does not exist on the target chain, so the
+      // analysis proceeds past the compatibility check to the ownership one.
+      expect(bridgeResultTypes).toEqual(['MISSING_OWNERSHIP']);
     });
 
     it('should return INCOMPATIBLE_SAFE for a 1.5.0 Safe when the target chain only has 1.4.1 deployments', async () => {

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
@@ -9,8 +9,10 @@ import {
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import {
+  getSafeToL2SetupVersions,
   hasCanonicalDeploymentSafeToL2Migration,
   hasCanonicalDeploymentSafeToL2Setup,
+  isExtensibleFallbackHandlerDeployed,
   isFallbackHandlerDeployed,
   isL1SingletonDeployed,
   isL2SingletonDeployed,
@@ -673,21 +675,29 @@ export class RecipientAnalysisService {
       address: safeCreationData.factoryAddress,
     });
 
-    const fallbackHandlerExists = isFallbackHandlerDeployed({
-      version,
-      chainId: chain.chainId,
-      address: safeCreationData.safeAccountConfig.fallbackHandler,
-    });
+    const fallbackHandlerExists =
+      isFallbackHandlerDeployed({
+        version,
+        chainId: chain.chainId,
+        address: safeCreationData.safeAccountConfig.fallbackHandler,
+      }) ||
+      isExtensibleFallbackHandlerDeployed({
+        version,
+        chainId: chain.chainId,
+        address: safeCreationData.safeAccountConfig.fallbackHandler,
+      });
 
     const includesSetupToL2 =
       safeCreationData.safeAccountConfig.to !== zeroAddress;
 
     const areSetupToL2ConditionsMet =
       !includesSetupToL2 ||
-      hasCanonicalDeploymentSafeToL2Setup({
-        chainId: chain.chainId,
-        version: '1.4.1',
-      });
+      getSafeToL2SetupVersions().some((setupVersion) =>
+        hasCanonicalDeploymentSafeToL2Setup({
+          chainId: chain.chainId,
+          version: setupVersion,
+        }),
+      );
 
     const isMigrationRequired = isL2Singleton && !includesSetupToL2 && chain.l2;
 


### PR DESCRIPTION
## Summary

WA-2921 / WA-2862

Safe 1.5.0 ships **two** official fallback handlers, but our trust checks only consulted the `CompatibilityFallbackHandler` deployment tables — so the official `ExtensibleFallbackHandler` (canonical `0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3` on 120 chains, v1.5.0) was treated as untrusted everywhere:

- **Safe Shield contract analysis**: a `setFallbackHandler(0x85a8…42c3)` transaction produced an `UNOFFICIAL_FALLBACK_HANDLER` WARN on every chain. Reproducible on staging today against any Sepolia Safe — the same result that flags the handler as unofficial also names it via the Decoder Service:

  ```json
  {
    "severity": "WARN",
    "type": "UNOFFICIAL_FALLBACK_HANDLER",
    "title": "Unofficial fallback handler",
    "fallbackHandler": {
      "address": "0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3",
      "name": "Safe: ExtensibleFallbackHandler 1.5.0"
    }
  }
  ```

- **Safe Shield recipient analysis**: a Safe *created* with the extensible handler failed the `fallbackHandlerExists` leg of `checkVersionCompatibility`, so bridge analysis reported `INCOMPATIBLE_SAFE` on every target chain.
- Same code path: the `SafeToL2Setup` existence check was pinned to `'1.4.1'`, so chains that only register the 1.5.0 setup contract would also be reported incompatible.

The fix derives everything from `@safe-global/safe-deployments` (no hardcoded addresses): new `ExtensibleFallbackHandler` wrappers in the deployments util, OR'd into both checks, and the `SafeToL2Setup` versions derived from the package instead of pinned.

Product context: creation/upgrade keeps setting the `CompatibilityFallbackHandler` (WA-2928 decides any change to that) — this PR is recognition-only, so users whose handler is the extensible one (CoW composable orders, module/policy setups) stop getting false warnings.

## Changes

- `src/domain/common/utils/deployments.ts` — add `getExtensibleFallbackHandlerDeployments` / `getExtensibleFallbackHandlerVersions` / `isExtensibleFallbackHandlerDeployed` (mirroring the existing compat wrappers) and `getSafeToL2SetupVersions`
- `src/modules/safe-shield/contract-analysis/contract-analysis.service.ts` — `isOfficialFallbackHandler` now also matches extensible deployments
- `src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts` — `fallbackHandlerExists` also matches extensible deployments; `SafeToL2Setup` check iterates the package's versions (1.4.1 + 1.5.0) instead of pinning `'1.4.1'`
- `src/domain/common/utils/__tests__/deployments.spec.ts` — new spec for the added wrappers, incl. the negative case (compat tables do **not** match the extensible address)
- `contract-analysis.service.spec.ts` / `recipient-analysis.service.spec.ts` — cases for `setFallbackHandler(extensible)` producing no warning, and an extensible-created 1.5.0 Safe no longer reported `INCOMPATIBLE_SAFE`