### PR TITLE
fix: recognise v1.5.0 migrations for safes with unknown mastercopies

### DIFF
--- a/src/domain/common/utils/__tests__/deployments.spec.ts
+++ b/src/domain/common/utils/__tests__/deployments.spec.ts
@@ -7,7 +7,6 @@ import {
   getSafeL2SingletonVersions,
   getSafeMigrationVersions,
   getSafeSingletonVersions,
-  getSafeToL2MigrationVersions,
   getSafeToL2SetupVersions,
   isExtensibleFallbackHandlerDeployed,
   isFallbackHandlerDeployed,
@@ -67,14 +66,6 @@ describe('deployments', () => {
     it('should include all SafeMigration versions', () => {
       expect(getSafeMigrationVersions()).toEqual(
         expect.arrayContaining(['1.4.1', '1.5.0']),
-      );
-    });
-  });
-
-  describe('getSafeToL2MigrationVersions', () => {
-    it('should include all SafeToL2Migration versions', () => {
-      expect(getSafeToL2MigrationVersions()).toEqual(
-        expect.arrayContaining(['1.4.1']),
       );
     });
   });

--- a/src/domain/common/utils/__tests__/deployments.spec.ts
+++ b/src/domain/common/utils/__tests__/deployments.spec.ts
@@ -4,6 +4,10 @@ import { getAddress } from 'viem';
 import {
   getExtensibleFallbackHandlerVersions,
   getFallbackHandlerVersions,
+  getSafeL2SingletonVersions,
+  getSafeMigrationVersions,
+  getSafeSingletonVersions,
+  getSafeToL2MigrationVersions,
   getSafeToL2SetupVersions,
   isExtensibleFallbackHandlerDeployed,
   isFallbackHandlerDeployed,
@@ -39,6 +43,38 @@ describe('deployments', () => {
     it('should include all SafeToL2Setup versions', () => {
       expect(getSafeToL2SetupVersions()).toEqual(
         expect.arrayContaining(['1.4.1', '1.5.0']),
+      );
+    });
+  });
+
+  describe('getSafeSingletonVersions', () => {
+    it('should include all L1 singleton versions', () => {
+      expect(getSafeSingletonVersions()).toEqual(
+        expect.arrayContaining(['1.3.0', '1.4.1', '1.5.0']),
+      );
+    });
+  });
+
+  describe('getSafeL2SingletonVersions', () => {
+    it('should include all L2 singleton versions', () => {
+      expect(getSafeL2SingletonVersions()).toEqual(
+        expect.arrayContaining(['1.3.0', '1.4.1', '1.5.0']),
+      );
+    });
+  });
+
+  describe('getSafeMigrationVersions', () => {
+    it('should include all SafeMigration versions', () => {
+      expect(getSafeMigrationVersions()).toEqual(
+        expect.arrayContaining(['1.4.1', '1.5.0']),
+      );
+    });
+  });
+
+  describe('getSafeToL2MigrationVersions', () => {
+    it('should include all SafeToL2Migration versions', () => {
+      expect(getSafeToL2MigrationVersions()).toEqual(
+        expect.arrayContaining(['1.4.1']),
       );
     });
   });

--- a/src/domain/common/utils/__tests__/safe.spec.ts
+++ b/src/domain/common/utils/__tests__/safe.spec.ts
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
+import semverSatisfies from 'semver/functions/satisfies';
 import { getAddress, type Hex } from 'viem';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
 import {
   getSafeL2SingletonDeployments,
+  getSafeL2SingletonVersions,
   getSafeMigrationDeployments,
   getSafeSingletonDeployments,
+  getSafeSingletonVersions,
 } from '@/domain/common/utils/deployments';
 import type { BaseMultisigTransaction } from '@/domain/common/utils/safe';
 import {
@@ -909,8 +912,16 @@ describe('Safe', () => {
           .with('data', migrateL2SingletonEncoder().encode())
           .build();
 
-        // Check if there are any singletons on this chain for the tested versions
-        const hasAnySingletons = ['1.3.0', '1.4.1', '1.5.0'].some((version) => {
+        // Check if there are any singletons on this chain for the versions a
+        // SafeMigration can target — tracked from the safe-deployments package
+        // so the guard does not drift when a new version is released
+        const migrationTargetVersions = Array.from(
+          new Set([
+            ...getSafeSingletonVersions(),
+            ...getSafeL2SingletonVersions(),
+          ]),
+        ).filter((version) => semverSatisfies(version, '>=1.3.0'));
+        const hasAnySingletons = migrationTargetVersions.some((version) => {
           const l1 = getSafeSingletonDeployments({
             chainId: testChainId,
             version,

--- a/src/domain/common/utils/__tests__/safe.spec.ts
+++ b/src/domain/common/utils/__tests__/safe.spec.ts
@@ -701,148 +701,87 @@ describe('Safe', () => {
     });
 
     describe('SafeMigration contract', () => {
-      it('should calculate safeTxHash for migrateL2Singleton delegate call when version is null', () => {
-        const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const migrationContracts = getSafeMigrationDeployments({
-          chainId,
-          version: '1.4.1',
+      // SafeMigration deployments exist per singleton release from 1.4.1 onwards
+      describe.each([
+        '1.4.1',
+        '1.5.0',
+      ])('SafeMigration %s deployment', (migrationVersion) => {
+        it.each([
+          ['migrateL2Singleton', migrateL2SingletonEncoder],
+          ['migrateL2WithFallbackHandler', migrateL2WithFallbackHandlerEncoder],
+          ['migrateSingleton', migrateSingletonEncoder],
+          ['migrateWithFallbackHandler', migrateWithFallbackHandlerEncoder],
+        ])('should calculate safeTxHash for %s delegate call when version is null', (_, encoder) => {
+          const safeAddress = getAddress(faker.finance.ethereumAddress());
+          const migrationContracts = getSafeMigrationDeployments({
+            chainId,
+            version: migrationVersion,
+          });
+          expect(migrationContracts.length).toBeGreaterThan(0);
+
+          const migrationContract =
+            faker.helpers.arrayElement(migrationContracts);
+          const safe = safeBuilder()
+            .with('address', safeAddress)
+            .with('version', null)
+            .build();
+
+          const transaction = safeTxHashMultisigTransactionBuilder()
+            .with('to', migrationContract)
+            .with('value', '0')
+            .with('operation', Operation.DELEGATE)
+            .with('data', encoder().encode())
+            .build();
+
+          // Should not throw and should calculate hash using detected version
+          expect(() =>
+            getSafeTxHash({
+              chainId,
+              safe,
+              transaction,
+            }),
+          ).not.toThrow();
         });
 
-        // Skip if no migration contract for this chain
-        if (migrationContracts.length === 0) {
-          return;
-        }
-
-        const migrationContract =
-          faker.helpers.arrayElement(migrationContracts);
-        const safe = safeBuilder()
-          .with('address', safeAddress)
-          .with('version', null)
-          .build();
-
-        const transaction = safeTxHashMultisigTransactionBuilder()
-          .with('to', migrationContract)
-          .with('value', '0')
-          .with('operation', Operation.DELEGATE)
-          .with('data', migrateL2SingletonEncoder().encode())
-          .build();
-
-        // Should not throw and should calculate hash using detected version
-        expect(() =>
-          getSafeTxHash({
+        it('should infer a version hashing identically to an explicit >=1.3.0 version', () => {
+          const safeAddress = getAddress(faker.finance.ethereumAddress());
+          const migrationContracts = getSafeMigrationDeployments({
             chainId,
-            safe,
-            transaction,
-          }),
-        ).not.toThrow();
-      });
+            version: migrationVersion,
+          });
+          expect(migrationContracts.length).toBeGreaterThan(0);
 
-      it('should calculate safeTxHash for migrateL2WithFallbackHandler delegate call when version is null', () => {
-        const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const migrationContracts = getSafeMigrationDeployments({
-          chainId,
-          version: '1.4.1',
+          const migrationContract =
+            faker.helpers.arrayElement(migrationContracts);
+          const transaction = safeTxHashMultisigTransactionBuilder()
+            .with('to', migrationContract)
+            .with('value', '0')
+            .with('operation', Operation.DELEGATE)
+            .with('data', migrateL2SingletonEncoder().encode())
+            .build();
+
+          const result = getSafeTxHash({
+            chainId,
+            safe: safeBuilder()
+              .with('address', safeAddress)
+              .with('version', null)
+              .build(),
+            transaction,
+          });
+
+          // All versions >=1.3.0 share the same domain/types, so the
+          // inferred version must produce the same hash as an explicit one
+          expect(result).toBe(
+            getSafeTxHash({
+              chainId,
+              safe: safeBuilder()
+                .with('address', safeAddress)
+                .with('version', '1.3.0')
+                .build(),
+              transaction,
+            }),
+          );
         });
-
-        // Skip if no migration contract for this chain
-        if (migrationContracts.length === 0) {
-          return;
-        }
-
-        const migrationContract =
-          faker.helpers.arrayElement(migrationContracts);
-        const safe = safeBuilder()
-          .with('address', safeAddress)
-          .with('version', null)
-          .build();
-
-        const transaction = safeTxHashMultisigTransactionBuilder()
-          .with('to', migrationContract)
-          .with('value', '0')
-          .with('operation', Operation.DELEGATE)
-          .with('data', migrateL2WithFallbackHandlerEncoder().encode())
-          .build();
-
-        // Should not throw and should calculate hash using detected version
-        expect(() =>
-          getSafeTxHash({
-            chainId,
-            safe,
-            transaction,
-          }),
-        ).not.toThrow();
-      });
-
-      it('should calculate safeTxHash for migrateSingleton delegate call when version is null', () => {
-        const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const migrationContracts = getSafeMigrationDeployments({
-          chainId,
-          version: '1.4.1',
-        });
-
-        // Skip if no migration contract for this chain
-        if (migrationContracts.length === 0) {
-          return;
-        }
-
-        const migrationContract =
-          faker.helpers.arrayElement(migrationContracts);
-        const safe = safeBuilder()
-          .with('address', safeAddress)
-          .with('version', null)
-          .build();
-
-        const transaction = safeTxHashMultisigTransactionBuilder()
-          .with('to', migrationContract)
-          .with('value', '0')
-          .with('operation', Operation.DELEGATE)
-          .with('data', migrateSingletonEncoder().encode())
-          .build();
-
-        // Should not throw and should calculate hash using detected version
-        expect(() =>
-          getSafeTxHash({
-            chainId,
-            safe,
-            transaction,
-          }),
-        ).not.toThrow();
-      });
-
-      it('should calculate safeTxHash for migrateWithFallbackHandler delegate call when version is null', () => {
-        const safeAddress = getAddress(faker.finance.ethereumAddress());
-        const migrationContracts = getSafeMigrationDeployments({
-          chainId,
-          version: '1.4.1',
-        });
-
-        // Skip if no migration contract for this chain
-        if (migrationContracts.length === 0) {
-          return;
-        }
-
-        const migrationContract =
-          faker.helpers.arrayElement(migrationContracts);
-        const safe = safeBuilder()
-          .with('address', safeAddress)
-          .with('version', null)
-          .build();
-
-        const transaction = safeTxHashMultisigTransactionBuilder()
-          .with('to', migrationContract)
-          .with('value', '0')
-          .with('operation', Operation.DELEGATE)
-          .with('data', migrateWithFallbackHandlerEncoder().encode())
-          .build();
-
-        // Should not throw and should calculate hash using detected version
-        expect(() =>
-          getSafeTxHash({
-            chainId,
-            safe,
-            transaction,
-          }),
-        ).not.toThrow();
       });
 
       it('should throw when version is null and SafeMigration contract is unofficial', () => {
@@ -971,7 +910,7 @@ describe('Safe', () => {
           .build();
 
         // Check if there are any singletons on this chain for the tested versions
-        const hasAnySingletons = ['1.3.0', '1.4.1'].some((version) => {
+        const hasAnySingletons = ['1.3.0', '1.4.1', '1.5.0'].some((version) => {
           const l1 = getSafeSingletonDeployments({
             chainId: testChainId,
             version,

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -14,6 +14,10 @@ import {
 import {
   _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS,
   _EXTENSIBLE_FALLBACK_HANDLER_DEPLOYMENTS,
+  _SAFE_DEPLOYMENTS,
+  _SAFE_L2_DEPLOYMENTS,
+  _SAFE_MIGRATION_DEPLOYMENTS,
+  _SAFE_TO_L2_MIGRATION_DEPLOYMENTS,
   _SAFE_TO_L2_SETUP_DEPLOYMENTS,
 } from '@safe-global/safe-deployments/dist/deployments';
 import { getSafeWebAuthnSignerFactoryDeployment } from '@safe-global/safe-modules-deployments';
@@ -33,7 +37,8 @@ type DeploymentGetter =
   | typeof _getFallbackHandlerDeployments
   | typeof _getExtensibleFallbackHandlerDeployments
   | typeof _getSafeToL2SetupDeployments
-  | typeof _getSafeToL2MigrationDeployments;
+  | typeof _getSafeToL2MigrationDeployments
+  | typeof _getSafeMigrationDeployments;
 
 /**
  * Type-only declaration of the SafeWebAuthnSignerFactory function signatures
@@ -234,6 +239,51 @@ export function getExtensibleFallbackHandlerVersions(): Array<string> {
  */
 export function getSafeToL2SetupVersions(): Array<string> {
   return _SAFE_TO_L2_SETUP_DEPLOYMENTS.map((deployment) => deployment.version);
+}
+
+/**
+ * Gets the list of L1 singleton versions available in the safe-deployments package.
+ * Infers versions from the _SAFE_DEPLOYMENTS constant exported by the package.
+ *
+ * @returns {Array<string>} - a list of L1 singleton versions in descending order
+ */
+export function getSafeSingletonVersions(): Array<string> {
+  return _SAFE_DEPLOYMENTS.map((deployment) => deployment.version);
+}
+
+/**
+ * Gets the list of L2 singleton versions available in the safe-deployments package.
+ * Infers versions from the _SAFE_L2_DEPLOYMENTS constant exported by the package.
+ * Note: the L2 singleton was introduced in Safe v1.3.0.
+ *
+ * @returns {Array<string>} - a list of L2 singleton versions in descending order
+ */
+export function getSafeL2SingletonVersions(): Array<string> {
+  return _SAFE_L2_DEPLOYMENTS.map((deployment) => deployment.version);
+}
+
+/**
+ * Gets the list of SafeMigration versions available in the safe-deployments package.
+ * Infers versions from the _SAFE_MIGRATION_DEPLOYMENTS constant exported by the package.
+ * Note: SafeMigration was introduced in Safe v1.4.1.
+ *
+ * @returns {Array<string>} - a list of SafeMigration versions in descending order
+ */
+export function getSafeMigrationVersions(): Array<string> {
+  return _SAFE_MIGRATION_DEPLOYMENTS.map((deployment) => deployment.version);
+}
+
+/**
+ * Gets the list of SafeToL2Migration versions available in the safe-deployments package.
+ * Infers versions from the _SAFE_TO_L2_MIGRATION_DEPLOYMENTS constant exported by the package.
+ * Note: SafeToL2Migration was introduced in Safe v1.4.1.
+ *
+ * @returns {Array<string>} - a list of SafeToL2Migration versions in descending order
+ */
+export function getSafeToL2MigrationVersions(): Array<string> {
+  return _SAFE_TO_L2_MIGRATION_DEPLOYMENTS.map(
+    (deployment) => deployment.version,
+  );
 }
 
 /**

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -17,7 +17,6 @@ import {
   _SAFE_DEPLOYMENTS,
   _SAFE_L2_DEPLOYMENTS,
   _SAFE_MIGRATION_DEPLOYMENTS,
-  _SAFE_TO_L2_MIGRATION_DEPLOYMENTS,
   _SAFE_TO_L2_SETUP_DEPLOYMENTS,
 } from '@safe-global/safe-deployments/dist/deployments';
 import { getSafeWebAuthnSignerFactoryDeployment } from '@safe-global/safe-modules-deployments';
@@ -244,6 +243,8 @@ export function getSafeToL2SetupVersions(): Array<string> {
 /**
  * Gets the list of L1 singleton versions available in the safe-deployments package.
  * Infers versions from the _SAFE_DEPLOYMENTS constant exported by the package.
+ * Note: includes legacy pre-1.3.0 versions (1.0.0, 1.1.1, 1.2.0) — callers feeding
+ * these into version-sensitive flows (e.g. SafeTx hashing) must filter by range.
  *
  * @returns {Array<string>} - a list of L1 singleton versions in descending order
  */
@@ -271,19 +272,6 @@ export function getSafeL2SingletonVersions(): Array<string> {
  */
 export function getSafeMigrationVersions(): Array<string> {
   return _SAFE_MIGRATION_DEPLOYMENTS.map((deployment) => deployment.version);
-}
-
-/**
- * Gets the list of SafeToL2Migration versions available in the safe-deployments package.
- * Infers versions from the _SAFE_TO_L2_MIGRATION_DEPLOYMENTS constant exported by the package.
- * Note: SafeToL2Migration was introduced in Safe v1.4.1.
- *
- * @returns {Array<string>} - a list of SafeToL2Migration versions in descending order
- */
-export function getSafeToL2MigrationVersions(): Array<string> {
-  return _SAFE_TO_L2_MIGRATION_DEPLOYMENTS.map(
-    (deployment) => deployment.version,
-  );
 }
 
 /**

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -36,8 +36,7 @@ type DeploymentGetter =
   | typeof _getFallbackHandlerDeployments
   | typeof _getExtensibleFallbackHandlerDeployments
   | typeof _getSafeToL2SetupDeployments
-  | typeof _getSafeToL2MigrationDeployments
-  | typeof _getSafeMigrationDeployments;
+  | typeof _getSafeToL2MigrationDeployments;
 
 /**
  * Type-only declaration of the SafeWebAuthnSignerFactory function signatures

--- a/src/domain/common/utils/safe.ts
+++ b/src/domain/common/utils/safe.ts
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import semverCompare from 'semver/functions/compare';
 import semverSatisfies from 'semver/functions/satisfies';
 import type { Address } from 'viem';
 import { hashMessage, hashTypedData, zeroAddress } from 'viem';
 import {
   getSafeL2SingletonDeployments,
+  getSafeL2SingletonVersions,
   getSafeMigrationDeployments,
+  getSafeMigrationVersions,
   getSafeSingletonDeployments,
+  getSafeSingletonVersions,
 } from '@/domain/common/utils/deployments';
 import { MessageSchema } from '@/modules/messages/domain/entities/message.entity';
 import type { TypedData } from '@/modules/messages/domain/entities/typed-data.entity';
@@ -17,6 +21,8 @@ const CHAIN_ID_DOMAIN_HASH_VERSION = '>=1.3.0';
 const TRANSACTION_PRIMARY_TYPE = 'SafeTx';
 const BASE_GAS_SAFETX_HASH_VERSION = '>=1.0.0';
 const MESSAGE_PRIMARY_TYPE = 'SafeMessage';
+// SafeMigration contracts (introduced in 1.4.1) only target 1.3.0+ singletons
+const SAFE_MIGRATION_TARGET_VERSION_RANGE = '>=1.3.0';
 
 export function getSafeMessageMessageHash(args: {
   chainId: string;
@@ -176,14 +182,15 @@ function detectSafeMigration(args: {
       return null;
     }
 
-    // Check if target is an official SafeMigration contract
-    const safeMigrationContracts = getSafeMigrationDeployments({
-      chainId: args.chainId,
-      version: '1.4.1', // SafeMigration was introduced in 1.4.1
-    });
-
-    const isSafeMigration = safeMigrationContracts.some(
-      (addr) => addr.toLowerCase() === args.transaction.to.toLowerCase(),
+    // Check if target is an official SafeMigration contract (any known version)
+    const isSafeMigration = getSafeMigrationVersions().some(
+      (migrationVersion) =>
+        getSafeMigrationDeployments({
+          chainId: args.chainId,
+          version: migrationVersion,
+        }).some(
+          (addr) => addr.toLowerCase() === args.transaction.to.toLowerCase(),
+        ),
     );
 
     if (!isSafeMigration) {
@@ -196,7 +203,7 @@ function detectSafeMigration(args: {
     }
 
     // Infer version from available singleton deployments on this chain
-    const versions = ['1.3.0', '1.4.1'];
+    const versions = getSafeMigrationTargetVersions();
 
     for (const version of versions) {
       const l1Singletons = getSafeSingletonDeployments({
@@ -218,6 +225,29 @@ function detectSafeMigration(args: {
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns the singleton versions a SafeMigration contract can target,
+ * in ascending order.
+ *
+ * Derived from the singleton deployments known to the safe-deployments
+ * package (L1 and L2), restricted to {@link SAFE_MIGRATION_TARGET_VERSION_RANGE},
+ * so that newly released versions (e.g. 1.5.0) are covered without
+ * maintaining a hardcoded list.
+ *
+ * @returns {Array<string>} - a list of candidate migration target versions
+ */
+function getSafeMigrationTargetVersions(): Array<string> {
+  const versions = new Set([
+    ...getSafeSingletonVersions(),
+    ...getSafeL2SingletonVersions(),
+  ]);
+  return Array.from(versions)
+    .filter((version) =>
+      semverSatisfies(version, SAFE_MIGRATION_TARGET_VERSION_RANGE),
+    )
+    .sort(semverCompare);
 }
 
 export function _getSafeDomain(args: {

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
@@ -9,6 +9,7 @@ import {
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import {
+  getSafeToL2MigrationVersions,
   getSafeToL2SetupVersions,
   hasCanonicalDeploymentSafeToL2Migration,
   hasCanonicalDeploymentSafeToL2Setup,
@@ -703,10 +704,12 @@ export class RecipientAnalysisService {
 
     const areMigrationConditionsMet =
       !isMigrationRequired ||
-      hasCanonicalDeploymentSafeToL2Migration({
-        chainId: chain.chainId,
-        version: '1.4.1',
-      });
+      getSafeToL2MigrationVersions().some((migrationVersion) =>
+        hasCanonicalDeploymentSafeToL2Migration({
+          chainId: chain.chainId,
+          version: migrationVersion,
+        }),
+      );
 
     return (
       masterCopyExists &&

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
@@ -9,7 +9,6 @@ import {
   type ICacheService,
 } from '@/datasources/cache/cache.service.interface';
 import {
-  getSafeToL2MigrationVersions,
   getSafeToL2SetupVersions,
   hasCanonicalDeploymentSafeToL2Migration,
   hasCanonicalDeploymentSafeToL2Setup,
@@ -704,12 +703,10 @@ export class RecipientAnalysisService {
 
     const areMigrationConditionsMet =
       !isMigrationRequired ||
-      getSafeToL2MigrationVersions().some((migrationVersion) =>
-        hasCanonicalDeploymentSafeToL2Migration({
-          chainId: chain.chainId,
-          version: migrationVersion,
-        }),
-      );
+      hasCanonicalDeploymentSafeToL2Migration({
+        chainId: chain.chainId,
+        version: '1.4.1',
+      });
 
     return (
       masterCopyExists &&


### PR DESCRIPTION
## Summary

WA-2933

For Safes whose mastercopy the Transaction Service does not recognise (`version = null`), CGW cannot compute `safeTxHash` from the Safe itself, so it infers the version from the transaction: a delegate call to an official `SafeMigration` contract identifies the target version (`detectSafeMigration`, added in #2746). That fix hardcoded the `SafeMigration` version to `1.4.1` and the candidate target versions to `['1.3.0', '1.4.1']`.

Now that chains are being flipped to recommend v1.5.0, migration transactions for these Safes target the `SafeMigration` **1.5.0** contract, which the hardcoded check does not recognise. `safeTxHash` computation then fails for the exact population the inference exists for — rejecting proposals/confirmations with 422 and failing queue/history rendering with `MalformedHash`. This is the same defect #2746 fixed, reintroduced by the next contract release. (The web app routes some unknown-mastercopy Safes to the CLI, but that does not shield CGW: CLI-proposed migrations still land in the Transaction Service and must pass CGW's hash verification to render, and other clients propose through CGW directly.)

Instead of appending `'1.5.0'` to the literals — and re-opening this bug at the next release — the versions are now derived from `@safe-global/safe-deployments`:

- `SafeMigration` recognition checks the transaction target against **all** versions the package ships.
- Target-version inference builds its candidates from the L1/L2 singleton versions in the package, filtered to `>=1.3.0` (the range `SafeMigration` can target). Any version in that range produces the same EIP-712 domain, so which candidate the loop picks does not affect the computed hash — the derivation changes recognition, not hashing.

Future `SafeMigration`/singleton releases are now covered by a `safe-deployments` dependency bump, with no code change.


## Changes

- `src/domain/common/utils/deployments.ts` — add version-list getters derived from the `safe-deployments` package constants: `getSafeSingletonVersions`, `getSafeL2SingletonVersions`, `getSafeMigrationVersions`
- `src/domain/common/utils/safe.ts` — `detectSafeMigration` matches the transaction target against all known `SafeMigration` versions; target-version candidates come from `getSafeMigrationTargetVersions()` (singleton versions `>=1.3.0`, ascending) instead of a hardcoded list
- `src/domain/common/utils/__tests__/deployments.spec.ts` — cases for the three new getters
- `src/domain/common/utils/__tests__/safe.spec.ts` — migration-detection cases rewritten against package-derived versions (covers the 1.5.0 contract)