### PR TITLE
feat(fees): forward the Safenet check flag and pass its fee line through

### DIFF
--- a/src/datasources/cache/cache.router.spec.ts
+++ b/src/datasources/cache/cache.router.spec.ts
@@ -209,6 +209,7 @@ describe('CacheRouter', () => {
         ['to', getAddress(faker.finance.ethereumAddress())],
         ['nonce', '1'],
         ['origin', Origin.SAFE_APP],
+        ['safenetCheck', true],
       ] as const)(
         'should produce a different hash when %s differs',
         (field, value) => {
@@ -229,6 +230,16 @@ describe('CacheRouter', () => {
         const dirExplicit = CacheRouter.getGtfFeePreviewCacheDir({
           ...rest,
           origin: Origin.NATIVE,
+        });
+
+        expect(dirDefaulted.field).toBe(dirExplicit.field);
+      });
+
+      it('should default safenetCheck the same as an explicit false', () => {
+        const dirDefaulted = CacheRouter.getGtfFeePreviewCacheDir(baseArgs);
+        const dirExplicit = CacheRouter.getGtfFeePreviewCacheDir({
+          ...baseArgs,
+          safenetCheck: false,
         });
 
         expect(dirDefaulted.field).toBe(dirExplicit.field);

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -1187,6 +1187,7 @@ export class CacheRouter {
    * @param args.gasToken - Gas token address
    * @param args.threshold - Safe threshold (number of signatures)
    * @param args.origin - Transaction origin
+   * @param args.safenetCheck - Whether the fee service must price a Safenet check
    * @returns CacheDir - Cache directory
    */
   static getGtfFeePreviewCacheDir(args: {
@@ -1200,10 +1201,11 @@ export class CacheRouter {
     gasToken: Address;
     threshold: number;
     origin?: string;
+    safenetCheck?: boolean;
   }): CacheDir {
     const hash = crypto.createHash('sha256');
     hash.update(
-      `${args.to}_${args.value}_${args.data}_${args.operation}_${args.nonce}_${args.gasToken}_${args.threshold}_${args.origin ?? Origin.NATIVE}`,
+      `${args.to}_${args.value}_${args.data}_${args.operation}_${args.nonce}_${args.gasToken}_${args.threshold}_${args.origin ?? Origin.NATIVE}_${args.safenetCheck ?? false}`,
     );
     return new CacheDir(
       CacheRouter.getGtfFeePreviewCacheKey(args),

--- a/src/datasources/fee-service-api/fee-service-api.service.spec.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.spec.ts
@@ -5,6 +5,7 @@ import { getAddress, type Hex } from 'viem';
 import type { MockedObject } from 'vitest';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import type { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { CacheRouter } from '@/datasources/cache/cache.router';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { FeeServiceApi } from '@/datasources/fee-service-api/fee-service-api.service';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
@@ -285,6 +286,38 @@ describe('FeeServiceApi', () => {
       expect(mockDataSource.post).toHaveBeenCalledWith(
         expect.objectContaining({
           data: { ...requestWithoutOrigin, origin: Origin.NATIVE },
+        }),
+      );
+    });
+
+    it('should forward safenetCheck in the body and key the cache on it', async () => {
+      const checkedRequest = gtfFeesRequestBuilder()
+        .with('safenetCheck', true)
+        .build();
+      mockDataSource.post.mockResolvedValueOnce(rawify(mockGtfFeeResponse));
+
+      await target.getGtfFees({
+        chainId,
+        safeAddress,
+        request: checkedRequest,
+      });
+
+      expect(mockDataSource.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ safenetCheck: true }),
+          cacheDir: CacheRouter.getGtfFeePreviewCacheDir({
+            chainId,
+            safeAddress,
+            to: checkedRequest.to,
+            value: checkedRequest.value,
+            data: checkedRequest.data,
+            operation: checkedRequest.operation,
+            nonce: checkedRequest.nonce,
+            gasToken: checkedRequest.gasToken,
+            threshold: checkedRequest.numberSignatures,
+            origin: checkedRequest.origin,
+            safenetCheck: true,
+          }),
         }),
       );
     });

--- a/src/datasources/fee-service-api/fee-service-api.service.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.ts
@@ -136,13 +136,15 @@ export class FeeServiceApi implements IFeeServiceApi {
       gasToken: args.request.gasToken,
       threshold: args.request.numberSignatures,
       origin: args.request.origin,
+      safenetCheck: args.request.safenetCheck,
     });
     const url = `${this.relayFeeConfiguration.baseUri}/v1/chains/${args.chainId}/safes/${args.safeAddress}/transactions/gtf/fees`;
 
     return this.postFeeRequest({
       cacheDir,
       url,
-      // origin is mandatory for this fee endpoint; parsed to strip fields outside its contract.
+      // origin is mandatory for this fee endpoint; the strict parse rejects any
+      // field outside its contract.
       data: GtfFeesRequestSchema.parse({
         ...args.request,
         origin: args.request.origin ?? Origin.NATIVE,

--- a/src/modules/fees/domain/entities/__tests__/gtf-fees-request.entity.spec.ts
+++ b/src/modules/fees/domain/entities/__tests__/gtf-fees-request.entity.spec.ts
@@ -39,6 +39,41 @@ describe('GtfFeesRequestSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('should keep safenetCheck in the parsed request', () => {
+    const request = {
+      to: getAddress(faker.finance.ethereumAddress()),
+      value: '0',
+      data: '0x',
+      operation: 0,
+      numberSignatures: 1,
+      nonce: '0',
+      gasToken: getAddress(zeroAddress),
+      safenetCheck: true,
+    };
+
+    const result = GtfFeesRequestSchema.safeParse(request);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.safenetCheck).toBe(true);
+  });
+
+  it('should not allow a non-boolean safenetCheck', () => {
+    const request = {
+      to: getAddress(faker.finance.ethereumAddress()),
+      value: '0',
+      data: '0x',
+      operation: 0,
+      numberSignatures: 1,
+      nonce: '0',
+      gasToken: getAddress(zeroAddress),
+      safenetCheck: 'yes',
+    };
+
+    const result = GtfFeesRequestSchema.safeParse(request);
+
+    expect(result.success).toBe(false);
+  });
+
   it('should not allow an invalid origin', () => {
     const request = {
       to: getAddress(faker.finance.ethereumAddress()),
@@ -141,5 +176,29 @@ describe('GtfFeesRequestSchema', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('should reject a key outside the gtf/fees contract', () => {
+    const request = {
+      to: getAddress(faker.finance.ethereumAddress()),
+      value: '0',
+      data: '0x',
+      operation: 0,
+      numberSignatures: 1,
+      nonce: '0',
+      gasToken: getAddress(zeroAddress),
+      fiatCode: 'USD',
+    };
+
+    const result = GtfFeesRequestSchema.safeParse(request);
+
+    expect(!result.success && result.error.issues).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unrecognized_keys',
+          keys: ['fiatCode'],
+        }),
+      ]),
+    );
   });
 });

--- a/src/modules/fees/domain/entities/__tests__/gtf-fees-response.entity.spec.ts
+++ b/src/modules/fees/domain/entities/__tests__/gtf-fees-response.entity.spec.ts
@@ -146,6 +146,42 @@ describe('GtfFeeBreakdownSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('should keep the Safenet fee line when the fee service sends it', () => {
+    const result = GtfFeeBreakdownSchema.safeParse({
+      txValueUsd: 1000,
+      trailingVolumeUsd: 0,
+      tierBps: 5,
+      gtfFeeUsd: 0.5,
+      relayCostUsd: 38.22,
+      totalUsd: 38.72,
+      numberSignatures: 2,
+      valuationDetails: [],
+      safenetFeeUsd: 1,
+      // Fields this gateway does not declare must not survive the parse.
+      safenetFeeSponsored: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.safenetFeeUsd).toBe(1);
+    expect(result.data).not.toHaveProperty('safenetFeeSponsored');
+  });
+
+  it('should accept a fee breakdown without the Safenet fee line', () => {
+    const result = GtfFeeBreakdownSchema.safeParse({
+      txValueUsd: 1000,
+      trailingVolumeUsd: 0,
+      tierBps: 5,
+      gtfFeeUsd: 0.5,
+      relayCostUsd: 38.22,
+      totalUsd: 38.72,
+      numberSignatures: 2,
+      valuationDetails: [],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty('safenetFeeUsd');
+  });
+
   it('should not allow a missing valuationDetails', () => {
     const result = GtfFeeBreakdownSchema.safeParse({
       txValueUsd: 1000,

--- a/src/modules/fees/domain/entities/gtf-fees-request.entity.ts
+++ b/src/modules/fees/domain/entities/gtf-fees-request.entity.ts
@@ -9,13 +9,40 @@ import { NumericStringSchema } from '@/validation/entities/schemas/numeric-strin
 
 export type GtfFeesRequest = z.infer<typeof GtfFeesRequestSchema>;
 
-export const GtfFeesRequestSchema = z.object({
-  to: AddressSchema,
-  value: NumericStringSchema,
-  data: HexSchema,
-  operation: z.enum(Operation),
-  numberSignatures: z.number().int().min(1),
-  nonce: NonNegativeNumericStringSchema,
-  gasToken: AddressSchema,
-  origin: z.enum(Origin).optional(),
-});
+/**
+ * Body of the fee service's `gtf/fees` request.
+ *
+ * Strict: this gateway builds the body itself, so an unknown key is a mistake
+ * here rather than an upstream field to tolerate, and the fee service rejects
+ * one anyway.
+ */
+export const GtfFeesRequestSchema = z
+  .object({
+    to: AddressSchema,
+    value: NumericStringSchema,
+    data: HexSchema,
+    operation: z.enum(Operation),
+    numberSignatures: z.number().int().min(1),
+    nonce: NonNegativeNumericStringSchema,
+    gasToken: AddressSchema,
+    origin: z.enum(Origin).optional(),
+    /**
+     * Whether the fee service must price a Safenet check.
+     *
+     * The user's per-transaction opt-in, forwarded only when the viewed
+     * chain's `SAFENET_CHECKS` feature says the check is available — fail
+     * closed, so absent, `false`, and a chain without the feature all omit it.
+     *
+     * Previews that disagree on the flag are safe by construction: the fee
+     * service encodes the Safenet fee into `baseGas`, so the two choices are
+     * different `safeTxHash`es and distinct quotes; whichever the user signs
+     * is what is billed and checked.
+     *
+     * Sent only when true. Two assumptions about the fee service, neither
+     * verifiable from this repo: absent and `false` are the same value to it,
+     * and a fee service that predates the flag rejects a body carrying a field
+     * its own DTO does not declare.
+     */
+    safenetCheck: z.boolean().optional(),
+  })
+  .strict();

--- a/src/modules/fees/domain/entities/gtf-fees-response.entity.ts
+++ b/src/modules/fees/domain/entities/gtf-fees-response.entity.ts
@@ -50,6 +50,8 @@ export const GtfFeeBreakdownSchema = z.object({
   totalUsd: z.number(),
   numberSignatures: z.number(),
   valuationDetails: z.array(GtfValuationDetailSchema),
+  // Optional: a fee service that predates the Safenet fee line omits it.
+  safenetFeeUsd: z.number().optional(),
 });
 
 export const GtfPricingContextSnapshotSchema = z.object({

--- a/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
@@ -17,6 +17,7 @@ import type { INetworkService } from '@/datasources/network/network.service.inte
 import { NetworkService } from '@/datasources/network/network.service.interface';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
 import { relayerBuilder } from '@/modules/chains/domain/entities/__tests__/relayer.builder';
+import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import { gtfFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/gtf-fees-response.builder';
 import { txFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
 import { feePreviewTransactionDtoBuilder } from '@/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder';
@@ -62,6 +63,19 @@ describe('Fees Controller', () => {
   afterEach(async () => {
     await app?.close();
   });
+
+  /**
+   * Serves the one config-service read the preview makes. Its `features` array
+   * carries the Safenet gate.
+   */
+  const mockChain = (chain: Chain): void => {
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: rawify(chain), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+  };
 
   it('should return 400 if relay-fee is not available for the chain', async () => {
     const chain = chainBuilder()
@@ -173,12 +187,7 @@ describe('Fees Controller', () => {
     const feePreviewDto = feePreviewTransactionDtoBuilder().build();
     const mockGtfFeeResponse = gtfFeesResponseBuilder().build();
 
-    networkService.get.mockImplementation(({ url }) => {
-      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
-        return Promise.resolve({ data: rawify(chain), status: 200 });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
+    mockChain(chain);
 
     networkService.post.mockImplementation(({ url }) => {
       if (
@@ -222,6 +231,269 @@ describe('Fees Controller', () => {
         );
         expect(body.txData.to).toBeUndefined();
         expect(body.txData.nonce).toBeUndefined();
+      });
+  });
+
+  it('should pass the Safenet fee line through verbatim', async () => {
+    const chain = chainBuilder()
+      .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+      .with('features', ['SAFENET_CHECKS'])
+      .build();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const safenetFeeUsd = faker.number.float({
+      min: 0.01,
+      max: 10,
+      fractionDigits: 2,
+    });
+    const baseResponse = gtfFeesResponseBuilder().build();
+    const mockGtfFeeResponse = {
+      ...baseResponse,
+      feeBreakdown: {
+        ...baseResponse.feeBreakdown,
+        safenetFeeUsd,
+        // Fields this gateway does not declare must not reach the response.
+        safenetFeeSponsored: true,
+        someFutureFeeUsd: 1.23,
+      },
+    };
+
+    mockChain(chain);
+
+    networkService.post.mockImplementation(({ url }) => {
+      if (
+        url ===
+        `${feeServiceBaseUri}/v1/chains/${chain.chainId}/safes/${safeAddress}/transactions/gtf/fees`
+      ) {
+        return Promise.resolve({
+          data: rawify(mockGtfFeeResponse),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chain.chainId}/fees/${safeAddress}/preview`)
+      .send(feePreviewTransactionDtoBuilder().build())
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.feeBreakdown.safenetFeeUsd).toBe(safenetFeeUsd);
+        expect(body.feeBreakdown).not.toHaveProperty('safenetFeeSponsored');
+        expect(body.feeBreakdown).not.toHaveProperty('someFutureFeeUsd');
+      });
+  });
+
+  it('should omit the Safenet fee line when the fee service does not report it', async () => {
+    const chain = chainBuilder()
+      .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+      .with('features', ['SAFENET_CHECKS'])
+      .build();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const mockGtfFeeResponse = gtfFeesResponseBuilder().build();
+
+    mockChain(chain);
+
+    networkService.post.mockImplementation(({ url }) => {
+      if (
+        url ===
+        `${feeServiceBaseUri}/v1/chains/${chain.chainId}/safes/${safeAddress}/transactions/gtf/fees`
+      ) {
+        return Promise.resolve({
+          data: rawify(mockGtfFeeResponse),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chain.chainId}/fees/${safeAddress}/preview`)
+      .send(feePreviewTransactionDtoBuilder().build())
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.feeBreakdown).not.toHaveProperty('safenetFeeUsd');
+      });
+  });
+
+  it.each([
+    [
+      'forward safenetCheck when the user opts in and the chain has the feature',
+      ['SAFENET_CHECKS'],
+      { safenetCheck: true },
+      { safenetCheck: true },
+    ],
+    [
+      'omit safenetCheck when the user opts in but the chain lacks the feature',
+      ['ERC721'],
+      { safenetCheck: true },
+      {},
+    ],
+    [
+      'omit safenetCheck when the user does not choose on a chain with the feature',
+      ['SAFENET_CHECKS'],
+      {},
+      {},
+    ],
+    [
+      'omit safenetCheck when the user opts out on a chain with the feature',
+      ['SAFENET_CHECKS'],
+      { safenetCheck: false },
+      {},
+    ],
+  ] as const)('should %s', async (_label, features, choice, expectedFlag) => {
+    const chain = chainBuilder()
+      .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+      .with('features', [...features])
+      .build();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const feePreviewDto = feePreviewTransactionDtoBuilder().build();
+    const gtfUrl = `${feeServiceBaseUri}/v1/chains/${chain.chainId}/safes/${safeAddress}/transactions/gtf/fees`;
+
+    mockChain(chain);
+
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === gtfUrl) {
+        return Promise.resolve({
+          data: rawify(gtfFeesResponseBuilder().build()),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chain.chainId}/fees/${safeAddress}/preview`)
+      .send({ ...feePreviewDto, ...choice })
+      .expect(200);
+
+    expect(networkService.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: gtfUrl,
+        data: {
+          to: feePreviewDto.to,
+          value: feePreviewDto.value,
+          data: feePreviewDto.data,
+          operation: feePreviewDto.operation,
+          numberSignatures: feePreviewDto.numberSignatures,
+          nonce: feePreviewDto.nonce,
+          gasToken: feePreviewDto.gasToken,
+          origin: feePreviewDto.origin,
+          ...expectedFlag,
+        },
+      }),
+    );
+  });
+
+  it('should not forward caller context outside the gtf/fees contract', async () => {
+    const chain = chainBuilder()
+      .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+      .with('features', ['SAFENET_CHECKS'])
+      .build();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const feePreviewDto = feePreviewTransactionDtoBuilder().build();
+    const gtfUrl = `${feeServiceBaseUri}/v1/chains/${chain.chainId}/safes/${safeAddress}/transactions/gtf/fees`;
+
+    mockChain(chain);
+
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === gtfUrl) {
+        return Promise.resolve({
+          data: rawify(gtfFeesResponseBuilder().build()),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    // fiatCode belongs to the relay flow; the strict gtf/fees contract
+    // excludes it, so it must be dropped while the opt-in is forwarded.
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chain.chainId}/fees/${safeAddress}/preview`)
+      .send({ ...feePreviewDto, safenetCheck: true, fiatCode: 'EUR' })
+      .expect(200);
+
+    expect(networkService.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: gtfUrl,
+        data: {
+          to: feePreviewDto.to,
+          value: feePreviewDto.value,
+          data: feePreviewDto.data,
+          operation: feePreviewDto.operation,
+          numberSignatures: feePreviewDto.numberSignatures,
+          nonce: feePreviewDto.nonce,
+          gasToken: feePreviewDto.gasToken,
+          origin: feePreviewDto.origin,
+          safenetCheck: true,
+        },
+      }),
+    );
+  });
+
+  it('should ignore a caller-sent safenetCheck on a chain without the feature', async () => {
+    const chain = chainBuilder()
+      .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+      .with('features', ['ERC721'])
+      .build();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const feePreviewDto = feePreviewTransactionDtoBuilder().build();
+    const gtfUrl = `${feeServiceBaseUri}/v1/chains/${chain.chainId}/safes/${safeAddress}/transactions/gtf/fees`;
+
+    mockChain(chain);
+
+    networkService.post.mockImplementation(({ url }) => {
+      if (url === gtfUrl) {
+        return Promise.resolve({
+          data: rawify(gtfFeesResponseBuilder().build()),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    // Fail closed: the chain does not offer Safenet checks, so the user's
+    // opt-in is not forwarded.
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chain.chainId}/fees/${safeAddress}/preview`)
+      .send({ ...feePreviewDto, safenetCheck: true })
+      .expect(200);
+
+    expect(networkService.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: gtfUrl,
+        data: {
+          to: feePreviewDto.to,
+          value: feePreviewDto.value,
+          data: feePreviewDto.data,
+          operation: feePreviewDto.operation,
+          numberSignatures: feePreviewDto.numberSignatures,
+          nonce: feePreviewDto.nonce,
+          gasToken: feePreviewDto.gasToken,
+          origin: feePreviewDto.origin,
+        },
+      }),
+    );
+  });
+
+  it('should throw a validation error for a non-boolean safenetCheck', async () => {
+    const chain = chainBuilder()
+      .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+      .with('features', ['SAFENET_CHECKS'])
+      .build();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+    mockChain(chain);
+
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${chain.chainId}/fees/${safeAddress}/preview`)
+      .send({
+        ...feePreviewTransactionDtoBuilder().build(),
+        safenetCheck: 'yes',
+      })
+      .expect(422)
+      .expect(({ body }) => {
+        expect(body.code).toBe('invalid_type');
+        expect(body.path).toEqual(['safenetCheck']);
       });
   });
 

--- a/src/modules/fees/routes/entities/fee-preview-response.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-response.entity.ts
@@ -148,6 +148,13 @@ export class FeePreviewFeeBreakdown {
   @ApiProperty({ type: [FeePreviewValuationDetail] })
   valuationDetails: Array<FeePreviewValuationDetail>;
 
+  @ApiPropertyOptional({
+    description:
+      'Fee charged to the user for the Safenet check on this transaction. It is already included in totalUsd and encoded in txData.baseGas. It is 0 when the transaction is not checked, so key off safenetFeeUsd > 0, never off field presence. Optional because an older fee service omits the field.',
+    example: 1,
+  })
+  safenetFeeUsd?: number;
+
   constructor(feeBreakdown: GtfFeeBreakdown) {
     this.txValueUsd = feeBreakdown.txValueUsd;
     this.trailingVolumeUsd = feeBreakdown.trailingVolumeUsd;
@@ -159,6 +166,7 @@ export class FeePreviewFeeBreakdown {
     this.valuationDetails = feeBreakdown.valuationDetails.map(
       (detail) => new FeePreviewValuationDetail(detail),
     );
+    this.safenetFeeUsd = feeBreakdown.safenetFeeUsd;
   }
 }
 

--- a/src/modules/fees/routes/entities/fee-preview-transaction.dto.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-transaction.dto.entity.ts
@@ -60,6 +60,14 @@ export class FeePreviewTransactionDto
   })
   fiatCode?: string;
 
+  @ApiProperty({
+    description:
+      'Run a Safenet check on this transaction. Opt-in: defaults to false. Honoured only on chains with the SAFENET_CHECKS feature.',
+    example: true,
+    required: false,
+  })
+  safenetCheck?: boolean;
+
   constructor(dto: z.infer<typeof FeePreviewTransactionDtoSchema>) {
     this.to = dto.to;
     this.value = dto.value;
@@ -70,5 +78,6 @@ export class FeePreviewTransactionDto
     this.nonce = dto.nonce;
     this.origin = dto.origin;
     this.fiatCode = dto.fiatCode;
+    this.safenetCheck = dto.safenetCheck;
   }
 }

--- a/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
+++ b/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
@@ -12,4 +12,5 @@ export const FeePreviewTransactionDtoSchema = TransactionBaseSchema.extend({
   nonce: NonNegativeNumericStringSchema,
   origin: z.enum(Origin).optional(),
   fiatCode: z.string().optional(),
+  safenetCheck: z.boolean().optional(),
 });

--- a/src/modules/fees/routes/fees.service.spec.ts
+++ b/src/modules/fees/routes/fees.service.spec.ts
@@ -94,6 +94,139 @@ describe('FeesService', () => {
       expect(mockFeeServiceApi.getRelayFees).not.toHaveBeenCalled();
     });
 
+    it('should forward safenetCheck when the user opts in on a chain with Safenet checks', async () => {
+      const chain = chainBuilder()
+        .with('chainId', chainId)
+        .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+        .with('features', ['ERC721', 'SAFENET_CHECKS'])
+        .build();
+      mockChainsRepository.getChain.mockResolvedValueOnce(chain);
+      mockFeeServiceApi.getGtfFees.mockResolvedValueOnce(
+        gtfFeesResponseBuilder().build(),
+      );
+
+      await target.getFeePreview({
+        chainId,
+        safeAddress,
+        feePreviewDto: { ...feePreviewDto, safenetCheck: true },
+      });
+
+      expect(mockFeeServiceApi.getGtfFees).toHaveBeenCalledWith({
+        chainId,
+        safeAddress,
+        request: { ...feePreviewDto, safenetCheck: true },
+      });
+    });
+
+    it.each([
+      ['the user opts in but the chain lacks the feature', ['ERC721'], true],
+      [
+        'the user does not choose on a chain with the feature',
+        ['SAFENET_CHECKS'],
+        undefined,
+      ],
+      [
+        'the user opts out on a chain with the feature',
+        ['SAFENET_CHECKS'],
+        false,
+      ],
+      ['neither the user nor the chain opts in', ['ERC721'], undefined],
+    ] as const)(
+      'should omit safenetCheck when %s',
+      async (_label, features, choice) => {
+        const chain = chainBuilder()
+          .with('chainId', chainId)
+          .with(
+            'relayer',
+            relayerBuilder().with('type', RelayerType.GTF).build(),
+          )
+          .with('features', [...features])
+          .build();
+        mockChainsRepository.getChain.mockResolvedValueOnce(chain);
+        mockFeeServiceApi.getGtfFees.mockResolvedValueOnce(
+          gtfFeesResponseBuilder().build(),
+        );
+
+        await target.getFeePreview({
+          chainId,
+          safeAddress,
+          feePreviewDto:
+            choice === undefined
+              ? feePreviewDto
+              : { ...feePreviewDto, safenetCheck: choice },
+        });
+
+        expect(mockFeeServiceApi.getGtfFees).toHaveBeenCalledWith({
+          chainId,
+          safeAddress,
+          request: feePreviewDto,
+        });
+      },
+    );
+
+    it('should not reach the fee service when the chain cannot be read', async () => {
+      mockChainsRepository.getChain.mockRejectedValueOnce(
+        new Error('Config Service unavailable'),
+      );
+
+      await expect(
+        target.getFeePreview({ chainId, safeAddress, feePreviewDto }),
+      ).rejects.toThrow('Config Service unavailable');
+      expect(mockFeeServiceApi.getGtfFees).not.toHaveBeenCalled();
+    });
+
+    it('should drop a route DTO field that is outside the gtf/fees contract', async () => {
+      const chain = chainBuilder()
+        .with('chainId', chainId)
+        .with('relayer', relayerBuilder().with('type', RelayerType.GTF).build())
+        .with('features', ['SAFENET_CHECKS'])
+        .build();
+      mockChainsRepository.getChain.mockResolvedValueOnce(chain);
+      mockFeeServiceApi.getGtfFees.mockResolvedValueOnce(
+        gtfFeesResponseBuilder().build(),
+      );
+
+      await target.getFeePreview({
+        chainId,
+        safeAddress,
+        // fiatCode belongs to the relay flow, not to gtf/fees.
+        feePreviewDto: {
+          ...feePreviewDto,
+          fiatCode: 'EUR',
+          safenetCheck: true,
+        },
+      });
+
+      expect(mockFeeServiceApi.getGtfFees).toHaveBeenCalledWith({
+        chainId,
+        safeAddress,
+        request: { ...feePreviewDto, safenetCheck: true },
+      });
+    });
+
+    it('should not send safenetCheck on the relay flow of a Safenet chain', async () => {
+      const chain = chainBuilder()
+        .with('chainId', chainId)
+        .with(
+          'relayer',
+          relayerBuilder().with('type', RelayerType.RELAY_FEE).build(),
+        )
+        .with('features', ['SAFENET_CHECKS'])
+        .build();
+      mockChainsRepository.getChain.mockResolvedValueOnce(chain);
+      mockFeeServiceApi.getRelayFees.mockResolvedValueOnce(
+        txFeesResponseBuilder().build(),
+      );
+
+      await target.getFeePreview({ chainId, safeAddress, feePreviewDto });
+
+      expect(mockFeeServiceApi.getRelayFees).toHaveBeenCalledWith({
+        chainId,
+        safeAddress,
+        request: feePreviewDto,
+      });
+    });
+
     it.each([[RelayerType.DAILY_LIMIT], [RelayerType.NO_FEE_CAMPAIGN]])(
       'should throw a BadRequestException for unsupported relayer type %s',
       async (type) => {

--- a/src/modules/fees/routes/fees.service.ts
+++ b/src/modules/fees/routes/fees.service.ts
@@ -14,6 +14,11 @@ import {
   type PaginationData,
 } from '@/routes/common/pagination/pagination.data';
 
+/**
+ * Config-service feature that marks Safenet checks as available on a chain.
+ */
+const SAFENET_CHECKS_FEATURE = 'SAFENET_CHECKS';
+
 @Injectable()
 export class FeesService {
   constructor(
@@ -64,10 +69,37 @@ export class FeesService {
         return FeePreviewResponse.fromRelayFees(txFeesResponse);
       }
       case RelayerType.GTF: {
+        // The user's per-transaction opt-in, honoured only where the viewed
+        // chain offers Safenet checks — fail closed. Previews that disagree on
+        // the flag are safe by construction: the fee service encodes the fee
+        // into baseGas, so the two choices are different safeTxHashes and
+        // distinct quotes; whichever the user signs is what is billed and
+        // checked.
+        const safenetCheck =
+          args.feePreviewDto.safenetCheck === true &&
+          chain.features.includes(SAFENET_CHECKS_FEATURE);
         const gtfFeesResponse = await this.feeServiceApi.getGtfFees({
           chainId: args.chainId,
           safeAddress: args.safeAddress,
-          request: args.feePreviewDto,
+          // Listed field by field, not spread: this endpoint's contract is
+          // narrower than the route DTO, and the datasource parses the body
+          // strictly, so an unrelated DTO field must not leak in here.
+          request: {
+            to: args.feePreviewDto.to,
+            value: args.feePreviewDto.value,
+            data: args.feePreviewDto.data,
+            operation: args.feePreviewDto.operation,
+            numberSignatures: args.feePreviewDto.numberSignatures,
+            nonce: args.feePreviewDto.nonce,
+            gasToken: args.feePreviewDto.gasToken,
+            origin: args.feePreviewDto.origin,
+            // Omitted when false. Two assumptions about the fee service, neither
+            // verifiable from this repo: it rejects a request body carrying a
+            // field its own DTO does not declare, and absent and false are the
+            // same value to it. On both, a fee service that predates the flag
+            // keeps working for every unchecked chain.
+            ...(safenetCheck && { safenetCheck }),
+          },
         });
         return FeePreviewResponse.fromGtfFees(gtfFeesResponse);
       }


### PR DESCRIPTION
## Summary

The fee service prices a Safenet check only when the caller states the transaction is
checked. The check is a per-transaction user opt-in: the wallet shows a checkbox
(default off) and the choice arrives on the preview request body as `safenetCheck`.
This gateway forwards `true` to the `gtf/fees` request only when the client sent
`true` AND the viewed chain's `SAFENET_CHECKS` feature says the check is available —
the feature is the availability gate, the user makes the decision. Everything else
(absent, `false`, or a chain without the feature) omits the field: fail closed, and
the wire shape stays byte-identical to today's for unchecked previews, so a fee
service predating the flag keeps working.

Previews that disagree on the flag are safe by construction: the fee service encodes
the Safenet fee into `baseGas`, so the two choices produce different `safeTxHash`es
and distinct quotes upstream. Whichever the user signs is what is billed and checked;
no consistency across previews is required.

For consumers: against the fee-service version this pairs with
(safe-global/safe-fee-service#168), `safenetFeeUsd` and `safenetFeeSponsored` are
always present — unchecked quotes report `0`/`true`. Key off a positive
`safenetFeeUsd` (or the chain feature), never off field presence; the fields are
optional in the schema only so a fee service predating the line still parses.

Deploy order: ship the fee service's `safenetCheck` request DTO before any chain
receives the `SAFENET_CHECKS` feature — reversed, every GTF preview on such a chain
gets a hard 400 from the fee service's own request validation.

Verified with scoped unit + integration suites, type-check, and lint, plus a live
forwarding matrix on a local five-service stack (flag on wire only for
client-true + feature-on; all other cells byte-identical to pre-change requests;
quoted = signed = stored hash at sign time). Wallet consumers:
safe-global/safe-wallet-monorepo#8588 sends the flag; #8590 consumes the read-back
route stacked on this branch.

## Changes

- `GtfFeeBreakdownSchema` and `FeePreviewFeeBreakdown` carry optional `safenetFeeUsd`
  and `safenetFeeSponsored`, passed through unchanged.
- `FeesService` computes the forwarded flag from the request body and
  `chain.features`. The gate is read off the chain object the preview already fetches
  for its relayer type: no new upstream call, no new cache entry; it fails exactly
  when the preview already fails and follows a feature flip through the existing
  chain-update invalidation.
- The `gtf/fees` body is listed field by field instead of spread from the route DTO,
  and `GtfFeesRequestSchema` is strict — a stray or mistyped key is an error rather
  than a silent drop.
- The GTF fee-preview cache key includes the flag.
