### PR TITLE
feat: add pre enforcement filtered payment links

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -198,7 +198,7 @@ export default (): ReturnType<typeof configuration> => ({
     },
   },
   entitlements: {
-    enforcementStartsAt: faker.date.future().toISOString(),
+    enforcementStartsAt: faker.date.future(),
   },
   expirationTimeInSeconds: {
     deviatePercent: faker.number.int({ min: 10, max: 20 }),

--- a/src/config/entities/configuration.spec.ts
+++ b/src/config/entities/configuration.spec.ts
@@ -63,3 +63,45 @@ describe('configuration - features.zerion', () => {
     expect(configuration().features.zerion).toBe(false);
   });
 });
+
+describe('configuration - entitlements.enforcementStartsAt', () => {
+  const ENV_KEY = 'ENTITLEMENTS_ENFORCEMENT_STARTS_AT';
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it('defaults far into the future when unset', () => {
+    delete process.env[ENV_KEY];
+
+    expect(configuration().entitlements.enforcementStartsAt).toStrictEqual(
+      new Date('2099-01-01T00:00:00Z'),
+    );
+  });
+
+  it('parses the provided value into a Date', () => {
+    process.env[ENV_KEY] = '2026-10-01T00:00:00Z';
+
+    expect(configuration().entitlements.enforcementStartsAt).toStrictEqual(
+      new Date('2026-10-01T00:00:00Z'),
+    );
+  });
+
+  // An Invalid Date would silently disable enforcement and offer the legacy
+  // grace to every workspace, so both failure directions are permissive.
+  it.each(['the first of october', '2026-13-45T00:00:00Z', ''])(
+    'throws when set to %s',
+    (value) => {
+      process.env[ENV_KEY] = value;
+
+      expect(() => configuration()).toThrow(
+        'ENTITLEMENTS_ENFORCEMENT_STARTS_AT is not a valid date',
+      );
+    },
+  );
+});

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -365,10 +365,6 @@ export default () => ({
       },
     },
   },
-  entitlements: {
-    enforcementStartsAt:
-      process.env.ENTITLEMENTS_ENFORCEMENT_STARTS_AT ?? '2099-01-01T00:00:00Z',
-  },
   expirationTimeInSeconds: {
     deviatePercent: Number.parseInt(
       process.env.EXPIRATION_DEVIATE_PERCENT ?? `${10}`,
@@ -556,6 +552,12 @@ export default () => ({
   jwt: {
     issuer: process.env.JWT_ISSUER,
     secret: process.env.JWT_SECRET,
+  },
+  entitlements: {
+    // When enforcement goes live; workspaces created before it predate it.
+    enforcementStartsAt: parseEnforcementStartsAt(
+      process.env.ENTITLEMENTS_ENFORCEMENT_STARTS_AT,
+    ),
   },
   billing: {
     baseUri:
@@ -1064,6 +1066,17 @@ export default () => ({
     secretKey: process.env.CAPTCHA_SECRET_KEY,
   },
 });
+
+// An Invalid Date here would read as "enforcement off, grace for everyone",
+// so it fails loudly instead. RootConfigurationSchema does not cover this:
+// configuration.validator skips validation entirely under NODE_ENV=test.
+const parseEnforcementStartsAt = (envValue: string | undefined): Date => {
+  const startsAt = new Date(envValue ?? '2099-01-01T00:00:00Z');
+  if (Number.isNaN(startsAt.getTime())) {
+    throw Error('ENTITLEMENTS_ENFORCEMENT_STARTS_AT is not a valid date');
+  }
+  return startsAt;
+};
 
 // Helper function to parse relay rules from environment variable
 const parseRelayRules = (

--- a/src/datasources/billing-api/entities/__tests__/payment-link.builder.ts
+++ b/src/datasources/billing-api/entities/__tests__/payment-link.builder.ts
@@ -4,6 +4,9 @@ import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
 import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
 
+// `trialPeriodDays` defaults to `null` — a paid link. The offer filter reads
+// it, so a random trial length would make every spec that builds a link depend
+// on which offer it happened to get.
 export function paymentLinkBuilder(): IBuilder<PaymentLink> {
   return new Builder<PaymentLink>()
     .with('id', faker.string.uuid())
@@ -26,5 +29,15 @@ export function paymentLinkBuilder(): IBuilder<PaymentLink> {
         },
         quantity: 1,
       },
-    ]);
+    ])
+    .with('trialPeriodDays', null);
+}
+
+/** A trial link tagged with the `gracePeriod` metadata `isOfferedToSpace` filters on. */
+export function trialPaymentLinkBuilder(
+  gracePeriod: boolean,
+): IBuilder<PaymentLink> {
+  return paymentLinkBuilder()
+    .with('trialPeriodDays', faker.number.int({ min: 1, max: 365 }))
+    .with('metadata', { gracePeriod: String(gracePeriod) });
 }

--- a/src/datasources/billing-api/entities/payment-link.entity.ts
+++ b/src/datasources/billing-api/entities/payment-link.entity.ts
@@ -38,4 +38,6 @@ export const PaymentLinkSchema = z.object({
   customText: z.record(z.string(), z.unknown()).optional(),
   afterCompletion: z.record(z.string(), z.unknown()).optional(),
   lineItems: z.array(PaymentLinkLineItemSchema).optional(),
+  /** The offer's free length; `null`/absent means the link bills immediately. */
+  trialPeriodDays: z.number().int().nullish(),
 });

--- a/src/modules/billing/billing.module.ts
+++ b/src/modules/billing/billing.module.ts
@@ -7,6 +7,7 @@ import { BillingAuthService } from '@/modules/billing/domain/billing-auth.servic
 import { BillingController } from '@/modules/billing/routes/billing.controller';
 import { BillingService } from '@/modules/billing/routes/billing.service';
 import { BillingWebhookAuthGuard } from '@/modules/billing/routes/guards/billing-webhook-auth.guard';
+import { EntitlementsRepositoryModule } from '@/modules/entitlements/domain/entitlements-repository.module';
 import { SubscriptionSyncModule } from '@/modules/entitlements/subscription-sync.module';
 import { SpacesModule } from '@/modules/spaces/spaces.module';
 import { UsersModule } from '@/modules/users/users.module';
@@ -16,6 +17,7 @@ import { UsersModule } from '@/modules/users/users.module';
     JwtModule,
     BillingApiModule,
     SubscriptionSyncModule,
+    EntitlementsRepositoryModule,
     forwardRef(() => AuthModule),
     forwardRef(() => UsersModule),
     forwardRef(() => SpacesModule),

--- a/src/modules/billing/domain/payment-link-offer.rules.spec.ts
+++ b/src/modules/billing/domain/payment-link-offer.rules.spec.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import {
+  paymentLinkBuilder,
+  trialPaymentLinkBuilder,
+} from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
+import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
+import {
+  gracePeriodOf,
+  isOfferedToSpace,
+  planNameOf,
+} from '@/modules/billing/domain/payment-link-offer.rules';
+
+/** A trial link carrying `metadata` instead of a recognized `gracePeriod` tag. */
+function trialLinkWithMetadata(metadata: Record<string, string>): PaymentLink {
+  return trialPaymentLinkBuilder(true).with('metadata', metadata).build();
+}
+
+/** A paid link, optionally tagged with a `planName`. */
+function paidLinkWithPlan(planName: string | null): PaymentLink {
+  return paymentLinkBuilder()
+    .with('metadata', planName === null ? {} : { planName })
+    .build();
+}
+
+describe('payment-link offer rules', () => {
+  describe('gracePeriodOf', () => {
+    it('should return true for a link tagged with gracePeriod=true', () => {
+      expect(gracePeriodOf(trialPaymentLinkBuilder(true).build())).toBe(true);
+    });
+
+    it('should return false for a link tagged with gracePeriod=false', () => {
+      expect(gracePeriodOf(trialPaymentLinkBuilder(false).build())).toBe(false);
+    });
+
+    it('should return null when the metadata key is absent', () => {
+      expect(gracePeriodOf(trialLinkWithMetadata({}))).toBeNull();
+    });
+
+    it('should return null for an unrecognized value', () => {
+      expect(
+        gracePeriodOf(trialLinkWithMetadata({ gracePeriod: 'garbled' })),
+      ).toBeNull();
+    });
+  });
+
+  describe('planNameOf', () => {
+    it('should return the plan name the link carries', () => {
+      const planName = faker.commerce.productName();
+
+      expect(planNameOf(paidLinkWithPlan(planName))).toBe(planName);
+    });
+
+    it('should return null when the metadata key is absent', () => {
+      expect(planNameOf(paidLinkWithPlan(null))).toBeNull();
+    });
+  });
+
+  describe('isOfferedToSpace', () => {
+    it('should not offer a paid link to a space that has never subscribed', () => {
+      const link = paidLinkWithPlan(null);
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: faker.datatype.boolean(),
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(false);
+    });
+
+    it('should offer a paid link to a space that has subscribed, when it is on no active plan', () => {
+      const link = paidLinkWithPlan(faker.commerce.productName());
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: faker.datatype.boolean(),
+          hasEverSubscribed: true,
+          activePlanName: null,
+        }),
+      ).toBe(true);
+    });
+
+    it('should offer a paid link whose plan does not match the active one', () => {
+      const link = paidLinkWithPlan('Business');
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: faker.datatype.boolean(),
+          hasEverSubscribed: true,
+          activePlanName: 'Starter',
+        }),
+      ).toBe(true);
+    });
+
+    it('should not offer the paid link matching the active plan', () => {
+      const planName = faker.commerce.productName();
+      const link = paidLinkWithPlan(planName);
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: faker.datatype.boolean(),
+          hasEverSubscribed: true,
+          activePlanName: planName,
+        }),
+      ).toBe(false);
+    });
+
+    it('should offer an untagged paid link even when the space is on an active plan', () => {
+      const link = paidLinkWithPlan(null);
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: faker.datatype.boolean(),
+          hasEverSubscribed: true,
+          activePlanName: faker.commerce.productName(),
+        }),
+      ).toBe(true);
+    });
+
+    it('should offer the legacy grace to a space created before enforcement', () => {
+      const link = trialPaymentLinkBuilder(true).build();
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: true,
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(true);
+    });
+
+    it('should not offer the standard trial to a space created before enforcement', () => {
+      const link = trialPaymentLinkBuilder(false).build();
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: true,
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(false);
+    });
+
+    it('should offer the standard trial to a space created from enforcement on', () => {
+      const link = trialPaymentLinkBuilder(false).build();
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: false,
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(true);
+    });
+
+    it('should not offer the legacy grace to a space created from enforcement on', () => {
+      const link = trialPaymentLinkBuilder(true).build();
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: false,
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(false);
+    });
+
+    it.each([true, false])(
+      'should not offer a trial link (gracePeriod=%s) to a space that has ever subscribed',
+      (gracePeriod) => {
+        const link = trialPaymentLinkBuilder(gracePeriod).build();
+
+        expect(
+          isOfferedToSpace(link, {
+            createdBeforeEnforcement: true,
+            hasEverSubscribed: true,
+            activePlanName: null,
+          }),
+        ).toBe(false);
+        expect(
+          isOfferedToSpace(link, {
+            createdBeforeEnforcement: false,
+            hasEverSubscribed: true,
+            activePlanName: null,
+          }),
+        ).toBe(false);
+      },
+    );
+
+    it('should not offer a trial link with no gracePeriod metadata', () => {
+      const link = trialLinkWithMetadata({});
+
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: true,
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(false);
+      expect(
+        isOfferedToSpace(link, {
+          createdBeforeEnforcement: false,
+          hasEverSubscribed: false,
+          activePlanName: null,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/modules/billing/domain/payment-link-offer.rules.ts
+++ b/src/modules/billing/domain/payment-link-offer.rules.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
+import {
+  GRACE_PERIOD_METADATA_KEY,
+  PLAN_NAME_METADATA_KEY,
+} from '@/modules/entitlements/domain/entitlements.constants';
+
+/** What the offer filter needs to know about the workspace. */
+export type SpaceOfferEligibility = {
+  createdBeforeEnforcement: boolean;
+  hasEverSubscribed: boolean;
+  activePlanName: string | null;
+};
+
+/**
+ * Which trial offer a link belongs to, read from its `gracePeriod` metadata:
+ * `true` for the legacy grace offered to pre-enforcement workspaces, `false`
+ * for the standard trial. `null` when the link carries no (or an
+ * unrecognized) value, which offers it to neither.
+ */
+export function gracePeriodOf(link: PaymentLink): boolean | null {
+  const value = link.metadata[GRACE_PERIOD_METADATA_KEY];
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return null;
+}
+
+export function planNameOf(link: PaymentLink): string | null {
+  return link.metadata[PLAN_NAME_METADATA_KEY] ?? null;
+}
+
+/** Whether the link offers a free period; a paid link bills immediately. */
+function isTrialLink(link: PaymentLink): boolean {
+  return link.trialPeriodDays != null;
+}
+
+/** A trial link no workspace is offered, because its tag is missing or unknown. */
+export function isUnclassifiedTrialLink(link: PaymentLink): boolean {
+  return isTrialLink(link) && gracePeriodOf(link) === null;
+}
+
+/** Whether the workspace is offered this link. */
+export function isOfferedToSpace(
+  link: PaymentLink,
+  args: SpaceOfferEligibility,
+): boolean {
+  const isTrial = isTrialLink(link);
+
+  switch (true) {
+    // Already subscribed once: trials are off the table.
+    case isTrial && args.hasEverSubscribed:
+      return false;
+    // Never subscribed: offer only the trial matching this enforcement side.
+    case isTrial:
+      return gracePeriodOf(link) === args.createdBeforeEnforcement;
+    // Never subscribed: no paid link until a plan is picked first.
+    case !args.hasEverSubscribed:
+      return false;
+    // Subscribed: every paid plan is offered except the current one.
+    default:
+      return (
+        args.activePlanName === null || planNameOf(link) !== args.activePlanName
+      );
+  }
+}

--- a/src/modules/billing/routes/__tests__/billing.controller.e2e-spec.ts
+++ b/src/modules/billing/routes/__tests__/billing.controller.e2e-spec.ts
@@ -115,8 +115,6 @@ describe('BillingController', () => {
   afterEach(() => {
     networkService.get.mockReset();
     networkService.post.mockReset();
-    // The general payment-link catalog is cached under a customer-independent
-    // key, so without this a previous test's catalog is served to the next one.
     fakeCacheService.clear();
   });
 

--- a/src/modules/billing/routes/__tests__/billing.controller.e2e-spec.ts
+++ b/src/modules/billing/routes/__tests__/billing.controller.e2e-spec.ts
@@ -17,9 +17,15 @@ import {
   checkoutSessionBuilder,
   checkoutSessionResultBuilder,
 } from '@/datasources/billing-api/entities/__tests__/checkout-session.builder';
-import { paymentLinkBuilder } from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
+import {
+  paymentLinkBuilder,
+  trialPaymentLinkBuilder,
+} from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
 import { planBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
 import { subscriptionBuilder } from '@/datasources/billing-api/entities/__tests__/subscription.builder';
+import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
+import type { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheService } from '@/datasources/cache/cache.service.interface';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import {
   type INetworkService,
@@ -41,6 +47,7 @@ describe('BillingController', () => {
   let networkService: MockedObject<INetworkService>;
   let billingBaseUri: string;
   let postLoginRedirectUri: string;
+  let fakeCacheService: FakeCacheService;
 
   beforeAll(async () => {
     vi.resetAllMocks();
@@ -53,6 +60,14 @@ describe('BillingController', () => {
         auth: true,
         users: true,
         billingService: true,
+      },
+      entitlements: {
+        ...defaultConfiguration.entitlements,
+        // In the past, so a workspace a spec creates now reads as
+        // post-enforcement and is offered the standard trial rather than the
+        // legacy grace. The shared default is a future date instead (safe for
+        // suites unrelated to billing: enforcement stays inactive).
+        enforcementStartsAt: new Date('2020-01-01T00:00:00Z'),
       },
       billing: {
         ...defaultConfiguration.billing,
@@ -84,6 +99,7 @@ describe('BillingController', () => {
 
     jwtService = moduleFixture.get<IJwtService>(IJwtService);
     networkService = moduleFixture.get(NetworkService);
+    fakeCacheService = moduleFixture.get<FakeCacheService>(CacheService);
     const configurationService = moduleFixture.get<IConfigurationService>(
       IConfigurationService,
     );
@@ -99,6 +115,9 @@ describe('BillingController', () => {
   afterEach(() => {
     networkService.get.mockReset();
     networkService.post.mockReset();
+    // The general payment-link catalog is cached under a customer-independent
+    // key, so without this a previous test's catalog is served to the next one.
+    fakeCacheService.clear();
   });
 
   afterAll(async () => {
@@ -122,6 +141,32 @@ describe('BillingController', () => {
       .send({ name: nameBuilder() });
 
     return { accessToken, spaceId: createSpaceResponse.body.uuid };
+  }
+
+  /**
+   * Serves the payment-link catalog, split the way the datasource asks for it:
+   * `spaceSpecific` answers the customer-scoped call, `general` the shared one.
+   */
+  function mockPaymentLinkCatalog(args: {
+    general?: Array<PaymentLink>;
+    spaceSpecific?: Array<PaymentLink>;
+  }): void {
+    networkService.get.mockImplementation(({ url, networkRequest }) => {
+      if (url === `${billingBaseUri}/api/v1/payment-links`) {
+        const customerId = (
+          networkRequest?.params as { customerId?: string } | undefined
+        )?.customerId;
+        return Promise.resolve({
+          data: rawify({
+            paymentLinks: customerId
+              ? (args.spaceSpecific ?? [])
+              : (args.general ?? []),
+          }),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
   }
 
   it('should require authentication for every space/session/plan endpoint', () => {
@@ -248,24 +293,12 @@ describe('BillingController', () => {
       .with('id', sharedId)
       .with('active', false)
       .build();
-    const onlyGeneralLink = paymentLinkBuilder().build();
+    // A never-subscribed space is not offered a plain paid link
+    const onlyGeneralLink = trialPaymentLinkBuilder(false).build();
 
-    networkService.get.mockImplementation(({ url, networkRequest }) => {
-      if (url === `${billingBaseUri}/api/v1/payment-links`) {
-        const hasCustomerId = Boolean(
-          (networkRequest?.params as { customerId?: string } | undefined)
-            ?.customerId,
-        );
-        return Promise.resolve({
-          data: rawify({
-            paymentLinks: hasCustomerId
-              ? [spaceLink]
-              : [generalLink, onlyGeneralLink],
-          }),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
+    mockPaymentLinkCatalog({
+      general: [generalLink, onlyGeneralLink],
+      spaceSpecific: [spaceLink],
     });
 
     await request(app.getHttpServer())
@@ -283,7 +316,74 @@ describe('BillingController', () => {
       });
   });
 
+  it('GET /v1/billing/spaces/:spaceId/payment-links returns 403 without an access token', async () => {
+    const { spaceId } = await registerAndCreateSpace();
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/payment-links`)
+      .expect(403);
+
+    expect(networkService.get).not.toHaveBeenCalled();
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/payment-links drops the offers the space is not entitled to', async () => {
+    const { accessToken, spaceId } = await registerAndCreateSpace();
+    // The space is created now, and the test configuration's enforcement date
+    // is in the past, so it is a post-enforcement, never-subscribed
+    // workspace: only the standard trial — never the legacy grace, and no
+    // paid link until it has picked a plan.
+    const graceLink = trialPaymentLinkBuilder(true).build();
+    const trialLink = trialPaymentLinkBuilder(false).build();
+    const paidLink = paymentLinkBuilder().build();
+
+    mockPaymentLinkCatalog({ general: [graceLink, trialLink, paidLink] });
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/payment-links`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.map((link: { id: string }) => link.id)).toEqual([
+          trialLink.id,
+        ]);
+      });
+  });
+
+  it('GET /v1/billing/spaces/:spaceId/payment-links always offers a space-specific link', async () => {
+    const { accessToken, spaceId } = await registerAndCreateSpace();
+    // Negotiated for this customer, untagged: the general-catalog enforcement
+    // filter would drop it, but a space-specific link is not subject to it.
+    const negotiatedLink = paymentLinkBuilder()
+      .with('trialPeriodDays', faker.number.int({ min: 1, max: 365 }))
+      .build();
+
+    mockPaymentLinkCatalog({ spaceSpecific: [negotiatedLink] });
+
+    await request(app.getHttpServer())
+      .get(`/v1/billing/spaces/${spaceId}/payment-links`)
+      .set('Cookie', [`access_token=${accessToken}`])
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.map((link: { id: string }) => link.id)).toEqual([
+          negotiatedLink.id,
+        ]);
+      });
+  });
+
   describe('GET /v1/billing/spaces/:spaceId/payment-links/:paymentLinkId/checkout-url', () => {
+    it('returns 403 without an access token', async () => {
+      const { spaceId } = await registerAndCreateSpace();
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/billing/spaces/${spaceId}/payment-links/${faker.string.alphanumeric(20)}/checkout-url`,
+        )
+        .query({ returnUrl: postLoginRedirectUri })
+        .expect(403);
+
+      expect(networkService.post).not.toHaveBeenCalled();
+    });
+
     it('returns 422 for a malformed paymentLinkId', async () => {
       const { accessToken, spaceId } = await registerAndCreateSpace();
 
@@ -314,6 +414,12 @@ describe('BillingController', () => {
       const { accessToken, spaceId } = await registerAndCreateSpace();
       const paymentLinkId = faker.string.alphanumeric(20);
       const checkoutSessionResult = checkoutSessionResultBuilder().build();
+      // The standard trial, which a post-enforcement never-subscribed space is
+      // offered — so the checkout is not rejected by the offer filter.
+      const offeredLink = trialPaymentLinkBuilder(false)
+        .with('id', paymentLinkId)
+        .build();
+      mockPaymentLinkCatalog({ general: [offeredLink] });
       networkService.post.mockImplementation(({ url }) => {
         if (
           url ===
@@ -337,6 +443,25 @@ describe('BillingController', () => {
         .expect(({ body }) => {
           expect(body.sessionId).toBe(checkoutSessionResult.sessionId);
         });
+    });
+
+    it('returns 403 for a payment link the space is not offered', async () => {
+      const { accessToken, spaceId } = await registerAndCreateSpace();
+      // The legacy grace, which a space created now is not entitled to.
+      const graceLink = trialPaymentLinkBuilder(true)
+        .with('id', faker.string.alphanumeric(20))
+        .build();
+      mockPaymentLinkCatalog({ general: [graceLink] });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/billing/spaces/${spaceId}/payment-links/${graceLink.id}/checkout-url`,
+        )
+        .query({ returnUrl: postLoginRedirectUri })
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(403);
+
+      expect(networkService.post).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/billing/routes/billing.service.spec.ts
+++ b/src/modules/billing/routes/billing.service.spec.ts
@@ -57,8 +57,7 @@ const subscriptionSyncServiceMock = {
 } as MockedObject<ISubscriptionSyncService>;
 
 const subscriptionsRepositoryMock = {
-  hasAnySubscription: vi.fn(),
-  getActivePlanName: vi.fn(),
+  getSubscriptionSummary: vi.fn(),
 } as MockedObject<ISubscriptionsRepository>;
 
 const spacesRepositoryMock = {
@@ -119,8 +118,10 @@ describe('BillingService', () => {
     // Defaults for the specs that are not about the offer filter: a workspace
     // created after the enforcement date that has never subscribed.
     spaceCreatedAt(AFTER_ENFORCEMENT);
-    subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(false);
-    subscriptionsRepositoryMock.getActivePlanName.mockResolvedValue(null);
+    subscriptionsRepositoryMock.getSubscriptionSummary.mockResolvedValue({
+      hasEverSubscribed: false,
+      activePlanName: null,
+    });
 
     service = new BillingService(
       billingApiMock,
@@ -317,7 +318,10 @@ describe('BillingService', () => {
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
       // A paid link in the general catalog needs the space to have subscribed
       // before to be offered; this test is about merge behaviour, not that.
-      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
+      subscriptionsRepositoryMock.getSubscriptionSummary.mockResolvedValue({
+        hasEverSubscribed: true,
+        activePlanName: null,
+      });
       billingApiMock.listPaymentLinks.mockImplementation((args) =>
         Promise.resolve(args?.upstreamCustomerId ? [spaceLink] : [generalLink]),
       );
@@ -419,6 +423,26 @@ describe('BillingService', () => {
       );
     });
 
+    it('should warn only once for the same untagged link across requests', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const untagged = trialPaymentLinkBuilder(true)
+        .with('metadata', {})
+        .build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      mockCatalog([untagged]);
+
+      for (let i = 0; i < 3; i++) {
+        await service.getSpacePaymentLinks({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+        });
+      }
+
+      // A misconfigured catalog is read on every request; the log is not.
+      expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
+    });
+
     it('should not warn when every trial link is tagged', async () => {
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
@@ -479,7 +503,10 @@ describe('BillingService', () => {
       const paidLink = paymentLinkBuilder().build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
       spaceCreatedAt(BEFORE_ENFORCEMENT);
-      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
+      subscriptionsRepositoryMock.getSubscriptionSummary.mockResolvedValue({
+        hasEverSubscribed: true,
+        activePlanName: null,
+      });
       mockCatalog([graceLink, paidLink]);
 
       const result = await service.getSpacePaymentLinks({
@@ -490,7 +517,7 @@ describe('BillingService', () => {
 
       expect(result).toEqual([paidLink]);
       expect(
-        subscriptionsRepositoryMock.hasAnySubscription,
+        subscriptionsRepositoryMock.getSubscriptionSummary,
       ).toHaveBeenCalledWith(spaceId);
     });
 
@@ -505,10 +532,10 @@ describe('BillingService', () => {
         .with('metadata', { planName: faker.commerce.productName() })
         .build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
-      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
-      subscriptionsRepositoryMock.getActivePlanName.mockResolvedValue(
-        activeSubscription.planName,
-      );
+      subscriptionsRepositoryMock.getSubscriptionSummary.mockResolvedValue({
+        hasEverSubscribed: true,
+        activePlanName: activeSubscription.planName,
+      });
       mockCatalog([currentPlanLink, otherPlanLink]);
 
       const result = await service.getSpacePaymentLinks({
@@ -551,7 +578,10 @@ describe('BillingService', () => {
         .build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
       // A paid link needs the space to have subscribed before to be offered.
-      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
+      subscriptionsRepositoryMock.getSubscriptionSummary.mockResolvedValue({
+        hasEverSubscribed: true,
+        activePlanName: null,
+      });
       mockCatalog([paymentLink]);
       billingApiMock.createCheckoutSession.mockResolvedValue(
         checkoutSessionResult,

--- a/src/modules/billing/routes/billing.service.spec.ts
+++ b/src/modules/billing/routes/billing.service.spec.ts
@@ -401,7 +401,7 @@ describe('BillingService', () => {
       expect(billingApiMock.listPaymentLinks).not.toHaveBeenCalled();
     });
 
-    it('should warn when a trial link carries no recognized gracePeriod tag', async () => {
+    it('should log an error when a trial link carries no recognized gracePeriod tag', async () => {
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
       // Tagged for neither side, so nobody is offered it: without a log the
       // catalog would just look emptier than it should.
@@ -418,32 +418,12 @@ describe('BillingService', () => {
       });
 
       expect(result).toEqual([]);
-      expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+      expect(loggingServiceMock.error).toHaveBeenCalledWith(
         expect.stringContaining(untagged.id),
       );
     });
 
-    it('should warn only once for the same untagged link across requests', async () => {
-      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
-      const untagged = trialPaymentLinkBuilder(true)
-        .with('metadata', {})
-        .build();
-      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
-      mockCatalog([untagged]);
-
-      for (let i = 0; i < 3; i++) {
-        await service.getSpacePaymentLinks({
-          spaceId: faker.number.int(),
-          spaceUuid: faker.string.uuid(),
-          authPayload,
-        });
-      }
-
-      // A misconfigured catalog is read on every request; the log is not.
-      expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not warn when every trial link is tagged', async () => {
+    it('should not log an error when every trial link is tagged', async () => {
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
       mockCatalog([trialPaymentLinkBuilder(false).build()]);
@@ -454,7 +434,7 @@ describe('BillingService', () => {
         authPayload,
       });
 
-      expect(loggingServiceMock.warn).not.toHaveBeenCalled();
+      expect(loggingServiceMock.error).not.toHaveBeenCalled();
     });
 
     it('should offer only the legacy grace link to a space created before the enforcement date', async () => {

--- a/src/modules/billing/routes/billing.service.spec.ts
+++ b/src/modules/billing/routes/billing.service.spec.ts
@@ -4,6 +4,7 @@ import { faker } from '@faker-js/faker';
 import {
   BadRequestException,
   ForbiddenException,
+  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import type { MockedObject } from 'vitest';
@@ -12,10 +13,15 @@ import {
   checkoutSessionBuilder,
   checkoutSessionResultBuilder,
 } from '@/datasources/billing-api/entities/__tests__/checkout-session.builder';
-import { paymentLinkBuilder } from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
+import {
+  paymentLinkBuilder,
+  trialPaymentLinkBuilder,
+} from '@/datasources/billing-api/entities/__tests__/payment-link.builder';
 import { planBuilder } from '@/datasources/billing-api/entities/__tests__/plan.builder';
 import { subscriptionBuilder } from '@/datasources/billing-api/entities/__tests__/subscription.builder';
+import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
 import type { IBillingApi } from '@/domain/interfaces/billing-api.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
 import {
   oidcAuthPayloadDtoBuilder,
   siweAuthPayloadDtoBuilder,
@@ -24,7 +30,10 @@ import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity'
 import { webhookEventBuilder } from '@/modules/billing/domain/entities/__tests__/webhook-event.builder';
 import { BillingService } from '@/modules/billing/routes/billing.service';
 import { toCheckoutSessionDto } from '@/modules/billing/routes/entities/checkout-session.entity';
+import { spaceSubscriptionBuilder } from '@/modules/entitlements/domain/entities/__tests__/space-subscription.builder';
 import type { ISubscriptionSyncService } from '@/modules/entitlements/domain/subscription-sync.service.interface';
+import type { ISubscriptionsRepository } from '@/modules/entitlements/domain/subscriptions.repository.interface';
+import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import type { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
 
@@ -47,12 +56,50 @@ const subscriptionSyncServiceMock = {
   handleWebhook: vi.fn(),
 } as MockedObject<ISubscriptionSyncService>;
 
+const subscriptionsRepositoryMock = {
+  hasAnySubscription: vi.fn(),
+  getActivePlanName: vi.fn(),
+} as MockedObject<ISubscriptionsRepository>;
+
+const spacesRepositoryMock = {
+  findCreatedAtById: vi.fn(),
+} as MockedObject<ISpacesRepository>;
+
+const loggingServiceMock = {
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+// The enforcement date the offer rule splits workspaces on, and one stamp on
+// each side of it.
+const ENFORCEMENT_STARTS_AT = '2026-10-01T00:00:00Z';
+const BEFORE_ENFORCEMENT = '2026-09-30T23:59:59Z';
+const AFTER_ENFORCEMENT = '2026-11-01T00:00:00Z';
+
 describe('BillingService', () => {
   let service: BillingService;
   let postLoginRedirectUri: string;
 
   function withinRedirectOrigin(): string {
     return new URL(faker.system.filePath(), postLoginRedirectUri).toString();
+  }
+
+  /**
+   * Serves `links` as the general catalog and nothing space-specific, which is
+   * the shape the offer filter runs on.
+   */
+  function mockCatalog(links: Array<PaymentLink>): void {
+    billingApiMock.listPaymentLinks.mockImplementation((args) =>
+      Promise.resolve(args?.upstreamCustomerId ? [] : links),
+    );
+  }
+
+  function spaceCreatedAt(createdAt: string): void {
+    spacesRepositoryMock.findCreatedAtById.mockResolvedValue(
+      new Date(createdAt),
+    );
   }
 
   beforeEach(() => {
@@ -64,13 +111,53 @@ describe('BillingService', () => {
       postLoginRedirectUri,
     );
     fakeConfigurationService.set('application.isProduction', false);
+    fakeConfigurationService.set(
+      'entitlements.enforcementStartsAt',
+      new Date(ENFORCEMENT_STARTS_AT),
+    );
+
+    // Defaults for the specs that are not about the offer filter: a workspace
+    // created after the enforcement date that has never subscribed.
+    spaceCreatedAt(AFTER_ENFORCEMENT);
+    subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(false);
+    subscriptionsRepositoryMock.getActivePlanName.mockResolvedValue(null);
 
     service = new BillingService(
       billingApiMock,
       membersRepositoryMock,
       fakeConfigurationService,
       subscriptionSyncServiceMock,
+      subscriptionsRepositoryMock,
+      spacesRepositoryMock,
+      loggingServiceMock,
     );
+  });
+
+  describe('constructor', () => {
+    // The date's *format* is guaranteed upstream: `configuration.ts` parses it
+    // and `RootConfigurationSchema` rejects a non-ISO env value at boot. What
+    // is still worth asserting here is that a missing key is not tolerated.
+    it('should throw when entitlements.enforcementStartsAt is not configured', () => {
+      const fakeConfigurationService = new FakeConfigurationService();
+      fakeConfigurationService.set(
+        'auth.postLoginRedirectUri',
+        faker.internet.url(),
+      );
+      fakeConfigurationService.set('application.isProduction', false);
+
+      expect(
+        () =>
+          new BillingService(
+            billingApiMock,
+            membersRepositoryMock,
+            fakeConfigurationService,
+            subscriptionSyncServiceMock,
+            subscriptionsRepositoryMock,
+            spacesRepositoryMock,
+            loggingServiceMock,
+          ),
+      ).toThrow('No value set for key entitlements.enforcementStartsAt');
+    });
   });
 
   describe('processWebhook', () => {
@@ -228,6 +315,9 @@ describe('BillingService', () => {
       const spaceLink = paymentLinkBuilder().build();
       const generalLink = paymentLinkBuilder().build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      // A paid link in the general catalog needs the space to have subscribed
+      // before to be offered; this test is about merge behaviour, not that.
+      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
       billingApiMock.listPaymentLinks.mockImplementation((args) =>
         Promise.resolve(args?.upstreamCustomerId ? [spaceLink] : [generalLink]),
       );
@@ -269,6 +359,29 @@ describe('BillingService', () => {
       expect(result).toEqual([spaceLink]);
     });
 
+    it('should always offer a space-specific link, regardless of the enforcement filter', async () => {
+      const spaceId = faker.number.int();
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      // A negotiated trial with no gracePeriod tag: the general catalog filter
+      // would drop it, but a space-specific link is not subject to it.
+      const negotiatedLink = paymentLinkBuilder()
+        .with('trialPeriodDays', faker.number.int({ min: 1, max: 365 }))
+        .build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      billingApiMock.listPaymentLinks.mockImplementation((args) =>
+        Promise.resolve(args?.upstreamCustomerId ? [negotiatedLink] : []),
+      );
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId,
+        spaceUuid,
+        authPayload,
+      });
+
+      expect(result).toEqual([negotiatedLink]);
+    });
+
     it('should throw when the user is not a space member', async () => {
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
       membersRepositoryMock.findOne.mockResolvedValue(null);
@@ -283,6 +396,146 @@ describe('BillingService', () => {
 
       expect(billingApiMock.listPaymentLinks).not.toHaveBeenCalled();
     });
+
+    it('should warn when a trial link carries no recognized gracePeriod tag', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      // Tagged for neither side, so nobody is offered it: without a log the
+      // catalog would just look emptier than it should.
+      const untagged = trialPaymentLinkBuilder(true)
+        .with('metadata', {})
+        .build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      mockCatalog([untagged]);
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId: faker.number.int(),
+        spaceUuid: faker.string.uuid(),
+        authPayload,
+      });
+
+      expect(result).toEqual([]);
+      expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+        expect.stringContaining(untagged.id),
+      );
+    });
+
+    it('should not warn when every trial link is tagged', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      mockCatalog([trialPaymentLinkBuilder(false).build()]);
+
+      await service.getSpacePaymentLinks({
+        spaceId: faker.number.int(),
+        spaceUuid: faker.string.uuid(),
+        authPayload,
+      });
+
+      expect(loggingServiceMock.warn).not.toHaveBeenCalled();
+    });
+
+    it('should offer only the legacy grace link to a space created before the enforcement date', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const graceLink = trialPaymentLinkBuilder(true).build();
+      const trialLink = trialPaymentLinkBuilder(false).build();
+      // A never-subscribed space is not offered paid links yet — it has to
+      // pick a trial first.
+      const paidLink = paymentLinkBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      spaceCreatedAt(BEFORE_ENFORCEMENT);
+      mockCatalog([graceLink, trialLink, paidLink]);
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId: faker.number.int(),
+        spaceUuid: faker.string.uuid(),
+        authPayload,
+      });
+
+      expect(result).toEqual([graceLink]);
+    });
+
+    it('should offer only the standard trial link to a space created from the enforcement date on', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const graceLink = trialPaymentLinkBuilder(true).build();
+      const trialLink = trialPaymentLinkBuilder(false).build();
+      const paidLink = paymentLinkBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      // The boundary itself: enforcement starts at this instant.
+      spaceCreatedAt(ENFORCEMENT_STARTS_AT);
+      mockCatalog([graceLink, trialLink, paidLink]);
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId: faker.number.int(),
+        spaceUuid: faker.string.uuid(),
+        authPayload,
+      });
+
+      expect(result).toEqual([trialLink]);
+    });
+
+    it('should offer only paid links to a space that has ever subscribed', async () => {
+      const spaceId = faker.number.int();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const graceLink = trialPaymentLinkBuilder(true).build();
+      const paidLink = paymentLinkBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      spaceCreatedAt(BEFORE_ENFORCEMENT);
+      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
+      mockCatalog([graceLink, paidLink]);
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId,
+        spaceUuid: faker.string.uuid(),
+        authPayload,
+      });
+
+      expect(result).toEqual([paidLink]);
+      expect(
+        subscriptionsRepositoryMock.hasAnySubscription,
+      ).toHaveBeenCalledWith(spaceId);
+    });
+
+    it('should not offer the paid link matching the plan the space is already on', async () => {
+      const spaceId = faker.number.int();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const activeSubscription = spaceSubscriptionBuilder().build();
+      const currentPlanLink = paymentLinkBuilder()
+        .with('metadata', { planName: activeSubscription.planName })
+        .build();
+      const otherPlanLink = paymentLinkBuilder()
+        .with('metadata', { planName: faker.commerce.productName() })
+        .build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
+      subscriptionsRepositoryMock.getActivePlanName.mockResolvedValue(
+        activeSubscription.planName,
+      );
+      mockCatalog([currentPlanLink, otherPlanLink]);
+
+      const result = await service.getSpacePaymentLinks({
+        spaceId,
+        spaceUuid: faker.string.uuid(),
+        authPayload,
+      });
+
+      expect(result).toEqual([otherPlanLink]);
+    });
+
+    it('should throw when the space no longer exists', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      spacesRepositoryMock.findCreatedAtById.mockRejectedValue(
+        new NotFoundException('Workspace not found.'),
+      );
+      billingApiMock.listPaymentLinks.mockResolvedValue([]);
+
+      await expect(
+        service.getSpacePaymentLinks({
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('createCheckoutUrl', () => {
@@ -293,7 +546,13 @@ describe('BillingService', () => {
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
       const returnUrl = withinRedirectOrigin();
       const checkoutSessionResult = checkoutSessionResultBuilder().build();
+      const paymentLink = paymentLinkBuilder()
+        .with('id', paymentLinkId)
+        .build();
       membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      // A paid link needs the space to have subscribed before to be offered.
+      subscriptionsRepositoryMock.hasAnySubscription.mockResolvedValue(true);
+      mockCatalog([paymentLink]);
       billingApiMock.createCheckoutSession.mockResolvedValue(
         checkoutSessionResult,
       );
@@ -346,6 +605,56 @@ describe('BillingService', () => {
       ).rejects.toThrow(BadRequestException);
 
       expect(billingApiMock.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the payment link is not offered to the space', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      // The legacy grace, which a post-enforcement workspace is not entitled to.
+      const graceLink = trialPaymentLinkBuilder(true).build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      spaceCreatedAt(AFTER_ENFORCEMENT);
+      mockCatalog([graceLink]);
+
+      await expect(
+        service.createCheckoutUrl({
+          paymentLinkId: graceLink.id,
+          spaceId: faker.number.int(),
+          spaceUuid: faker.string.uuid(),
+          authPayload,
+          returnUrl: withinRedirectOrigin(),
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(billingApiMock.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('should check out a payment link the space is offered', async () => {
+      const spaceUuid = faker.string.uuid();
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const returnUrl = withinRedirectOrigin();
+      const graceLink = trialPaymentLinkBuilder(true).build();
+      const checkoutSessionResult = checkoutSessionResultBuilder().build();
+      membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
+      spaceCreatedAt(BEFORE_ENFORCEMENT);
+      mockCatalog([graceLink]);
+      billingApiMock.createCheckoutSession.mockResolvedValue(
+        checkoutSessionResult,
+      );
+
+      const result = await service.createCheckoutUrl({
+        paymentLinkId: graceLink.id,
+        spaceId: faker.number.int(),
+        spaceUuid,
+        authPayload,
+        returnUrl,
+      });
+
+      expect(result).toBe(checkoutSessionResult);
+      expect(billingApiMock.createCheckoutSession).toHaveBeenCalledWith({
+        paymentLinkId: graceLink.id,
+        upstreamCustomerId: spaceUuid,
+        returnUrl,
+      });
     });
   });
 

--- a/src/modules/billing/routes/billing.service.ts
+++ b/src/modules/billing/routes/billing.service.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { PaymentLink } from '@/datasources/billing-api/entities/payment-link.entity';
 import type { Plan } from '@/datasources/billing-api/entities/plan.entity';
@@ -8,6 +8,8 @@ import type {
   SubscriptionStatusFilter,
 } from '@/datasources/billing-api/entities/subscription.entity';
 import { IBillingApi } from '@/domain/interfaces/billing-api.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { LoggingService } from '@/logging/logging.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import {
@@ -16,17 +18,27 @@ import {
   resolveAndValidateRedirectUrl,
 } from '@/modules/auth/utils/auth-redirect.helper';
 import type { WebhookEvent } from '@/modules/billing/domain/entities/webhook-event.entity';
+import type { SpaceOfferEligibility } from '@/modules/billing/domain/payment-link-offer.rules';
+import {
+  isOfferedToSpace,
+  isUnclassifiedTrialLink,
+} from '@/modules/billing/domain/payment-link-offer.rules';
 import type { CheckoutSession } from '@/modules/billing/routes/entities/checkout-session.entity';
 import { toCheckoutSessionDto } from '@/modules/billing/routes/entities/checkout-session.entity';
 import type { CheckoutSessionResult } from '@/modules/billing/routes/entities/checkout-session-result.entity';
+import { GRACE_PERIOD_METADATA_KEY } from '@/modules/entitlements/domain/entitlements.constants';
+import { predatesEnforcement } from '@/modules/entitlements/domain/entitlements.rules';
 import { ISubscriptionSyncService } from '@/modules/entitlements/domain/subscription-sync.service.interface';
+import { ISubscriptionsRepository } from '@/modules/entitlements/domain/subscriptions.repository.interface';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { assertMember } from '@/modules/spaces/routes/utils/space-assert.utils';
 import { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
 
 @Injectable()
 export class BillingService {
   private readonly redirectConfig: RedirectConfig;
+  private readonly enforcementStartsAt: Date;
 
   public constructor(
     @Inject(IBillingApi)
@@ -37,8 +49,17 @@ export class BillingService {
     private readonly configurationService: IConfigurationService,
     @Inject(ISubscriptionSyncService)
     private readonly subscriptionSyncService: ISubscriptionSyncService,
+    @Inject(ISubscriptionsRepository)
+    private readonly subscriptionsRepository: ISubscriptionsRepository,
+    @Inject(ISpacesRepository)
+    private readonly spacesRepository: ISpacesRepository,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
   ) {
     this.redirectConfig = getRedirectConfig(this.configurationService);
+    this.enforcementStartsAt = this.configurationService.getOrThrow<Date>(
+      'entitlements.enforcementStartsAt',
+    );
   }
 
   public async processWebhook(payload: WebhookEvent): Promise<void> {
@@ -86,17 +107,7 @@ export class BillingService {
   }): Promise<Array<PaymentLink>> {
     await this.assertSpaceMember(args.spaceId, args.authPayload);
 
-    const [spaceLinks, generalLinks] = await Promise.all([
-      this.billingApi.listPaymentLinks({
-        upstreamCustomerId: args.spaceUuid,
-      }),
-      this.billingApi.listPaymentLinks(),
-    ]);
-
-    const byId = new Map(
-      [...generalLinks, ...spaceLinks].map((link) => [link.id, link]),
-    );
-    return Array.from(byId.values());
+    return await this.listOfferedPaymentLinks(args);
   }
 
   public async createCheckoutUrl(args: {
@@ -107,11 +118,21 @@ export class BillingService {
     returnUrl: string;
   }): Promise<CheckoutSessionResult> {
     await this.assertSpaceMember(args.spaceId, args.authPayload);
+    const returnUrl = this.validateReturnUrl(args.returnUrl);
+
+    // A link the workspace is not offered is not checkable out either, or the
+    // filtered list would only be a hint.
+    const offeredLinks = await this.listOfferedPaymentLinks(args);
+    if (!offeredLinks.some((link) => link.id === args.paymentLinkId)) {
+      throw new ForbiddenException(
+        'This subscription is not available for this workspace',
+      );
+    }
 
     return await this.billingApi.createCheckoutSession({
       paymentLinkId: args.paymentLinkId,
       upstreamCustomerId: args.spaceUuid,
-      returnUrl: this.validateReturnUrl(args.returnUrl),
+      returnUrl,
     });
   }
 
@@ -119,6 +140,72 @@ export class BillingService {
     const session = await this.billingApi.getCheckoutSession({ sessionId });
 
     return toCheckoutSessionDto(session);
+  }
+
+  /**
+   * The general catalog narrowed to what this workspace is entitled to, with
+   * the space-specific catalog merged in on top, always offered: a link
+   * negotiated for one customer is not subject to the general enforcement
+   * rule. Space-specific wins on a shared id.
+   */
+  private async listOfferedPaymentLinks(args: {
+    spaceId: Space['id'];
+    spaceUuid: Space['uuid'];
+  }): Promise<Array<PaymentLink>> {
+    const [spaceLinks, generalLinks, eligibility] = await Promise.all([
+      this.billingApi.listPaymentLinks({
+        upstreamCustomerId: args.spaceUuid,
+      }),
+      this.billingApi.listPaymentLinks(),
+      this.getOfferEligibility(args.spaceId),
+    ]);
+
+    this.warnOnUnclassifiedTrials(generalLinks);
+
+    const offeredGeneralLinks = generalLinks.filter((link) =>
+      isOfferedToSpace(link, eligibility),
+    );
+    const linksById = new Map(
+      [...offeredGeneralLinks, ...spaceLinks].map((link) => [link.id, link]),
+    );
+    return Array.from(linksById.values());
+  }
+
+  /**
+   * A trial link with no recognized `gracePeriod` tag is offered to nobody, so
+   * an untagged catalog looks like an empty one. Surface it rather than serving
+   * fewer offers in silence.
+   */
+  private warnOnUnclassifiedTrials(generalLinks: Array<PaymentLink>): void {
+    const unclassified = generalLinks.filter(isUnclassifiedTrialLink);
+    if (unclassified.length === 0) {
+      return;
+    }
+    this.loggingService.warn(
+      `Dropping ${unclassified.length} trial payment link(s) with no recognized ${GRACE_PERIOD_METADATA_KEY} metadata: ${unclassified
+        .map((link) => link.id)
+        .join(', ')}`,
+    );
+  }
+
+  private async getOfferEligibility(
+    spaceId: Space['id'],
+  ): Promise<SpaceOfferEligibility> {
+    const [spaceCreatedAt, hasEverSubscribed, activePlanName] =
+      await Promise.all([
+        this.spacesRepository.findCreatedAtById(spaceId),
+        this.subscriptionsRepository.hasAnySubscription(spaceId),
+        this.subscriptionsRepository.getActivePlanName(spaceId),
+      ]);
+
+    return {
+      createdBeforeEnforcement: predatesEnforcement({
+        createdAt: spaceCreatedAt,
+        startsAt: this.enforcementStartsAt,
+      }),
+      hasEverSubscribed,
+      activePlanName,
+    };
   }
 
   private validateReturnUrl(returnUrl: string): string {

--- a/src/modules/billing/routes/billing.service.ts
+++ b/src/modules/billing/routes/billing.service.ts
@@ -39,6 +39,8 @@ import { IMembersRepository } from '@/modules/users/domain/members/members.repos
 export class BillingService {
   private readonly redirectConfig: RedirectConfig;
   private readonly enforcementStartsAt: Date;
+  /** Link ids already reported as untagged, so the warning fires once each. */
+  private readonly warnedUnclassifiedLinkIds = new Set<PaymentLink['id']>();
 
   public constructor(
     @Inject(IBillingApi)
@@ -174,12 +176,19 @@ export class BillingService {
   /**
    * A trial link with no recognized `gracePeriod` tag is offered to nobody, so
    * an untagged catalog looks like an empty one. Surface it rather than serving
-   * fewer offers in silence.
+   * fewer offers in silence — once per link, since this runs on every payment
+   * links and checkout request and a misconfigured catalog would otherwise
+   * repeat the same line at request rate.
    */
   private warnOnUnclassifiedTrials(generalLinks: Array<PaymentLink>): void {
-    const unclassified = generalLinks.filter(isUnclassifiedTrialLink);
+    const unclassified = generalLinks
+      .filter(isUnclassifiedTrialLink)
+      .filter((link) => !this.warnedUnclassifiedLinkIds.has(link.id));
     if (unclassified.length === 0) {
       return;
+    }
+    for (const link of unclassified) {
+      this.warnedUnclassifiedLinkIds.add(link.id);
     }
     this.loggingService.warn(
       `Dropping ${unclassified.length} trial payment link(s) with no recognized ${GRACE_PERIOD_METADATA_KEY} metadata: ${unclassified
@@ -191,20 +200,18 @@ export class BillingService {
   private async getOfferEligibility(
     spaceId: Space['id'],
   ): Promise<SpaceOfferEligibility> {
-    const [spaceCreatedAt, hasEverSubscribed, activePlanName] =
-      await Promise.all([
-        this.spacesRepository.findCreatedAtById(spaceId),
-        this.subscriptionsRepository.hasAnySubscription(spaceId),
-        this.subscriptionsRepository.getActivePlanName(spaceId),
-      ]);
+    const [spaceCreatedAt, subscription] = await Promise.all([
+      this.spacesRepository.findCreatedAtById(spaceId),
+      this.subscriptionsRepository.getSubscriptionSummary(spaceId),
+    ]);
 
     return {
       createdBeforeEnforcement: predatesEnforcement({
         createdAt: spaceCreatedAt,
         startsAt: this.enforcementStartsAt,
       }),
-      hasEverSubscribed,
-      activePlanName,
+      hasEverSubscribed: subscription.hasEverSubscribed,
+      activePlanName: subscription.activePlanName,
     };
   }
 

--- a/src/modules/billing/routes/billing.service.ts
+++ b/src/modules/billing/routes/billing.service.ts
@@ -39,8 +39,6 @@ import { IMembersRepository } from '@/modules/users/domain/members/members.repos
 export class BillingService {
   private readonly redirectConfig: RedirectConfig;
   private readonly enforcementStartsAt: Date;
-  /** Link ids already reported as untagged, so the warning fires once each. */
-  private readonly warnedUnclassifiedLinkIds = new Set<PaymentLink['id']>();
 
   public constructor(
     @Inject(IBillingApi)
@@ -162,7 +160,14 @@ export class BillingService {
       this.getOfferEligibility(args.spaceId),
     ]);
 
-    this.warnOnUnclassifiedTrials(generalLinks);
+    const unclassified = generalLinks.filter(isUnclassifiedTrialLink);
+    if (unclassified.length > 0) {
+      this.loggingService.error(
+        `Trial payment link(s) offered to nobody, missing a recognized ${GRACE_PERIOD_METADATA_KEY} tag: ${unclassified
+          .map((link) => link.id)
+          .join(', ')}`,
+      );
+    }
 
     const offeredGeneralLinks = generalLinks.filter((link) =>
       isOfferedToSpace(link, eligibility),
@@ -171,30 +176,6 @@ export class BillingService {
       [...offeredGeneralLinks, ...spaceLinks].map((link) => [link.id, link]),
     );
     return Array.from(linksById.values());
-  }
-
-  /**
-   * A trial link with no recognized `gracePeriod` tag is offered to nobody, so
-   * an untagged catalog looks like an empty one. Surface it rather than serving
-   * fewer offers in silence — once per link, since this runs on every payment
-   * links and checkout request and a misconfigured catalog would otherwise
-   * repeat the same line at request rate.
-   */
-  private warnOnUnclassifiedTrials(generalLinks: Array<PaymentLink>): void {
-    const unclassified = generalLinks
-      .filter(isUnclassifiedTrialLink)
-      .filter((link) => !this.warnedUnclassifiedLinkIds.has(link.id));
-    if (unclassified.length === 0) {
-      return;
-    }
-    for (const link of unclassified) {
-      this.warnedUnclassifiedLinkIds.add(link.id);
-    }
-    this.loggingService.warn(
-      `Dropping ${unclassified.length} trial payment link(s) with no recognized ${GRACE_PERIOD_METADATA_KEY} metadata: ${unclassified
-        .map((link) => link.id)
-        .join(', ')}`,
-    );
   }
 
   private async getOfferEligibility(

--- a/src/modules/billing/routes/billing.service.ts
+++ b/src/modules/billing/routes/billing.service.ts
@@ -172,10 +172,12 @@ export class BillingService {
     const offeredGeneralLinks = generalLinks.filter((link) =>
       isOfferedToSpace(link, eligibility),
     );
-    const linksById = new Map(
-      [...offeredGeneralLinks, ...spaceLinks].map((link) => [link.id, link]),
-    );
-    return Array.from(linksById.values());
+
+    return [
+      ...new Map(
+        [...offeredGeneralLinks, ...spaceLinks].map((link) => [link.id, link]),
+      ).values(),
+    ];
   }
 
   private async getOfferEligibility(

--- a/src/modules/billing/routes/entities/payment-link.entity.ts
+++ b/src/modules/billing/routes/entities/payment-link.entity.ts
@@ -21,4 +21,6 @@ export class PaymentLink implements DomainPaymentLink {
   afterCompletion?: Record<string, unknown>;
   @ApiPropertyOptional({ type: [Object] })
   lineItems?: Array<PaymentLinkLineItem>;
+  @ApiPropertyOptional({ type: Number, nullable: true })
+  trialPeriodDays?: number | null;
 }

--- a/src/modules/entitlements/domain/entities/__tests__/space-subscription.builder.ts
+++ b/src/modules/entitlements/domain/entities/__tests__/space-subscription.builder.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import { SubscriptionStatuses } from '@/datasources/billing-api/entities/subscription.entity';
+import type { SpaceSubscription } from '@/modules/entitlements/domain/entities/space-subscription.entity';
+
+export function spaceSubscriptionBuilder(): IBuilder<SpaceSubscription> {
+  return new Builder<SpaceSubscription>()
+    .with('id', faker.number.int())
+    .with('createdAt', faker.date.recent())
+    .with('updatedAt', faker.date.recent())
+    .with('upstreamSubscriptionId', faker.string.uuid())
+    .with('status', faker.helpers.arrayElement(SubscriptionStatuses))
+    .with('planId', faker.string.uuid())
+    .with('planName', faker.commerce.productName())
+    .with('currentPeriodStart', faker.date.recent())
+    .with('currentPeriodEnd', faker.date.future())
+    .with('lastEventAt', faker.date.recent());
+}

--- a/src/modules/entitlements/domain/entitlements.constants.ts
+++ b/src/modules/entitlements/domain/entitlements.constants.ts
@@ -74,6 +74,13 @@ export const FEATURE_METADATA_PREFIX = 'FEATURE_';
 export const PLAN_NAME_METADATA_KEY = 'planName';
 
 /**
+ * Metadata key marking which trial a payment link offers: `'true'` for the
+ * legacy grace given to pre-enforcement workspaces, `'false'` for the standard
+ * trial. Same upstream vocabulary as `PLAN_NAME_METADATA_KEY`.
+ */
+export const GRACE_PERIOD_METADATA_KEY = 'gracePeriod';
+
+/**
  * Mirrors the `subscription_entitlements.value` column's `varchar(255)`: a
  * longer value is skipped rather than left to fail the insert.
  */

--- a/src/modules/entitlements/domain/entitlements.rules.spec.ts
+++ b/src/modules/entitlements/domain/entitlements.rules.spec.ts
@@ -9,6 +9,7 @@ import {
   eventPeriodStart,
   fitsWithinQuota,
   isEnforcementActive,
+  predatesEnforcement,
   resetsAt,
 } from '@/modules/entitlements/domain/entitlements.rules';
 
@@ -26,6 +27,18 @@ describe('entitlements rules', () => {
       ['after the date', new Date(startsAt.getTime() + 1), true],
     ])('is %s', (_label, now, expected) => {
       expect(isEnforcementActive({ now, startsAt })).toBe(expected);
+    });
+  });
+
+  describe('predatesEnforcement', () => {
+    const startsAt = faker.date.recent();
+
+    it.each([
+      ['created before the date', new Date(startsAt.getTime() - 1), true],
+      ['created on the date', new Date(startsAt.getTime()), false],
+      ['created after the date', new Date(startsAt.getTime() + 1), false],
+    ])('is %s', (_label, createdAt, expected) => {
+      expect(predatesEnforcement({ createdAt, startsAt })).toBe(expected);
     });
   });
 

--- a/src/modules/entitlements/domain/entitlements.rules.ts
+++ b/src/modules/entitlements/domain/entitlements.rules.ts
@@ -40,14 +40,26 @@ type BillingCycle = Pick<
 
 /**
  * Whether the workspace's own entitlements decide its quotas yet. `startsAt`
- * is always a valid date: `EntitlementsService` refuses to construct with an
- * unparseable one, so this can never silently answer `true` for a typo.
+ * is always a valid date: `configuration.ts` parses it once and throws on an
+ * unparseable value, so this can never silently answer `true` for a typo.
  */
 export function isEnforcementActive(args: {
   now: Date;
   startsAt: Date;
 }): boolean {
   return args.now >= args.startsAt;
+}
+
+/**
+ * Whether a workspace created at `createdAt` predates enforcement. The exact
+ * complement of `isEnforcementActive`, so the boundary — a workspace created
+ * exactly at `startsAt` is already enforced — is defined once.
+ */
+export function predatesEnforcement(args: {
+  createdAt: Date;
+  startsAt: Date;
+}): boolean {
+  return !isEnforcementActive({ now: args.createdAt, startsAt: args.startsAt });
 }
 
 /**

--- a/src/modules/entitlements/domain/subscriptions.repository.integration.spec.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.integration.spec.ts
@@ -157,44 +157,84 @@ describe('SubscriptionsRepository', () => {
     return planName;
   }
 
-  describe('hasAnySubscription', () => {
-    it('should return false for a space that never subscribed', async () => {
+  describe('getSubscriptionSummary', () => {
+    it('should report a space that never subscribed', async () => {
       const spaceId = await createSpace();
 
       await expect(
-        subscriptionsRepository.hasAnySubscription(spaceId),
-      ).resolves.toBe(false);
+        subscriptionsRepository.getSubscriptionSummary(spaceId),
+      ).resolves.toStrictEqual({
+        hasEverSubscribed: false,
+        activePlanName: null,
+      });
     });
 
-    it('should return true for a space whose only subscription is terminal', async () => {
+    it.each(['active', 'trialing'] as const)(
+      'should report the plan name of a %s subscription',
+      async (status) => {
+        const spaceId = await createSpace();
+        const planName = await subscribe(spaceId, status);
+
+        await expect(
+          subscriptionsRepository.getSubscriptionSummary(spaceId),
+        ).resolves.toStrictEqual({
+          hasEverSubscribed: true,
+          activePlanName: planName,
+        });
+      },
+    );
+
+    it('should report a terminal subscription as subscribed but on no plan', async () => {
       const spaceId = await createSpace();
       await subscribe(spaceId, 'canceled');
 
       await expect(
-        subscriptionsRepository.hasAnySubscription(spaceId),
-      ).resolves.toBe(true);
-    });
-
-    it('should return true for a space holding the active slot', async () => {
-      const spaceId = await createSpace();
-      await subscribe(spaceId, 'trialing');
-
-      await expect(
-        subscriptionsRepository.hasAnySubscription(spaceId),
-      ).resolves.toBe(true);
+        subscriptionsRepository.getSubscriptionSummary(spaceId),
+      ).resolves.toStrictEqual({
+        hasEverSubscribed: true,
+        activePlanName: null,
+      });
     });
 
     it.each(['incomplete', 'incomplete_expired'] as const)(
-      'should return true for a space whose only subscription is %s',
+      'should count a %s subscription as having subscribed',
       async (status) => {
         const spaceId = await createSpace();
         await subscribe(spaceId, status);
 
         await expect(
-          subscriptionsRepository.hasAnySubscription(spaceId),
-        ).resolves.toBe(true);
+          subscriptionsRepository.getSubscriptionSummary(spaceId),
+        ).resolves.toStrictEqual({
+          hasEverSubscribed: true,
+          activePlanName: null,
+        });
       },
     );
+
+    it('should report no plan name when the active subscription is untagged', async () => {
+      const spaceId = await createSpace();
+      await subscribe(spaceId, 'active', null);
+
+      await expect(
+        subscriptionsRepository.getSubscriptionSummary(spaceId),
+      ).resolves.toStrictEqual({
+        hasEverSubscribed: true,
+        activePlanName: null,
+      });
+    });
+
+    it('should keep the active plan name when a terminal row also exists', async () => {
+      const spaceId = await createSpace();
+      await subscribe(spaceId, 'canceled');
+      const planName = await subscribe(spaceId, 'active');
+
+      await expect(
+        subscriptionsRepository.getSubscriptionSummary(spaceId),
+      ).resolves.toStrictEqual({
+        hasEverSubscribed: true,
+        activePlanName: planName,
+      });
+    });
 
     it('should not leak another space subscriptions', async () => {
       const [spaceId, otherSpaceId] = await Promise.all([
@@ -204,60 +244,11 @@ describe('SubscriptionsRepository', () => {
       await subscribe(otherSpaceId, 'active');
 
       await expect(
-        subscriptionsRepository.hasAnySubscription(spaceId),
-      ).resolves.toBe(false);
-    });
-  });
-
-  describe('getActivePlanName', () => {
-    it.each(['active', 'trialing'] as const)(
-      'should return the plan name of a %s subscription',
-      async (status) => {
-        const spaceId = await createSpace();
-        const planName = await subscribe(spaceId, status);
-
-        await expect(
-          subscriptionsRepository.getActivePlanName(spaceId),
-        ).resolves.toBe(planName);
-      },
-    );
-
-    it('should return null for a space that never subscribed', async () => {
-      const spaceId = await createSpace();
-
-      await expect(
-        subscriptionsRepository.getActivePlanName(spaceId),
-      ).resolves.toBeNull();
-    });
-
-    it('should return null when the only subscription is terminal', async () => {
-      const spaceId = await createSpace();
-      await subscribe(spaceId, 'canceled');
-
-      await expect(
-        subscriptionsRepository.getActivePlanName(spaceId),
-      ).resolves.toBeNull();
-    });
-
-    it('should return null when the active subscription is untagged', async () => {
-      const spaceId = await createSpace();
-      await subscribe(spaceId, 'active', null);
-
-      await expect(
-        subscriptionsRepository.getActivePlanName(spaceId),
-      ).resolves.toBeNull();
-    });
-
-    it('should not leak another space plan name', async () => {
-      const [spaceId, otherSpaceId] = await Promise.all([
-        createSpace(),
-        createSpace(),
-      ]);
-      await subscribe(otherSpaceId, 'active');
-
-      await expect(
-        subscriptionsRepository.getActivePlanName(spaceId),
-      ).resolves.toBeNull();
+        subscriptionsRepository.getSubscriptionSummary(spaceId),
+      ).resolves.toStrictEqual({
+        hasEverSubscribed: false,
+        activePlanName: null,
+      });
     });
   });
 });

--- a/src/modules/entitlements/domain/subscriptions.repository.integration.spec.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.integration.spec.ts
@@ -184,20 +184,18 @@ describe('SubscriptionsRepository', () => {
       },
     );
 
-    it('should report a terminal subscription as subscribed but on no plan', async () => {
-      const spaceId = await createSpace();
-      await subscribe(spaceId, 'canceled');
-
-      await expect(
-        subscriptionsRepository.getSubscriptionSummary(spaceId),
-      ).resolves.toStrictEqual({
-        hasEverSubscribed: true,
-        activePlanName: null,
-      });
-    });
-
-    it.each(['incomplete', 'incomplete_expired'] as const)(
-      'should count a %s subscription as having subscribed',
+    // Every status outside ACTIVE_SUBSCRIPTION_STATUSES, listed literally
+    // rather than derived from it: the point is to pin which side of the line
+    // each one falls on, which a list computed from that constant could not do.
+    it.each([
+      'canceled',
+      'incomplete',
+      'incomplete_expired',
+      'past_due',
+      'paused',
+      'unpaid',
+    ] as const)(
+      'should report a %s subscription as subscribed but on no plan',
       async (status) => {
         const spaceId = await createSpace();
         await subscribe(spaceId, status);

--- a/src/modules/entitlements/domain/subscriptions.repository.integration.spec.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.integration.spec.ts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { randomUUID } from 'node:crypto';
+import { faker } from '@faker-js/faker';
+import type { ConfigService } from '@nestjs/config';
+import { DataSource, type ObjectLiteral } from 'typeorm';
+import type { MockedObject } from 'vitest';
+import configuration from '@/config/entities/__tests__/configuration';
+import { postgresConfig } from '@/config/entities/postgres.config';
+import type { SubscriptionStatus } from '@/datasources/billing-api/entities/subscription.entity';
+import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { nameBuilder } from '@/domain/common/entities/name.builder';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { Feature } from '@/modules/entitlements/datasources/entities/feature.entity.db';
+import { SpaceFeatureUsage } from '@/modules/entitlements/datasources/entities/space-feature-usage.entity.db';
+import { SpaceSubscription } from '@/modules/entitlements/datasources/entities/space-subscription.entity.db';
+import { SubscriptionEntitlement } from '@/modules/entitlements/datasources/entities/subscription-entitlement.entity.db';
+import { SubscriptionsRepository } from '@/modules/entitlements/domain/subscriptions.repository';
+import { SpaceSafe } from '@/modules/spaces/datasources/safes/entities/space-safes.entity.db';
+import { Space } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
+import { Member } from '@/modules/users/datasources/entities/member.entity.db';
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+
+const mockLoggingService = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+} as MockedObject<ILoggingService>;
+
+describe('SubscriptionsRepository', () => {
+  let postgresDatabaseService: PostgresDatabaseService;
+  let subscriptionsRepository: SubscriptionsRepository;
+
+  // Not faker: a fixed FAKER_SEED would hand every spec file the same name.
+  const testDatabaseName = `test_${randomUUID().replaceAll('-', '')}`;
+  const testConfiguration = configuration();
+
+  const dataSource = new DataSource({
+    ...postgresConfig({
+      ...testConfiguration.db.connection.postgres,
+      type: 'postgres',
+      database: testDatabaseName,
+    }),
+    migrationsTableName: testConfiguration.db.orm.migrationsTableName,
+    entities: [
+      Feature,
+      Member,
+      Space,
+      SpaceFeatureUsage,
+      SpaceSafe,
+      SpaceSubscription,
+      SubscriptionEntitlement,
+      User,
+      Wallet,
+    ],
+  });
+
+  beforeAll(async () => {
+    const testDataSource = new DataSource({
+      ...postgresConfig({
+        ...testConfiguration.db.connection.postgres,
+        type: 'postgres',
+        database: 'postgres',
+      }),
+    });
+    const testPostgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      testDataSource,
+    );
+    await testPostgresDatabaseService.initializeDatabaseConnection();
+    await testPostgresDatabaseService
+      .getDataSource()
+      .query(`CREATE DATABASE ${testDatabaseName}`);
+    await testPostgresDatabaseService.destroyDatabaseConnection();
+
+    postgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      dataSource,
+    );
+    await postgresDatabaseService.initializeDatabaseConnection();
+
+    const mockConfigService = {
+      getOrThrow: vi.fn().mockImplementation((key: string) => {
+        if (key === 'db.migrator.numberOfRetries') {
+          return testConfiguration.db.migrator.numberOfRetries;
+        }
+        if (key === 'db.migrator.retryAfterMs') {
+          return testConfiguration.db.migrator.retryAfterMs;
+        }
+      }),
+    } as MockedObject<ConfigService>;
+    const migrator = new DatabaseMigrator(
+      mockLoggingService,
+      postgresDatabaseService,
+      mockConfigService,
+    );
+    await migrator.migrate();
+
+    subscriptionsRepository = new SubscriptionsRepository(
+      postgresDatabaseService,
+    );
+  });
+
+  afterEach(async () => {
+    vi.resetAllMocks();
+
+    // Delete in dependency order; the subscription rows reference the space.
+    await deleteAll(SpaceSubscription);
+    await deleteAll(Space);
+  });
+
+  afterAll(async () => {
+    await postgresDatabaseService.getDataSource().dropDatabase();
+    await postgresDatabaseService.destroyDatabaseConnection();
+  });
+
+  async function deleteAll<T extends ObjectLiteral>(entity: {
+    new (): T;
+  }): Promise<void> {
+    await dataSource
+      .getRepository(entity)
+      .createQueryBuilder()
+      .delete()
+      .execute();
+  }
+
+  async function createSpace(): Promise<Space['id']> {
+    const inserted = await dataSource.getRepository(Space).insert({
+      name: nameBuilder(),
+      status: 'ACTIVE',
+    });
+    return inserted.generatedMaps[0].id as Space['id'];
+  }
+
+  // The status is what each case is about; the rest of the row is incidental.
+  // Returns the plan name written, so a case can assert what it reads back.
+  async function subscribe(
+    spaceId: Space['id'],
+    status: SubscriptionStatus,
+    planName: string | null = nameBuilder(),
+  ): Promise<string | null> {
+    await subscriptionsRepository.upsertSubscription({
+      spaceId,
+      upstreamSubscriptionId: faker.string.uuid(),
+      values: {
+        status,
+        planId: faker.string.uuid(),
+        planName,
+        currentPeriodStart: null,
+        currentPeriodEnd: null,
+        lastEventAt: null,
+      },
+    });
+    return planName;
+  }
+
+  describe('hasAnySubscription', () => {
+    it('should return false for a space that never subscribed', async () => {
+      const spaceId = await createSpace();
+
+      await expect(
+        subscriptionsRepository.hasAnySubscription(spaceId),
+      ).resolves.toBe(false);
+    });
+
+    it('should return true for a space whose only subscription is terminal', async () => {
+      const spaceId = await createSpace();
+      await subscribe(spaceId, 'canceled');
+
+      await expect(
+        subscriptionsRepository.hasAnySubscription(spaceId),
+      ).resolves.toBe(true);
+    });
+
+    it('should return true for a space holding the active slot', async () => {
+      const spaceId = await createSpace();
+      await subscribe(spaceId, 'trialing');
+
+      await expect(
+        subscriptionsRepository.hasAnySubscription(spaceId),
+      ).resolves.toBe(true);
+    });
+
+    it.each(['incomplete', 'incomplete_expired'] as const)(
+      'should return true for a space whose only subscription is %s',
+      async (status) => {
+        const spaceId = await createSpace();
+        await subscribe(spaceId, status);
+
+        await expect(
+          subscriptionsRepository.hasAnySubscription(spaceId),
+        ).resolves.toBe(true);
+      },
+    );
+
+    it('should not leak another space subscriptions', async () => {
+      const [spaceId, otherSpaceId] = await Promise.all([
+        createSpace(),
+        createSpace(),
+      ]);
+      await subscribe(otherSpaceId, 'active');
+
+      await expect(
+        subscriptionsRepository.hasAnySubscription(spaceId),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe('getActivePlanName', () => {
+    it.each(['active', 'trialing'] as const)(
+      'should return the plan name of a %s subscription',
+      async (status) => {
+        const spaceId = await createSpace();
+        const planName = await subscribe(spaceId, status);
+
+        await expect(
+          subscriptionsRepository.getActivePlanName(spaceId),
+        ).resolves.toBe(planName);
+      },
+    );
+
+    it('should return null for a space that never subscribed', async () => {
+      const spaceId = await createSpace();
+
+      await expect(
+        subscriptionsRepository.getActivePlanName(spaceId),
+      ).resolves.toBeNull();
+    });
+
+    it('should return null when the only subscription is terminal', async () => {
+      const spaceId = await createSpace();
+      await subscribe(spaceId, 'canceled');
+
+      await expect(
+        subscriptionsRepository.getActivePlanName(spaceId),
+      ).resolves.toBeNull();
+    });
+
+    it('should return null when the active subscription is untagged', async () => {
+      const spaceId = await createSpace();
+      await subscribe(spaceId, 'active', null);
+
+      await expect(
+        subscriptionsRepository.getActivePlanName(spaceId),
+      ).resolves.toBeNull();
+    });
+
+    it('should not leak another space plan name', async () => {
+      const [spaceId, otherSpaceId] = await Promise.all([
+        createSpace(),
+        createSpace(),
+      ]);
+      await subscribe(otherSpaceId, 'active');
+
+      await expect(
+        subscriptionsRepository.getActivePlanName(spaceId),
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/src/modules/entitlements/domain/subscriptions.repository.interface.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.interface.ts
@@ -18,6 +18,19 @@ export interface ISubscriptionsRepository {
   ): Promise<SpaceSubscription | null>;
 
   /**
+   * Whether the space ever held a subscription, in any status — terminal and
+   * incomplete rows included.
+   */
+  hasAnySubscription(spaceId: Space['id']): Promise<boolean>;
+
+  /**
+   * Plan name on the workspace's active subscription; `null` when it has none
+   * or the row is untagged. Reads only that column — prefer it over
+   * `getActiveSubscriptionBySpaceId` when the entitlement package is not needed.
+   */
+  getActivePlanName(spaceId: Space['id']): Promise<string | null>;
+
+  /**
    * Atomic upsert by `upstreamSubscriptionId`: inserts a new row, or updates
    * the existing one in place if the id is already known.
    */

--- a/src/modules/entitlements/domain/subscriptions.repository.interface.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.interface.ts
@@ -6,6 +6,13 @@ import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 
 export const ISubscriptionsRepository = Symbol('ISubscriptionsRepository');
 
+export type SpaceSubscriptionSummary = {
+  /** Whether the space ever subscribed, in any status — terminal rows included. */
+  hasEverSubscribed: boolean;
+  /** Plan on the active subscription; `null` with none, or when untagged. */
+  activePlanName: string | null;
+};
+
 /** Queries over the `subscriptions` table. */
 export interface ISubscriptionsRepository {
   /**
@@ -18,17 +25,13 @@ export interface ISubscriptionsRepository {
   ): Promise<SpaceSubscription | null>;
 
   /**
-   * Whether the space ever held a subscription, in any status — terminal and
-   * incomplete rows included.
+   * The space's subscription standing, in one read. Prefer it over
+   * `getActiveSubscriptionBySpaceId` when the entitlement package is not needed:
+   * this one reads two columns instead of hydrating the relation tree.
    */
-  hasAnySubscription(spaceId: Space['id']): Promise<boolean>;
-
-  /**
-   * Plan name on the workspace's active subscription; `null` when it has none
-   * or the row is untagged. Reads only that column — prefer it over
-   * `getActiveSubscriptionBySpaceId` when the entitlement package is not needed.
-   */
-  getActivePlanName(spaceId: Space['id']): Promise<string | null>;
+  getSubscriptionSummary(
+    spaceId: Space['id'],
+  ): Promise<SpaceSubscriptionSummary>;
 
   /**
    * Atomic upsert by `upstreamSubscriptionId`: inserts a new row, or updates

--- a/src/modules/entitlements/domain/subscriptions.repository.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.ts
@@ -41,6 +41,37 @@ export class SubscriptionsRepository implements ISubscriptionsRepository {
     });
   }
 
+  public async hasAnySubscription(spaceId: Space['id']): Promise<boolean> {
+    const repository = await getScopedRepository(
+      this.postgresDatabaseService,
+      SpaceSubscription,
+    );
+    // Filters the FK column rather than `{ space: { id } }`, which would make
+    // TypeORM join `spaces` to answer what space_id already holds.
+    return await repository
+      .createQueryBuilder('subscription')
+      .where('space_id = :spaceId', { spaceId })
+      .getExists();
+  }
+
+  public async getActivePlanName(spaceId: Space['id']): Promise<string | null> {
+    const repository = await getScopedRepository(
+      this.postgresDatabaseService,
+      SpaceSubscription,
+    );
+    // Deliberately not `getActiveSubscriptionBySpaceId`: that one hydrates the
+    // entitlements/feature tree, which a caller wanting one column pays for.
+    const active = await repository
+      .createQueryBuilder('subscription')
+      .select('subscription.planName', 'planName')
+      .where('space_id = :spaceId', { spaceId })
+      .andWhere('status IN (:...activeStatuses)', {
+        activeStatuses: [...ACTIVE_SUBSCRIPTION_STATUSES],
+      })
+      .getRawOne<{ planName: string | null }>();
+    return active?.planName ?? null;
+  }
+
   public async upsertSubscription(
     args: {
       spaceId: Space['id'];

--- a/src/modules/entitlements/domain/subscriptions.repository.ts
+++ b/src/modules/entitlements/domain/subscriptions.repository.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import { type EntityManager, In } from 'typeorm';
+import { toSqlList } from '@/datasources/db/v2/entities/sql.utils';
 import { getScopedRepository } from '@/datasources/db/v2/get-scoped-repository.util';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { SpaceSubscription } from '@/modules/entitlements/datasources/entities/space-subscription.entity.db';
 import type { SubscriptionValues } from '@/modules/entitlements/domain/entities/space-subscription.entity';
 import { ACTIVE_SUBSCRIPTION_STATUSES } from '@/modules/entitlements/domain/entitlements.constants';
-import type { ISubscriptionsRepository } from '@/modules/entitlements/domain/subscriptions.repository.interface';
+import type {
+  ISubscriptionsRepository,
+  SpaceSubscriptionSummary,
+} from '@/modules/entitlements/domain/subscriptions.repository.interface';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 
 /**
@@ -41,35 +45,28 @@ export class SubscriptionsRepository implements ISubscriptionsRepository {
     });
   }
 
-  public async hasAnySubscription(spaceId: Space['id']): Promise<boolean> {
+  public async getSubscriptionSummary(
+    spaceId: Space['id'],
+  ): Promise<SpaceSubscriptionSummary> {
     const repository = await getScopedRepository(
       this.postgresDatabaseService,
       SpaceSubscription,
     );
-    // Filters the FK column rather than `{ space: { id } }`, which would make
-    // TypeORM join `spaces` to answer what space_id already holds.
-    return await repository
+    // `MAX` collapses the active rows, of which the partial unique index
+    // allows at most one.
+    const summary = await repository
       .createQueryBuilder('subscription')
+      .select('COUNT(*) > 0', 'hasEverSubscribed')
+      .addSelect(
+        `MAX(CASE WHEN status IN (${toSqlList(ACTIVE_SUBSCRIPTION_STATUSES)}) THEN plan_name END)`,
+        'activePlanName',
+      )
       .where('space_id = :spaceId', { spaceId })
-      .getExists();
-  }
-
-  public async getActivePlanName(spaceId: Space['id']): Promise<string | null> {
-    const repository = await getScopedRepository(
-      this.postgresDatabaseService,
-      SpaceSubscription,
-    );
-    // Deliberately not `getActiveSubscriptionBySpaceId`: that one hydrates the
-    // entitlements/feature tree, which a caller wanting one column pays for.
-    const active = await repository
-      .createQueryBuilder('subscription')
-      .select('subscription.planName', 'planName')
-      .where('space_id = :spaceId', { spaceId })
-      .andWhere('status IN (:...activeStatuses)', {
-        activeStatuses: [...ACTIVE_SUBSCRIPTION_STATUSES],
-      })
-      .getRawOne<{ planName: string | null }>();
-    return active?.planName ?? null;
+      .getRawOne<SpaceSubscriptionSummary>();
+    return {
+      hasEverSubscribed: summary?.hasEverSubscribed ?? false,
+      activePlanName: summary?.activePlanName ?? null,
+    };
   }
 
   public async upsertSubscription(

--- a/src/modules/entitlements/routes/entitlements.service.integration.spec.ts
+++ b/src/modules/entitlements/routes/entitlements.service.integration.spec.ts
@@ -1136,7 +1136,9 @@ describe('EntitlementsService', () => {
       // The date's format is guaranteed upstream — `configuration.ts` parses it
       // and `RootConfigurationSchema` rejects a non-ISO env value at boot. A
       // missing key must still fail loudly rather than enforce everywhere.
-      expect(() => buildService(undefined)).toThrow();
+      expect(() => buildService(undefined)).toThrow(
+        'No value set for key entitlements.enforcementStartsAt',
+      );
     });
 
     it("applies the caller's static limit before the enforcement date", async () => {

--- a/src/modules/entitlements/routes/entitlements.service.integration.spec.ts
+++ b/src/modules/entitlements/routes/entitlements.service.integration.spec.ts
@@ -117,9 +117,9 @@ describe('EntitlementsService', () => {
   let service: EntitlementsService;
   // The same service with the enforcement date already past.
   let enforcingService: EntitlementsService;
-  // Exposed because one test builds a service with a broken date.
+  // Exposed because one test builds a service with no date configured.
   let buildService: (
-    enforcementStartsAt: Date | string | undefined,
+    enforcementStartsAt: Date | undefined,
   ) => EntitlementsService;
   let subscriptionsRepository: SubscriptionsRepository;
   let seededFeatureKeys: Array<string> = [];
@@ -162,6 +162,13 @@ describe('EntitlementsService', () => {
         .findOne({ where: { id }, select: { uuid: true } });
       if (!space) throw new NotFoundException('Workspace not found.');
       return space.uuid;
+    },
+    findCreatedAtById: async (id: Space['id']): Promise<Space['createdAt']> => {
+      const space = await dataSource
+        .getRepository(Space)
+        .findOne({ where: { id }, select: { createdAt: true } });
+      if (!space) throw new NotFoundException('Workspace not found.');
+      return space.createdAt;
     },
   } as unknown as ISpacesRepository;
 
@@ -226,14 +233,12 @@ describe('EntitlementsService', () => {
       postgresDatabaseService,
     );
     buildService = (
-      enforcementStartsAt: Date | string | undefined,
+      enforcementStartsAt: Date | undefined,
     ): EntitlementsService => {
       const configurationService = new FakeConfigurationService();
       configurationService.set(
         'entitlements.enforcementStartsAt',
-        enforcementStartsAt instanceof Date
-          ? enforcementStartsAt.toISOString()
-          : enforcementStartsAt,
+        enforcementStartsAt,
       );
       configurationService.set(
         'expirationTimeInSeconds.entitlements',
@@ -1127,12 +1132,11 @@ describe('EntitlementsService', () => {
       });
     }
 
-    it('refuses to construct with an unparseable enforcement date', () => {
-      // Not only a typo: a date without a time, or no value at all, must fail
-      // the same way. Enforcing everywhere is what an Invalid Date would do.
-      for (const value of ['the first of october', '2026-10-01', undefined]) {
-        expect(() => buildService(value)).toThrow();
-      }
+    it('refuses to construct with no enforcement date configured', () => {
+      // The date's format is guaranteed upstream — `configuration.ts` parses it
+      // and `RootConfigurationSchema` rejects a non-ISO env value at boot. A
+      // missing key must still fail loudly rather than enforce everywhere.
+      expect(() => buildService(undefined)).toThrow();
     });
 
     it("applies the caller's static limit before the enforcement date", async () => {

--- a/src/modules/entitlements/routes/entitlements.service.ts
+++ b/src/modules/entitlements/routes/entitlements.service.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import {
@@ -61,7 +61,6 @@ import { ISpaceSafesRepository } from '@/modules/spaces/domain/safes/space-safes
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { assertMember } from '@/modules/spaces/routes/utils/space-assert.utils';
 import { IMembersRepository } from '@/modules/users/domain/members/members.repository.interface';
-import { DateStringSchema } from '@/validation/entities/schemas/date-string.schema';
 
 /**
  * Orchestrates the entitlements feature: reads and writes rows through the
@@ -102,15 +101,9 @@ export class EntitlementsService implements IEntitlementEnforcement {
     @Inject(LoggingService)
     private readonly loggingService: ILoggingService,
   ) {
-    const enforcementStartsAt = DateStringSchema.safeParse(
-      configurationService.getOrThrow('entitlements.enforcementStartsAt'),
+    this.enforcementStartsAt = configurationService.getOrThrow<Date>(
+      'entitlements.enforcementStartsAt',
     );
-    if (!enforcementStartsAt.success) {
-      throw new Error(
-        'entitlements.enforcementStartsAt is not an ISO date string',
-      );
-    }
-    this.enforcementStartsAt = new Date(enforcementStartsAt.data);
     this.grantsCacheTtlSeconds = configurationService.getOrThrow<number>(
       'expirationTimeInSeconds.entitlements',
     );
@@ -303,7 +296,7 @@ export class EntitlementsService implements IEntitlementEnforcement {
     purchased: Map<number, SubscriptionEntitlement>;
   }> {
     const [spaceCreatedAt, features, activeSubscription] = await Promise.all([
-      this.getSpaceCreatedAtOrFail(spaceId),
+      this.spacesRepository.findCreatedAtById(spaceId),
       this.featuresRepository.getFeatures(),
       this.subscriptionsRepository.getActiveSubscriptionBySpaceId(spaceId),
     ]);
@@ -775,16 +768,5 @@ export class EntitlementsService implements IEntitlementEnforcement {
         : null,
       entitlements,
     };
-  }
-
-  private async getSpaceCreatedAtOrFail(spaceId: Space['id']): Promise<Date> {
-    const space = await this.spacesRepository.findOne({
-      where: { id: spaceId },
-      select: { createdAt: true },
-    });
-    if (!space) {
-      throw new NotFoundException('Workspace not found.');
-    }
-    return space.createdAt;
   }
 }

--- a/src/modules/spaces/domain/spaces.repository.interface.ts
+++ b/src/modules/spaces/domain/spaces.repository.interface.ts
@@ -69,5 +69,8 @@ export interface ISpacesRepository {
   // Resolves the internal numeric id to the client-facing UUID for response mapping.
   findUuidById(id: Space['id']): Promise<Space['uuid']>;
 
+  // The enforcement rules compare this against the go-live date.
+  findCreatedAtById(id: Space['id']): Promise<Space['createdAt']>;
+
   delete(args: { id: number; actorUserId: number }): Promise<void>;
 }

--- a/src/modules/spaces/domain/spaces.repository.ts
+++ b/src/modules/spaces/domain/spaces.repository.ts
@@ -345,6 +345,14 @@ export class SpacesRepository implements ISpacesRepository {
     return space.uuid;
   }
 
+  public async findCreatedAtById(id: Space['id']): Promise<Space['createdAt']> {
+    const space = await this.findOneOrFail({
+      where: { id },
+      select: { createdAt: true },
+    });
+    return space.createdAt;
+  }
+
   // @todo Add a soft delete method
   public async delete(args: {
     id: number;

--- a/src/modules/spaces/routes/safes/space-safes.enforcement.integration.spec.ts
+++ b/src/modules/spaces/routes/safes/space-safes.enforcement.integration.spec.ts
@@ -72,7 +72,7 @@ describe('Safe seat enforcement', () => {
       entitlements: {
         ...defaultConfiguration.entitlements,
         // Enforcing: the point of this suite is what the plan decides.
-        enforcementStartsAt: faker.date.past().toISOString(),
+        enforcementStartsAt: faker.date.past(),
       },
     });
 


### PR DESCRIPTION
<!--
  SPDX-License-Identifier: FSL-1.1-MIT
 -->
## Summary

`GET /v1/billing/spaces/:spaceId/payment-links` returned the full upstream catalog, so a workspace saw offers it could not take. It now returns only what the workspace is eligible for, and `.../checkout-url` rejects anything outside that set with a 403 — otherwise the filtered list would only be a hint.

The rule: a workspace that has never subscribed is offered exactly one trial, the one matching its enforcement side (the legacy grace for workspaces created before `ENTITLEMENTS_ENFORCEMENT_STARTS_AT`, the standard trial otherwise). Once it has subscribed in any status, trials are off and every paid link is offered except the plan it is already on. Links negotiated for a single customer are always offered — they are not subject to the general rule. An absent or unmatched `planName` never excludes, so under-tagging cannot hide a purchase option.

Two rollout notes for reviewers. `ENTITLEMENTS_ENFORCEMENT_STARTS_AT` defaults to `2099-01-01`, so until it is set every workspace reads as pre-enforcement and is offered the legacy grace — the deliberate direction, since over-granting grace beats under-granting it. And a trial link whose `gracePeriod` metadata is missing or unrecognized is offered to nobody, which makes an untagged catalog look like an empty one; that case now logs a warning naming the dropped link ids rather than silently serving fewer offers.

Also here: `entitlements.enforcementStartsAt` is parsed to a `Date` once at config load and throws on an unparseable value, replacing the same parse-or-throw block that had been copied into two service constructors. `RootConfigurationSchema` does not cover this on its own — `configuration.validator` skips validation entirely under `NODE_ENV=test`, and an `Invalid Date` would read as "enforcement off, grace for everyone". No new env var, no migration.

One deliberate perf choice: reading the active plan name uses a new single-column repository query instead of `getActiveSubscriptionBySpaceId`, which hydrates the entitlements/feature relation tree to serve one string.

PLA-1870

## Changes

- `src/modules/billing/domain/` — `payment-link-offer.rules.ts`: the offer predicate and its `gracePeriod`/`planName` metadata readers, plus specs
- `src/modules/billing/routes/` — `billing.service.ts` filters the general catalog, merges space-specific links over it, gates checkout on the same rule, and warns on unclassified trial links
- `src/modules/entitlements/domain/` — `hasAnySubscription` and `getActivePlanName` on the subscriptions repository; `predatesEnforcement` rule; `GRACE_PERIOD_METADATA_KEY`
- `src/modules/spaces/domain/` — `findCreatedAtById` accessor, replacing two copies of the same hand-composed query
- `src/config/entities/` — parse `enforcementStartsAt` to a `Date` at load time, with specs for the default, a valid value, and malformed input
- `src/datasources/billing-api/entities/` — additive optional `trialPeriodDays` on the payment-link schema and DTO, plus a `trialPaymentLinkBuilder`
