### PR TITLE
ci: sync releases to the Linear release pipeline

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   linear-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # A hung sync should fail today, not in six hours
     permissions:
       contents: read
 
@@ -50,11 +51,6 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ -z "$RELEASE_TAG" ]; then
-            echo "::error::Release tag is empty; refusing to sync an untagged release."
-            exit 1
-          fi
-
           # Linear versions its releases without the tag's `v` prefix.
           echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
           echo "Linear release ${RELEASE_TAG#v} (tag $RELEASE_TAG)"

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -4,14 +4,16 @@ name: Linear Release
 
 # Syncs Client Gateway releases to the continuous "CGW" pipeline in Linear.
 #
-# Automated path: publishing a GitHub release (tag `vX.Y.Z`) runs `sync`, which
-# scans the commits since the last release for Linear issue IDs, attaches them,
-# links the GitHub release, and completes it in one step - continuous pipelines
+# Publishing a GitHub release (tag `vX.Y.Z`) runs `sync`, which scans the
+# commits since the last release for Linear issue IDs, attaches them, links the
+# GitHub release, and completes it in one step - continuous pipelines
 # auto-complete, so there is no separate `complete` call and no stage to move
-# between. The step is guarded so a Linear outage never fails a shipped release.
+# between.
 #
-# Manual path: `workflow_dispatch` is the backfill / repair tool - re-sync a
-# release, or preview the result with dry_run.
+# The sync fails loudly rather than fail-open: if Linear is unreachable or the
+# key is rejected, this run goes red and is re-run from the Actions UI. It
+# publishes nothing itself, so a red run here never blocks or reverts a release
+# that has already shipped.
 #
 # Setup: add the pipeline access key as the `LINEAR_ACCESS_KEY` repository
 # secret (Settings -> Secrets and variables -> Actions). This must be a pipeline
@@ -21,101 +23,46 @@ name: Linear Release
 on:
   release:
     types: [released]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version (e.g. 1.122.0 or v1.122.0) - defaults to the latest published GitHub release'
-        required: false
-        type: string
-      dry_run:
-        description: 'Preview the action without modifying Linear'
-        required: false
-        type: boolean
-        default: false
 
 permissions: {}
 
 concurrency:
-  group: linear-release-${{ github.event.release.tag_name || inputs.version || github.ref }}
+  group: linear-release-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
-  # One job for both triggers: the continuous pipeline needs a single `sync`
-  # either way, so the paths differ only in where the version comes from and in
-  # whether a failure is allowed to surface.
   linear-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      # Resolved before checkout, because the tag it produces is what gets
-      # checked out. `gh api` needs no working copy.
-      - name: Resolve release
+      # Checks out the release tag itself, so the commit scan covers that
+      # release's history rather than whatever main happens to be at.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
         id: release
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          INPUT_VERSION: ${{ inputs.version }}
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
         run: |
-          if [ -n "$RELEASE_TAG" ]; then
-            # The tag that was actually published is ground truth, so it is
-            # taken as-is - a shipped release must never be rejected here.
-            TAG="$RELEASE_TAG"
-          elif [ -n "$INPUT_VERSION" ]; then
-            # Human-typed, so it is checked before a typo becomes a junk
-            # release in Linear that someone has to clean up by hand.
-            CANDIDATE="${INPUT_VERSION#v}"
-            if ! [[ "$CANDIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::error::Invalid version '$INPUT_VERSION'. Expected X.Y.Z, e.g. 1.122.0."
-              exit 1
-            fi
-            TAG="v$CANDIDATE"
-          else
-            TAG=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
-          fi
-
-          if [ -z "$TAG" ]; then
-            echo "::error::Could not resolve a release tag. Pass a version explicitly."
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "::error::Release tag is empty; refusing to sync an untagged release."
             exit 1
           fi
 
           # Linear versions its releases without the tag's `v` prefix.
-          VERSION="${TAG#v}"
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Linear release ${RELEASE_TAG#v} (tag $RELEASE_TAG)"
 
-          # Both paths attach the same link: the release event already carries
-          # the URL, a manual run looks it up by tag.
-          URL="$RELEASE_URL"
-          if [ -z "$URL" ]; then
-            URL=$(gh api "repos/$REPO/releases/tags/$TAG" --jq '.html_url' || true)
-          fi
-
-          {
-            echo "version=$VERSION"
-            echo "tag=$TAG"
-            echo "url=$URL"
-          } >> "$GITHUB_OUTPUT"
-          echo "Linear release $VERSION (tag $TAG)"
-
-      # Checks out the release tag rather than the branch the run was launched
-      # from, so a backfill scans that release's history and not main's.
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: refs/tags/${{ steps.release.outputs.tag }}
-          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
-
-      # Fail-open on the automated path only: the release has already shipped by
-      # the time this runs, so Linear must never be able to turn it red. A manual
-      # run fails loudly, because someone is watching and wants to know it no-oped.
       - name: Sync release to Linear
-        continue-on-error: ${{ github.event_name == 'release' }}
         uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync
           version: ${{ steps.release.outputs.version }}
-          links: ${{ steps.release.outputs.url }}
-          dry_run: ${{ inputs.dry_run || false }}
+          links: ${{ github.event.release.html_url }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+name: Linear Release
+
+# Syncs Client Gateway releases to the scheduled release pipeline in Linear.
+#
+# Automated path: publishing a GitHub release (tag `vX.Y.Z`) runs `sync` to
+# attach the issues shipped since the last release, then `complete` to mark the
+# Linear release as Released, which auto-generates its release notes. Both steps
+# are guarded so a Linear outage never fails a shipped release.
+#
+# Manual path: `workflow_dispatch` is the backfill / repair tool - re-sync a
+# release, move it between stages, or preview the result with dry_run.
+#
+# Setup: add the pipeline access key as the `LINEAR_ACCESS_KEY` repository
+# secret (Settings -> Secrets and variables -> Actions). This must be a pipeline
+# access key generated from the pipeline settings in Linear, not a personal API
+# key. Without the secret both jobs no-op on the automated path and fail loudly
+# on the manual one.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.122.0 or v1.122.0) - defaults to the latest published GitHub release'
+        required: false
+        type: string
+      command:
+        description: 'Linear release command'
+        required: true
+        type: choice
+        default: sync
+        options:
+          - sync
+          - update
+          - complete
+      stage:
+        description: 'Deployment stage (required for the "update" command, e.g. In Progress)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Preview the action without modifying Linear'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: linear-release-${{ github.event.release.tag_name || inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Automated path: a published GitHub release closes out the matching Linear
+  # release. Every step is fail-open - the release has already shipped by the
+  # time this runs, so Linear must never be able to turn it red.
+  release-published:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Linear releases are versioned without the tag's `v` prefix, matching
+          # the Wallet and Mobile pipelines.
+          VERSION="${RELEASE_TAG#v}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Release tag is empty; cannot resolve a Linear release version."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Linear release version: $VERSION"
+
+      - name: Sync release to Linear
+        continue-on-error: true
+        uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          version: ${{ steps.version.outputs.version }}
+          links: ${{ github.event.release.html_url }}
+
+      - name: Complete Linear release
+        continue-on-error: true
+        uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ steps.version.outputs.version }}
+
+  # Manual path: backfill or repair. Unlike the automated job this one fails
+  # loudly, because a human is watching the run and wants to know it did nothing.
+  manual:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Validate inputs
+        env:
+          INPUT_COMMAND: ${{ inputs.command }}
+          INPUT_STAGE: ${{ inputs.stage }}
+        run: |
+          if [ "$INPUT_COMMAND" = "update" ] && [ -z "$INPUT_STAGE" ]; then
+            echo "::error::The \"update\" command requires a stage (e.g. In Progress)."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
+          fi
+
+          # Accept `v1.122.0` or `1.122.0` so the tag can be pasted verbatim.
+          VERSION="${VERSION#v}"
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve a release version. Pass one explicitly."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Linear release version: $VERSION"
+
+      - name: Run Linear release (${{ inputs.command }})
+        uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: ${{ inputs.command }}
+          version: ${{ steps.version.outputs.version }}
+          stage: ${{ inputs.stage }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -2,21 +2,21 @@
 
 name: Linear Release
 
-# Syncs Client Gateway releases to the scheduled release pipeline in Linear.
+# Syncs Client Gateway releases to the continuous "CGW" pipeline in Linear.
 #
-# Automated path: publishing a GitHub release (tag `vX.Y.Z`) runs `sync` to
-# attach the issues shipped since the last release, then `complete` to mark the
-# Linear release as Released, which auto-generates its release notes. Both steps
-# are guarded so a Linear outage never fails a shipped release.
+# Automated path: publishing a GitHub release (tag `vX.Y.Z`) runs `sync`, which
+# scans the commits since the last release for Linear issue IDs, attaches them,
+# links the GitHub release, and completes it in one step - continuous pipelines
+# auto-complete, so there is no separate `complete` call and no stage to move
+# between. The step is guarded so a Linear outage never fails a shipped release.
 #
 # Manual path: `workflow_dispatch` is the backfill / repair tool - re-sync a
-# release, move it between stages, or preview the result with dry_run.
+# release, or preview the result with dry_run.
 #
 # Setup: add the pipeline access key as the `LINEAR_ACCESS_KEY` repository
 # secret (Settings -> Secrets and variables -> Actions). This must be a pipeline
 # access key generated from the pipeline settings in Linear, not a personal API
-# key. Without the secret both jobs no-op on the automated path and fail loudly
-# on the manual one.
+# key.
 
 on:
   release:
@@ -25,19 +25,6 @@ on:
     inputs:
       version:
         description: 'Release version (e.g. 1.122.0 or v1.122.0) - defaults to the latest published GitHub release'
-        required: false
-        type: string
-      command:
-        description: 'Linear release command'
-        required: true
-        type: choice
-        default: sync
-        options:
-          - sync
-          - update
-          - complete
-      stage:
-        description: 'Deployment stage (required for the "update" command, e.g. In Progress)'
         required: false
         type: string
       dry_run:
@@ -53,11 +40,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Automated path: a published GitHub release closes out the matching Linear
-  # release. Every step is fail-open - the release has already shipped by the
-  # time this runs, so Linear must never be able to turn it red.
-  release-published:
-    if: github.event_name == 'release'
+  # One job for both triggers: the continuous pipeline needs a single `sync`
+  # either way, so the paths differ only in where the version comes from and in
+  # whether a failure is allowed to surface.
+  linear-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -66,79 +52,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.ref }}
           fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
 
       - name: Resolve release version
         id: version
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          # Linear releases are versioned without the tag's `v` prefix, matching
-          # the Wallet and Mobile pipelines.
-          VERSION="${RELEASE_TAG#v}"
-          if [ -z "$VERSION" ]; then
-            echo "::error::Release tag is empty; cannot resolve a Linear release version."
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Linear release version: $VERSION"
-
-      - name: Sync release to Linear
-        continue-on-error: true
-        uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
-          command: sync
-          version: ${{ steps.version.outputs.version }}
-          links: ${{ github.event.release.html_url }}
-
-      - name: Complete Linear release
-        continue-on-error: true
-        uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
-          command: complete
-          version: ${{ steps.version.outputs.version }}
-
-  # Manual path: backfill or repair. Unlike the automated job this one fails
-  # loudly, because a human is watching the run and wants to know it did nothing.
-  manual:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Validate inputs
-        env:
-          INPUT_COMMAND: ${{ inputs.command }}
-          INPUT_STAGE: ${{ inputs.stage }}
-        run: |
-          if [ "$INPUT_COMMAND" = "update" ] && [ -z "$INPUT_STAGE" ]; then
-            echo "::error::The \"update\" command requires a stage (e.g. In Progress)."
-            exit 1
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
-
-      - name: Resolve release version
-        id: version
-        env:
           INPUT_VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
+          if [ -n "$RELEASE_TAG" ]; then
+            VERSION="$RELEASE_TAG"
+          elif [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
           else
             VERSION=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
           fi
 
-          # Accept `v1.122.0` or `1.122.0` so the tag can be pasted verbatim.
+          # Linear releases are versioned without the tag's `v` prefix. Stripping
+          # it here also lets the manual input be pasted verbatim from the tag.
           VERSION="${VERSION#v}"
 
           if [ -z "$VERSION" ]; then
@@ -148,11 +82,15 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Linear release version: $VERSION"
 
-      - name: Run Linear release (${{ inputs.command }})
+      # Fail-open on the automated path only: the release has already shipped by
+      # the time this runs, so Linear must never be able to turn it red. A manual
+      # run fails loudly, because someone is watching and wants to know it no-oped.
+      - name: Sync release to Linear
+        continue-on-error: ${{ github.event_name == 'release' }}
         uses: linear/linear-release-action@3858a5d7892435dc63302ac76b0cdb587435caa9 # v0.14.6
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
-          command: ${{ inputs.command }}
+          command: sync
           version: ${{ steps.version.outputs.version }}
-          stage: ${{ inputs.stage }}
+          links: ${{ github.event.release.html_url }}
           dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -49,38 +49,63 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.release.tag_name || github.ref }}
-          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
-
-      - name: Resolve release version
-        id: version
+      # Resolved before checkout, because the tag it produces is what gets
+      # checked out. `gh api` needs no working copy.
+      - name: Resolve release
+        id: release
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
           INPUT_VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           if [ -n "$RELEASE_TAG" ]; then
-            VERSION="$RELEASE_TAG"
+            # The tag that was actually published is ground truth, so it is
+            # taken as-is - a shipped release must never be rejected here.
+            TAG="$RELEASE_TAG"
           elif [ -n "$INPUT_VERSION" ]; then
-            VERSION="$INPUT_VERSION"
+            # Human-typed, so it is checked before a typo becomes a junk
+            # release in Linear that someone has to clean up by hand.
+            CANDIDATE="${INPUT_VERSION#v}"
+            if ! [[ "$CANDIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid version '$INPUT_VERSION'. Expected X.Y.Z, e.g. 1.122.0."
+              exit 1
+            fi
+            TAG="v$CANDIDATE"
           else
-            VERSION=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
+            TAG=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
           fi
 
-          # Linear releases are versioned without the tag's `v` prefix. Stripping
-          # it here also lets the manual input be pasted verbatim from the tag.
-          VERSION="${VERSION#v}"
-
-          if [ -z "$VERSION" ]; then
-            echo "::error::Could not resolve a release version. Pass one explicitly."
+          if [ -z "$TAG" ]; then
+            echo "::error::Could not resolve a release tag. Pass a version explicitly."
             exit 1
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Linear release version: $VERSION"
+
+          # Linear versions its releases without the tag's `v` prefix.
+          VERSION="${TAG#v}"
+
+          # Both paths attach the same link: the release event already carries
+          # the URL, a manual run looks it up by tag.
+          URL="$RELEASE_URL"
+          if [ -z "$URL" ]; then
+            URL=$(gh api "repos/$REPO/releases/tags/$TAG" --jq '.html_url' || true)
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "url=$URL"
+          } >> "$GITHUB_OUTPUT"
+          echo "Linear release $VERSION (tag $TAG)"
+
+      # Checks out the release tag rather than the branch the run was launched
+      # from, so a backfill scans that release's history and not main's.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/tags/${{ steps.release.outputs.tag }}
+          fetch-depth: 0 # Full history required to scan commits for Linear issue IDs
 
       # Fail-open on the automated path only: the release has already shipped by
       # the time this runs, so Linear must never be able to turn it red. A manual
@@ -91,6 +116,6 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync
-          version: ${{ steps.version.outputs.version }}
-          links: ${{ github.event.release.html_url }}
-          dry_run: ${{ inputs.dry_run }}
+          version: ${{ steps.release.outputs.version }}
+          links: ${{ steps.release.outputs.url }}
+          dry_run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

Extends [WA-2846](https://linear.app/safe-global/issue/WA-2846/integrate-github-with-linear-releases-web-mobile) to the Client Gateway. That one wired the web and mobile pipelines in the wallet monorepo ([safe-wallet-monorepo#8291](https://github.com/safe-global/safe-wallet-monorepo/pull/8291)) and deliberately left CGW out of scope; this is that follow-up.

Publishing a GitHub release now records it in the [CGW pipeline](https://linear.app/safe-global/pipeline/cgw-7ua/releases) in Linear, so you can tell which issues are actually live instead of just merged. Same action as the wallet repo, pinned to the same commit, adapted to how we release. Two differences, both because our flow is simpler: we have no release branch or code freeze, so everything hangs off the published GitHub release rather than a release-start workflow; and the CGW pipeline is **continuous**, so a release auto-completes the moment it syncs. No separate `complete` call, and its single `Released` stage means there's nothing to move between.

It lives in its own workflow rather than in `ci.yml` so Linear never rides on the docker build. The sync fails loudly instead of failing open: if Linear is unreachable or rejects the key, the run goes red and you re-run it from the Actions UI. That's safe here because this workflow publishes nothing itself, so a red run can't block or revert a release that already shipped.

**Before this works**, someone needs to add `LINEAR_ACCESS_KEY` as a repo secret — the CGW pipeline's access key from its Linear settings, not a personal API key.

The risk worth flagging: our commit subjects don't carry Linear issue IDs. They look like `feat: recognise Safe 1.5.0 as a known, trusted version (#3329)`, while the wallet's look like `feat(web): support 1.5.0 in multichain creation (WA-2930)`. The action falls back to PR references, which may resolve through the Linear/GitHub integration, but I couldn't verify that. With no manual trigger there's no way to dry-run first, so the next published tag is also the first real test — if the Linear release comes back with no issues attached, that's the missing issue keys, not a broken workflow, and the fix is putting them in PR titles. Nothing has run yet; YAML and the inline shell are syntax-checked.

## Changes

**`.github/workflows/linear-release.yml`** (new)

- Triggers only on `release: [released]`. Resolves the version from the tag (`v1.122.0` → `1.122.0`) and runs `sync` with the GitHub release attached as a link.
- Checks out the release tag rather than a branch, so the commit scan covers that release's history.
- Full history (`fetch-depth: 0`) so the action can scan commits. No `include_paths` — we're not a monorepo, so any path filter would silently drop commits.
- Reads the tag and release URL straight off the event, so it makes no API calls of its own.
- `timeout-minutes: 10`, matching how `claude-code-review.yml` and `architecture-check.yml` bound their jobs.
