### PR TITLE
feat(fees): expose the stored GTF fee quote by safeTxHash

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -102,6 +102,7 @@ export class CacheRouter {
   private static readonly GAS_PRICE_KEY = 'gas_price';
   private static readonly RELAY_FEE_PREVIEW_KEY = 'relay_fee_preview';
   private static readonly GTF_FEE_PREVIEW_KEY = 'gtf_fee_preview';
+  private static readonly GTF_FEE_SNAPSHOT_KEY = 'gtf_fee_snapshot';
 
   static getAuthNonceCacheKey(nonce: string): string {
     return `${CacheRouter.AUTH_NONCE_KEY}_${nonce}`;
@@ -1210,6 +1211,24 @@ export class CacheRouter {
     return new CacheDir(
       CacheRouter.getGtfFeePreviewCacheKey(args),
       hash.digest('hex'),
+    );
+  }
+
+  /**
+   * Gets cache directory for a stored GTF fee quote.
+   * The quote is write-once upstream, so the safeTxHash alone identifies it.
+   *
+   * @param args.chainId - Chain ID
+   * @param args.safeTxHash - Safe transaction hash the quote was stored under
+   * @returns CacheDir - Cache directory
+   */
+  static getGtfFeeSnapshotCacheDir(args: {
+    chainId: string;
+    safeTxHash: Hash;
+  }): CacheDir {
+    return new CacheDir(
+      `${args.chainId}_${CacheRouter.GTF_FEE_SNAPSHOT_KEY}`,
+      args.safeTxHash,
     );
   }
 

--- a/src/datasources/fee-service-api/fee-service-api.service.spec.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.spec.ts
@@ -342,4 +342,72 @@ describe('FeeServiceApi', () => {
       ).rejects.toThrow(new DataSourceError('Unexpected error', status));
     });
   });
+
+  describe('getGtfFeeSnapshot', () => {
+    const chainId = faker.string.numeric();
+    const safeTxHash = faker.string.hexadecimal({
+      length: 64,
+      casing: 'lower',
+    }) as Hex;
+
+    it('should call dataSource.get with correct arguments', async () => {
+      const storedQuote = gtfFeesResponseBuilder().build();
+      mockDataSource.get.mockResolvedValueOnce(rawify(storedQuote));
+
+      const result = await target.getGtfFeeSnapshot({ chainId, safeTxHash });
+
+      expect(result).toEqual(storedQuote);
+      expect(mockDataSource.get).toHaveBeenCalledWith({
+        cacheDir: CacheRouter.getGtfFeeSnapshotCacheDir({
+          chainId,
+          safeTxHash,
+        }),
+        url: `${baseUri}/v1/fee-snapshots/${safeTxHash}`,
+        notFoundExpireTimeSeconds: 30,
+        expireTimeSeconds: 60,
+      });
+    });
+
+    it('should forward a not-found from the fee service', async () => {
+      const error = new NetworkResponseError(
+        new URL(`${baseUri}/v1/fee-snapshots/${safeTxHash}`),
+        { status: 404 } as Response,
+        { message: 'Fee snapshot not found' },
+      );
+      mockDataSource.get.mockRejectedValueOnce(error);
+
+      await expect(
+        target.getGtfFeeSnapshot({ chainId, safeTxHash }),
+      ).rejects.toThrow(new DataSourceError('Fee snapshot not found', 404));
+    });
+
+    it.each([
+      ['the same chain and hash', {}, true],
+      [
+        'another hash',
+        { safeTxHash: faker.string.hexadecimal({ length: 64 }) as Hex },
+        false,
+      ],
+      ['another chain', { chainId: `${chainId}9` }, false],
+    ] as const)(
+      'should key the cache dir on %s',
+      async (_label, override, isSameDir) => {
+        mockDataSource.get.mockResolvedValue(
+          rawify(gtfFeesResponseBuilder().build()),
+        );
+        const baseline = expect.objectContaining({
+          cacheDir: CacheRouter.getGtfFeeSnapshotCacheDir({
+            chainId,
+            safeTxHash,
+          }),
+        });
+
+        await target.getGtfFeeSnapshot({ chainId, safeTxHash, ...override });
+
+        const matcher = expect(mockDataSource.get);
+        if (isSameDir) matcher.toHaveBeenCalledWith(baseline);
+        else matcher.not.toHaveBeenCalledWith(baseline);
+      },
+    );
+  });
 });

--- a/src/datasources/fee-service-api/fee-service-api.service.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.ts
@@ -153,6 +153,29 @@ export class FeeServiceApi implements IFeeServiceApi {
     });
   }
 
+  /**
+   * {@inheritdoc IFeeServiceApi.getGtfFeeSnapshot}
+   *
+   * Uses {@link CacheFirstDataSource} keyed on chain and safeTxHash — the
+   * stored quote is write-once upstream, so a hit is always current.
+   */
+  async getGtfFeeSnapshot(args: {
+    chainId: string;
+    safeTxHash: Hex;
+  }): Promise<GtfFeesResponse> {
+    try {
+      const data = await this.dataSource.get<GtfFeesResponse>({
+        cacheDir: CacheRouter.getGtfFeeSnapshotCacheDir(args),
+        url: `${this.relayFeeConfiguration.baseUri}/v1/fee-snapshots/${args.safeTxHash}`,
+        notFoundExpireTimeSeconds: this.notFoundExpireTimeSeconds,
+        expireTimeSeconds: this.relayFeeConfiguration.feePreviewTtlSeconds,
+      });
+      return GtfFeesResponseSchema.parse(data);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
   private async postFeeRequest<TResponse, TRequest extends object>(args: {
     cacheDir: CacheDir;
     url: string;

--- a/src/domain/interfaces/fee-service-api.interface.ts
+++ b/src/domain/interfaces/fee-service-api.interface.ts
@@ -51,4 +51,17 @@ export interface IFeeServiceApi {
     safeAddress: Address;
     request: GtfFeesRequest;
   }): Promise<GtfFeesResponse>;
+
+  /**
+   * Gets the fee quote the fee service stored for an already-quoted transaction.
+   *
+   * @param args.chainId - Chain ID
+   * @param args.safeTxHash - Safe transaction hash the quote was stored under
+   * @returns GTF fee response with safeTxHash, txData, feeBreakdown, and pricing snapshot
+   * @throws {DataSourceError} If no quote is stored or the fee service request fails
+   */
+  getGtfFeeSnapshot(args: {
+    chainId: string;
+    safeTxHash: Hex;
+  }): Promise<GtfFeesResponse>;
 }

--- a/src/modules/fees/routes/__tests__/fee-preview-by-hash.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/fee-preview-by-hash.fees.controller.integration.spec.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { getAddress, type Hex } from 'viem';
+import type { MockedObject } from 'vitest';
+import {
+  initTestApplication,
+  TestAppProvider,
+} from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import type { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
+import { CacheService } from '@/datasources/cache/cache.service.interface';
+import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import {
+  gtfFeesResponseBuilder,
+  gtfTxDataBuilder,
+} from '@/modules/fees/domain/entities/__tests__/gtf-fees-response.builder';
+import type { GtfFeesResponse } from '@/modules/fees/domain/entities/gtf-fees-response.entity';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('Fees Controller - stored fee quote', () => {
+  let app: INestApplication<Server>;
+  let feeServiceBaseUri: string;
+  let networkService: MockedObject<INetworkService>;
+  let cacheService: FakeCacheService;
+
+  const chainId = faker.string.numeric({ length: 3, allowLeadingZeros: false });
+  const safeAddress = getAddress(faker.finance.ethereumAddress());
+  const safeTxHash = faker.string.hexadecimal({
+    length: 64,
+    casing: 'lower',
+  }) as Hex;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const baseConfiguration = configuration();
+    const testConfiguration = (): typeof baseConfiguration => ({
+      ...baseConfiguration,
+      relay: {
+        ...baseConfiguration.relay,
+        fee: {
+          baseUri: faker.internet.url({ appendSlash: false }),
+          // Positive so cache writes actually happen: hSet returns early on a
+          // non-positive TTL, which would make every cache assertion vacuous.
+          feePreviewTtlSeconds: 60,
+        },
+      },
+    });
+
+    const moduleFixture = await createTestModule({
+      config: testConfiguration,
+    });
+
+    const configService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    feeServiceBaseUri = configService.getOrThrow('relay.fee.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+    cacheService = moduleFixture.get(CacheService);
+    cacheService.clear();
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await initTestApplication(app);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  const routeUrl = `/v1/chains/${chainId}/fees/${safeAddress}/preview/${safeTxHash}`;
+
+  const mockStoredQuote = (quote: unknown): void => {
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${feeServiceBaseUri}/v1/fee-snapshots/${safeTxHash}`) {
+        return Promise.resolve({ data: rawify(quote), status: 200 });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+  };
+
+  const storedQuote = (): GtfFeesResponse =>
+    gtfFeesResponseBuilder()
+      .with('safeTxHash', safeTxHash)
+      .with(
+        'txData',
+        gtfTxDataBuilder()
+          .with('chainId', chainId)
+          .with('safeAddress', safeAddress)
+          .build(),
+      )
+      .build();
+
+  it('should normalize an uppercase hash for the upstream URL and the cache', async () => {
+    const upperHash = safeTxHash.toUpperCase().replace('0X', '0x') as Hex;
+    mockStoredQuote(storedQuote());
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/${safeAddress}/preview/${upperHash}`)
+      .expect(200);
+
+    expect(networkService.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `${feeServiceBaseUri}/v1/fee-snapshots/${safeTxHash}`,
+      }),
+    );
+    const cacheKey = `${chainId}_gtf_fee_snapshot`;
+    expect(
+      await cacheService.hGet(new CacheDir(cacheKey, safeTxHash)),
+    ).not.toBeNull();
+    expect(
+      await cacheService.hGet(new CacheDir(cacheKey, upperHash)),
+    ).toBeNull();
+  });
+
+  it('should return the stored quote including the Safenet fee line', async () => {
+    const safenetFeeUsd = faker.number.float({
+      min: 0.01,
+      max: 10,
+      fractionDigits: 2,
+    });
+    const quote = storedQuote();
+    mockStoredQuote({
+      ...quote,
+      feeBreakdown: {
+        ...quote.feeBreakdown,
+        safenetFeeUsd,
+        // A field this gateway does not declare must not reach the response.
+        someFutureFeeUsd: 1.23,
+      },
+    });
+
+    await request(app.getHttpServer())
+      .get(routeUrl)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toEqual({
+          txData: {
+            chainId,
+            safeAddress,
+            safeTxGas: quote.txData.safeTxGas,
+            baseGas: quote.txData.baseGas,
+            gasPrice: quote.txData.gasPrice,
+            gasToken: quote.txData.gasToken,
+            refundReceiver: quote.txData.refundReceiver,
+            numberSignatures: quote.feeBreakdown.numberSignatures,
+          },
+          feeBreakdown: {
+            txValueUsd: quote.feeBreakdown.txValueUsd,
+            trailingVolumeUsd: quote.feeBreakdown.trailingVolumeUsd,
+            tierBps: quote.feeBreakdown.tierBps,
+            gtfFeeUsd: quote.feeBreakdown.gtfFeeUsd,
+            relayCostUsd: quote.feeBreakdown.relayCostUsd,
+            totalUsd: quote.feeBreakdown.totalUsd,
+            numberSignatures: quote.feeBreakdown.numberSignatures,
+            valuationDetails: quote.feeBreakdown.valuationDetails,
+            safenetFeeUsd,
+          },
+          maxFeeCapUsd: quote.pricingContextSnapshot.maxFeeCapUsd,
+        });
+      });
+  });
+
+  it('should preserve non-404 failures from the fee service', async () => {
+    const message = 'Fee service temporarily unavailable';
+    networkService.get.mockImplementation(({ url }) =>
+      Promise.reject(
+        new NetworkResponseError(new URL(url), { status: 503 } as Response, {
+          message,
+        }),
+      ),
+    );
+
+    await request(app.getHttpServer())
+      .get(routeUrl)
+      .expect(503)
+      .expect({ code: 503, message });
+  });
+
+  it.each([
+    ['another chain', { chainId: `${chainId}9` }],
+    [
+      'another Safe',
+      { safeAddress: getAddress(faker.finance.ethereumAddress()) },
+    ],
+  ] as const)(
+    'should make a missing quote indistinguishable from a quote for %s',
+    async (_label, scope) => {
+      networkService.get.mockImplementation(({ url }) =>
+        Promise.reject(
+          new NetworkResponseError(new URL(url), { status: 404 } as Response, {
+            message: `Fee snapshot not found: ${safeTxHash}`,
+          }),
+        ),
+      );
+      const missing = await request(app.getHttpServer())
+        .get(routeUrl)
+        .expect(404);
+
+      // Do not let the cached upstream 404 mask the scope check.
+      cacheService.clear();
+      const quote = storedQuote();
+      mockStoredQuote({ ...quote, txData: { ...quote.txData, ...scope } });
+
+      const outOfScope = await request(app.getHttpServer())
+        .get(routeUrl)
+        .expect(404);
+
+      expect(outOfScope.body).toEqual(missing.body);
+      expect(outOfScope.body).toEqual({
+        statusCode: 404,
+        message: 'Fee quote not found',
+      });
+    },
+  );
+
+  it('should throw a validation error for a hash that is not 32 bytes', async () => {
+    const shortHash = faker.string.hexadecimal({
+      length: 62,
+      casing: 'lower',
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/${safeAddress}/preview/${shortHash}`)
+      .expect(422)
+      .expect({
+        statusCode: 422,
+        code: 'custom',
+        path: [],
+        message: 'Invalid hash',
+      });
+
+    expect(networkService.get).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/fees/routes/fees.controller.ts
+++ b/src/modules/fees/routes/fees.controller.ts
@@ -3,13 +3,15 @@ import { Body, Controller, Get, HttpCode, Param, Post } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBody,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiTags,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
-import type { Address } from 'viem';
+import type { Address, Hex } from 'viem';
 import { FeePreviewResponse } from '@/modules/fees/routes/entities/fee-preview-response.entity';
 import { FeePreviewTransactionDto } from '@/modules/fees/routes/entities/fee-preview-transaction.dto.entity';
 import { GasToken } from '@/modules/fees/routes/entities/gas-token.entity';
@@ -21,6 +23,7 @@ import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorato
 import type { Page } from '@/routes/common/entities/page.entity';
 import type { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HashSchema } from '@/validation/entities/schemas/hash.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
@@ -105,6 +108,52 @@ export class FeesController {
       chainId,
       safeAddress,
       feePreviewDto,
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Get the stored fee quote of an already-quoted transaction',
+    description:
+      'Returns the fee quote the fee service stored when the transaction was quoted, so a co-signer can review the itemized fees behind a payload that is already signed.',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID where the Safe is deployed',
+    example: '1',
+  })
+  @ApiParam({
+    name: 'safeAddress',
+    type: 'string',
+    description: 'Safe contract address (0x prefixed hex string)',
+  })
+  @ApiParam({
+    name: 'safeTxHash',
+    type: 'string',
+    description: 'Safe transaction hash the quote was stored under',
+  })
+  @ApiOkResponse({
+    type: FeePreviewResponse,
+    description: 'Stored fee quote with transaction data and fee breakdown',
+  })
+  @ApiNotFoundResponse({
+    description:
+      'No fee quote is stored for this Safe transaction hash, or the stored quote belongs to another chain or Safe',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'Invalid chain ID, Safe address, or Safe transaction hash',
+  })
+  @Get(':safeAddress/preview/:safeTxHash')
+  getFeePreviewBySafeTxHash(
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Param('safeAddress', new ValidationPipe(AddressSchema))
+    safeAddress: Address,
+    @Param('safeTxHash', new ValidationPipe(HashSchema)) safeTxHash: Hex,
+  ): Promise<FeePreviewResponse> {
+    return this.feesService.getFeePreviewBySafeTxHash({
+      chainId,
+      safeAddress,
+      safeTxHash,
     });
   }
 }

--- a/src/modules/fees/routes/fees.service.spec.ts
+++ b/src/modules/fees/routes/fees.service.spec.ts
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
-import { BadRequestException } from '@nestjs/common';
-import { getAddress } from 'viem';
+import { BadRequestException, HttpStatus } from '@nestjs/common';
+import { type Address, getAddress, type Hex } from 'viem';
 import type { MockedObject } from 'vitest';
+import { HttpExceptionNoLog } from '@/domain/common/errors/http-exception-no-log.error';
 import type { IFeeServiceApi } from '@/domain/interfaces/fee-service-api.interface';
 import type { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
 import { relayerBuilder } from '@/modules/chains/domain/entities/__tests__/relayer.builder';
-import { gtfFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/gtf-fees-response.builder';
+import {
+  gtfFeeBreakdownBuilder,
+  gtfFeesResponseBuilder,
+  gtfTxDataBuilder,
+} from '@/modules/fees/domain/entities/__tests__/gtf-fees-response.builder';
 import { txFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
+import type { GtfFeesResponse } from '@/modules/fees/domain/entities/gtf-fees-response.entity';
 import type { IGasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository.interface';
 import { feePreviewTransactionDtoBuilder } from '@/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder';
 import { FeesService } from '@/modules/fees/routes/fees.service';
@@ -18,6 +24,7 @@ const mockFeeServiceApi = vi.mocked({
   canRelay: vi.fn(),
   getRelayFees: vi.fn(),
   getGtfFees: vi.fn(),
+  getGtfFeeSnapshot: vi.fn(),
 } as unknown as MockedObject<IFeeServiceApi>);
 
 const mockGasTokensRepository = vi.mocked({
@@ -273,5 +280,92 @@ describe('FeesService', () => {
         target.getFeePreview({ chainId, safeAddress, feePreviewDto }),
       ).rejects.toThrow(BadRequestException);
     });
+  });
+
+  describe('getFeePreviewBySafeTxHash', () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const safeTxHash = faker.string.hexadecimal({
+      length: 64,
+      casing: 'lower',
+    }) as Hex;
+
+    const storedQuoteFor = (args: {
+      chainId: string;
+      safeAddress: Address;
+    }): GtfFeesResponse =>
+      gtfFeesResponseBuilder()
+        .with('safeTxHash', safeTxHash)
+        .with(
+          'txData',
+          gtfTxDataBuilder()
+            .with('chainId', args.chainId)
+            .with('safeAddress', args.safeAddress)
+            .build(),
+        )
+        .with(
+          'feeBreakdown',
+          gtfFeeBreakdownBuilder()
+            .with(
+              'safenetFeeUsd',
+              faker.number.float({ min: 0.01, max: 10, fractionDigits: 2 }),
+            )
+            .build(),
+        )
+        .build();
+
+    it('should return the stored quote for the requested chain and Safe', async () => {
+      const storedQuote = storedQuoteFor({ chainId, safeAddress });
+      mockFeeServiceApi.getGtfFeeSnapshot.mockResolvedValueOnce(storedQuote);
+
+      const result = await target.getFeePreviewBySafeTxHash({
+        chainId,
+        safeAddress,
+        safeTxHash,
+      });
+
+      expect(mockFeeServiceApi.getGtfFeeSnapshot).toHaveBeenCalledWith({
+        chainId,
+        safeTxHash,
+      });
+      expect(result.relayCost).toBeUndefined();
+      expect(result.feeBreakdown).toEqual(
+        expect.objectContaining({
+          totalUsd: storedQuote.feeBreakdown.totalUsd,
+          safenetFeeUsd: storedQuote.feeBreakdown.safenetFeeUsd,
+        }),
+      );
+      expect(result.maxFeeCapUsd).toBe(
+        storedQuote.pricingContextSnapshot.maxFeeCapUsd,
+      );
+      expect(result.txData).toEqual(
+        expect.objectContaining({ chainId, safeAddress }),
+      );
+    });
+
+    it.each([
+      ['another chain', { chainId: `${chainId}9` }],
+      [
+        'another Safe',
+        { safeAddress: getAddress(faker.finance.ethereumAddress()) },
+      ],
+    ] as const)(
+      'should throw a 404 when the stored quote is for %s',
+      async (_label, scope) => {
+        mockFeeServiceApi.getGtfFeeSnapshot.mockResolvedValueOnce(
+          storedQuoteFor({ chainId, safeAddress, ...scope }),
+        );
+
+        await expect(
+          target.getFeePreviewBySafeTxHash({
+            chainId,
+            safeAddress,
+            safeTxHash,
+          }),
+        ).rejects.toThrow(
+          new HttpExceptionNoLog('Fee quote not found', HttpStatus.NOT_FOUND),
+        );
+      },
+    );
   });
 });

--- a/src/modules/fees/routes/fees.service.ts
+++ b/src/modules/fees/routes/fees.service.ts
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
-import type { Address } from 'viem';
+import {
+  BadRequestException,
+  HttpStatus,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import type { Address, Hex } from 'viem';
+import { HttpExceptionNoLog } from '@/domain/common/errors/http-exception-no-log.error';
 import type { Page } from '@/domain/entities/page.entity';
+import { DataSourceError } from '@/domain/errors/data-source.error';
 import { IFeeServiceApi } from '@/domain/interfaces/fee-service-api.interface';
 import { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
 import { IGasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository.interface';
@@ -108,5 +115,45 @@ export class FeesService {
           'Fee preview is not available for this chain',
         );
     }
+  }
+
+  /**
+   * Reads back the quote the fee service stored for an already-quoted
+   * transaction, so a co-signer can see the fee breakdown behind a signed
+   * payload without re-quoting it.
+   */
+  async getFeePreviewBySafeTxHash(args: {
+    chainId: string;
+    safeAddress: Address;
+    safeTxHash: Hex;
+  }): Promise<FeePreviewResponse> {
+    const gtfFeesResponse = await this.feeServiceApi
+      .getGtfFeeSnapshot({
+        chainId: args.chainId,
+        safeTxHash: args.safeTxHash,
+      })
+      .catch((error: unknown) => {
+        if (
+          error instanceof DataSourceError &&
+          error.code === HttpStatus.NOT_FOUND
+        ) {
+          throw new HttpExceptionNoLog(
+            'Fee quote not found',
+            HttpStatus.NOT_FOUND,
+          );
+        }
+        throw error;
+      });
+
+    // The route claims chain and Safe scoping; a quote stored for another
+    // chain or Safe is not found here rather than readable through this path.
+    if (
+      gtfFeesResponse.txData.chainId !== args.chainId ||
+      gtfFeesResponse.txData.safeAddress !== args.safeAddress
+    ) {
+      throw new HttpExceptionNoLog('Fee quote not found', HttpStatus.NOT_FOUND);
+    }
+
+    return FeePreviewResponse.fromGtfFees(gtfFeesResponse);
   }
 }

--- a/src/validation/entities/schemas/hash.schema.ts
+++ b/src/validation/entities/schemas/hash.schema.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { Hex } from 'viem';
+import { isHash } from 'viem';
+import { z } from 'zod';
+
+// Lower-cased so one hash cannot reach an upstream URL or a cache field in two
+// spellings.
+export const HashSchema = z
+  .string()
+  .refine(isHash, { error: 'Invalid hash' })
+  .transform((hash) => hash.toLowerCase() as Hex);


### PR DESCRIPTION
## Summary

Staged delivery: this PR is stacked on `Fbartoli/safenet-fee-passthrough` (#3402) and
will be rebased onto `main` once it merges — do not merge this one first.

A later co-signer of an already-signed GTF Safe-pays transaction cannot re-quote: the
fees are baked into the signed payload, so the Safenet fee sits invisibly inside the
gas totals and the co-signer cannot tell whether the first signer opted into the
check. The gateway stores the quote against the signed `safeTxHash` and the stored
quote is immutable, so reading it back reports exactly what the signers signed.

New route:
`GET /v1/chains/{chainId}/fees/{safeAddress}/preview/{safeTxHash}` →
200 `FeePreviewResponse` (GTF arm: `{ txData, feeBreakdown, maxFeeCapUsd }`, no
`relayCost`), or 404 when no quote is stored for the hash or the stored quote belongs
to a different chain or Safe — a scope mismatch is indistinguishable from absence.
There is no feature gate on the read: the stored quote is the truth about what was
signed, independent of the chain's current `SAFENET_CHECKS` state.

Verified with scoped suites, type-check, and lint, plus live probes through the local
stack (stored, missing, mismatched-scope, and case-variant hashes). Consumed by
safe-global/safe-wallet-monorepo#8590, which treats 404 as "no row" and is safe to
merge ahead of this route going live.

## Changes

- Route + controller wiring in the fees module; `safeTxHash` validated and lowercased
  by the hash schema before lookup, so checksummed and lowercase requests hit the
  same stored row.
- Scope check: the stored quote must match both the chain and the Safe in the path; a
  mismatch is a 404, not a leak of another scope's quote.
- Read is display-only: no write path; the response is built from the stored row, and
  the lookup ordering was probed against the preview cache during verification.
