### PR TITLE
fix(transactions): drop the redirect on every message-by-hash lookup

### DIFF
--- a/src/modules/messages/routes/messages.controller.integration.spec.ts
+++ b/src/modules/messages/routes/messages.controller.integration.spec.ts
@@ -108,7 +108,7 @@ describe('Messages controller', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -176,7 +176,7 @@ describe('Messages controller', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -241,7 +241,7 @@ describe('Messages controller', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -309,7 +309,7 @@ describe('Messages controller', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -374,7 +374,7 @@ describe('Messages controller', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -439,7 +439,7 @@ describe('Messages controller', () => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: rawify(chain), status: 200 });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -928,7 +928,7 @@ describe('Messages controller', () => {
           case `${chain.transactionService}/api/v1/safes/${safe.address}`:
             return Promise.resolve({ data: rawify(safe), status: 200 });
           // The message is indexed asynchronously and not yet readable
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.reject(
               new NetworkResponseError(
                 new URL(url),
@@ -1342,7 +1342,7 @@ describe('Messages controller', () => {
               data: rawify(safe),
               status: 200,
             });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -1406,7 +1406,7 @@ describe('Messages controller', () => {
               data: rawify(safe),
               status: 200,
             });
-          case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+          case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
             return Promise.resolve({
               data: rawify(messageToJson(message)),
               status: 200,
@@ -1484,7 +1484,7 @@ describe('Messages controller', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+            case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
               return Promise.resolve({
                 data: rawify(messageToJson(message)),
                 status: 200,
@@ -1545,7 +1545,7 @@ describe('Messages controller', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+            case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
               return Promise.resolve({
                 data: rawify(messageToJson(message)),
                 status: 200,
@@ -1679,7 +1679,7 @@ describe('Messages controller', () => {
                   data: rawify(safe),
                   status: 200,
                 });
-              case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+              case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
                 return Promise.resolve({
                   data: rawify(messageToJson(message)),
                   status: 200,
@@ -1746,7 +1746,7 @@ describe('Messages controller', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+            case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
               return Promise.resolve({
                 data: rawify(messageToJson(message)),
                 status: 200,
@@ -1819,7 +1819,7 @@ describe('Messages controller', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+            case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
               return Promise.resolve({
                 data: rawify(messageToJson(message)),
                 status: 200,
@@ -1871,7 +1871,7 @@ describe('Messages controller', () => {
                 data: rawify(safe),
                 status: 200,
               });
-            case `${chain.transactionService}/api/v1/messages/${message.messageHash}`:
+            case `${chain.transactionService}/api/v1/messages/${message.messageHash}/`:
               return Promise.resolve({
                 data: rawify(messageToJson(message)),
                 status: 200,

--- a/src/modules/notifications/domain/push/push-notification.integration.spec.ts
+++ b/src/modules/notifications/domain/push/push-notification.integration.spec.ts
@@ -793,7 +793,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),
@@ -857,7 +857,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(messageBuilder().build()),
@@ -924,7 +924,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),
@@ -994,7 +994,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),
@@ -1075,7 +1075,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),
@@ -1158,7 +1158,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),
@@ -1249,7 +1249,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),
@@ -1525,7 +1525,7 @@ describe('Push notification queue integration', () => {
         }
         if (
           url ===
-          `${chain.transactionService}/api/v1/messages/${event.messageHash}`
+          `${chain.transactionService}/api/v1/messages/${event.messageHash}/`
         ) {
           return Promise.resolve({
             data: rawify(message),

--- a/src/modules/transactions/datasources/transaction-api.service.spec.ts
+++ b/src/modules/transactions/datasources/transaction-api.service.spec.ts
@@ -2553,7 +2553,7 @@ describe('TransactionApi', () => {
   describe('getMessageByHash', () => {
     it('should return the message hash received', async () => {
       const messageHash = faker.string.hexadecimal();
-      const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}`;
+      const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}/`;
       const message = messageBuilder().build();
       const cacheDir = new CacheDir(`${chainId}_message_${messageHash}`, '');
       mockDataSource.get.mockResolvedValueOnce(rawify(message));
@@ -2581,7 +2581,7 @@ describe('TransactionApi', () => {
       ['standard', new Error(errorMessage)],
     ])(`should forward a %s error`, async (_, error) => {
       const messageHash = faker.string.hexadecimal();
-      const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}`;
+      const getMessageByHashUrl = `${baseUrl}/api/v1/messages/${messageHash}/`;
       const statusCode = errorStatusCodeExcluding(
         UNAVAILABLE_FOR_LEGAL_REASONS_STATUS,
       );

--- a/src/modules/transactions/datasources/transaction-api.service.ts
+++ b/src/modules/transactions/datasources/transaction-api.service.ts
@@ -1053,7 +1053,7 @@ export class TransactionApi implements ITransactionApi {
 
   async getMessageByHash(messageHash: string): Promise<Raw<Message>> {
     try {
-      const url = `${this.baseUrl}/api/v1/messages/${messageHash}`;
+      const url = `${this.baseUrl}/api/v1/messages/${messageHash}/`;
       const cacheDir = CacheRouter.getMessageByHashCacheDir({
         chainId: this.chainId,
         messageHash,


### PR DESCRIPTION
Resolves: https://linear.app/safe-global/issue/WA-3510/fix-5xx-and-redirect-on-the-message-by-hash-endpoint

## Problem

`getMessageByHash` (`transaction-api.service.ts:1056`) builds `/api/v1/messages/{hash}` without a trailing slash. Django's `APPEND_SLASH` answers with a **301** to the slashed path, so every single-message lookup costs two round trips instead of one.

## Evidence

Production APM spans, 15 days, `service:safe-client-nest`:

| Upstream path | Status | Spans |
|---|---|---|
| `/api/v1/messages/?` (no slash) | **301** | 3,501 |
| `/api/v1/messages/?/` (followed) | 404 | 4,252 |
| `/api/v1/messages/?/` (followed) | 200 | 1,402 |

The slashless path returned **301 and nothing else**, across 25 chain hosts. The neighbouring URLs in the same file — `safes/{address}/messages/` and `messages/{hash}/signatures/` — already end in a slash; this one was the outlier.

## This fixes no errors

The redirect is followed and the correct data comes back, so this removes **zero** 5xx. It is a latency and request-count change only: one round trip instead of two on the busiest message path, on every chain. The 5xx on this endpoint are addressed by #3397.

## Notes

- **No cache invalidation.** The key comes from `CacheRouter.getMessageByHashCacheDir({ chainId, messageHash })`, not the URL, so existing entries stay valid.
- Test mocks for this endpoint updated to match; the `/signatures/` mocks are a different endpoint and are untouched.

## Verification

Run locally against staging with the message cache evicted first, so the new URL was genuinely exercised rather than served from cache: the message fetched **200**, and 404s and all other cases were unchanged from `main`. `yarn test` green — 359 files, 6,349 tests.

The 301 itself cannot be reproduced locally: both `api.5afe.dev` and `api.safe.global` answer 200/404 for either form. It occurs only on the in-cluster `*-safe-transaction-web…svc.cluster.local` host that deployed CGW uses, so the saved round trip is confirmed by the production span data above and will be visible on staging after merge.

Independent of #3397 — branched separately from `main`, either can merge first.
