### PR TITLE
fix(auth): keep the prior session expiry on step-up

### DIFF
--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -692,9 +692,12 @@ describe('OidcAuthController', () => {
       async function roundTrip({
         elevate,
         amr,
+        priorSessionExp,
       }: {
         elevate: boolean;
         amr?: Array<string>;
+        /** When set, the callback arrives with a live session cookie expiring then. */
+        priorSessionExp?: Date;
       }): Promise<Record<string, unknown> | undefined> {
         vi.setSystemTime(NOW_MS);
 
@@ -729,9 +732,19 @@ describe('OidcAuthController', () => {
           .find((cookie) => cookie.startsWith('auth_state='))
           ?.split(';')[0];
 
+        const cookies = [stateCookie!];
+        if (priorSessionExp) {
+          const priorToken = jwtService.sign({
+            auth_method: 'oidc',
+            sub: faker.string.numeric({ exclude: ['0'] }),
+            exp: priorSessionExp,
+          });
+          cookies.push(`access_token=${priorToken}`);
+        }
+
         const callbackResponse = await request(app.getHttpServer())
           .get('/v1/auth/oidc/callback')
-          .set('Cookie', stateCookie!)
+          .set('Cookie', cookies)
           .query({ code: 'auth-code', state })
           .expect(302);
 
@@ -773,12 +786,28 @@ describe('OidcAuthController', () => {
       });
 
       it('should elevate the session when the provider performed MFA', async () => {
-        const payload = await roundTrip({ elevate: true, amr: ['mfa'] });
+        const remainingSeconds = 4 * 3_600;
+        const payload = await roundTrip({
+          elevate: true,
+          amr: ['mfa'],
+          priorSessionExp: new Date(NOW_MS + remainingSeconds * 1_000),
+        });
 
         expect(payload).toMatchObject({
           auth_method: 'oidc',
           mfa_verified_at: NOW_SECONDS,
+          // The prior session's expiry is carried over, not extended.
+          exp: NOW_SECONDS + remainingSeconds,
         });
+      });
+
+      // A step-up elevates an existing session; with none to elevate — it
+      // expired while the user was on the challenge page — the callback fails
+      // instead of minting a fresh session.
+      it('should refuse to elevate when there is no session to elevate', async () => {
+        const payload = await roundTrip({ elevate: true, amr: ['mfa'] });
+
+        expect(payload).toBeUndefined();
       });
 
       it('should refuse to elevate when the provider did not perform MFA', async () => {

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -20,6 +20,7 @@ import {
   NetworkService,
 } from '@/datasources/network/network.service.interface';
 import { getSecondsUntil } from '@/domain/common/utils/time';
+import { oidcAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import {
   type Auth0JwksFixture,
   getAuth0JwksFixture,
@@ -735,8 +736,7 @@ describe('OidcAuthController', () => {
         const cookies = [stateCookie!];
         if (priorSessionExp) {
           const priorToken = jwtService.sign({
-            auth_method: 'oidc',
-            sub: faker.string.numeric({ exclude: ['0'] }),
+            ...oidcAuthPayloadDtoBuilder().build(),
             exp: priorSessionExp,
           });
           cookies.push(`access_token=${priorToken}`);

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -786,7 +786,13 @@ describe('OidcAuthController', () => {
       });
 
       it('should elevate the session when the provider performed MFA', async () => {
-        const remainingSeconds = 4 * 3_600;
+        // Strictly inside the configured max-validity window — which the test
+        // configuration randomizes per run — so the carry-over, not the bound,
+        // decides the elevated token's expiry.
+        const remainingSeconds = Math.max(
+          1,
+          Math.floor(maxValidityPeriodInMs / 1_000 / 2),
+        );
         const payload = await roundTrip({
           elevate: true,
           amr: ['mfa'],

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.ts
@@ -235,6 +235,7 @@ export class OidcAuthController {
         await this.oidcAuthService.authenticateWithOidc(
           code,
           this.oidcAuthService.isElevationState(state),
+          req.cookies?.[ACCESS_TOKEN_COOKIE_NAME],
         );
 
       if (this.oidcAuthService.isEnrollmentState(state)) {

--- a/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
@@ -8,7 +8,9 @@ import {
 } from '@nestjs/common';
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import type { ILoggingService } from '@/logging/logging.interface';
 import type { IAuthRepository } from '@/modules/auth/domain/auth.repository.interface';
+import { oidcAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import {
   AuthMethod,
   AuthPayload,
@@ -30,6 +32,13 @@ const usersRepositoryMock = {
   findOneOrFail: vi.fn(),
   findEmailById: vi.fn(),
 } as MockedObject<IUsersRepository>;
+
+const loggingServiceMock: MockedObject<ILoggingService> = {
+  info: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+};
 
 const auth0RepositoryMock = {
   getAuthorizationUrl: vi.fn(),
@@ -69,6 +78,7 @@ describe('OidcAuthService', () => {
       fakeConfigurationService,
       usersRepositoryMock,
       auth0RepositoryMock,
+      loggingServiceMock,
     );
   });
 
@@ -477,13 +487,162 @@ describe('OidcAuthService', () => {
     });
 
     it('should accept an elevation callback whose token proves MFA', async () => {
+      const now = new Date();
+      vi.setSystemTime(now);
       arrange(['mfa']);
+      // A step-up needs a live session to elevate.
+      authRepositoryMock.decodeToken.mockReturnValue({
+        ...oidcAuthPayloadDtoBuilder().build(),
+        exp: new Date(now.getTime() + 3_600 * 1_000),
+        nbf: undefined,
+        iat: undefined,
+      });
 
       await expect(
-        target.authenticateWithOidc(faker.string.alphanumeric(32), true),
+        target.authenticateWithOidc(
+          faker.string.alphanumeric(32),
+          true,
+          faker.string.alphanumeric(64),
+        ),
       ).resolves.toEqual(
         expect.objectContaining({ accessToken: expect.any(String) }),
       );
+    });
+  });
+
+  describe('session lifetime on step-up', () => {
+    const arrange = (): void => {
+      auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
+        sub: `auth0|${faker.string.uuid()}`,
+        email: fakeEmailAddress(),
+        email_verified: true,
+        exp: undefined,
+        nbf: undefined,
+        iat: undefined,
+        amr: ['mfa'],
+      });
+      usersRepositoryMock.findOrCreateByExtUserIdAndEmail.mockResolvedValue(
+        faker.number.int(),
+      );
+      authRepositoryMock.signToken.mockReturnValue(
+        faker.string.alphanumeric(64),
+      );
+    };
+
+    // The session lifetime is an absolute timeout. A step-up proves only the
+    // second factor, so it must not reset that clock.
+    it('should keep the prior session expiry instead of extending the session', async () => {
+      const now = new Date();
+      vi.setSystemTime(now);
+      arrange();
+      // Strictly inside the max-validity window, so the carry-over branch —
+      // not the bound — decides the expiry.
+      const remainingSeconds = faker.number.int({
+        min: 60,
+        max: maxValidityPeriodInSeconds - 60,
+      });
+      const priorExp = new Date(now.getTime() + remainingSeconds * 1_000);
+      const priorAccessToken = faker.string.alphanumeric(64);
+      authRepositoryMock.decodeToken.mockReturnValue({
+        ...oidcAuthPayloadDtoBuilder().build(),
+        exp: priorExp,
+        nbf: undefined,
+        iat: undefined,
+      });
+
+      const result = await target.authenticateWithOidc(
+        faker.string.alphanumeric(32),
+        true,
+        priorAccessToken,
+      );
+
+      expect(authRepositoryMock.decodeToken).toHaveBeenCalledWith(
+        priorAccessToken,
+      );
+      expect(authRepositoryMock.signToken).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ exp: priorExp }),
+      );
+      expect(result.maxAge).toBe(remainingSeconds);
+    });
+
+    // The max-validity bound applies to the carried-over expiry too: a prior
+    // token claiming more than the constant allows never propagates.
+    it('should not carry over a prior expiry beyond the max-validity bound', async () => {
+      const now = new Date();
+      vi.setSystemTime(now);
+      arrange();
+      const beyondMax = new Date(
+        now.getTime() + (maxValidityPeriodInSeconds + 60) * 1_000,
+      );
+      authRepositoryMock.decodeToken.mockReturnValue({
+        ...oidcAuthPayloadDtoBuilder().build(),
+        exp: beyondMax,
+        nbf: undefined,
+        iat: undefined,
+      });
+
+      await target.authenticateWithOidc(
+        faker.string.alphanumeric(32),
+        true,
+        faker.string.alphanumeric(64),
+      );
+
+      expect(authRepositoryMock.signToken).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          exp: new Date(now.getTime() + maxValidityPeriodInSeconds * 1_000),
+        }),
+      );
+    });
+
+    // A step-up elevates an existing session; without one — e.g. it expired
+    // while the user was on the challenge page — there is nothing to elevate,
+    // and minting a fresh session would let elevation double as a login.
+    it('should reject the step-up when the prior session cannot be decoded', async () => {
+      const now = new Date();
+      vi.setSystemTime(now);
+      arrange();
+      authRepositoryMock.decodeToken.mockImplementation(() => {
+        throw new Error('jwt expired');
+      });
+
+      await expect(
+        target.authenticateWithOidc(
+          faker.string.alphanumeric(32),
+          true,
+          faker.string.alphanumeric(64),
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(authRepositoryMock.signToken).not.toHaveBeenCalled();
+    });
+
+    it('should reject the step-up when there is no prior session', async () => {
+      const now = new Date();
+      vi.setSystemTime(now);
+      arrange();
+
+      await expect(
+        target.authenticateWithOidc(faker.string.alphanumeric(32), true),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(authRepositoryMock.signToken).not.toHaveBeenCalled();
+    });
+
+    it('should ignore the prior session on a plain login', async () => {
+      const now = new Date();
+      vi.setSystemTime(now);
+      arrange();
+
+      const result = await target.authenticateWithOidc(
+        faker.string.alphanumeric(32),
+        false,
+        faker.string.alphanumeric(64),
+      );
+
+      expect(authRepositoryMock.decodeToken).not.toHaveBeenCalled();
+      expect(result.maxAge).toBe(maxValidityPeriodInSeconds);
     });
   });
 
@@ -624,6 +783,7 @@ describe('OidcAuthService', () => {
           fakeConfigurationService,
           usersRepositoryMock,
           auth0RepositoryMock,
+          loggingServiceMock,
         );
       });
 
@@ -744,6 +904,7 @@ describe('OidcAuthService', () => {
           fakeConfigurationService,
           usersRepositoryMock,
           auth0RepositoryMock,
+          loggingServiceMock,
         );
 
         // A subdomain that would pass the domain-suffix check should be

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -131,14 +131,6 @@ export class OidcAuthService {
       this.maxValidityPeriodInSeconds,
     );
 
-    if (expirationTime) {
-      assertExpirationTime(
-        expirationTime,
-        maxExpirationTime,
-        this.maxValidityPeriodInSeconds,
-      );
-    }
-
     const exp = this.getSessionExpiration({
       elevate,
       expirationTime,
@@ -185,6 +177,9 @@ export class OidcAuthService {
    * second factor, it does not restart the absolute-timeout clock. The
    * max-validity bound applies either way.
    *
+   * @throws {ForbiddenException} When the provider asks for an expiry beyond
+   *   the max-validity bound — a tenant misconfiguration worth surfacing
+   *   rather than silently shortening.
    * @throws {UnauthorizedException} On a step-up with no live session to
    *   elevate — it expired while the user was on the challenge page. Minting a
    *   fresh session here would let a step-up double as a login whose only
@@ -201,6 +196,14 @@ export class OidcAuthService {
     priorAccessToken: string | undefined;
     maxExpirationTime: Date;
   }): Date {
+    if (expirationTime) {
+      assertExpirationTime(
+        expirationTime,
+        maxExpirationTime,
+        this.maxValidityPeriodInSeconds,
+      );
+    }
+
     if (!elevate) {
       return expirationTime ?? maxExpirationTime;
     }

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -139,28 +139,12 @@ export class OidcAuthService {
       );
     }
 
-    // A step-up elevates an existing session, so it must not extend it: the
-    // elevated token keeps the prior session's expiry, and the hard logout
-    // still lands where the original login put it. With no live session to
-    // elevate — it expired while the user was on the challenge page — the
-    // step-up fails rather than minting a fresh session: elevation would
-    // otherwise double as a login whose first factor is only Auth0's
-    // longer-lived SSO session. The carried-over expiry is our own verified
-    // token's, so it can only shorten the lifetime — but the max-validity
-    // bound is enforced rather than argued.
-    let exp: Date;
-    if (elevate) {
-      const priorExpiration = this.getPriorExpiration(priorAccessToken);
-      if (!priorExpiration) {
-        throw new UnauthorizedException('There is no session to elevate');
-      }
-      exp =
-        priorExpiration < maxExpirationTime
-          ? priorExpiration
-          : maxExpirationTime;
-    } else {
-      exp = expirationTime ?? maxExpirationTime;
-    }
+    const exp = this.getSessionExpiration({
+      elevate,
+      expirationTime,
+      priorAccessToken,
+      maxExpirationTime,
+    });
 
     const userId = await this.usersRepository.findOrCreateByExtUserIdAndEmail(
       extUserId,
@@ -191,6 +175,49 @@ export class OidcAuthService {
       maxAge: getSecondsUntil(exp),
       userId,
     };
+  }
+
+  /**
+   * The expiry for the token about to be signed.
+   *
+   * A plain login takes the provider's expiry. A step-up elevates the session
+   * the user already has, so it keeps that session's expiry: it proves the
+   * second factor, it does not restart the absolute-timeout clock. The
+   * max-validity bound applies either way.
+   *
+   * @throws {UnauthorizedException} On a step-up with no live session to
+   *   elevate — it expired while the user was on the challenge page. Minting a
+   *   fresh session here would let a step-up double as a login whose only
+   *   first factor is Auth0's longer-lived SSO session.
+   */
+  private getSessionExpiration({
+    elevate,
+    expirationTime,
+    priorAccessToken,
+    maxExpirationTime,
+  }: {
+    elevate: boolean;
+    expirationTime: Date | undefined;
+    priorAccessToken: string | undefined;
+    maxExpirationTime: Date;
+  }): Date {
+    if (!elevate) {
+      return expirationTime ?? maxExpirationTime;
+    }
+
+    const priorExpiration = this.getPriorExpiration(priorAccessToken);
+    if (!priorExpiration) {
+      throw new UnauthorizedException('There is no session to elevate');
+    }
+
+    // Only fires if the configured max validity was shortened after this
+    // session was issued: re-signing must not carry over a lifetime the
+    // current policy would no longer grant.
+    if (priorExpiration > maxExpirationTime) {
+      return maxExpirationTime;
+    }
+
+    return priorExpiration;
   }
 
   /**

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -3,6 +3,11 @@ import { randomBytes } from 'node:crypto';
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { getSecondsUntil } from '@/domain/common/utils/time';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
 import { IAuthRepository } from '@/modules/auth/domain/auth.repository.interface';
 import {
   AuthMethod,
@@ -50,6 +55,8 @@ export class OidcAuthService {
     private readonly usersRepository: IUsersRepository,
     @Inject(IAuth0Repository)
     private readonly auth0Repository: IAuth0Repository,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
   ) {
     this.maxValidityPeriodInSeconds = this.configurationService.getOrThrow(
       'auth.maxValidityPeriodSeconds',
@@ -81,10 +88,15 @@ export class OidcAuthService {
    * @param elevate - Whether this callback completes a step-up round-trip. When
    *   true the provider must have performed a multi-factor challenge, and the
    *   request is rejected if it did not.
+   * @param priorAccessToken - The session cookie that was present when the
+   *   step-up round-trip completed, if any. On elevation its expiry is carried
+   *   over to the new token, so a step-up never extends the session; without a
+   *   valid one there is nothing to elevate and the request is rejected.
    */
   public async authenticateWithOidc(
     code: string,
     elevate = false,
+    priorAccessToken?: string,
   ): Promise<OidcAuthTokenResponse> {
     const {
       sub: extUserId,
@@ -127,6 +139,29 @@ export class OidcAuthService {
       );
     }
 
+    // A step-up elevates an existing session, so it must not extend it: the
+    // elevated token keeps the prior session's expiry, and the hard logout
+    // still lands where the original login put it. With no live session to
+    // elevate — it expired while the user was on the challenge page — the
+    // step-up fails rather than minting a fresh session: elevation would
+    // otherwise double as a login whose first factor is only Auth0's
+    // longer-lived SSO session. The carried-over expiry is our own verified
+    // token's, so it can only shorten the lifetime — but the max-validity
+    // bound is enforced rather than argued.
+    let exp: Date;
+    if (elevate) {
+      const priorExpiration = this.getPriorExpiration(priorAccessToken);
+      if (!priorExpiration) {
+        throw new UnauthorizedException('There is no session to elevate');
+      }
+      exp =
+        priorExpiration < maxExpirationTime
+          ? priorExpiration
+          : maxExpirationTime;
+    } else {
+      exp = expirationTime ?? maxExpirationTime;
+    }
+
     const userId = await this.usersRepository.findOrCreateByExtUserIdAndEmail(
       extUserId,
       email,
@@ -146,17 +181,39 @@ export class OidcAuthService {
       },
       {
         nbf,
-        exp: expirationTime ?? maxExpirationTime,
+        exp,
         iat: iat ?? new Date(),
       },
     );
 
-    const exp = expirationTime ?? maxExpirationTime;
     return {
       accessToken,
       maxAge: getSecondsUntil(exp),
       userId,
     };
+  }
+
+  /**
+   * The expiry the elevated session must keep: the prior session's own.
+   *
+   * The session lifetime is an absolute timeout — its job is to bound how
+   * long any one session lives, and a step-up proves only the second factor,
+   * so it must not reset that clock. Returns undefined when there is no
+   * (valid) prior session; the caller rejects the elevation in that case.
+   */
+  private getPriorExpiration(priorAccessToken?: string): Date | undefined {
+    if (!priorAccessToken) {
+      return undefined;
+    }
+
+    try {
+      return this.authRepository.decodeToken(priorAccessToken).exp;
+    } catch (err) {
+      // Expected on a session that expired while the user was on the
+      // challenge page; only the error message is logged, never the token.
+      this.loggingService.debug(asError(err).message);
+      return undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

A step-up round-trip minted a brand-new session, so elevating at hour 20 of a
24h session handed back a fresh lifetime instead of the 4h the user had left.
The session lifetime is an absolute timeout — its job is to bound how long any
one session lives, and a step-up proves only the second factor — so it must
not reset that clock. The elevated token now carries over the prior cookie's
`exp`, bounded by the max-validity constant.

With no live session to elevate — it expired while the user was on the
challenge page — the step-up now fails (`401`, surfaced to the client as the
usual `authentication_failed` redirect) instead of minting a fresh session:
elevation would otherwise double as a login whose first factor is only Auth0's
longer-lived SSO session. The user signs in again through the normal flow.
WA-3268.

## Changes

- `src/modules/auth/oidc/routes/oidc-auth.service.ts` — on elevation, require a
  valid prior session and carry its verified `exp` into the new token, bounded by
  `maxExpirationTime`; reject with `UnauthorizedException` when there is none
  (decode failures are debug-logged, message only, never the token)
- `src/modules/auth/oidc/routes/oidc-auth.controller.ts` — pass the session cookie
  into authentication on the callback
- `src/modules/auth/oidc/routes/oidc-auth.service.spec.ts` — carry-over, bound,
  rejected-when-undecodable, rejected-when-absent, and plain-login cases
- `src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts` — the
  elevate round-trip carries a live session cookie; asserts the carried-over `exp`
  and the refusal when no session is present
