### PR TITLE
fix(targeted-messaging)!: answer 204 when a Safe is not targeted

### DIFF
--- a/src/modules/targeted-messaging/routes/targeted-messaging.controller.integration.spec.ts
+++ b/src/modules/targeted-messaging/routes/targeted-messaging.controller.integration.spec.ts
@@ -74,7 +74,12 @@ describe('TargetedMessagingController', () => {
         });
     });
 
-    it('should return 404 Not Found if the Safe is not targeted', async () => {
+    // "Not targeted" is the expected answer for nearly every Safe on a route
+    // that is probed on every Safe load, so it is not a failure. A 404 makes
+    // the browser write a console error the client cannot suppress, which is
+    // what WA-2991 set out to remove; 204 is what the sibling submissions
+    // route below already answers for the same TargetedSafeNotFoundError.
+    it('should return 204 No Content if the Safe is not targeted', async () => {
       const outreachId = faker.number.int();
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
@@ -86,7 +91,34 @@ describe('TargetedMessagingController', () => {
         .get(
           `/v1/targeted-messaging/outreaches/${outreachId}/chains/${chain.chainId}/safes/${safe.address}`,
         )
-        .expect(404);
+        .expect(204)
+        .expect({});
+    });
+
+    it('should set Cache-Control: no-cache on both answers', async () => {
+      const outreachId = faker.number.int();
+      const chain = chainBuilder().build();
+      const safe = safeBuilder().build();
+      const targetedSafe = targetedSafeBuilder()
+        .with('address', safe.address)
+        .build();
+      const url = `/v1/targeted-messaging/outreaches/${outreachId}/chains/${chain.chainId}/safes/${safe.address}`;
+
+      targetedMessagingDatasource.getTargetedSafe.mockResolvedValue(
+        targetedSafe,
+      );
+      await request(app.getHttpServer())
+        .get(url)
+        .expect(200)
+        .expect('Cache-Control', 'no-cache');
+
+      targetedMessagingDatasource.getTargetedSafe.mockRejectedValue(
+        new TargetedSafeNotFoundError(),
+      );
+      await request(app.getHttpServer())
+        .get(url)
+        .expect(204)
+        .expect('Cache-Control', 'no-cache');
     });
   });
 

--- a/src/modules/targeted-messaging/routes/targeted-messaging.controller.ts
+++ b/src/modules/targeted-messaging/routes/targeted-messaging.controller.ts
@@ -13,7 +13,7 @@ import {
 import {
   ApiBody,
   ApiCreatedResponse,
-  ApiNotFoundResponse,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -41,9 +41,10 @@ export class TargetedMessagingController {
   constructor(private readonly service: TargetedMessagingService) {}
 
   @ApiOkResponse({ type: TargetedSafe })
-  @ApiNotFoundResponse({ description: 'Safe not targeted.' })
+  @ApiNoContentResponse({ description: 'Safe not targeted.' })
   @Get(':outreachId/chains/:chainId/safes/:safeAddress')
-  getTargetedSafe(
+  async getTargetedSafe(
+    @Res() res: FastifyReply,
     @Param(
       'outreachId',
       ParseIntPipe,
@@ -53,8 +54,36 @@ export class TargetedMessagingController {
     @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: Address,
-  ): Promise<TargetedSafe> {
-    return this.service.getTargetedSafe({ outreachId, chainId, safeAddress });
+  ): Promise<FastifyReply> {
+    try {
+      const targetedSafe = await this.service.getTargetedSafe({
+        outreachId,
+        chainId,
+        safeAddress,
+      });
+      return res
+        .status(HttpStatus.OK)
+        .header('Cache-Control', 'no-cache')
+        .send(targetedSafe);
+    } catch (err) {
+      if (err instanceof TargetedSafeNotFoundError) {
+        // "Safe not targeted" is the expected answer for nearly every Safe,
+        // and clients probe this route on every Safe load. Answering 404 made
+        // browsers write an unsuppressible console error for a non-failure —
+        // the noise WA-2991 exists to remove. 204 carries the same "no
+        // targeting for this Safe" answer as the sibling submissions route
+        // below, which already maps this error that way.
+        //
+        // `Cache-Control` is set explicitly on both paths: `@Res()` marks the
+        // reply sent, so CacheControlInterceptor skips it (same reason
+        // getSubmission sets it by hand).
+        return res
+          .status(HttpStatus.NO_CONTENT)
+          .header('Cache-Control', 'no-cache')
+          .send();
+      }
+      throw err;
+    }
   }
 
   @ApiOkResponse({ type: Submission })


### PR DESCRIPTION
## Summary

`GET /v1/targeted-messaging/outreaches/{outreachId}/chains/{chainId}/safes/{safeAddress}` answered `404` when the Safe is not part of the outreach. Clients probe this route on every Safe load, and "not targeted" is the answer for nearly every Safe — so the dominant response on this endpoint was a 4xx describing normal operation. Browsers write their own `Failed to load resource: … 404` console entry for that, from the network stack rather than from any application code, so no client-side filter can remove it. That console noise is what [WA-2991](https://linear.app/safe-global/issue/WA-2991/reduce-expected-404403-console-noise-in-the-web-app) exists to fix, and it originates here.

This maps `TargetedSafeNotFoundError` to `204 No Content` on that route. It is the same mapping the sibling submissions route in this controller has applied to the same error since the API landed — `getSubmission` already answers 204 rather than 404 when the Safe is not targeted — so this makes one resource answer consistently rather than introducing a new convention.

**In-place rather than a new version, per `api-dtos-and-validation.md`'s URI-versioning rule.** The 200 response shape is unchanged; only the not-found status moves. The one released client is the Safe web app, which reads the body (`data?.outreachId === outreachId`) and never branches on the response status — RTK Query's default JSON handler maps an empty 2xx body to `null`, so it already resolves to "not targeted" with no code change. The mobile app does not consume this endpoint (grepped `apps/mobile/src` in `safe-wallet-monorepo`). A new `/v2` would also not achieve the goal: the noise comes from the deployed client's calls to `/v1`, which would keep answering 404 until every client migrated. The subject carries `!` because the documented contract does change for any third-party consumer that treats 404 as the "not targeted" signal.

One behaviour worth a reviewer's eye: moving to `@Res()` marks the reply sent, so `CacheControlInterceptor` no longer applies. `Cache-Control: no-cache` is therefore set explicitly on both the 200 and the 204 path — otherwise the header this route serves today would have silently disappeared. A test now asserts it on both.

## Changes

- `src/modules/targeted-messaging/routes/targeted-messaging.controller.ts` — `getTargetedSafe` catches `TargetedSafeNotFoundError` and answers `204`; `@ApiNotFoundResponse` → `@ApiNoContentResponse` so the generated schema documents it; `Cache-Control: no-cache` set on both paths
- `src/modules/targeted-messaging/routes/targeted-messaging.controller.integration.spec.ts` — the not-targeted case now expects `204`; new case asserting `Cache-Control` on both the 200 and 204 answers

## Follow-up (not in this PR)

Once this ships, `safe-wallet-monorepo` should regenerate `packages/store/scripts/api-schema/schema.json` and the RTK types so the response is typed nullable, and drop the now-dead RUM resource filter for this route in `apps/web/src/services/observability/providers/datadog.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
