### PR TITLE
fix(users): reject account deletion by a space's last admin

### DIFF
--- a/src/modules/users/domain/members/members.repository.ts
+++ b/src/modules/users/domain/members/members.repository.ts
@@ -41,6 +41,7 @@ import {
   isActiveAdmin,
   isLastActiveAdminOfSpace,
   lockSpaceForAdminChange,
+  lockUserForAdminChange,
 } from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -525,6 +526,11 @@ export class MembersRepository implements IMembersRepository {
     const actingUserId = getAuthenticatedUserIdOrFail(args.authPayload);
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
+      // A role change touches no FK column, so on its own it takes no lock on
+      // the target's account row - while their in-flight account deletion picks
+      // which spaces to lock from the memberships it can see. Lock that row so
+      // the two serialize; user rows before space rows, per the helper's doc.
+      await lockUserForAdminChange(entityManager, args.userId);
       await lockSpaceForAdminChange(entityManager, args.spaceId);
       const activeAdmins = await this.findActiveAdminsForUpdateOrFail(
         entityManager,

--- a/src/modules/users/domain/members/members.repository.ts
+++ b/src/modules/users/domain/members/members.repository.ts
@@ -40,6 +40,7 @@ import {
   activeOrPendingMemberWhere,
   isActiveAdmin,
   isLastActiveAdminOfSpace,
+  lockSpaceForAdminChange,
 } from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -493,11 +494,26 @@ export class MembersRepository implements IMembersRepository {
     });
   }
 
-  private findActiveAdminsOrFail(spaceId: Space['id']): Promise<Array<Member>> {
-    return this.findOrFail({
+  /**
+   * Active admins of one space, read through the caller's transaction so the
+   * space lock covers them. Skips `findOrFail`'s email decryption: the admin
+   * rules read only role, status and user id, and a KMS call would sit inside
+   * the lock.
+   */
+  private async findActiveAdminsForUpdateOrFail(
+    entityManager: EntityManager,
+    spaceId: Space['id'],
+  ): Promise<Array<DbMember>> {
+    const members = await entityManager.find(DbMember, {
       where: { space: { id: spaceId }, role: 'ADMIN', status: 'ACTIVE' },
       relations: { user: true },
     });
+
+    if (members.length === 0) {
+      throw new NotFoundException('No members found.');
+    }
+
+    return members;
   }
 
   public async updateRole(args: {
@@ -508,18 +524,22 @@ export class MembersRepository implements IMembersRepository {
   }): Promise<void> {
     const actingUserId = getAuthenticatedUserIdOrFail(args.authPayload);
 
-    const activeAdmins = await this.findActiveAdminsOrFail(args.spaceId);
-
-    this.assertIsActiveAdmin({ members: activeAdmins, userId: actingUserId });
-    const isSelf = actingUserId === args.userId;
-    if (isSelf && args.role !== 'ADMIN') {
-      this.assertIsNotLastAdmin({
-        members: activeAdmins,
-        userId: actingUserId,
-      });
-    }
-
     await this.postgresDatabaseService.transaction(async (entityManager) => {
+      await lockSpaceForAdminChange(entityManager, args.spaceId);
+      const activeAdmins = await this.findActiveAdminsForUpdateOrFail(
+        entityManager,
+        args.spaceId,
+      );
+
+      this.assertIsActiveAdmin({ members: activeAdmins, userId: actingUserId });
+      const isSelf = actingUserId === args.userId;
+      if (isSelf && args.role !== 'ADMIN') {
+        this.assertIsNotLastAdmin({
+          members: activeAdmins,
+          userId: actingUserId,
+        });
+      }
+
       const member = await entityManager.findOne(DbMember, {
         where: { user: { id: args.userId }, space: { id: args.spaceId } },
       });
@@ -599,18 +619,22 @@ export class MembersRepository implements IMembersRepository {
   }): Promise<void> {
     const actingUserId = getAuthenticatedUserIdOrFail(args.authPayload);
 
-    const activeAdmins = await this.findActiveAdminsOrFail(args.spaceId);
-
-    this.assertIsActiveAdmin({ members: activeAdmins, userId: actingUserId });
-    const isSelf = actingUserId === args.userId;
-    if (isSelf) {
-      this.assertIsNotLastAdmin({
-        members: activeAdmins,
-        userId: actingUserId,
-      });
-    }
-
     await this.postgresDatabaseService.transaction(async (entityManager) => {
+      await lockSpaceForAdminChange(entityManager, args.spaceId);
+      const activeAdmins = await this.findActiveAdminsForUpdateOrFail(
+        entityManager,
+        args.spaceId,
+      );
+
+      this.assertIsActiveAdmin({ members: activeAdmins, userId: actingUserId });
+      const isSelf = actingUserId === args.userId;
+      if (isSelf) {
+        this.assertIsNotLastAdmin({
+          members: activeAdmins,
+          userId: actingUserId,
+        });
+      }
+
       const member = await entityManager.findOne(DbMember, {
         where: { user: { id: args.userId }, space: { id: args.spaceId } },
       });
@@ -640,11 +664,15 @@ export class MembersRepository implements IMembersRepository {
   }): Promise<void> {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
 
-    const activeAdmins = await this.findActiveAdminsOrFail(args.spaceId);
-
-    this.assertIsNotLastAdmin({ members: activeAdmins, userId });
-
     await this.postgresDatabaseService.transaction(async (entityManager) => {
+      await lockSpaceForAdminChange(entityManager, args.spaceId);
+      const activeAdmins = await this.findActiveAdminsForUpdateOrFail(
+        entityManager,
+        args.spaceId,
+      );
+
+      this.assertIsNotLastAdmin({ members: activeAdmins, userId });
+
       const member = await entityManager.findOne(DbMember, {
         where: { user: { id: userId }, space: { id: args.spaceId } },
       });

--- a/src/modules/users/domain/members/members.repository.ts
+++ b/src/modules/users/domain/members/members.repository.ts
@@ -36,7 +36,11 @@ import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import { MemberEncryptionService } from '@/modules/users/domain/members/member-encryption.service';
 import type { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
-import { activeOrPendingMemberWhere } from '@/modules/users/domain/members/utils/members.utils';
+import {
+  activeOrPendingMemberWhere,
+  isActiveAdmin,
+  isLastActiveAdmin,
+} from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
@@ -670,7 +674,7 @@ export class MembersRepository implements IMembersRepository {
   }): void {
     if (
       !args.members.some((member) => {
-        return this.isActiveAdmin(member) && member.user.id === args.userId;
+        return isActiveAdmin(member) && member.user.id === args.userId;
       })
     ) {
       throw new ForbiddenException('User is not an active admin.');
@@ -681,17 +685,9 @@ export class MembersRepository implements IMembersRepository {
     members: Array<DbMember>;
     userId: User['id'];
   }): void {
-    if (
-      args.members.length === 1 &&
-      args.members[0].user.id === args.userId &&
-      this.isActiveAdmin(args.members[0])
-    ) {
+    if (isLastActiveAdmin(args)) {
       throw new ConflictException('Cannot remove last admin.');
     }
-  }
-
-  private isActiveAdmin(member: DbMember): boolean {
-    return member.role === 'ADMIN' && member.status === 'ACTIVE';
   }
 
   /**

--- a/src/modules/users/domain/members/members.repository.ts
+++ b/src/modules/users/domain/members/members.repository.ts
@@ -39,7 +39,7 @@ import type { IMembersRepository } from '@/modules/users/domain/members/members.
 import {
   activeOrPendingMemberWhere,
   isActiveAdmin,
-  isLastActiveAdmin,
+  isLastActiveAdminOfSpace,
 } from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -685,7 +685,7 @@ export class MembersRepository implements IMembersRepository {
     members: Array<DbMember>;
     userId: User['id'];
   }): void {
-    if (isLastActiveAdmin(args)) {
+    if (isLastActiveAdminOfSpace(args)) {
       throw new ConflictException('Cannot remove last admin.');
     }
   }

--- a/src/modules/users/domain/members/utils/members.utils.spec.ts
+++ b/src/modules/users/domain/members/utils/members.utils.spec.ts
@@ -1,8 +1,16 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
+import { faker } from '@faker-js/faker';
 import { In, MoreThan } from 'typeorm';
+import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
+import type { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
+import type { User } from '@/modules/users/datasources/entities/users.entity.db';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
-import { activeOrPendingMemberWhere } from '@/modules/users/domain/members/utils/members.utils';
+import {
+  activeOrPendingMemberWhere,
+  isActiveAdmin,
+  isLastActiveAdmin,
+} from '@/modules/users/domain/members/utils/members.utils';
 
 describe('activeOrPendingMemberWhere', () => {
   it('returns an ACTIVE clause and an unexpired-INVITED clause AND-ed onto the base', () => {
@@ -57,5 +65,101 @@ describe('activeOrPendingMemberWhere', () => {
     const activeRole = (where[0] as { role: unknown }).role;
     const invitedRole = (where[1] as { role: unknown }).role;
     expect(activeRole).not.toBe(invitedRole);
+  });
+});
+
+describe('isActiveAdmin', () => {
+  it.each([
+    { role: 'ADMIN', status: 'ACTIVE', expected: true },
+    { role: 'ADMIN', status: 'INVITED', expected: false },
+    { role: 'ADMIN', status: 'DECLINED', expected: false },
+    { role: 'MEMBER', status: 'ACTIVE', expected: false },
+    { role: 'MEMBER', status: 'INVITED', expected: false },
+    { role: 'MEMBER', status: 'DECLINED', expected: false },
+  ] as const)(
+    'is $expected for a $status $role',
+    ({ role, status, expected }) => {
+      const member = memberBuilder()
+        .with('role', role)
+        .with('status', status)
+        .build();
+
+      expect(isActiveAdmin(member)).toBe(expected);
+    },
+  );
+});
+
+describe('isLastActiveAdmin', () => {
+  const activeAdminOf = (userId: User['id']): DbMember =>
+    memberBuilder()
+      .with('role', 'ADMIN')
+      .with('status', 'ACTIVE')
+      .with('user', { id: userId } as User)
+      .build();
+
+  it('is true when the user is the only active admin', () => {
+    const userId = faker.number.int();
+
+    expect(
+      isLastActiveAdmin({ members: [activeAdminOf(userId)], userId }),
+    ).toBe(true);
+  });
+
+  it('is false when no members are given', () => {
+    expect(isLastActiveAdmin({ members: [], userId: faker.number.int() })).toBe(
+      false,
+    );
+  });
+
+  it('is false when the only active admin is someone else', () => {
+    const [userId, otherUserId] = faker.helpers.uniqueArray(
+      () => faker.number.int(),
+      2,
+    );
+
+    expect(
+      isLastActiveAdmin({ members: [activeAdminOf(otherUserId)], userId }),
+    ).toBe(false);
+  });
+
+  it('is false when a second active admin remains', () => {
+    const [userId, otherUserId] = faker.helpers.uniqueArray(
+      () => faker.number.int(),
+      2,
+    );
+
+    expect(
+      isLastActiveAdmin({
+        members: [activeAdminOf(userId), activeAdminOf(otherUserId)],
+        userId,
+      }),
+    ).toBe(false);
+  });
+
+  // The rule counts active admins, not members: an admin who has not accepted
+  // their invite cannot administer the space, so it does not keep the space
+  // administrable once this user leaves.
+  it('ignores non-active admins and active non-admins when counting', () => {
+    const [userId, invitedAdminId, activeMemberId] = faker.helpers.uniqueArray(
+      () => faker.number.int(),
+      3,
+    );
+    const invitedAdmin = memberBuilder()
+      .with('role', 'ADMIN')
+      .with('status', 'INVITED')
+      .with('user', { id: invitedAdminId } as User)
+      .build();
+    const activeMember = memberBuilder()
+      .with('role', 'MEMBER')
+      .with('status', 'ACTIVE')
+      .with('user', { id: activeMemberId } as User)
+      .build();
+
+    expect(
+      isLastActiveAdmin({
+        members: [activeAdminOf(userId), invitedAdmin, activeMember],
+        userId,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/modules/users/domain/members/utils/members.utils.spec.ts
+++ b/src/modules/users/domain/members/utils/members.utils.spec.ts
@@ -9,7 +9,7 @@ import type { Member } from '@/modules/users/domain/entities/member.entity';
 import {
   activeOrPendingMemberWhere,
   isActiveAdmin,
-  isLastActiveAdmin,
+  isLastActiveAdminOfSpace,
 } from '@/modules/users/domain/members/utils/members.utils';
 
 describe('activeOrPendingMemberWhere', () => {
@@ -89,7 +89,7 @@ describe('isActiveAdmin', () => {
   );
 });
 
-describe('isLastActiveAdmin', () => {
+describe('isLastActiveAdminOfSpace', () => {
   const activeAdminOf = (userId: User['id']): DbMember =>
     memberBuilder()
       .with('role', 'ADMIN')
@@ -101,14 +101,14 @@ describe('isLastActiveAdmin', () => {
     const userId = faker.number.int();
 
     expect(
-      isLastActiveAdmin({ members: [activeAdminOf(userId)], userId }),
+      isLastActiveAdminOfSpace({ members: [activeAdminOf(userId)], userId }),
     ).toBe(true);
   });
 
   it('is false when no members are given', () => {
-    expect(isLastActiveAdmin({ members: [], userId: faker.number.int() })).toBe(
-      false,
-    );
+    expect(
+      isLastActiveAdminOfSpace({ members: [], userId: faker.number.int() }),
+    ).toBe(false);
   });
 
   it('is false when the only active admin is someone else', () => {
@@ -118,7 +118,10 @@ describe('isLastActiveAdmin', () => {
     );
 
     expect(
-      isLastActiveAdmin({ members: [activeAdminOf(otherUserId)], userId }),
+      isLastActiveAdminOfSpace({
+        members: [activeAdminOf(otherUserId)],
+        userId,
+      }),
     ).toBe(false);
   });
 
@@ -129,7 +132,7 @@ describe('isLastActiveAdmin', () => {
     );
 
     expect(
-      isLastActiveAdmin({
+      isLastActiveAdminOfSpace({
         members: [activeAdminOf(userId), activeAdminOf(otherUserId)],
         userId,
       }),
@@ -156,7 +159,7 @@ describe('isLastActiveAdmin', () => {
       .build();
 
     expect(
-      isLastActiveAdmin({
+      isLastActiveAdminOfSpace({
         members: [activeAdminOf(userId), invitedAdmin, activeMember],
         userId,
       }),

--- a/src/modules/users/domain/members/utils/members.utils.ts
+++ b/src/modules/users/domain/members/utils/members.utils.ts
@@ -28,11 +28,18 @@ export function isActiveAdmin(
  * True when `userId` is the only active admin among `members` - i.e. removing
  * that membership would leave the space with nobody able to administer it.
  *
+ * `members` must be the membership rows of a **single** space. The rule counts
+ * active admins, so rows from several spaces at once answer a question nobody
+ * asked: a user who solely administers two spaces yields two active admins and
+ * the function returns `false`, silently reporting the removal as safe. A
+ * caller holding rows for more than one space partitions them first - see
+ * `UsersRepository.assertIsNotLastAdminOfAnySpace`, which loops per space.
+ *
  * Shared by every flow that can drop an admin membership: member removal and
  * self-demotion in `MembersRepository`, and account deletion in
  * `UsersRepository`, whose cascade deletes the row just as directly.
  */
-export function isLastActiveAdmin(args: {
+export function isLastActiveAdminOfSpace(args: {
   members: Array<ActiveAdminCandidate>;
   userId: User['id'];
 }): boolean {

--- a/src/modules/users/domain/members/utils/members.utils.ts
+++ b/src/modules/users/domain/members/utils/members.utils.ts
@@ -4,17 +4,31 @@ import type { EntityManager, FindOptionsWhere } from 'typeorm';
 import { MoreThan } from 'typeorm';
 import { Space as DbSpace } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
 import type { Member } from '@/modules/users/datasources/entities/member.entity.db';
-import type { User } from '@/modules/users/datasources/entities/users.entity.db';
+import { User as DbUser } from '@/modules/users/datasources/entities/users.entity.db';
 
 /**
- * Serializes the paths that can drop an admin membership: each locks the space
- * row before reading its admin list, so two cannot both check the same
- * pre-change list and both conclude they are safe. Must run in a transaction.
+ * Locks needed by the paths that can drop an admin membership, so two of them
+ * cannot check the same pre-change admin list and both conclude they are safe.
  *
- * No relations loaded - Postgres refuses `FOR UPDATE` on the nullable side of
- * an outer join. A missing space is not an error here; the caller's own admin
- * read reports it.
+ * **Ordering, for any new path:** user rows first, then space rows, spaces in
+ * ascending id order. Nothing may hold a space row and then wait on a user row
+ * - that is the only shape that could deadlock these two against each other.
+ *
+ * Both must run inside a transaction, and load no relations: Postgres refuses
+ * `FOR UPDATE` on the nullable side of an outer join. A missing row is not an
+ * error here; the caller's own read reports it.
  */
+export async function lockUserForAdminChange(
+  entityManager: EntityManager,
+  userId: DbUser['id'],
+): Promise<void> {
+  await entityManager.findOne(DbUser, {
+    where: { id: userId },
+    select: { id: true },
+    lock: { mode: 'pessimistic_write' },
+  });
+}
+/** See {@link lockUserForAdminChange} for the ordering rule both share. */
 export async function lockSpaceForAdminChange(
   entityManager: EntityManager,
   spaceId: DbSpace['id'],
@@ -31,7 +45,7 @@ export async function lockSpaceForAdminChange(
  * both a fully loaded row and a relation-limited projection satisfy it.
  */
 type ActiveAdminCandidate = Pick<Member, 'role' | 'status'> & {
-  user: Pick<User, 'id'>;
+  user: Pick<DbUser, 'id'>;
 };
 
 /** An `INVITED` or `DECLINED` admin administers nothing, so status counts too. */
@@ -51,7 +65,7 @@ export function isActiveAdmin(
  */
 export function isLastActiveAdminOfSpace(args: {
   members: Array<ActiveAdminCandidate>;
-  userId: User['id'];
+  userId: DbUser['id'];
 }): boolean {
   const activeAdmins = args.members.filter(isActiveAdmin);
 

--- a/src/modules/users/domain/members/utils/members.utils.ts
+++ b/src/modules/users/domain/members/utils/members.utils.ts
@@ -1,9 +1,30 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
-import type { FindOptionsWhere } from 'typeorm';
+import type { EntityManager, FindOptionsWhere } from 'typeorm';
 import { MoreThan } from 'typeorm';
+import { Space as DbSpace } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
 import type { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import type { User } from '@/modules/users/datasources/entities/users.entity.db';
+
+/**
+ * Serializes the paths that can drop an admin membership: each locks the space
+ * row before reading its admin list, so two cannot both check the same
+ * pre-change list and both conclude they are safe. Must run in a transaction.
+ *
+ * No relations loaded - Postgres refuses `FOR UPDATE` on the nullable side of
+ * an outer join. A missing space is not an error here; the caller's own admin
+ * read reports it.
+ */
+export async function lockSpaceForAdminChange(
+  entityManager: EntityManager,
+  spaceId: DbSpace['id'],
+): Promise<void> {
+  await entityManager.findOne(DbSpace, {
+    where: { id: spaceId },
+    select: { id: true },
+    lock: { mode: 'pessimistic_write' },
+  });
+}
 
 /**
  * The subset of a member row the active-admin rules read. Kept structural so
@@ -13,11 +34,7 @@ type ActiveAdminCandidate = Pick<Member, 'role' | 'status'> & {
   user: Pick<User, 'id'>;
 };
 
-/**
- * Single source of truth for what makes a member an admin of a space: the role
- * alone is not enough, an `INVITED` or `DECLINED` admin cannot administer
- * anything.
- */
+/** An `INVITED` or `DECLINED` admin administers nothing, so status counts too. */
 export function isActiveAdmin(
   member: Pick<Member, 'role' | 'status'>,
 ): boolean {
@@ -25,19 +42,12 @@ export function isActiveAdmin(
 }
 
 /**
- * True when `userId` is the only active admin among `members` - i.e. removing
- * that membership would leave the space with nobody able to administer it.
+ * True when removing `userId`'s membership would leave the space with no admin.
  *
- * `members` must be the membership rows of a **single** space. The rule counts
- * active admins, so rows from several spaces at once answer a question nobody
- * asked: a user who solely administers two spaces yields two active admins and
- * the function returns `false`, silently reporting the removal as safe. A
- * caller holding rows for more than one space partitions them first - see
- * `UsersRepository.assertIsNotLastAdminOfAnySpace`, which loops per space.
- *
- * Shared by every flow that can drop an admin membership: member removal and
- * self-demotion in `MembersRepository`, and account deletion in
- * `UsersRepository`, whose cascade deletes the row just as directly.
+ * `members` must come from a **single** space: the rule counts active admins,
+ * so rows spanning two spaces yield two and this returns `false` - wrongly
+ * reporting the removal as safe. Callers holding more than one space partition
+ * first (see `UsersRepository.assertIsNotLastAdminOfAnySpace`).
  */
 export function isLastActiveAdminOfSpace(args: {
   members: Array<ActiveAdminCandidate>;

--- a/src/modules/users/domain/members/utils/members.utils.ts
+++ b/src/modules/users/domain/members/utils/members.utils.ts
@@ -2,6 +2,44 @@
 
 import type { FindOptionsWhere } from 'typeorm';
 import { MoreThan } from 'typeorm';
+import type { Member } from '@/modules/users/datasources/entities/member.entity.db';
+import type { User } from '@/modules/users/datasources/entities/users.entity.db';
+
+/**
+ * The subset of a member row the active-admin rules read. Kept structural so
+ * both a fully loaded row and a relation-limited projection satisfy it.
+ */
+type ActiveAdminCandidate = Pick<Member, 'role' | 'status'> & {
+  user: Pick<User, 'id'>;
+};
+
+/**
+ * Single source of truth for what makes a member an admin of a space: the role
+ * alone is not enough, an `INVITED` or `DECLINED` admin cannot administer
+ * anything.
+ */
+export function isActiveAdmin(
+  member: Pick<Member, 'role' | 'status'>,
+): boolean {
+  return member.role === 'ADMIN' && member.status === 'ACTIVE';
+}
+
+/**
+ * True when `userId` is the only active admin among `members` - i.e. removing
+ * that membership would leave the space with nobody able to administer it.
+ *
+ * Shared by every flow that can drop an admin membership: member removal and
+ * self-demotion in `MembersRepository`, and account deletion in
+ * `UsersRepository`, whose cascade deletes the row just as directly.
+ */
+export function isLastActiveAdmin(args: {
+  members: Array<ActiveAdminCandidate>;
+  userId: User['id'];
+}): boolean {
+  const activeAdmins = args.members.filter(isActiveAdmin);
+
+  return activeAdmins.length === 1 && activeAdmins[0].user.id === args.userId;
+}
 
 /**
  * Single source of truth for the "active or pending" membership rule: an OR of

--- a/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
@@ -213,4 +213,62 @@ describe('UsersRepository concurrency', () => {
       dataSource.getRepository(User).findOneBy({ id: userId }),
     ).resolves.not.toBeNull();
   });
+
+  // A space can start being administered after the deletion read its
+  // memberships, so the user-row lock - not the space locks - is what covers it.
+  it('rejects a deletion that would orphan a concurrently created space', async () => {
+    const userId = await insertUser();
+
+    const queryRunner = dataSource.createQueryRunner();
+    let deletion: Promise<void> | undefined;
+    try {
+      await queryRunner.connect();
+      await queryRunner.startTransaction();
+      // Mimics SpacesRepository.create: space plus its creator as active admin.
+      const inserted = await queryRunner.manager
+        .getRepository(Space)
+        .insert({ name: faker.word.noun(), status: 'ACTIVE' });
+      await queryRunner.manager.getRepository(Member).insert({
+        user: { id: userId },
+        space: { id: inserted.identifiers[0].id as Space['id'] },
+        name: faker.person.firstName(),
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: null,
+      });
+
+      // Reads no memberships - the creation is still uncommitted.
+      deletion = usersRepository.delete(
+        new AuthPayload(
+          siweAuthPayloadDtoBuilder().with('sub', userId.toString()).build(),
+        ),
+      );
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        deletion.then(
+          () => undefined,
+          () => undefined,
+        ),
+        new Promise((resolve) => {
+          timer = setTimeout(resolve, 250);
+        }),
+      ]);
+      clearTimeout(timer);
+
+      await queryRunner.commitTransaction();
+    } finally {
+      if (queryRunner.isTransactionActive) {
+        await queryRunner.rollbackTransaction();
+      }
+      await queryRunner.release();
+    }
+
+    await expect(deletion).rejects.toThrow(ConflictException);
+    await expect(
+      dataSource.getRepository(User).findOneBy({ id: userId }),
+    ).resolves.not.toBeNull();
+    await expect(dataSource.getRepository(Member).find()).resolves.toHaveLength(
+      1,
+    );
+  });
 });

--- a/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { ConflictException } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import type { MockedObject } from 'vitest';
+import configuration from '@/config/entities/__tests__/configuration';
+import { postgresConfig } from '@/config/entities/postgres.config';
+import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { SpaceSafe } from '@/modules/spaces/datasources/safes/entities/space-safes.entity.db';
+import { Space } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
+import { Member } from '@/modules/users/datasources/entities/member.entity.db';
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import { createMockUserEncryptionService } from '@/modules/users/domain/__tests__/user-encryption.service.mock';
+import { UsersRepository } from '@/modules/users/domain/users.repository';
+import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import { createMockWalletEncryptionService } from '@/modules/wallets/domain/__tests__/wallet-encryption.service.mock';
+import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
+
+const mockLoggingService = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+/**
+ * Separate file because proving the lock needs two connections held at once,
+ * and a spec file's TypeORM pool is shared: forcing it open changes the
+ * interleaving of sibling cases that await two repository calls concurrently.
+ */
+describe('UsersRepository concurrency', () => {
+  let postgresDatabaseService: PostgresDatabaseService;
+  let usersRepository: UsersRepository;
+
+  const testDatabaseName = faker.string.alpha({ length: 10, casing: 'lower' });
+  const testConfiguration = configuration();
+
+  const dataSource = new DataSource({
+    ...postgresConfig({
+      ...testConfiguration.db.connection.postgres,
+      type: 'postgres',
+      database: testDatabaseName,
+    }),
+    migrationsTableName: testConfiguration.db.orm.migrationsTableName,
+    entities: [Member, Space, SpaceSafe, User, Wallet],
+  });
+
+  beforeAll(async () => {
+    const testDataSource = new DataSource({
+      ...postgresConfig({
+        ...testConfiguration.db.connection.postgres,
+        type: 'postgres',
+        database: 'postgres',
+      }),
+    });
+    const testPostgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      testDataSource,
+    );
+    await testPostgresDatabaseService.initializeDatabaseConnection();
+    await testPostgresDatabaseService
+      .getDataSource()
+      .query(`CREATE DATABASE ${testDatabaseName}`);
+    await testPostgresDatabaseService.destroyDatabaseConnection();
+
+    postgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      dataSource,
+    );
+    await postgresDatabaseService.initializeDatabaseConnection();
+
+    const mockConfigService = {
+      getOrThrow: vi.fn().mockImplementation((key: string) => {
+        if (key === 'db.migrator.numberOfRetries') {
+          return testConfiguration.db.migrator.numberOfRetries;
+        }
+        if (key === 'db.migrator.retryAfterMs') {
+          return testConfiguration.db.migrator.retryAfterMs;
+        }
+      }),
+    } as MockedObject<ConfigService>;
+    await new DatabaseMigrator(
+      mockLoggingService,
+      postgresDatabaseService,
+      mockConfigService,
+    ).migrate();
+
+    usersRepository = new UsersRepository(
+      postgresDatabaseService,
+      new WalletsRepository(
+        postgresDatabaseService,
+        createMockWalletEncryptionService(),
+      ),
+      createMockSpaceAuditRepository(),
+      createMockUserEncryptionService(),
+      createMockWalletEncryptionService(),
+    );
+  });
+
+  afterEach(async () => {
+    await dataSource
+      .getRepository(User)
+      .createQueryBuilder()
+      .delete()
+      .execute();
+    await dataSource
+      .getRepository(Space)
+      .createQueryBuilder()
+      .delete()
+      .execute();
+  });
+
+  afterAll(async () => {
+    await postgresDatabaseService.getDataSource().dropDatabase();
+    await postgresDatabaseService.destroyDatabaseConnection();
+  });
+
+  const insertUser = async (): Promise<User['id']> => {
+    const result = await dataSource
+      .getRepository(User)
+      .insert({ status: 'ACTIVE' });
+    return result.identifiers[0].id as User['id'];
+  };
+
+  const insertSpace = async (): Promise<Space['id']> => {
+    const result = await dataSource
+      .getRepository(Space)
+      .insert({ name: faker.word.noun(), status: 'ACTIVE' });
+    return result.identifiers[0].id as Space['id'];
+  };
+
+  const insertActiveAdmin = async (args: {
+    userId: User['id'];
+    spaceId: Space['id'];
+  }): Promise<Member['id']> => {
+    const result = await dataSource.getRepository(Member).insert({
+      user: { id: args.userId },
+      space: { id: args.spaceId },
+      name: faker.person.firstName(),
+      role: 'ADMIN',
+      status: 'ACTIVE',
+      invitedBy: null,
+    });
+    return result.identifiers[0].id as Member['id'];
+  };
+
+  // The co-admin is mid-departure: holding the space lock, membership deleted
+  // but uncommitted. A deletion reading now would still see two admins and
+  // wrongly allow itself, leaving the space with none.
+  it('waits for an in-flight admin change before deciding', async () => {
+    const userId = await insertUser();
+    const coAdminUserId = await insertUser();
+    const spaceId = await insertSpace();
+    await insertActiveAdmin({ userId, spaceId });
+    const coAdminMemberId = await insertActiveAdmin({
+      userId: coAdminUserId,
+      spaceId,
+    });
+    const authPayload = new AuthPayload(
+      siweAuthPayloadDtoBuilder().with('sub', userId.toString()).build(),
+    );
+
+    const queryRunner = dataSource.createQueryRunner();
+    let deletion: Promise<void> | undefined;
+    try {
+      await queryRunner.connect();
+      await queryRunner.startTransaction();
+      await queryRunner.manager.findOne(Space, {
+        where: { id: spaceId },
+        select: { id: true },
+        lock: { mode: 'pessimistic_write' },
+      });
+      await queryRunner.manager.delete(Member, coAdminMemberId);
+
+      deletion = usersRepository.delete(authPayload);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        deletion.then(
+          () => 'decided',
+          () => 'decided',
+        ),
+        new Promise((resolve) => {
+          timer = setTimeout(() => resolve('waiting'), 500);
+        }),
+      ]);
+      clearTimeout(timer);
+
+      expect(outcome).toBe('waiting');
+
+      await queryRunner.commitTransaction();
+    } finally {
+      // A failed assertion must not leave the row locked - it blocks cleanup.
+      if (queryRunner.isTransactionActive) {
+        await queryRunner.rollbackTransaction();
+      }
+      await queryRunner.release();
+    }
+
+    await expect(deletion).rejects.toThrow(
+      new ConflictException(
+        'Cannot delete account while last admin of a workspace.',
+      ),
+    );
+    // The co-admin lost their membership, not their account, so both remain.
+    await expect(
+      dataSource.getRepository(User).findOneBy({ id: userId }),
+    ).resolves.not.toBeNull();
+  });
+});

--- a/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
@@ -5,6 +5,7 @@ import { ConflictException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import type { MockedObject } from 'vitest';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
 import { postgresConfig } from '@/config/entities/postgres.config';
 import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
@@ -14,10 +15,14 @@ import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__test
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { SpaceSafe } from '@/modules/spaces/datasources/safes/entities/space-safes.entity.db';
 import { Space } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
+import { createMockSpaceEncryptionService } from '@/modules/spaces/domain/__tests__/space-encryption.service.mock';
 import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
+import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
 import { createMockUserEncryptionService } from '@/modules/users/domain/__tests__/user-encryption.service.mock';
+import { createMockMemberEncryptionService } from '@/modules/users/domain/members/__tests__/member-encryption.service.mock';
+import { MembersRepository } from '@/modules/users/domain/members/members.repository';
 import { UsersRepository } from '@/modules/users/domain/users.repository';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { createMockWalletEncryptionService } from '@/modules/wallets/domain/__tests__/wallet-encryption.service.mock';
@@ -38,6 +43,7 @@ const mockLoggingService = {
 describe('UsersRepository concurrency', () => {
   let postgresDatabaseService: PostgresDatabaseService;
   let usersRepository: UsersRepository;
+  let membersRepository: MembersRepository;
 
   const testDatabaseName = faker.string.alpha({ length: 10, casing: 'lower' });
   const testConfiguration = configuration();
@@ -101,6 +107,25 @@ describe('UsersRepository concurrency', () => {
       createMockSpaceAuditRepository(),
       createMockUserEncryptionService(),
       createMockWalletEncryptionService(),
+    );
+
+    const mockConfigurationService = vi.mocked({
+      getOrThrow: vi.fn().mockReturnValue(10),
+    } as MockedObject<IConfigurationService>);
+    membersRepository = new MembersRepository(
+      postgresDatabaseService,
+      usersRepository,
+      new SpacesRepository(
+        postgresDatabaseService,
+        mockConfigurationService,
+        createMockSpaceAuditRepository(),
+        createMockSpaceEncryptionService(),
+        createMockMemberEncryptionService(),
+      ),
+      createMockSpaceAuditRepository(),
+      createMockUserEncryptionService(),
+      createMockWalletEncryptionService(),
+      createMockMemberEncryptionService(),
     );
   });
 
@@ -270,5 +295,69 @@ describe('UsersRepository concurrency', () => {
     await expect(dataSource.getRepository(Member).find()).resolves.toHaveLength(
       1,
     );
+  });
+
+  // Promoting a member does not touch `members.user_id`, so it takes no lock on
+  // the promoted user's row on its own - an account deletion in flight would
+  // not see the new admin membership it is about to cascade away.
+  it('makes a promotion wait for an in-flight account deletion', async () => {
+    const userId = await insertUser();
+    const adminUserId = await insertUser();
+    const spaceId = await insertSpace();
+    await insertActiveAdmin({ userId: adminUserId, spaceId });
+    await dataSource.getRepository(Member).insert({
+      user: { id: userId },
+      space: { id: spaceId },
+      name: faker.person.firstName(),
+      role: 'MEMBER',
+      status: 'ACTIVE',
+      invitedBy: null,
+    });
+
+    const queryRunner = dataSource.createQueryRunner();
+    let promotion: Promise<void> | undefined;
+    try {
+      await queryRunner.connect();
+      await queryRunner.startTransaction();
+      // Stands in for the deletion holding its own account row.
+      await queryRunner.manager.findOne(User, {
+        where: { id: userId },
+        select: { id: true },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      promotion = membersRepository.updateRole({
+        authPayload: new AuthPayload(
+          siweAuthPayloadDtoBuilder()
+            .with('sub', adminUserId.toString())
+            .build(),
+        ),
+        spaceId,
+        userId,
+        role: 'ADMIN',
+      });
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        promotion.then(
+          () => 'decided',
+          () => 'decided',
+        ),
+        new Promise((resolve) => {
+          timer = setTimeout(() => resolve('waiting'), 500);
+        }),
+      ]);
+      clearTimeout(timer);
+
+      expect(outcome).toBe('waiting');
+
+      await queryRunner.commitTransaction();
+    } finally {
+      if (queryRunner.isTransactionActive) {
+        await queryRunner.rollbackTransaction();
+      }
+      await queryRunner.release();
+    }
+
+    await promotion;
   });
 });

--- a/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.concurrency.integration.spec.ts
@@ -5,7 +5,7 @@ import { ConflictException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import type { MockedObject } from 'vitest';
-import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import configuration from '@/config/entities/__tests__/configuration';
 import { postgresConfig } from '@/config/entities/postgres.config';
 import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
@@ -109,15 +109,17 @@ describe('UsersRepository concurrency', () => {
       createMockWalletEncryptionService(),
     );
 
-    const mockConfigurationService = vi.mocked({
-      getOrThrow: vi.fn().mockReturnValue(10),
-    } as MockedObject<IConfigurationService>);
+    const fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'spaces.maxSpaceCreationsPerUser',
+      testConfiguration.spaces.maxSpaceCreationsPerUser,
+    );
     membersRepository = new MembersRepository(
       postgresDatabaseService,
       usersRepository,
       new SpacesRepository(
         postgresDatabaseService,
-        mockConfigurationService,
+        fakeConfigurationService,
         createMockSpaceAuditRepository(),
         createMockSpaceEncryptionService(),
         createMockMemberEncryptionService(),

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -6,7 +6,11 @@ import {
   KMSClient,
 } from '@aws-sdk/client-kms';
 import { faker } from '@faker-js/faker';
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import {
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { mockClient } from 'aws-sdk-client-mock';
 import { DataSource } from 'typeorm';
@@ -134,9 +138,11 @@ describe('UsersRepository', () => {
 
     const dbWalletRepository = dataSource.getRepository(Wallet);
     const dbUserRepository = dataSource.getRepository(User);
+    const dbSpaceRepository = dataSource.getRepository(Space);
 
     await dbWalletRepository.createQueryBuilder().delete().execute();
     await dbUserRepository.createQueryBuilder().delete().execute();
+    await dbSpaceRepository.createQueryBuilder().delete().execute();
   });
 
   afterAll(async () => {
@@ -641,6 +647,42 @@ describe('UsersRepository', () => {
   });
 
   describe('delete', () => {
+    const insertUser = async (): Promise<User['id']> => {
+      const result = await dataSource.getRepository(User).insert({
+        status: faker.helpers.arrayElement(UserStatusKeys),
+      });
+      return result.identifiers[0].id as User['id'];
+    };
+
+    const insertSpace = async (): Promise<Space['id']> => {
+      const result = await dataSource.getRepository(Space).insert({
+        name: faker.word.noun(),
+        status: 'ACTIVE',
+      });
+      return result.identifiers[0].id as Space['id'];
+    };
+
+    const insertMember = async (args: {
+      userId: User['id'];
+      spaceId: Space['id'];
+      role: Member['role'];
+      status: Member['status'];
+    }): Promise<void> => {
+      await dataSource.getRepository(Member).insert({
+        user: { id: args.userId },
+        space: { id: args.spaceId },
+        name: faker.person.firstName(),
+        role: args.role,
+        status: args.status,
+        invitedBy: null,
+      });
+    };
+
+    const authPayloadFor = (userId: User['id']): AuthPayload =>
+      new AuthPayload(
+        siweAuthPayloadDtoBuilder().with('sub', userId.toString()).build(),
+      );
+
     it('should delete a user and their wallets', async () => {
       const dbWalletRepository = dataSource.getRepository(Wallet);
       const dbUserRepository = dataSource.getRepository(User);
@@ -687,6 +729,118 @@ describe('UsersRepository', () => {
       await usersRepository.delete(authPayload);
 
       await expect(dbUserRepository.find()).resolves.toEqual([]);
+    });
+
+    it('should not delete a user who is the sole active admin of a space', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const dbMemberRepository = dataSource.getRepository(Member);
+      const userId = await insertUser();
+      const spaceId = await insertSpace();
+      await insertMember({ userId, spaceId, role: 'ADMIN', status: 'ACTIVE' });
+
+      await expect(
+        usersRepository.delete(authPayloadFor(userId)),
+      ).rejects.toThrow(
+        new ConflictException(
+          'Cannot delete account while last admin of a workspace.',
+        ),
+      );
+
+      await expect(dbUserRepository.find()).resolves.toHaveLength(1);
+      await expect(dbMemberRepository.find()).resolves.toHaveLength(1);
+    });
+
+    it('should delete a user who shares a space with another active admin', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const dbMemberRepository = dataSource.getRepository(Member);
+      const userId = await insertUser();
+      const coAdminUserId = await insertUser();
+      const spaceId = await insertSpace();
+      await insertMember({ userId, spaceId, role: 'ADMIN', status: 'ACTIVE' });
+      await insertMember({
+        userId: coAdminUserId,
+        spaceId,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      });
+
+      await usersRepository.delete(authPayloadFor(userId));
+
+      await expect(dbUserRepository.find()).resolves.toEqual([
+        expect.objectContaining({ id: coAdminUserId }),
+      ]);
+      await expect(dbMemberRepository.find()).resolves.toHaveLength(1);
+    });
+
+    it('should delete a user whose only admin membership is not active', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const dbMemberRepository = dataSource.getRepository(Member);
+      const userId = await insertUser();
+      const spaceId = await insertSpace();
+      await insertMember({ userId, spaceId, role: 'ADMIN', status: 'INVITED' });
+
+      await usersRepository.delete(authPayloadFor(userId));
+
+      await expect(dbUserRepository.find()).resolves.toEqual([]);
+      await expect(dbMemberRepository.find()).resolves.toEqual([]);
+    });
+
+    it('should delete a user who is only a non-admin member of a space', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const userId = await insertUser();
+      const adminUserId = await insertUser();
+      const spaceId = await insertSpace();
+      await insertMember({ userId, spaceId, role: 'MEMBER', status: 'ACTIVE' });
+      await insertMember({
+        userId: adminUserId,
+        spaceId,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      });
+
+      await usersRepository.delete(authPayloadFor(userId));
+
+      await expect(dbUserRepository.find()).resolves.toEqual([
+        expect.objectContaining({ id: adminUserId }),
+      ]);
+    });
+
+    it('should not delete a user who is the sole active admin of one of several spaces', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const dbMemberRepository = dataSource.getRepository(Member);
+      const userId = await insertUser();
+      const coAdminUserId = await insertUser();
+      const sharedSpaceId = await insertSpace();
+      const soleAdminSpaceId = await insertSpace();
+      await insertMember({
+        userId,
+        spaceId: sharedSpaceId,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      });
+      await insertMember({
+        userId: coAdminUserId,
+        spaceId: sharedSpaceId,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      });
+      await insertMember({
+        userId,
+        spaceId: soleAdminSpaceId,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      });
+
+      await expect(
+        usersRepository.delete(authPayloadFor(userId)),
+      ).rejects.toThrow(
+        new ConflictException(
+          'Cannot delete account while last admin of a workspace.',
+        ),
+      );
+
+      await expect(dbUserRepository.find()).resolves.toHaveLength(2);
+      await expect(dbMemberRepository.find()).resolves.toHaveLength(3);
     });
   });
 

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -35,6 +35,7 @@ import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity'
 import { SpaceSafe } from '@/modules/spaces/datasources/safes/entities/space-safes.entity.db';
 import { Space } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
 import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
+import type { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
 import { createMockUserEncryptionService } from '@/modules/users/domain/__tests__/user-encryption.service.mock';
@@ -60,6 +61,7 @@ const UserStatusKeys = getStringEnumKeys(UserStatus);
 describe('UsersRepository', () => {
   let postgresDatabaseService: PostgresDatabaseService;
   let usersRepository: UsersRepository;
+  let spaceAuditRepository: MockedObject<ISpaceAuditRepository>;
 
   const testDatabaseName = faker.string.alpha({
     length: 10,
@@ -121,13 +123,14 @@ describe('UsersRepository', () => {
     );
     await migrator.migrate();
 
+    spaceAuditRepository = createMockSpaceAuditRepository();
     usersRepository = new UsersRepository(
       postgresDatabaseService,
       new WalletsRepository(
         postgresDatabaseService,
         createMockWalletEncryptionService(),
       ),
-      createMockSpaceAuditRepository(),
+      spaceAuditRepository,
       createMockUserEncryptionService(),
       createMockWalletEncryptionService(),
     );
@@ -748,6 +751,9 @@ describe('UsersRepository', () => {
 
       await expect(dbUserRepository.find()).resolves.toHaveLength(1);
       await expect(dbMemberRepository.find()).resolves.toHaveLength(1);
+      // The guard has to run ahead of the MEMBER_LEFT writes, not just roll
+      // them back - the audit table rejects DELETE.
+      expect(spaceAuditRepository.record).not.toHaveBeenCalled();
     });
 
     it('should delete a user who shares a space with another active admin', async () => {
@@ -841,6 +847,7 @@ describe('UsersRepository', () => {
 
       await expect(dbUserRepository.find()).resolves.toHaveLength(2);
       await expect(dbMemberRepository.find()).resolves.toHaveLength(3);
+      expect(spaceAuditRepository.record).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -237,14 +237,20 @@ export class UsersRepository implements IUsersRepository {
       relations: { space: true, user: true },
     });
 
-    for (const spaceId of administeredSpaceIds) {
-      const spaceAdmins = activeAdmins.filter(
-        (activeAdmin) => activeAdmin.space.id === spaceId,
-      );
+    // Grouped in one pass: promotion into other people's spaces is not capped,
+    // so the administered set has no bound to scan per space.
+    const adminsBySpace = new Map<DbMember['space']['id'], Array<DbMember>>();
+    for (const activeAdmin of activeAdmins) {
+      const group = adminsBySpace.get(activeAdmin.space.id);
+      if (group) {
+        group.push(activeAdmin);
+      } else {
+        adminsBySpace.set(activeAdmin.space.id, [activeAdmin]);
+      }
+    }
 
-      if (
-        isLastActiveAdminOfSpace({ members: spaceAdmins, userId: args.userId })
-      ) {
+    for (const members of adminsBySpace.values()) {
+      if (isLastActiveAdminOfSpace({ members, userId: args.userId })) {
         throw new ConflictException(
           'Cannot delete account while last admin of a workspace.',
         );

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -22,7 +22,7 @@ import { UserStatus } from '@/modules/users/domain/entities/user.entity';
 import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-email-already-in-use.error';
 import {
   isActiveAdmin,
-  isLastActiveAdmin,
+  isLastActiveAdminOfSpace,
 } from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -243,7 +243,9 @@ export class UsersRepository implements IUsersRepository {
         (activeAdmin) => activeAdmin.space.id === spaceId,
       );
 
-      if (isLastActiveAdmin({ members: spaceAdmins, userId: args.userId })) {
+      if (
+        isLastActiveAdminOfSpace({ members: spaceAdmins, userId: args.userId })
+      ) {
         throw new ConflictException(
           'Cannot delete account while last admin of a workspace.',
         );

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -24,6 +24,7 @@ import {
   isActiveAdmin,
   isLastActiveAdminOfSpace,
   lockSpaceForAdminChange,
+  lockUserForAdminChange,
 } from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -258,11 +259,8 @@ export class UsersRepository implements IUsersRepository {
       // A `members` insert for this user takes FOR KEY SHARE on their row,
       // which this conflicts with: a space created concurrently either waits
       // and then fails its foreign key, or commits in time to be read below.
-      await entityManager.findOne(DbUser, {
-        where: { id: userId },
-        select: { id: true },
-        lock: { mode: 'pessimistic_write' },
-      });
+      // A promotion changes no FK column, so `updateRole` takes this same lock.
+      await lockUserForAdminChange(entityManager, userId);
 
       const memberships = await entityManager.find(DbMember, {
         where: { user: { id: userId } },

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -205,8 +205,16 @@ export class UsersRepository implements IUsersRepository {
    * already applies (`MembersRepository.assertIsNotLastAdmin`): the user can
    * promote another admin or delete the space, then retry.
    *
-   * Runs inside the deletion transaction so a concurrent role change cannot
-   * slip between this check and the delete.
+   * Runs on the deletion's own `entityManager`, immediately before the writes,
+   * which keeps the window between check and delete as narrow as this codebase's
+   * transaction handling allows. It is *not* mutual exclusion: `transaction()`
+   * takes no row locks and Postgres defaults to READ COMMITTED, so two co-admins
+   * of one space deleting their accounts concurrently can both pass this check
+   * and leave the space admin-less. Closing that needs a row lock here, or a
+   * DB-level "at least one active admin per space" invariant, applied to every
+   * path that drops an admin membership - `removeSelf`, `removeUser` and
+   * `updateRole` read their admin list before opening a transaction at all, so
+   * they share the hole and a fix confined to this path would not close it.
    */
   private async assertIsNotLastAdminOfAnySpace(args: {
     entityManager: EntityManager;

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -206,7 +206,8 @@ export class UsersRepository implements IUsersRepository {
    *
    * Locks each space before reading its admins, or READ COMMITTED would let two
    * co-admins acting at once each still see the other. Ascending id order, so
-   * two deletions over the same spaces cannot deadlock.
+   * two deletions over the same spaces cannot deadlock. The caller locks this
+   * user's row first, which is what makes the space set complete.
    */
   private async assertIsNotLastAdminOfAnySpace(args: {
     entityManager: EntityManager;
@@ -254,6 +255,15 @@ export class UsersRepository implements IUsersRepository {
     const userId = getAuthenticatedUserIdOrFail(authPayload);
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
+      // A `members` insert for this user takes FOR KEY SHARE on their row,
+      // which this conflicts with: a space created concurrently either waits
+      // and then fails its foreign key, or commits in time to be read below.
+      await entityManager.findOne(DbUser, {
+        where: { id: userId },
+        select: { id: true },
+        lock: { mode: 'pessimistic_write' },
+      });
+
       const memberships = await entityManager.find(DbMember, {
         where: { user: { id: userId } },
         relations: { space: true },

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -20,6 +20,10 @@ import { User as DbUser } from '@/modules/users/datasources/entities/users.entit
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import { UserStatus } from '@/modules/users/domain/entities/user.entity';
 import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-email-already-in-use.error';
+import {
+  isActiveAdmin,
+  isLastActiveAdmin,
+} from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
@@ -193,6 +197,52 @@ export class UsersRepository implements IUsersRepository {
     );
   }
 
+  /**
+   * Deleting the user cascade-deletes their `members` rows, so a space whose
+   * only active admin is this user would be left with nobody able to administer
+   * it - not even to delete it, and its remaining members unable to leave.
+   * Reject the deletion instead, mirroring the guard every member-removal flow
+   * already applies (`MembersRepository.assertIsNotLastAdmin`): the user can
+   * promote another admin or delete the space, then retry.
+   *
+   * Runs inside the deletion transaction so a concurrent role change cannot
+   * slip between this check and the delete.
+   */
+  private async assertIsNotLastAdminOfAnySpace(args: {
+    entityManager: EntityManager;
+    userId: User['id'];
+    memberships: Array<DbMember>;
+  }): Promise<void> {
+    const administeredSpaceIds = args.memberships
+      .filter(isActiveAdmin)
+      .map((membership) => membership.space.id);
+
+    if (administeredSpaceIds.length === 0) {
+      return;
+    }
+
+    const activeAdmins = await args.entityManager.find(DbMember, {
+      where: {
+        space: { id: In(administeredSpaceIds) },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      },
+      relations: { space: true, user: true },
+    });
+
+    for (const spaceId of administeredSpaceIds) {
+      const spaceAdmins = activeAdmins.filter(
+        (activeAdmin) => activeAdmin.space.id === spaceId,
+      );
+
+      if (isLastActiveAdmin({ members: spaceAdmins, userId: args.userId })) {
+        throw new ConflictException(
+          'Cannot delete account while last admin of a workspace.',
+        );
+      }
+    }
+  }
+
   public async delete(authPayload: AuthPayload): Promise<void> {
     const userId = getAuthenticatedUserIdOrFail(authPayload);
 
@@ -200,6 +250,12 @@ export class UsersRepository implements IUsersRepository {
       const memberships = await entityManager.find(DbMember, {
         where: { user: { id: userId } },
         relations: { space: true },
+      });
+
+      await this.assertIsNotLastAdminOfAnySpace({
+        entityManager,
+        userId,
+        memberships,
       });
 
       for (const membership of memberships) {

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -23,6 +23,7 @@ import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-e
 import {
   isActiveAdmin,
   isLastActiveAdminOfSpace,
+  lockSpaceForAdminChange,
 } from '@/modules/users/domain/members/utils/members.utils';
 import { UserEncryptionService } from '@/modules/users/domain/user-encryption.service';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -198,23 +199,14 @@ export class UsersRepository implements IUsersRepository {
   }
 
   /**
-   * Deleting the user cascade-deletes their `members` rows, so a space whose
-   * only active admin is this user would be left with nobody able to administer
-   * it - not even to delete it, and its remaining members unable to leave.
-   * Reject the deletion instead, mirroring the guard every member-removal flow
-   * already applies (`MembersRepository.assertIsNotLastAdmin`): the user can
-   * promote another admin or delete the space, then retry.
+   * Deleting the user cascade-deletes their `members` rows, so a space they
+   * solely administer would be left un-administrable - and its members unable
+   * to leave. Reject instead, as every member-removal flow already does: the
+   * user can promote another admin or delete the space, then retry.
    *
-   * Runs on the deletion's own `entityManager`, immediately before the writes,
-   * which keeps the window between check and delete as narrow as this codebase's
-   * transaction handling allows. It is *not* mutual exclusion: `transaction()`
-   * takes no row locks and Postgres defaults to READ COMMITTED, so two co-admins
-   * of one space deleting their accounts concurrently can both pass this check
-   * and leave the space admin-less. Closing that needs a row lock here, or a
-   * DB-level "at least one active admin per space" invariant, applied to every
-   * path that drops an admin membership - `removeSelf`, `removeUser` and
-   * `updateRole` read their admin list before opening a transaction at all, so
-   * they share the hole and a fix confined to this path would not close it.
+   * Locks each space before reading its admins, or READ COMMITTED would let two
+   * co-admins acting at once each still see the other. Ascending id order, so
+   * two deletions over the same spaces cannot deadlock.
    */
   private async assertIsNotLastAdminOfAnySpace(args: {
     entityManager: EntityManager;
@@ -223,10 +215,15 @@ export class UsersRepository implements IUsersRepository {
   }): Promise<void> {
     const administeredSpaceIds = args.memberships
       .filter(isActiveAdmin)
-      .map((membership) => membership.space.id);
+      .map((membership) => membership.space.id)
+      .sort((a, b) => a - b);
 
     if (administeredSpaceIds.length === 0) {
       return;
+    }
+
+    for (const spaceId of administeredSpaceIds) {
+      await lockSpaceForAdminChange(args.entityManager, spaceId);
     }
 
     const activeAdmins = await args.entityManager.find(DbMember, {

--- a/src/modules/users/routes/users.controller.ts
+++ b/src/modules/users/routes/users.controller.ts
@@ -80,6 +80,10 @@ export class UsersController {
     description:
       'User not found - the authenticated wallet is not associated with any user',
   })
+  @ApiConflictResponse({
+    description:
+      'User is the last admin of at least one workspace - promote another admin or delete the workspace first',
+  })
   @Delete()
   @UseGuards(AuthGuard)
   public async delete(@Auth() authPayload: AuthPayload): Promise<void> {


### PR DESCRIPTION
<!--
  SPDX-License-Identifier: FSL-1.1-MIT
 -->

## Summary

`DELETE /v1/users` skipped the "Cannot remove last admin" guard that every other member-removal flow enforces. When a space's only active admin deleted their account, the `ON DELETE CASCADE` on `members.user_id` removed the admin row and left the space behind: nobody could be promoted, the space could not be renamed or deleted, and the remaining members could not even leave it. Twenty spaces are in this state in production today.

Account deletion now returns **409** while the caller is the last active admin of any space. They can promote another admin or delete the space, then retry — no new endpoint needed.

The guard is only sound if it cannot decide against a membership list another request is about to change, so this also closes three concurrency holes, each found by review and each reproduced against a real database first:

- The four paths that can drop an admin membership (account deletion, plus `updateRole`, `removeUser` and `removeSelf`) now lock the space row before reading its admin list. The three member paths previously read that list before opening a transaction at all.
- Account deletion locks the caller's `users` row first. A space created concurrently would otherwise never be in the lock set, and its only membership got cascaded away — leaving a space with zero members.
- `updateRole` locks the promoted member's `users` row too. A role change touches no foreign-key column, so it took no lock on that account by itself.

Locking order is documented for future paths: user rows first, then space rows in ascending id order.

A database-level "every space keeps an active admin" trigger was tried first and abandoned — it is incompatible with the fixtures of 7 integration specs, which deliberately construct member-only and admin-less spaces to exercise the paths that handle them.

Two things are deliberately **out of scope**, and need a follow-up: the twenty spaces already in this state, and the 404 that stops their remaining members from leaving (`removeSelf` requires an admin list to exist before it will let anyone out).

Refs [WA-2980](https://linear.app/safe-global/issue/WA-2980/spaces-deleting-the-last-admins-user-account-leaves-the-space-in-an-un)

## Changes

- `src/modules/users/domain/users.repository.ts` — reject the deletion with 409; lock the caller's account row and each administered space inside the deletion transaction
- `src/modules/users/domain/members/utils/members.utils.ts` — `isActiveAdmin` / `isLastActiveAdminOfSpace`, shared with `MembersRepository` so the rule has one definition, plus the two lock helpers and the ordering rule
- `src/modules/users/domain/members/members.repository.ts` — move the admin read inside the transaction behind the space lock on all three member paths; lock the promoted member's account row in `updateRole`
- `src/modules/users/routes/users.controller.ts` — document the 409
- Tests — 11 unit cases for the shared predicates; 6 integration cases for the guard; a separate `*.concurrency.integration.spec.ts` for the three race regressions, which needs two connections held at once and so cannot share a spec file's connection pool

<!-- Per-area bullets, grouped by directory or module. -->

<!--
  Author checklist (docs/agents/reviewing.md — delete this comment before submitting):
  - [ ] Read the guides the routing table in AGENTS.md maps this diff to
  - [ ] One concern per PR; nothing unrelated refactored or reformatted
  - [ ] Env var? Declared in configuration.ts AND RootConfigurationSchema, added to
        .env.sample.json, mirrored in __tests__/configuration.ts, `yarn env:validate` clean
  - [ ] Migration? Every FK and WHERE-target column indexed in the same migration; `down` reverts
  - [ ] New/changed endpoint? Every input through `new ValidationPipe(Schema)`; DTO implements
        z.infer; guard on state-changing or caller-scoped routes
  - [ ] Cached read added or TTL raised? Invalidation lands in this PR, or the trade-off is
        stated in this description
  - [ ] SPDX license header on every file this PR touched, not only the new ones
  - [ ] No debug scripts, seed helpers, or transient logging left in the branch
  - [ ] Ratchet-baseline growth (if any) justified in this description
-->
