### PR TITLE
build(deps): resolve open dependabot advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@nestjs/common": "11.1.29",
     "@nestjs/config": "4.0.4",
     "@nestjs/core": "11.1.29",
-    "@nestjs/platform-fastify": "11.1.28",
+    "@nestjs/platform-fastify": "11.1.29",
     "@nestjs/schedule": "6.1.3",
     "@nestjs/serve-static": "5.0.5",
     "@nestjs/swagger": "11.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,13 +719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/cors@npm:11.2.0":
-  version: 11.2.0
-  resolution: "@fastify/cors@npm:11.2.0"
+"@fastify/cors@npm:11.3.0":
+  version: 11.3.0
+  resolution: "@fastify/cors@npm:11.3.0"
   dependencies:
-    fastify-plugin: "npm:^5.0.0"
+    fastify-plugin: "npm:^6.0.0"
     toad-cache: "npm:^3.7.0"
-  checksum: 10/3c2defc8a8624ad2f5d88cc21b97a5bb2ae9d4eca836e276815c18e791b0628b1638ce62c208a8167794ba6e7ed57c531226459d35ba02b9c4a0ad31b95d72a0
+  checksum: 10/cce3be2daa753a5dab891a13a0b6f27595488647f700ddd040e4d9aa777d6854a9d1189d1374a10f7166092486f3fc2bc5d8520db40edfb28441a349252b1956
   languageName: node
   linkType: hard
 
@@ -1631,22 +1631,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/platform-fastify@npm:11.1.28":
-  version: 11.1.28
-  resolution: "@nestjs/platform-fastify@npm:11.1.28"
+"@nestjs/platform-fastify@npm:11.1.29":
+  version: 11.1.29
+  resolution: "@nestjs/platform-fastify@npm:11.1.29"
   dependencies:
-    "@fastify/cors": "npm:11.2.0"
+    "@fastify/cors": "npm:11.3.0"
     "@fastify/formbody": "npm:8.0.2"
     fast-querystring: "npm:1.1.2"
-    fastify: "npm:5.10.0"
+    fastify: "npm:5.11.0"
     fastify-plugin: "npm:6.0.0"
-    find-my-way: "npm:9.6.0"
+    find-my-way: "npm:9.7.0"
     light-my-request: "npm:6.6.0"
     path-to-regexp: "npm:8.4.2"
     reusify: "npm:1.1.0"
     tslib: "npm:2.8.1"
   peerDependencies:
-    "@fastify/static": ^8.0.0 || ^9.0.0
+    "@fastify/static": ^10.1.2
     "@fastify/view": ^10.0.0 || ^11.0.0 || ^12.0.0
     "@nestjs/common": ^11.0.0
     "@nestjs/core": ^11.0.0
@@ -1655,7 +1655,7 @@ __metadata:
       optional: true
     "@fastify/view":
       optional: true
-  checksum: 10/7c70285b42bfc2a6469b17984b71535f3484468d6fa6e1c9b84af7efe36fc1f3c06075590d826adeaddb88f6549433fc49b756ca1e28908bf0ccdb8b3006db73
+  checksum: 10/a23d88654bb82773b1d04db0805ff05676d5941359c7a7a4ab8f458e46a00c984b0be2dfb7e2109571fd57305fc20ee64e42d6b34da21411f7e8796e6dc96357
   languageName: node
   linkType: hard
 
@@ -3288,21 +3288,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
+  checksum: 10/b55a3c03239b8d2127c7cbb3408c9ad3a556a8c303bf3064df78bfb7c093160fc8f6e0a32e42a850a78eba12f29ccf6ef997690b9acf945d242c56c61c4aa977
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
+  checksum: 10/d8683d612919212c7cf298861acd1c15101e7e2ad186e7ae9747390e5b3fc9e9b55ce71107570d32985784d9d88fbbe438d725863aed7b0f3d08d5f080535eec
   languageName: node
   linkType: hard
 
@@ -4306,9 +4306,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.0, fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
   languageName: node
   linkType: hard
 
@@ -4326,9 +4326,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastify@npm:5.10.0":
-  version: 5.10.0
-  resolution: "fastify@npm:5.10.0"
+"fastify@npm:5.11.0":
+  version: 5.11.0
+  resolution: "fastify@npm:5.11.0"
   dependencies:
     "@fastify/ajv-compiler": "npm:^4.0.5"
     "@fastify/error": "npm:^4.0.0"
@@ -4345,7 +4345,7 @@ __metadata:
     secure-json-parse: "npm:^4.0.0"
     semver: "npm:^7.6.0"
     toad-cache: "npm:^3.7.0"
-  checksum: 10/c05dcd12da795af7571d8cd0aa1fadc49f4cfc2deb4ceb5a4c317d7b9b45708cd0a75522c39b24cac5e2c9956fd45b7b18e4a093e7b85fcb78cf1cf8cae840d8
+  checksum: 10/1a3ce68177ba529a5983bd1426202e237d8fafb38e8ba8036a71c0884cae213d73526aec91a38c7a4084417c2df7e88e11d64e6419f809a330625f9d789ca2c9
   languageName: node
   linkType: hard
 
@@ -4389,18 +4389,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-my-way@npm:9.6.0":
-  version: 9.6.0
-  resolution: "find-my-way@npm:9.6.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-querystring: "npm:^1.0.0"
-    safe-regex2: "npm:^5.0.0"
-  checksum: 10/68010a23b64f44f7b97a23ce4691e8f57f592ae8d2d9d50704b389c6bba6d41f9e9a470dab2e6b6ec51a17b4490f1246abece48d5d8d8858d4d3d199b21f46ff
-  languageName: node
-  linkType: hard
-
-"find-my-way@npm:^9.6.0":
+"find-my-way@npm:9.7.0, find-my-way@npm:^9.6.0":
   version: 9.7.0
   resolution: "find-my-way@npm:9.7.0"
   dependencies:
@@ -4908,13 +4897,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
+  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
   languageName: node
   linkType: hard
 
@@ -5543,12 +5532,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/6eec280694e2088d18fb802b1e3bfc4578e27b665b7ecfbe36c7356612fea2f814277056e671e2a1529dff551588a652efdc0bfa39f8a3185bc2247be311872e
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 
@@ -5942,25 +5931,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
+"postcss@npm:^8.3.11, postcss@npm:^8.5.16":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.17"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/d02ad19eb1e0fa53a1229ee6d53807eb88f903f2b9a8cac66993367f3ac7dd3b97238c783a54ccbf4145f82f6ca9a5cbd58f089846285d759c8a3259fbea8318
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.16":
-  version: 8.5.19
-  resolution: "postcss@npm:8.5.19"
-  dependencies:
-    nanoid: "npm:^3.3.12"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/f51162887cd683afc02fa6c1f06b6485ebc18c62eec7dc2841c8fe0a0c4b53b9a834cc26aa1a233e87f0e3a10179db916a276464c0ee1d00354d1670ebc32953
+  checksum: 10/842a624f822f77cb37264cc24f0cf97c0a69dd8d6f7b4a6d76b5a8dc95355899dd044f33a2d4e890da858293de570fce18dff453f3b629ff14cac67a3591895a
   languageName: node
   linkType: hard
 
@@ -6271,7 +6249,7 @@ __metadata:
     "@nestjs/common": "npm:11.1.29"
     "@nestjs/config": "npm:4.0.4"
     "@nestjs/core": "npm:11.1.29"
-    "@nestjs/platform-fastify": "npm:11.1.28"
+    "@nestjs/platform-fastify": "npm:11.1.29"
     "@nestjs/schedule": "npm:6.1.3"
     "@nestjs/schematics": "npm:11.1.0"
     "@nestjs/serve-static": "npm:5.0.5"
@@ -6779,15 +6757,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.20
-  resolution: "tar@npm:7.5.20"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/90a0fe423ac921197ad5eefc5e5f7ad7f42b06e80444c8c347c1e4112384cbe9cb53ade3ef71748eed3684888756869c2aeef6b6303c766101f3217e254d4be9
+  checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
   languageName: node
   linkType: hard
 
@@ -7168,17 +7146,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:8.10.0":
+"undici@npm:8.10.0, undici@npm:^8.4.1":
   version: 8.10.0
   resolution: "undici@npm:8.10.0"
   checksum: 10/254219966d4a2fb110f565ffe73131caa82e949f207b9dd88930ebc23dfb6561db72ca187391cbd408ceeba7c647cb47d4110e8ae00df44c0c66e8a21e091dc0
-  languageName: node
-  linkType: hard
-
-"undici@npm:^8.4.1":
-  version: 8.7.0
-  resolution: "undici@npm:8.7.0"
-  checksum: 10/e9644903bda97f825228b4c7bee95b3586609f94df685b598c32bdaf3ac795928cbd25b0ed2690c3ea0b5abd324f5a9641b63b6c81c9b19f3ef4d5b3e402a48c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Clears 15 of the 16 open Dependabot alerts on `main`. All of them are transitive — no direct dependency of this service is itself vulnerable — so the fix is a lockfile lift plus one direct bump where a parent pins the vulnerable version exactly.

**`find-my-way`** was pinned to `9.6.0` by `@nestjs/platform-fastify@11.1.28`. Bumping that dependency to `11.1.29` pulls in `find-my-way@9.7.0` and also aligns it with `@nestjs/common`/`@nestjs/core`, which are already on `11.1.29`. As a side effect the peer requirement on `@fastify/static` improves: `11.1.29` requests `^10.1.2`, which the project's `10.1.3` satisfies (`11.1.28` requested `^8 || ^9`, which it did not).

Everything else resolved inside the existing semver ranges via `yarn up -R`. `@nestjs/platform-fastify@11.2.x` and `find-my-way@9.8.0` were left alone as too young for the 7-day `npmMinimalAgeGate` in `.yarnrc.yml`; `9.7.0` is above the advisory's `<=9.6.0` vulnerable range, so it is sufficient.

**One alert is deliberately left open:** the `js-yaml` 5.x DoS advisory (`>=5.0.0 <=5.2.1`, high). `@nestjs/swagger@11.4.6` pins `js-yaml@5.2.1` exactly, and `11.4.7` already ships the fix upstream (it pins `5.3.0`) — it is just younger than the age gate right now. Rather than carry a `resolutions` entry that would have to be removed again, this clears on the next `@nestjs/swagger` bump.

`yarn npm audit --all --recursive` reports no other security advisories. The three remaining entries it prints are npm *deprecation* notices, not advisories, and all are dev-only transitives with no fixed version available: `@sinonjs/text-encoding` and `lodash.get` (via `aws-sdk-client-mock` → `sinon`) and `cron-parser@4` (via `bullmq`).

Verified with `yarn format`, `yarn lint`, `yarn build`, and `yarn test` (348 files, 6169 tests passing).

## Changes

- `package.json` — bump `@nestjs/platform-fastify` `11.1.28` → `11.1.29`
- `yarn.lock` — patched transitives: `brace-expansion` `1.1.16` → `1.1.18` and `5.0.7` → `5.0.9`, `fast-uri` `3.1.4` → `3.1.5`, `find-my-way` `9.6.0` → `9.7.0`, `js-yaml` `4.3.0` → `4.3.1`, `nanoid` `3.3.12` → `3.3.18`, `postcss` `8.5.15`/`8.5.19` → `8.5.26`, `tar` `7.5.20` → `7.5.22`, `undici` `8.7.0` → `8.10.0`