### PR TITLE
fix(relay): log the provider's rejection reason on relay failures

### DIFF
--- a/src/modules/relay/datasources/rhinestone-api.service.spec.ts
+++ b/src/modules/relay/datasources/rhinestone-api.service.spec.ts
@@ -154,6 +154,130 @@ describe('RhinestoneApi', () => {
       );
     });
 
+    it('should log the provider error message and traceId', async () => {
+      const chainId = faker.string.numeric();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const data = faker.string.hexadecimal() as Hex;
+      const status = faker.internet.httpStatusCode({ types: ['clientError'] });
+      const statusText = faker.lorem.words();
+      const message = faker.lorem.sentence();
+      const traceId = faker.string.hexadecimal({
+        length: 32,
+        prefix: '',
+      });
+      mockNetworkService.post.mockRejectedValue(
+        new NetworkResponseError(
+          new URL(`${baseUri}/safe-transactions`),
+          { status, statusText } as Response,
+          { errors: [{ message }], traceId },
+        ),
+      );
+
+      await expect(target.relay({ chainId, to, data })).rejects.toThrow(
+        DataSourceError,
+      );
+      expect(mockLoggingService.error).toHaveBeenCalledWith(
+        `Error relaying transaction for chain ${chainId}: status=${status} ${statusText} upstreamErrors="${message}" traceId=${traceId}`,
+      );
+    });
+
+    it('should keep the provider error detail out of the thrown error', async () => {
+      const chainId = faker.string.numeric();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const data = faker.string.hexadecimal() as Hex;
+      const message = faker.lorem.sentence();
+      const traceId = faker.string.hexadecimal({ length: 32, prefix: '' });
+      mockNetworkService.post.mockRejectedValue(
+        new NetworkResponseError(
+          new URL(`${baseUri}/safe-transactions`),
+          { status: 400, statusText: 'Bad Request' } as Response,
+          { errors: [{ message }], traceId },
+        ),
+      );
+
+      // The provider's reason is a diagnostic for our logs only - clients get
+      // the generic HttpErrorFactory message, never the upstream detail.
+      await expect(target.relay({ chainId, to, data })).rejects.toThrow(
+        new DataSourceError('An error occurred', 400),
+      );
+    });
+
+    it('should not log the context of a provider error', async () => {
+      const chainId = faker.string.numeric();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const data = faker.string.hexadecimal() as Hex;
+      const message = faker.lorem.sentence();
+      const contextAddress = getAddress(faker.finance.ethereumAddress());
+      mockNetworkService.post.mockRejectedValue(
+        new NetworkResponseError(
+          new URL(`${baseUri}/safe-transactions`),
+          { status: 400, statusText: 'Bad Request' } as Response,
+          {
+            errors: [
+              {
+                message,
+                context: {
+                  chainId: Number(chainId),
+                  address: contextAddress,
+                },
+              },
+            ],
+          },
+        ),
+      );
+
+      await expect(target.relay({ chainId, to, data })).rejects.toThrow(
+        DataSourceError,
+      );
+      // Asserting the whole line: `context` is absent, not merely unasserted.
+      expect(mockLoggingService.error).toHaveBeenCalledWith(
+        `Error relaying transaction for chain ${chainId}: status=400 Bad Request upstreamErrors="${message}"`,
+      );
+    });
+
+    it('should collapse newlines and cap the length of a provider error message', async () => {
+      const chainId = faker.string.numeric();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const data = faker.string.hexadecimal() as Hex;
+      const injected = faker.lorem.word();
+      const message = `${'a'.repeat(250)}\n${injected}`;
+      mockNetworkService.post.mockRejectedValue(
+        new NetworkResponseError(
+          new URL(`${baseUri}/safe-transactions`),
+          { status: 400, statusText: 'Bad Request' } as Response,
+          { errors: [{ message }] },
+        ),
+      );
+
+      await expect(target.relay({ chainId, to, data })).rejects.toThrow(
+        DataSourceError,
+      );
+      expect(mockLoggingService.error).toHaveBeenCalledWith(
+        `Error relaying transaction for chain ${chainId}: status=400 Bad Request upstreamErrors="${'a'.repeat(200)}…"`,
+      );
+    });
+
+    it('should cap the number of provider error messages logged', async () => {
+      const chainId = faker.string.numeric();
+      const to = getAddress(faker.finance.ethereumAddress());
+      const data = faker.string.hexadecimal() as Hex;
+      const messages = Array.from({ length: 5 }, () => faker.lorem.word());
+      mockNetworkService.post.mockRejectedValue(
+        new NetworkResponseError(
+          new URL(`${baseUri}/safe-transactions`),
+          { status: 400, statusText: 'Bad Request' } as Response,
+          { errors: messages.map((message) => ({ message })) },
+        ),
+      );
+
+      await expect(target.relay({ chainId, to, data })).rejects.toThrow(
+        DataSourceError,
+      );
+      expect(mockLoggingService.error).toHaveBeenCalledWith(
+        `Error relaying transaction for chain ${chainId}: status=400 Bad Request upstreamErrors="${messages.slice(0, 3).join('; ')}"`,
+      );
+    });
+
     it('should log the target URL when no response was received', async () => {
       const chainId = faker.string.numeric();
       const to = getAddress(faker.finance.ethereumAddress());

--- a/src/modules/relay/datasources/rhinestone-api.service.ts
+++ b/src/modules/relay/datasources/rhinestone-api.service.ts
@@ -22,6 +22,7 @@ import {
   LoggingService,
 } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
+import { RhinestoneErrorResponseSchema } from '@/modules/relay/datasources/schemas/rhinestone-error.schema';
 import {
   type Relay,
   type RhinestoneRelayResponse,
@@ -32,6 +33,19 @@ import {
   type RhinestoneTaskStatusResponse,
   RhinestoneTaskStatusResponseSchema,
 } from '@/modules/relay/domain/entities/relay-task-status.entity';
+
+/**
+ * Cap on how many of a Rhinestone error body's `errors[]` entries are copied
+ * into a log line. Rhinestone can report several validation failures at once;
+ * the first few carry the diagnosis, the rest would only bloat the entry.
+ */
+const MAX_LOGGED_UPSTREAM_ERRORS = 3;
+
+/**
+ * Per-message character cap for upstream-controlled strings copied into a log
+ * line, so a long or hostile body cannot flood log storage.
+ */
+const MAX_LOGGED_UPSTREAM_MESSAGE_LENGTH = 200;
 
 @Injectable()
 export class RhinestoneApi implements IRelayApi {
@@ -61,18 +75,69 @@ export class RhinestoneApi implements IRelayApi {
    *
    * Both network error classes extend {@link Error} without setting a message,
    * so `asError(error).message` alone is empty and undiagnosable. This surfaces
-   * the HTTP status (or the target URL, when no response was received) instead.
-   * Response bodies are deliberately not logged — they are attacker-influenced
-   * and may carry request details we do not want in logs.
+   * the HTTP status (or the target URL, when no response was received), plus
+   * the whitelisted diagnostic fields of the response body — see
+   * {@link describeUpstreamError} for what is and is not copied out of it.
    */
   private formatError(error: unknown): string {
     if (error instanceof NetworkResponseError) {
-      return `status=${error.response.status} ${error.response.statusText}`;
+      return `status=${error.response.status} ${error.response.statusText}${this.describeUpstreamError(error.data)}`;
     }
     if (error instanceof NetworkRequestError) {
       return `no response received from ${error.url}`;
     }
     return asError(error).message;
+  }
+
+  /**
+   * Extracts the loggable part of a Rhinestone error body.
+   *
+   * Rhinestone nests its rejection reason under `errors[].message`, which
+   * {@link HttpErrorFactory} cannot see (it reads only `data.message`), so
+   * without this the reason — e.g. "`to` is not a canonical Safe proxy
+   * factory" — is discarded and the failure is undiagnosable from logs alone.
+   *
+   * The body is not logged wholesale: only `errors[].message` and `traceId`
+   * are copied, per the structured-logging rule in `docs/agents/security.md`.
+   * The `errors[].context` object is dropped — it echoes back request details
+   * (chain ID, addresses) that do not belong in log storage. Messages are
+   * whitespace-collapsed and length-capped so an upstream-controlled string
+   * cannot forge additional log lines or flood a log entry.
+   *
+   * @returns a leading-space-prefixed fragment ready to append to a log line,
+   * or an empty string when the body carries nothing loggable.
+   */
+  private describeUpstreamError(data: unknown): string {
+    const parsed = RhinestoneErrorResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      return '';
+    }
+
+    const messages = (parsed.data.errors ?? [])
+      .slice(0, MAX_LOGGED_UPSTREAM_ERRORS)
+      .map((error) => this.truncateForLog(error.message))
+      .filter((message) => message.length > 0);
+
+    const fragments: Array<string> = [];
+    if (messages.length > 0) {
+      fragments.push(`upstreamErrors="${messages.join('; ')}"`);
+    }
+    if (parsed.data.traceId) {
+      fragments.push(`traceId=${this.truncateForLog(parsed.data.traceId)}`);
+    }
+
+    return fragments.length > 0 ? ` ${fragments.join(' ')}` : '';
+  }
+
+  /**
+   * Collapses whitespace (including newlines, which would otherwise let an
+   * upstream string forge log lines) and caps length.
+   */
+  private truncateForLog(value: string): string {
+    const collapsed = value.replace(/\s+/g, ' ').trim();
+    return collapsed.length > MAX_LOGGED_UPSTREAM_MESSAGE_LENGTH
+      ? `${collapsed.slice(0, MAX_LOGGED_UPSTREAM_MESSAGE_LENGTH)}…`
+      : collapsed;
   }
 
   /**

--- a/src/modules/relay/datasources/schemas/rhinestone-error.schema.ts
+++ b/src/modules/relay/datasources/schemas/rhinestone-error.schema.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+/**
+ * Shape of a Rhinestone error response body.
+ *
+ * Rhinestone reports failures as
+ * `{ errors: [{ message, context }], traceId }` — it does not use the
+ * top-level `message` field that {@link HttpErrorFactory} reads, so without
+ * this schema a rejection reaches the client as a bare
+ * `{ code: <status>, message: 'An error occurred' }` and the reason is lost.
+ *
+ * Every field is optional: this parses an error path, so it must never throw
+ * and mask the original failure. `context` is deliberately not declared —
+ * it echoes request details (chain ID, addresses) that the structured-logging
+ * rule in `docs/agents/security.md` keeps out of logs, and Zod strips
+ * undeclared keys.
+ */
+export const RhinestoneErrorResponseSchema = z.object({
+  errors: z.array(z.object({ message: z.string() })).optional(),
+  traceId: z.string().optional(),
+});
+
+export type RhinestoneErrorResponse = z.infer<
+  typeof RhinestoneErrorResponseSchema
+>;


### PR DESCRIPTION
## Summary
A relay rejection from Rhinestone reached the logs as nothing but a status code. Rhinestone nests its reason under `errors[].message`, while `HttpErrorFactory` reads only `data.message`, so the reason hit the literal
`'An error occurred'` fallback and was thrown away.

Because the body is third-party-controlled text, only two fields are copied out of it: `errors[].message` and `traceId`. The `errors[].context` object is deliberately dropped — it echoes back the chain ID and addresses from the
request, which the structured-logging rule in `docs/agents/security.md` keeps out of log storage; the schema simply does not declare it, so Zod strips it.
Messages are whitespace-collapsed (newlines would let an upstream string forge log lines) and capped at 3 entries x 200 chars.

The client-facing response is unchanged and deliberately so: the throw still goes through `httpErrorFactory.from()`, so callers keep the generic `{code, message}` payload and the provider's text stays server-side. A test asserts that, so a later change wiring the detail into the throw fails rather than silently leaking it.

`getTaskStatus` shares `formatError` and gains the same detail.

## Changes
- `src/modules/relay/datasources/schemas/rhinestone-error.schema.ts` — new; the error envelope, all fields optional so parsing an error path cannot throw and mask the original failure
- `src/modules/relay/datasources/rhinestone-api.service.ts` — `formatError` appends the whitelisted fields; `describeUpstreamError` + `truncateForLog` helpers
- `src/modules/relay/datasources/rhinestone-api.service.spec.ts` — 5 cases: message + traceId, `context` absent, truncation/newline collapsing, the error-count cap, and the response staying generic
