### PR TITLE
fix(balances): serve only currencies the positions provider supports

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -126,6 +126,7 @@ export default () => ({
         assetsApiKey:
           process.env.ZERION_ASSETS_API_KEY ?? process.env.ZERION_API_KEY,
         baseUri: process.env.ZERION_BASE_URI || 'https://api.zerion.io',
+        // Also the source of truth for /v1/balances/supported-fiat-codes.
         currencies: [
           'USD',
           'EUR',

--- a/src/modules/balances/datasources/balances-api.manager.spec.ts
+++ b/src/modules/balances/datasources/balances-api.manager.spec.ts
@@ -53,10 +53,16 @@ const networkService = {
 
 const networkServiceMock = vi.mocked(networkService);
 
+const fiatCodes = Array.from(
+  { length: faker.number.int({ min: 2, max: 5 }) },
+  () => faker.finance.currencyCode(),
+);
+
 beforeEach(() => {
   vi.resetAllMocks();
   configurationServiceMock.getOrThrow.mockImplementation((key) => {
     if (key === 'safeTransaction.useVpcUrl') return false;
+    if (key === 'balances.providers.zerion.currencies') return fiatCodes;
     // TODO: Remove after Vault decoding has been released
     if (key === 'application.isProduction') return true;
   });
@@ -116,6 +122,7 @@ describe('Balances API Manager Tests', () => {
       const notFoundExpireTimeSeconds = faker.number.int();
       configurationServiceMock.getOrThrow.mockImplementation((key) => {
         if (key === 'safeTransaction.useVpcUrl') return useVpcUrl;
+        if (key === 'balances.providers.zerion.currencies') return fiatCodes;
         if (key === 'expirationTimeInSeconds.default')
           return expirationTimeInSeconds;
         if (key === 'expirationTimeInSeconds.notFound.default')
@@ -166,8 +173,7 @@ describe('Balances API Manager Tests', () => {
   });
 
   describe('getFiatCodes checks', () => {
-    it('should return Safe balances supported currencies', async () => {
-      coingeckoApiMock.getFiatCodes.mockResolvedValue(rawify(['EUR', 'GBP']));
+    it('should return the configured Zerion currencies', async () => {
       const manager = new BalancesApiManager(
         configurationService,
         configApiMock,
@@ -180,7 +186,23 @@ describe('Balances API Manager Tests', () => {
 
       const result = await manager.getFiatCodes();
 
-      expect(result).toStrictEqual(['EUR', 'GBP']);
+      expect(result).toStrictEqual(fiatCodes);
+    });
+
+    it('should not query CoinGecko for the supported currencies', async () => {
+      const manager = new BalancesApiManager(
+        configurationService,
+        configApiMock,
+        dataSourceMock,
+        cacheService,
+        httpErrorFactory,
+        coingeckoApiMock,
+        networkServiceMock,
+      );
+
+      await manager.getFiatCodes();
+
+      expect(coingeckoApiMock.getFiatCodes).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/balances/datasources/balances-api.manager.spec.ts
+++ b/src/modules/balances/datasources/balances-api.manager.spec.ts
@@ -173,7 +173,7 @@ describe('Balances API Manager Tests', () => {
   });
 
   describe('getFiatCodes checks', () => {
-    it('should return the configured Zerion currencies', async () => {
+    it('should return the configured Zerion currencies without querying CoinGecko', async () => {
       const manager = new BalancesApiManager(
         configurationService,
         configApiMock,
@@ -187,21 +187,6 @@ describe('Balances API Manager Tests', () => {
       const result = await manager.getFiatCodes();
 
       expect(result).toStrictEqual(fiatCodes);
-    });
-
-    it('should not query CoinGecko for the supported currencies', async () => {
-      const manager = new BalancesApiManager(
-        configurationService,
-        configApiMock,
-        dataSourceMock,
-        cacheService,
-        httpErrorFactory,
-        coingeckoApiMock,
-        networkServiceMock,
-      );
-
-      await manager.getFiatCodes();
-
       expect(coingeckoApiMock.getFiatCodes).not.toHaveBeenCalled();
     });
   });

--- a/src/modules/balances/datasources/balances-api.manager.ts
+++ b/src/modules/balances/datasources/balances-api.manager.ts
@@ -18,7 +18,7 @@ import { IConfigApi } from '@/domain/interfaces/config-api.interface';
 import { IPricesApi } from '@/modules/balances/datasources/prices-api.interface';
 import { SafeBalancesApi } from '@/modules/balances/datasources/safe-balances-api.service';
 import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
-import type { Raw } from '@/validation/entities/raw.entity';
+import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 @Injectable()
 export class BalancesApiManager
@@ -26,6 +26,7 @@ export class BalancesApiManager
   implements IBalancesApiManager
 {
   private readonly useVpcUrl: boolean;
+  private readonly fiatCodes: Array<string>;
 
   constructor(
     @Inject(IConfigurationService)
@@ -41,14 +42,21 @@ export class BalancesApiManager
     this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
       'safeTransaction.useVpcUrl',
     );
+    this.fiatCodes = this.configurationService.getOrThrow<Array<string>>(
+      'balances.providers.zerion.currencies',
+    );
   }
 
   getApi(chainId: string): Promise<IBalancesApi> {
     return this.getOrCreateApi(chainId);
   }
 
+  /**
+   * Returns `balances.providers.zerion.currencies`, not CoinGecko's wider
+   * `simple/supported_vs_currencies`.
+   */
   getFiatCodes(): Promise<Raw<Array<string>>> {
-    return this.coingeckoApi.getFiatCodes();
+    return Promise.resolve(rawify(this.fiatCodes));
   }
 
   protected async createApi(chainId: string): Promise<SafeBalancesApi> {

--- a/src/modules/balances/datasources/balances-api.manager.ts
+++ b/src/modules/balances/datasources/balances-api.manager.ts
@@ -56,7 +56,7 @@ export class BalancesApiManager
    * `simple/supported_vs_currencies`.
    */
   getFiatCodes(): Promise<Raw<Array<string>>> {
-    return Promise.resolve(rawify(this.fiatCodes));
+    return Promise.resolve(rawify([...this.fiatCodes]));
   }
 
   protected async createApi(chainId: string): Promise<SafeBalancesApi> {

--- a/src/modules/balances/routes/balances.controller.integration.spec.ts
+++ b/src/modules/balances/routes/balances.controller.integration.spec.ts
@@ -28,6 +28,7 @@ describe('Balances Controller', () => {
   let app: INestApplication<Server>;
   let safeConfigUrl: string;
   let pricesProviderUrl: string;
+  let zerionCurrencies: Array<string>;
   let networkService: MockedObject<INetworkService>;
 
   beforeEach(async () => {
@@ -41,6 +42,9 @@ describe('Balances Controller', () => {
     safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
     pricesProviderUrl = configurationService.getOrThrow(
       'balances.providers.safe.prices.baseUri',
+    );
+    zerionCurrencies = configurationService.getOrThrow(
+      'balances.providers.zerion.currencies',
     );
     networkService = moduleFixture.get(NetworkService);
 
@@ -870,69 +874,24 @@ describe('Balances Controller', () => {
   });
 
   describe('GET /balances/supported-fiat-codes', () => {
-    it("should return supported fiat codes from the prices provider (assuming provider's response contains lowercase codes)", async () => {
-      const chain = chainBuilder().build();
-      const pricesProviderFiatCodes = ['usd', 'eth', 'eur'];
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/1`:
-            return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({
-              data: rawify(pricesProviderFiatCodes),
-              status: 200,
-            });
-          default:
-            return Promise.reject(new Error(`Could not match ${url}`));
-        }
-      });
-
+    it('should return the currencies the positions provider supports', async () => {
       await request(app.getHttpServer())
         .get('/v1/balances/supported-fiat-codes')
         .expect(200)
-        .expect(['USD', 'ETH', 'EUR']);
+        .expect(zerionCurrencies);
     });
 
-    it("should return supported fiat codes from the prices provider (assuming provider's response contains uppercase codes)", async () => {
-      const chain = chainBuilder().build();
-      const pricesProviderFiatCodes = ['USD', 'ETH'];
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/1`:
-            return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.resolve({
-              data: rawify(pricesProviderFiatCodes),
-              status: 200,
-            });
-          default:
-            return Promise.reject(new Error(`Could not match ${url}`));
-        }
-      });
+    it('should not depend on the prices provider', async () => {
+      networkService.get.mockImplementation(({ url }) =>
+        Promise.reject(new Error(`Could not match ${url}`)),
+      );
 
       await request(app.getHttpServer())
         .get('/v1/balances/supported-fiat-codes')
         .expect(200)
-        .expect(['USD', 'ETH']);
-    });
+        .expect(zerionCurrencies);
 
-    it('should get an empty array of fiat currencies on failure', async () => {
-      const chain = chainBuilder().build();
-      networkService.get.mockImplementation(({ url }) => {
-        switch (url) {
-          case `${safeConfigUrl}/api/v1/chains/1`:
-            return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${pricesProviderUrl}/simple/supported_vs_currencies`:
-            return Promise.reject(new Error());
-          default:
-            return Promise.reject(new Error(`Could not match ${url}`));
-        }
-      });
-
-      await request(app.getHttpServer())
-        .get('/v1/balances/supported-fiat-codes')
-        .expect(200)
-        .expect([]);
+      expect(networkService.get).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

WA-3157

`/v1/balances/supported-fiat-codes` returned CoinGecko's `simple/supported_vs_currencies` verbatim — 63 codes today, of which only 16 work end to end. Clients populate their currency selector from this endpoint, so the extra 47 are all selectable and each breaks something:

- `LINK`, `BITS` and `SATS` are not well-formed ISO 4217 codes, so `Intl.NumberFormat({ style: 'currency' })` throws `RangeError: Invalid currency code`. On web that throws while rendering every fiat value, and the selection is persisted — so a reload reproduces it.
- The remaining ~44 (`BRL`, `MXN`, `SEK`, `XAU`, …) are accepted by the balances path, since prices come from CoinGecko, but `ZerionPositionsApi` rejects any code outside `balances.providers.zerion.currencies` with a 400. Positions silently fail while token balances still render.

Zerion is the narrowest constraint in the stack, and all 16 of its codes are in CoinGecko's list, so the intersection is exactly the Zerion list. The endpoint now returns that config value directly rather than intersecting the two: the constraint is Zerion's, and `CoingeckoApi.getFiatCodes()` swallows errors and returns `[]`, so intersecting would empty the currency selector during a CoinGecko outage. Dropping the dependency removes that failure mode — the new integration test asserts the endpoint still answers when the prices provider is entirely unreachable.

Narrowing the advertised list is a deliberate regression for anyone who has `BRL`, `MXN` or another CoinGecko-only fiat selected today: balances stop being denominated in it, and their selector shows no match until they pick again. That is accepted — those users' positions are already broken, and serving positions in USD alongside balances in BRL would be a mixed-currency UI.

This leaves the CoinGecko fiat-codes path with no callers. It is not deleted here to keep this fix to one concern; WA-3158 tracks removing it.

## Changes

- `src/modules/balances/datasources/balances-api.manager.ts` — `getFiatCodes()` returns `balances.providers.zerion.currencies`, read via `getOrThrow` in the constructor, instead of delegating to `CoingeckoApi`
- `src/config/entities/configuration.ts` — note that the list is also the source of truth for the endpoint, so it is not widened past what Zerion accepts
- `src/modules/balances/datasources/balances-api.manager.spec.ts` — assert against the configured codes and that CoinGecko is not queried; the `vpcUrl` case gains the new config key, as its mock throws on unexpected keys
- `src/modules/balances/routes/balances.controller.integration.spec.ts` — replace the three CoinGecko-passthrough cases (lowercase, uppercase, empty-on-failure) with the configured-codes response and the prices-provider-outage case
