### PR TITLE
feat(tokens): expose token metadata by address

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1512,6 +1512,18 @@
     "required": false
   },
   {
+    "name": "TOKENS_RATE_LIMIT_MAX",
+    "description": "Maximum requests per time window for the token metadata routes",
+    "defaultValue": 60,
+    "required": false
+  },
+  {
+    "name": "TOKENS_RATE_LIMIT_WINDOW_SECONDS",
+    "description": "Time window in seconds for the token metadata rate limit",
+    "defaultValue": 60,
+    "required": false
+  },
+  {
     "name": "SPACES_RATE_LIMIT_MAX",
     "description": "Maximum requests per time window for Spaces API",
     "defaultValue": 10,

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -454,6 +454,12 @@ export default (): ReturnType<typeof configuration> => ({
       max: 300_000,
     }),
   },
+  tokens: {
+    rateLimit: {
+      max: faker.number.int({ min: 100, max: 200 }),
+      windowSeconds: faker.number.int({ min: 100, max: 200 }),
+    },
+  },
   safeWebApp: {
     baseUri: faker.internet.url({ appendSlash: false }),
   },

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -817,6 +817,15 @@ export default () => ({
       10,
     ),
   },
+  tokens: {
+    rateLimit: {
+      max: Number.parseInt(process.env.TOKENS_RATE_LIMIT_MAX ?? `${60}`, 10),
+      windowSeconds: Number.parseInt(
+        process.env.TOKENS_RATE_LIMIT_WINDOW_SECONDS ?? `${60}`,
+        10,
+      ),
+    },
+  },
   safeWebApp: {
     baseUri: process.env.SAFE_WEB_APP_BASE_URI || 'https://app.safe.global',
   },

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -151,6 +151,10 @@ export const RootConfigurationSchema = z
       .min(1)
       .max(100)
       .optional(),
+    // Per-caller bound on the unauthenticated token metadata routes. A zero or
+    // negative budget would reject every caller, so fail at boot instead.
+    TOKENS_RATE_LIMIT_MAX: z.coerce.number().int().min(1).optional(),
+    TOKENS_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().min(1).optional(),
     SAFE_CONFIG_CGW_KEY: z.string().min(1).optional(),
     LOG_LEVEL: z
       .enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'])

--- a/src/modules/tokens/routes/entities/token-addresses.dto.entity.spec.ts
+++ b/src/modules/tokens/routes/entities/token-addresses.dto.entity.spec.ts
@@ -34,6 +34,7 @@ describe('TokenAddressesSchema', () => {
 
     const result = TokenAddressesSchema.safeParse(`${address},${address}`);
 
+    expect(result.success).toBe(true);
     expect(result.data).toHaveLength(2);
   });
 

--- a/src/modules/tokens/routes/entities/token-addresses.dto.entity.spec.ts
+++ b/src/modules/tokens/routes/entities/token-addresses.dto.entity.spec.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import {
+  MAX_TOKEN_ADDRESSES,
+  TokenAddressesSchema,
+} from '@/modules/tokens/routes/entities/token-addresses.dto.entity';
+
+describe('TokenAddressesSchema', () => {
+  it('splits a comma-separated list into checksummed addresses, preserving order', () => {
+    const addresses = Array.from({ length: 3 }, () =>
+      getAddress(faker.finance.ethereumAddress()),
+    );
+
+    const result = TokenAddressesSchema.safeParse(addresses.join(','));
+
+    expect(result.success).toBe(true);
+    expect(result.data).toStrictEqual(addresses);
+  });
+
+  it('checksums lower-case input and trims whitespace around entries', () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+
+    const result = TokenAddressesSchema.safeParse(
+      ` ${address.toLowerCase()} , ${address} `,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toStrictEqual([address, address]);
+  });
+
+  it("keeps duplicates (de-duplication is the service's job)", () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+
+    const result = TokenAddressesSchema.safeParse(`${address},${address}`);
+
+    expect(result.data).toHaveLength(2);
+  });
+
+  it('rejects an empty list', () => {
+    expect(TokenAddressesSchema.safeParse('').success).toBe(false);
+    expect(TokenAddressesSchema.safeParse(' , ').success).toBe(false);
+  });
+
+  it(`rejects more than ${MAX_TOKEN_ADDRESSES} addresses`, () => {
+    const addresses = Array.from({ length: MAX_TOKEN_ADDRESSES + 1 }, () =>
+      getAddress(faker.finance.ethereumAddress()),
+    );
+
+    expect(TokenAddressesSchema.safeParse(addresses.join(',')).success).toBe(
+      false,
+    );
+  });
+
+  it(`accepts exactly ${MAX_TOKEN_ADDRESSES} addresses`, () => {
+    const addresses = Array.from({ length: MAX_TOKEN_ADDRESSES }, () =>
+      getAddress(faker.finance.ethereumAddress()),
+    );
+
+    expect(TokenAddressesSchema.safeParse(addresses.join(',')).success).toBe(
+      true,
+    );
+  });
+
+  it('rejects a malformed address anywhere in the list', () => {
+    const address = getAddress(faker.finance.ethereumAddress());
+
+    const result = TokenAddressesSchema.safeParse(
+      `${address},0xnot-an-address`,
+    );
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/modules/tokens/routes/entities/token-addresses.dto.entity.ts
+++ b/src/modules/tokens/routes/entities/token-addresses.dto.entity.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+
+/** Upper bound for one batch lookup. The web app's popular list is at most 8 tokens per chain. */
+export const MAX_TOKEN_ADDRESSES = 20;
+
+/**
+ * `?addresses=0x…,0x…` → checksummed addresses in request order.
+ * Empty, malformed or more than MAX_TOKEN_ADDRESSES entries fail validation (422).
+ * Duplicates are kept here; the service collapses them.
+ */
+export const TokenAddressesSchema = z
+  .string()
+  .transform((value) =>
+    value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  )
+  .pipe(z.array(AddressSchema).min(1).max(MAX_TOKEN_ADDRESSES));
+
+export type TokenAddresses = z.infer<typeof TokenAddressesSchema>;

--- a/src/modules/tokens/routes/entities/token-addresses.dto.entity.ts
+++ b/src/modules/tokens/routes/entities/token-addresses.dto.entity.ts
@@ -2,7 +2,15 @@
 import { z } from 'zod';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
-/** Upper bound for one batch lookup. The web app's popular list is at most 8 tokens per chain. */
+/**
+ * Upper bound for one batch lookup. The web app's popular list is at most 8
+ * tokens per chain, so 20 leaves headroom without inviting amplification.
+ *
+ * Read together with `tokens.rateLimit.max`: the two multiply into the
+ * worst-case upstream fan-out per caller per window. Tightening that ceiling
+ * is a rate-limit change, not a change here, because this bound is part of
+ * the published API contract and is interpolated into the OpenAPI schema.
+ */
 export const MAX_TOKEN_ADDRESSES = 20;
 
 /**

--- a/src/modules/tokens/routes/entities/token.dto.entity.ts
+++ b/src/modules/tokens/routes/entities/token.dto.entity.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty } from '@nestjs/swagger';
+import type { Address } from 'viem';
+import type {
+  Erc20Token as DomainErc20Token,
+  Erc721Token as DomainErc721Token,
+  NativeToken as DomainNativeToken,
+} from '@/modules/tokens/domain/entities/token.entity';
+
+class BaseToken {
+  @ApiProperty()
+  address!: Address;
+  @ApiProperty()
+  decimals!: number;
+  @ApiProperty()
+  logoUri!: string;
+  @ApiProperty()
+  name!: string;
+  @ApiProperty()
+  symbol!: string;
+  @ApiProperty({
+    description:
+      'Whether the Transaction Service lists the token in one of its imported token lists',
+  })
+  trusted!: boolean;
+}
+
+export class NativeToken extends BaseToken implements DomainNativeToken {
+  @ApiProperty({ enum: ['NATIVE_TOKEN'] })
+  type!: 'NATIVE_TOKEN';
+}
+
+export class Erc20Token extends BaseToken implements DomainErc20Token {
+  @ApiProperty({ enum: ['ERC20'] })
+  type!: 'ERC20';
+}
+
+export class Erc721Token extends BaseToken implements DomainErc721Token {
+  @ApiProperty({ enum: ['ERC721'] })
+  type!: 'ERC721';
+}

--- a/src/modules/tokens/routes/entities/token.dto.entity.ts
+++ b/src/modules/tokens/routes/entities/token.dto.entity.ts
@@ -25,17 +25,23 @@ class BaseToken {
   trusted!: boolean;
 }
 
-export class NativeToken extends BaseToken implements DomainNativeToken {
+export class NativeTokenMetadata
+  extends BaseToken
+  implements DomainNativeToken
+{
   @ApiProperty({ enum: ['NATIVE_TOKEN'] })
   type!: 'NATIVE_TOKEN';
 }
 
-export class Erc20Token extends BaseToken implements DomainErc20Token {
+export class Erc20TokenMetadata extends BaseToken implements DomainErc20Token {
   @ApiProperty({ enum: ['ERC20'] })
   type!: 'ERC20';
 }
 
-export class Erc721Token extends BaseToken implements DomainErc721Token {
+export class Erc721TokenMetadata
+  extends BaseToken
+  implements DomainErc721Token
+{
   @ApiProperty({ enum: ['ERC721'] })
   type!: 'ERC721';
 }

--- a/src/modules/tokens/routes/entities/token.dto.entity.ts
+++ b/src/modules/tokens/routes/entities/token.dto.entity.ts
@@ -7,7 +7,7 @@ import type {
   NativeToken as DomainNativeToken,
 } from '@/modules/tokens/domain/entities/token.entity';
 
-class BaseToken {
+class BaseTokenMetadata {
   @ApiProperty()
   address!: Address;
   @ApiProperty()
@@ -26,20 +26,23 @@ class BaseToken {
 }
 
 export class NativeTokenMetadata
-  extends BaseToken
+  extends BaseTokenMetadata
   implements DomainNativeToken
 {
   @ApiProperty({ enum: ['NATIVE_TOKEN'] })
   type!: 'NATIVE_TOKEN';
 }
 
-export class Erc20TokenMetadata extends BaseToken implements DomainErc20Token {
+export class Erc20TokenMetadata
+  extends BaseTokenMetadata
+  implements DomainErc20Token
+{
   @ApiProperty({ enum: ['ERC20'] })
   type!: 'ERC20';
 }
 
 export class Erc721TokenMetadata
-  extends BaseToken
+  extends BaseTokenMetadata
   implements DomainErc721Token
 {
   @ApiProperty({ enum: ['ERC721'] })

--- a/src/modules/tokens/routes/guards/tokens-rate-limit.guard.ts
+++ b/src/modules/tokens/routes/guards/tokens-rate-limit.guard.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import { RateLimitGuard } from '@/routes/common/guards/rate-limit.guard';
+
+/**
+ * Per-caller bound for the unauthenticated token metadata routes. The batch route turns one
+ * request into up to `MAX_TOKEN_ADDRESSES` upstream lookups, so its own limit is kept separate
+ * from every other endpoint's.
+ */
+@Injectable()
+export class TokensRateLimitGuard extends RateLimitGuard {
+  constructor(
+    @Inject(IConfigurationService)
+    readonly configurationService: IConfigurationService,
+    @Inject(CacheService) cacheService: ICacheService,
+    @Inject(LoggingService) loggingService: ILoggingService,
+  ) {
+    const rateLimits = {
+      max: configurationService.getOrThrow<number>('tokens.rateLimit.max'),
+      windowSeconds: configurationService.getOrThrow<number>(
+        'tokens.rateLimit.windowSeconds',
+      ),
+    };
+    super(cacheService, loggingService, rateLimits);
+  }
+}

--- a/src/modules/tokens/routes/guards/tokens-rate-limit.guard.ts
+++ b/src/modules/tokens/routes/guards/tokens-rate-limit.guard.ts
@@ -19,8 +19,10 @@ import { RateLimitGuard } from '@/routes/common/guards/rate-limit.guard';
 @Injectable()
 export class TokensRateLimitGuard extends RateLimitGuard {
   constructor(
+    // Read only to build `rateLimits` below, never after construction, so it is
+    // a plain parameter like `cacheService`/`loggingService` rather than a field.
     @Inject(IConfigurationService)
-    readonly configurationService: IConfigurationService,
+    configurationService: IConfigurationService,
     @Inject(CacheService) cacheService: ICacheService,
     @Inject(LoggingService) loggingService: ILoggingService,
   ) {

--- a/src/modules/tokens/routes/tokens.controller.integration.spec.ts
+++ b/src/modules/tokens/routes/tokens.controller.integration.spec.ts
@@ -84,7 +84,9 @@ describe('Tokens controller', () => {
           new NetworkResponseError(new URL(url), { status: 404 } as Response),
         );
       }
-      return Promise.reject(`No matching rule for url: ${url}`);
+      return Promise.reject(
+        new NetworkResponseError(new URL(url), { status: 418 } as Response),
+      );
     });
   };
 
@@ -168,6 +170,8 @@ describe('Tokens controller', () => {
         .query({ addresses: `${token.address},${token.address.toLowerCase()}` })
         .expect(200)
         .expect([token]);
+      // R-005 exception: the same mock also serves the chain-config call, so
+      // toHaveBeenCalledTimes cannot express "the token URL was requested once".
       expect(
         networkService.get.mock.calls.filter(
           ([{ url }]) => url === tokenUrl(chain, token.address),
@@ -238,7 +242,9 @@ describe('Tokens controller', () => {
             new NetworkResponseError(new URL(url), { status: 503 } as Response),
           );
         }
-        return Promise.reject(`No matching rule for url: ${url}`);
+        return Promise.reject(
+          new NetworkResponseError(new URL(url), { status: 418 } as Response),
+        );
       });
 
       await request(app.getHttpServer())

--- a/src/modules/tokens/routes/tokens.controller.integration.spec.ts
+++ b/src/modules/tokens/routes/tokens.controller.integration.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@/__tests__/test-app.provider';
 import { createTestModule } from '@/__tests__/testing-module';
 import { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { NetworkService } from '@/datasources/network/network.service.interface';
@@ -251,6 +252,53 @@ describe('Tokens controller', () => {
         .get(`/v1/chains/${chain.chainId}/tokens`)
         .query({ addresses: `${token.address},${failing}` })
         .expect(503);
+    });
+  });
+
+  describe('rate limiting', () => {
+    let limitedApp: INestApplication<Server>;
+
+    beforeAll(async () => {
+      const defaultConfiguration = configuration();
+      const testConfiguration = (): typeof defaultConfiguration => ({
+        ...defaultConfiguration,
+        tokens: { rateLimit: { max: 1, windowSeconds: 60 } },
+      });
+      const moduleFixture = await createTestModule({
+        config: testConfiguration,
+      });
+
+      limitedApp = await new TestAppProvider().provide(moduleFixture);
+      await initTestApplication(limitedApp);
+    });
+
+    afterAll(async () => {
+      await limitedApp?.close();
+    });
+
+    it('bounds one caller to the configured number of requests', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const url = `/v1/chains/${chain.chainId}/tokens`;
+
+      // Guards run before pipes, so even a request the ValidationPipe rejects
+      // spends the caller's budget — which is the point of the bound.
+      await request(limitedApp.getHttpServer())
+        .get(url)
+        .query({ addresses: '0xnope' })
+        .expect(422);
+
+      await request(limitedApp.getHttpServer())
+        .get(url)
+        .query({ addresses: '0xnope' })
+        .expect(429);
+    });
+
+    it('bounds the single-token route as well', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const url = `/v1/chains/${chain.chainId}/tokens/0xnope`;
+
+      await request(limitedApp.getHttpServer()).get(url).expect(422);
+      await request(limitedApp.getHttpServer()).get(url).expect(429);
     });
   });
 });

--- a/src/modules/tokens/routes/tokens.controller.integration.spec.ts
+++ b/src/modules/tokens/routes/tokens.controller.integration.spec.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import {
+  initTestApplication,
+  TestAppProvider,
+} from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
+import {
+  erc20TokenBuilder,
+  nativeTokenBuilder,
+} from '@/modules/tokens/domain/__tests__/token.builder';
+import type { Token } from '@/modules/tokens/domain/entities/token.entity';
+import { MAX_TOKEN_ADDRESSES } from '@/modules/tokens/routes/entities/token-addresses.dto.entity';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('Tokens controller', () => {
+  let app: INestApplication<Server>;
+  let safeConfigUrl: string;
+  let networkService: MockedObject<INetworkService>;
+
+  // chainBuilder()'s default chainId is a single digit (faker.string.numeric()),
+  // and TransactionApiManager caches one API instance per chainId for the
+  // lifetime of this describe block's shared `app`. With 12 tests sharing one
+  // app, two tests drawing the same digit is near-certain and makes the later
+  // test silently reuse the earlier test's (wrong-host) cached client. Forcing
+  // a unique chainId per test removes that cross-test collision without
+  // changing any assertion.
+  let nextChainId = 1;
+  const uniqueChainId = (): string => `${1000 + nextChainId++}`;
+
+  beforeAll(async () => {
+    const moduleFixture = await createTestModule();
+
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await initTestApplication(app);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const tokenUrl = (chain: Chain, address: string): string =>
+    `${chain.transactionService}/api/v1/tokens/${address}`;
+
+  /** Chain config resolves; each known token resolves; each listed address in `notFound` 404s. */
+  const mockUpstream = (
+    chain: Chain,
+    tokens: Array<Token>,
+    notFound: Array<string> = [],
+  ): void => {
+    networkService.get.mockImplementation(({ url }) => {
+      if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+        return Promise.resolve({ data: rawify(chain), status: 200 });
+      }
+      const token = tokens.find(
+        (item) => url === tokenUrl(chain, item.address),
+      );
+      if (token) {
+        return Promise.resolve({ data: rawify(token), status: 200 });
+      }
+      if (notFound.some((address) => url === tokenUrl(chain, address))) {
+        return Promise.reject(
+          new NetworkResponseError(new URL(url), { status: 404 } as Response),
+        );
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+  };
+
+  describe('GET /v1/chains/:chainId/tokens/:address', () => {
+    it('returns an ERC-20 token', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const token = erc20TokenBuilder().build();
+      mockUpstream(chain, [token]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens/${token.address}`)
+        .expect(200)
+        .expect(token);
+    });
+
+    it('returns the native token entry', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const token = nativeTokenBuilder().build();
+      mockUpstream(chain, [token]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens/${token.address}`)
+        .expect(200)
+        .expect(token);
+    });
+
+    it('returns 404 when the Transaction Service does not know the token', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const address = getAddress(faker.finance.ethereumAddress());
+      mockUpstream(chain, [], [address]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens/${address}`)
+        .expect(404);
+    });
+
+    it('returns 422 for a malformed address', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens/0xnot-an-address`)
+        .expect(422);
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 when the Config Service fails', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const token = erc20TokenBuilder().build();
+      networkService.get.mockRejectedValue(new Error());
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens/${token.address}`)
+        .expect(503);
+    });
+  });
+
+  describe('GET /v1/chains/:chainId/tokens?addresses=', () => {
+    it('returns the known tokens in request order and omits unknown ones', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const first = erc20TokenBuilder().build();
+      const second = erc20TokenBuilder().build();
+      const unknown = getAddress(faker.finance.ethereumAddress());
+      mockUpstream(chain, [first, second], [unknown]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({
+          addresses: [first.address, unknown, second.address].join(','),
+        })
+        .expect(200)
+        .expect([first, second]);
+    });
+
+    it('looks a duplicated address up once and returns it once', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const token = erc20TokenBuilder().build();
+      mockUpstream(chain, [token]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({ addresses: `${token.address},${token.address.toLowerCase()}` })
+        .expect(200)
+        .expect([token]);
+      expect(
+        networkService.get.mock.calls.filter(
+          ([{ url }]) => url === tokenUrl(chain, token.address),
+        ),
+      ).toHaveLength(1);
+    });
+
+    it('returns an empty list when no address is known', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const unknown = getAddress(faker.finance.ethereumAddress());
+      mockUpstream(chain, [], [unknown]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({ addresses: unknown })
+        .expect(200)
+        .expect([]);
+    });
+
+    it('returns 422 when addresses is missing or empty', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .expect(422);
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({ addresses: '' })
+        .expect(422);
+    });
+
+    it(`returns 422 for more than ${MAX_TOKEN_ADDRESSES} addresses`, async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const addresses = Array.from({ length: MAX_TOKEN_ADDRESSES + 1 }, () =>
+        getAddress(faker.finance.ethereumAddress()),
+      );
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({ addresses: addresses.join(',') })
+        .expect(422);
+      expect(networkService.get).not.toHaveBeenCalled();
+    });
+
+    it('returns 422 when one address is malformed', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({ addresses: `${address},0xnot-an-address` })
+        .expect(422);
+    });
+
+    it('propagates a Transaction Service failure that is not a 404', async () => {
+      const chain = chainBuilder().with('chainId', uniqueChainId()).build();
+      const token = erc20TokenBuilder().build();
+      const failing = getAddress(faker.finance.ethereumAddress());
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
+          return Promise.resolve({ data: rawify(chain), status: 200 });
+        }
+        if (url === tokenUrl(chain, token.address)) {
+          return Promise.resolve({ data: rawify(token), status: 200 });
+        }
+        if (url === tokenUrl(chain, failing)) {
+          return Promise.reject(
+            new NetworkResponseError(new URL(url), { status: 503 } as Response),
+          );
+        }
+        return Promise.reject(`No matching rule for url: ${url}`);
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/tokens`)
+        .query({ addresses: `${token.address},${failing}` })
+        .expect(503);
+    });
+  });
+});

--- a/src/modules/tokens/routes/tokens.controller.ts
+++ b/src/modules/tokens/routes/tokens.controller.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import type { Address } from 'viem';
+import type { Token } from '@/modules/tokens/domain/entities/token.entity';
+import {
+  Erc20TokenMetadata,
+  Erc721TokenMetadata,
+  NativeTokenMetadata,
+} from '@/modules/tokens/routes/entities/token.dto.entity';
+import {
+  MAX_TOKEN_ADDRESSES,
+  type TokenAddresses,
+  TokenAddressesSchema,
+} from '@/modules/tokens/routes/entities/token-addresses.dto.entity';
+import { TokensService } from '@/modules/tokens/routes/tokens.service';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+
+const TOKEN_SCHEMA = {
+  oneOf: [
+    { $ref: getSchemaPath(NativeTokenMetadata) },
+    { $ref: getSchemaPath(Erc20TokenMetadata) },
+    { $ref: getSchemaPath(Erc721TokenMetadata) },
+  ],
+};
+
+@ApiTags('tokens')
+@ApiExtraModels(NativeTokenMetadata, Erc20TokenMetadata, Erc721TokenMetadata)
+@Controller({
+  path: '',
+  version: '1',
+})
+export class TokensController {
+  constructor(private readonly tokensService: TokensService) {}
+
+  @ApiOperation({
+    summary: 'Get token metadata',
+    description:
+      'Symbol, name, decimals, logo and trust flag of a token on the given chain, as known by the Transaction Service.',
+  })
+  @ApiParam({ name: 'chainId', type: 'string', example: '1' })
+  @ApiParam({
+    name: 'address',
+    type: 'string',
+    description: 'Token contract address (0x prefixed hex string)',
+  })
+  @ApiOkResponse({ schema: TOKEN_SCHEMA })
+  @ApiNotFoundResponse({
+    description: 'The Transaction Service does not know this token',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'Invalid chain ID or address',
+  })
+  @Get('chains/:chainId/tokens/:address')
+  getToken(
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Param('address', new ValidationPipe(AddressSchema)) address: Address,
+  ): Promise<Token> {
+    return this.tokensService.getToken({ chainId, address });
+  }
+
+  @ApiOperation({
+    summary: 'Get metadata for several tokens',
+    description: `Metadata for up to ${MAX_TOKEN_ADDRESSES} tokens of one chain, in request order. Addresses the Transaction Service does not know are omitted.`,
+  })
+  @ApiParam({ name: 'chainId', type: 'string', example: '1' })
+  @ApiQuery({
+    name: 'addresses',
+    type: 'string',
+    description: `Comma-separated token contract addresses, at most ${MAX_TOKEN_ADDRESSES}`,
+    example:
+      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  })
+  @ApiOkResponse({ schema: { type: 'array', items: TOKEN_SCHEMA } })
+  @ApiUnprocessableEntityResponse({
+    description: `Invalid chain ID, malformed address, empty list or more than ${MAX_TOKEN_ADDRESSES} addresses`,
+  })
+  @Get('chains/:chainId/tokens')
+  getTokens(
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Query('addresses', new ValidationPipe(TokenAddressesSchema))
+    addresses: TokenAddresses,
+  ): Promise<Array<Token>> {
+    return this.tokensService.getTokens({ chainId, addresses });
+  }
+}

--- a/src/modules/tokens/routes/tokens.controller.ts
+++ b/src/modules/tokens/routes/tokens.controller.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import {
   ApiExtraModels,
   ApiNotFoundResponse,
@@ -8,10 +8,12 @@ import {
   ApiParam,
   ApiQuery,
   ApiTags,
+  ApiTooManyRequestsResponse,
   ApiUnprocessableEntityResponse,
   getSchemaPath,
 } from '@nestjs/swagger';
 import type { Address } from 'viem';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
 import type { Token } from '@/modules/tokens/domain/entities/token.entity';
 import {
   Erc20TokenMetadata,
@@ -23,9 +25,9 @@ import {
   type TokenAddresses,
   TokenAddressesSchema,
 } from '@/modules/tokens/routes/entities/token-addresses.dto.entity';
+import { TokensRateLimitGuard } from '@/modules/tokens/routes/guards/tokens-rate-limit.guard';
 import { TokensService } from '@/modules/tokens/routes/tokens.service';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
 const TOKEN_SCHEMA = {
@@ -37,6 +39,9 @@ const TOKEN_SCHEMA = {
 };
 
 @ApiTags('tokens')
+// Unauthenticated lookups: the batch route fans out one request into up to
+// MAX_TOKEN_ADDRESSES upstream calls, so it carries its own per-caller bound.
+@UseGuards(TokensRateLimitGuard)
 @ApiExtraModels(NativeTokenMetadata, Erc20TokenMetadata, Erc721TokenMetadata)
 @Controller({
   path: '',
@@ -65,12 +70,13 @@ export class TokensController {
   @ApiNotFoundResponse({
     description: 'The Transaction Service does not know this token',
   })
+  @ApiTooManyRequestsResponse({ description: 'Rate limit exceeded' })
   @ApiUnprocessableEntityResponse({
     description: 'Invalid chain ID or address',
   })
   @Get('chains/:chainId/tokens/:address')
   getToken(
-    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Param('chainId', new ValidationPipe(ChainIdSchema)) chainId: string,
     @Param('address', new ValidationPipe(AddressSchema)) address: Address,
   ): Promise<Token> {
     return this.tokensService.getToken({ chainId, address });
@@ -97,12 +103,13 @@ export class TokensController {
     schema: { type: 'array', items: TOKEN_SCHEMA },
     description: 'Token metadata for the known addresses, in request order',
   })
+  @ApiTooManyRequestsResponse({ description: 'Rate limit exceeded' })
   @ApiUnprocessableEntityResponse({
     description: `Invalid chain ID, malformed address, empty list or more than ${MAX_TOKEN_ADDRESSES} addresses`,
   })
   @Get('chains/:chainId/tokens')
   getTokens(
-    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @Param('chainId', new ValidationPipe(ChainIdSchema)) chainId: string,
     @Query('addresses', new ValidationPipe(TokenAddressesSchema))
     addresses: TokenAddresses,
   ): Promise<Array<Token>> {

--- a/src/modules/tokens/routes/tokens.controller.ts
+++ b/src/modules/tokens/routes/tokens.controller.ts
@@ -50,13 +50,18 @@ export class TokensController {
     description:
       'Symbol, name, decimals, logo and trust flag of a token on the given chain, as known by the Transaction Service.',
   })
-  @ApiParam({ name: 'chainId', type: 'string', example: '1' })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID the token is deployed on',
+    example: '1',
+  })
   @ApiParam({
     name: 'address',
     type: 'string',
     description: 'Token contract address (0x prefixed hex string)',
   })
-  @ApiOkResponse({ schema: TOKEN_SCHEMA })
+  @ApiOkResponse({ schema: TOKEN_SCHEMA, description: 'Token metadata' })
   @ApiNotFoundResponse({
     description: 'The Transaction Service does not know this token',
   })
@@ -75,7 +80,12 @@ export class TokensController {
     summary: 'Get metadata for several tokens',
     description: `Metadata for up to ${MAX_TOKEN_ADDRESSES} tokens of one chain, in request order. Addresses the Transaction Service does not know are omitted.`,
   })
-  @ApiParam({ name: 'chainId', type: 'string', example: '1' })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID the token is deployed on',
+    example: '1',
+  })
   @ApiQuery({
     name: 'addresses',
     type: 'string',
@@ -83,7 +93,10 @@ export class TokensController {
     example:
       '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,0xdAC17F958D2ee523a2206206994597C13D831ec7',
   })
-  @ApiOkResponse({ schema: { type: 'array', items: TOKEN_SCHEMA } })
+  @ApiOkResponse({
+    schema: { type: 'array', items: TOKEN_SCHEMA },
+    description: 'Token metadata for the known addresses, in request order',
+  })
   @ApiUnprocessableEntityResponse({
     description: `Invalid chain ID, malformed address, empty list or more than ${MAX_TOKEN_ADDRESSES} addresses`,
   })

--- a/src/modules/tokens/routes/tokens.service.spec.ts
+++ b/src/modules/tokens/routes/tokens.service.spec.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { HttpStatus } from '@nestjs/common';
+import { getAddress } from 'viem';
+import type { MockedObject } from 'vitest';
+import { DataSourceError } from '@/domain/errors/data-source.error';
+import {
+  erc20TokenBuilder,
+  nativeTokenBuilder,
+} from '@/modules/tokens/domain/__tests__/token.builder';
+import type { ITokenRepository } from '@/modules/tokens/domain/token.repository.interface';
+import { TokensService } from '@/modules/tokens/routes/tokens.service';
+
+const tokenRepository = {
+  getToken: vi.fn(),
+  getTokens: vi.fn(),
+} as MockedObject<ITokenRepository>;
+
+describe('TokensService', () => {
+  const chainId = faker.string.numeric();
+  const service = new TokensService(tokenRepository);
+
+  describe('getToken', () => {
+    it('delegates to the repository with the same arguments', async () => {
+      const token = erc20TokenBuilder().build();
+      tokenRepository.getToken.mockResolvedValue(token);
+
+      await expect(
+        service.getToken({ chainId, address: token.address }),
+      ).resolves.toStrictEqual(token);
+      expect(tokenRepository.getToken).toHaveBeenCalledWith({
+        chainId,
+        address: token.address,
+      });
+    });
+  });
+
+  describe('getTokens', () => {
+    it('returns the tokens in request order', async () => {
+      const first = nativeTokenBuilder().build();
+      const second = erc20TokenBuilder().build();
+      tokenRepository.getToken.mockImplementation(({ address }) =>
+        Promise.resolve(address === first.address ? first : second),
+      );
+
+      const result = await service.getTokens({
+        chainId,
+        addresses: [first.address, second.address],
+      });
+
+      expect(result).toStrictEqual([first, second]);
+    });
+
+    it('skips an address the Transaction Service does not know (404)', async () => {
+      const known = erc20TokenBuilder().build();
+      const unknown = getAddress(faker.finance.ethereumAddress());
+      tokenRepository.getToken.mockImplementation(({ address }) =>
+        address === unknown
+          ? Promise.reject(
+              new DataSourceError('Not found', HttpStatus.NOT_FOUND),
+            )
+          : Promise.resolve(known),
+      );
+
+      const result = await service.getTokens({
+        chainId,
+        addresses: [unknown, known.address],
+      });
+
+      expect(result).toStrictEqual([known]);
+    });
+
+    it('returns an empty list when every address is unknown', async () => {
+      tokenRepository.getToken.mockRejectedValue(
+        new DataSourceError('Not found', HttpStatus.NOT_FOUND),
+      );
+
+      await expect(
+        service.getTokens({
+          chainId,
+          addresses: [getAddress(faker.finance.ethereumAddress())],
+        }),
+      ).resolves.toStrictEqual([]);
+    });
+
+    it('propagates the first non-404 failure', async () => {
+      const token = erc20TokenBuilder().build();
+      const failing = getAddress(faker.finance.ethereumAddress());
+      const error = new DataSourceError(
+        'Service unavailable',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      tokenRepository.getToken.mockImplementation(({ address }) =>
+        address === failing ? Promise.reject(error) : Promise.resolve(token),
+      );
+
+      await expect(
+        service.getTokens({ chainId, addresses: [token.address, failing] }),
+      ).rejects.toBe(error);
+    });
+
+    it('propagates a non-DataSourceError failure as an Error', async () => {
+      tokenRepository.getToken.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        service.getTokens({
+          chainId,
+          addresses: [getAddress(faker.finance.ethereumAddress())],
+        }),
+      ).rejects.toThrow('boom');
+    });
+
+    it('collapses case-insensitive duplicates and looks each address up once', async () => {
+      const token = erc20TokenBuilder().build();
+      tokenRepository.getToken.mockResolvedValue(token);
+
+      const result = await service.getTokens({
+        chainId,
+        addresses: [
+          token.address,
+          token.address.toLowerCase() as typeof token.address,
+          token.address,
+        ],
+      });
+
+      expect(result).toStrictEqual([token]);
+      expect(tokenRepository.getToken).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/modules/tokens/routes/tokens.service.spec.ts
+++ b/src/modules/tokens/routes/tokens.service.spec.ts
@@ -99,6 +99,39 @@ describe('TokensService', () => {
       ).rejects.toBe(error);
     });
 
+    it('propagates the failure at the lower request index when two requests fail', async () => {
+      const addresses = Array.from({ length: 3 }, () =>
+        getAddress(faker.finance.ethereumAddress()),
+      );
+      const token = erc20TokenBuilder().build();
+      const firstError = new DataSourceError(
+        'Service unavailable',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      const secondError = new DataSourceError(
+        'Internal error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      tokenRepository.getToken.mockImplementation(({ address }) => {
+        if (address === addresses[0]) {
+          // Settles after the index-2 rejection below: Promise.allSettled
+          // preserves request order regardless of which promise settles
+          // first, so the index-0 error must still be the one that propagates.
+          return new Promise((_, reject) =>
+            setTimeout(() => reject(firstError), 10),
+          );
+        }
+        if (address === addresses[2]) {
+          return Promise.reject(secondError);
+        }
+        return Promise.resolve(token);
+      });
+
+      await expect(service.getTokens({ chainId, addresses })).rejects.toBe(
+        firstError,
+      );
+    });
+
     it('propagates a non-DataSourceError failure as an Error', async () => {
       tokenRepository.getToken.mockRejectedValue(new Error('boom'));
 

--- a/src/modules/tokens/routes/tokens.service.ts
+++ b/src/modules/tokens/routes/tokens.service.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import uniqBy from 'lodash/uniqBy';
 import type { Address } from 'viem';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import { asError } from '@/logging/utils';
@@ -8,19 +9,6 @@ import { ITokenRepository } from '@/modules/tokens/domain/token.repository.inter
 
 const isNotFound = (error: unknown): boolean =>
   error instanceof DataSourceError && error.code === HttpStatus.NOT_FOUND;
-
-/** Case-insensitive de-duplication that keeps each address at its first position. */
-const uniqueAddresses = (addresses: Array<Address>): Array<Address> => {
-  const seen = new Set<string>();
-  return addresses.filter((address) => {
-    const key = address.toLowerCase();
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
-};
 
 @Injectable()
 export class TokensService {
@@ -43,8 +31,10 @@ export class TokensService {
     addresses: Array<Address>;
   }): Promise<Array<Token>> {
     const settled = await Promise.allSettled(
-      uniqueAddresses(args.addresses).map((address) =>
-        this.tokenRepository.getToken({ chainId: args.chainId, address }),
+      // Case-insensitive, keeps each address at its first position.
+      uniqBy(args.addresses, (address) => address.toLowerCase()).map(
+        (address) =>
+          this.tokenRepository.getToken({ chainId: args.chainId, address }),
       ),
     );
 

--- a/src/modules/tokens/routes/tokens.service.ts
+++ b/src/modules/tokens/routes/tokens.service.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import type { Address } from 'viem';
+import { DataSourceError } from '@/domain/errors/data-source.error';
+import { asError } from '@/logging/utils';
+import type { Token } from '@/modules/tokens/domain/entities/token.entity';
+import { ITokenRepository } from '@/modules/tokens/domain/token.repository.interface';
+
+const isNotFound = (error: unknown): boolean =>
+  error instanceof DataSourceError && error.code === HttpStatus.NOT_FOUND;
+
+/** Case-insensitive de-duplication that keeps each address at its first position. */
+const uniqueAddresses = (addresses: Array<Address>): Array<Address> => {
+  const seen = new Set<string>();
+  return addresses.filter((address) => {
+    const key = address.toLowerCase();
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+};
+
+@Injectable()
+export class TokensService {
+  constructor(
+    @Inject(ITokenRepository)
+    private readonly tokenRepository: ITokenRepository,
+  ) {}
+
+  getToken(args: { chainId: string; address: Address }): Promise<Token> {
+    return this.tokenRepository.getToken(args);
+  }
+
+  /**
+   * Metadata for several tokens of one chain, in request order.
+   * An address the Transaction Service does not know (404) is left out; any other
+   * failure is propagated so the client sees an error rather than a silently short list.
+   */
+  async getTokens(args: {
+    chainId: string;
+    addresses: Array<Address>;
+  }): Promise<Array<Token>> {
+    const settled = await Promise.allSettled(
+      uniqueAddresses(args.addresses).map((address) =>
+        this.tokenRepository.getToken({ chainId: args.chainId, address }),
+      ),
+    );
+
+    const tokens: Array<Token> = [];
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        tokens.push(result.value);
+      } else if (!isNotFound(result.reason)) {
+        throw asError(result.reason);
+      }
+    }
+    return tokens;
+  }
+}

--- a/src/modules/tokens/tokens.module.ts
+++ b/src/modules/tokens/tokens.module.ts
@@ -3,14 +3,18 @@ import { Module } from '@nestjs/common';
 import { TransactionApiManagerModule } from '@/domain/interfaces/transaction-api.manager.interface';
 import { TokenRepository } from '@/modules/tokens/domain/token.repository';
 import { ITokenRepository } from '@/modules/tokens/domain/token.repository.interface';
+import { TokensController } from '@/modules/tokens/routes/tokens.controller';
+import { TokensService } from '@/modules/tokens/routes/tokens.service';
 
 @Module({
   imports: [TransactionApiManagerModule],
+  controllers: [TokensController],
   providers: [
     {
       provide: ITokenRepository,
       useClass: TokenRepository,
     },
+    TokensService,
   ],
   exports: [ITokenRepository],
 })


### PR DESCRIPTION
- Closes [WA-3516](https://linear.app/safe-global/issue/WA-3516/implement-get-chainschainidtokens)

## Summary

Adds two public read endpoints on the existing `tokens` module so clients can resolve token metadata (symbol, name, decimals, logo, trusted) from the Transaction Service by address, instead of freezing it into their own source:

- `GET /v1/chains/{chainId}/tokens/{address}` — one token; 404 when the Transaction Service does not know it.
- `GET /v1/chains/{chainId}/tokens?addresses=a,b,c` — up to 20 tokens in request order; addresses the Transaction Service does not know are omitted, any other upstream failure propagates.

First consumer is the Space-level spending-limit token selector ([WA-3149](https://linear.app/safe-global/issue/WA-3149/build-the-chain-aware-token-selector), safe-wallet-monorepo #8662): its popular-token list keeps only per-chain addresses and resolves everything else through these routes, so the metadata can never drift from what the assets page already shows.

Two design points worth a reviewer's judgement. The batch route fans out at most 20 parallel single-token lookups; each is already cached per `(chainId, address)` by the existing datasource and covered by the per-chain circuit breaker, so no new caching was added and the fan-out is not chunked, matching the existing Safe-overview batch. Because that amplification sits behind an unauthenticated route, both routes carry a `TokensRateLimitGuard`: 60 requests per 60 seconds per caller per route, tunable via `TOKENS_RATE_LIMIT_MAX` and `TOKENS_RATE_LIMIT_WINDOW_SECONDS` — the first rate-limited GET in this repo, added after `@claude arch-review` flagged the abuse-controls rule.

The 20-address cap stays a named constant rather than a config value: it is a published API contract bound, interpolated into the OpenAPI descriptions, and two deployments advertising different bounds would be worse than one fixed number. The `Batch and chunk upstream calls` rule asks for config there, but its own canonical example (`CoingeckoApi.MAX_BATCH_SIZE`) is a static class constant, and that rule governs chunk sizes for splitting a large input rather than a validation bound that rejects with 422. Flagged for the reviewer rather than changed unilaterally.

## Changes

- `routes/tokens.controller.ts`: the two routes, every `@Param` and `@Query` through `new ValidationPipe(Schema)`, and a Swagger response for each outcome the routes can produce.
- `routes/tokens.service.ts`: the only new logic. De-duplicates addresses case-insensitively, skips an address the Transaction Service returns 404 for, propagates the first non-404 failure, and preserves request order.
- `routes/entities/token-addresses.dto.entity.ts`: parses the comma-separated `addresses` query into `Address[]`; empty or more than 20 entries fail validation with 422.
- `routes/entities/token.dto.entity.ts`: Swagger classes for the Native / ERC-20 / ERC-721 union. Named `*TokenMetadata` because `components.schemas` is keyed by class name across the whole app and the balances module already owns `NativeToken` / `Erc20Token` / `Erc721Token`, which omit `trusted`.
- `routes/guards/tokens-rate-limit.guard.ts`: `RateLimitGuard` subclass reading `tokens.rateLimit.*`.
- `tokens.module.ts`: registers the controller and the route service.
- `src/config/entities/configuration.ts`, `schemas/configuration.schema.ts`, `entities/__tests__/configuration.ts`, `.env.sample.json`: `TOKENS_RATE_LIMIT_MAX` / `TOKENS_RATE_LIMIT_WINDOW_SECONDS` (default 60 / 60), mapped, validated at boot with `.min(1)`, mirrored in the test config and documented.
- Tests: address-schema spec (7), service spec (8), controller integration spec (14, two of them covering the rate limit).