### PR TITLE
feat: audit log address book requests

### DIFF
--- a/src/modules/spaces/domain/address-books/address-book-items.repository.spec.ts
+++ b/src/modules/spaces/domain/address-books/address-book-items.repository.spec.ts
@@ -226,11 +226,13 @@ describe('AddressBookItemsRepository', () => {
       const address = getAddress(faker.finance.ethereumAddress());
       const name = 'Alice';
       spaceEncryptionService.itemAddressIndex.mockReturnValue('idx');
+
       const item = { id: 9, address: 'kms:v1:a', name: 'kms:v1:n' };
+      const decrypted = [{ id: 9, address, name }];
       entityManager.findOne.mockResolvedValue(item);
-      spaceEncryptionService.decryptAddressBookItems.mockResolvedValue([
-        { id: 9, address, name },
-      ]);
+      spaceEncryptionService.decryptAddressBookItems.mockResolvedValue(
+        decrypted,
+      );
 
       await target.deleteByAddress({ authPayload, spaceId, address });
 

--- a/src/modules/spaces/domain/address-books/address-book-requests.repository.interface.ts
+++ b/src/modules/spaces/domain/address-books/address-book-requests.repository.interface.ts
@@ -28,6 +28,7 @@ export interface IAddressBookRequestsRepository {
   findOneOrFail(args: {
     id: AddressBookRequest['id'];
     spaceId: Space['id'];
+    entityManager?: EntityManager;
   }): Promise<AddressBookRequest>;
 
   countPending(args: {
@@ -40,6 +41,12 @@ export interface IAddressBookRequestsRepository {
     requestedById: User['id'];
     item: AddressBookItem;
   }): Promise<AddressBookRequest>;
+
+  reject(args: {
+    id: AddressBookRequest['id'];
+    spaceId: Space['id'];
+    reviewedBy: User['id'];
+  }): Promise<boolean>;
 
   transitionFromPending(args: {
     id: AddressBookRequest['id'];

--- a/src/modules/spaces/domain/address-books/address-book-requests.repository.spec.ts
+++ b/src/modules/spaces/domain/address-books/address-book-requests.repository.spec.ts
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
+import { NotFoundException } from '@nestjs/common';
 import { getAddress } from 'viem';
 import type { Mock, MockedObject } from 'vitest';
 import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { AddressBookRequest as DbAddressBookRequest } from '@/modules/spaces/datasources/address-books/entities/address-book-request.entity.db';
 import { createMockSpaceEncryptionService } from '@/modules/spaces/domain/__tests__/space-encryption.service.mock';
 import { AddressBookRequestsRepository } from '@/modules/spaces/domain/address-books/address-book-requests.repository';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
 
 describe('AddressBookRequestsRepository', () => {
   const spaceId = faker.number.int({ min: 1, max: 100_000 });
@@ -14,12 +18,19 @@ describe('AddressBookRequestsRepository', () => {
   let spaceEncryptionService: ReturnType<
     typeof createMockSpaceEncryptionService
   >;
+  let spaceAuditRepository: ReturnType<typeof createMockSpaceAuditRepository>;
   let requestRepository: {
     find: Mock;
     findOne: Mock;
-    insert: Mock;
     count: Mock;
     update: Mock;
+  };
+  let entityManager: {
+    getRepository: Mock;
+    findBy: Mock;
+    findOne: Mock;
+    insert: Mock;
+    delete: Mock;
   };
   let db: MockedObject<PostgresDatabaseService>;
   let target: AddressBookRequestsRepository;
@@ -28,31 +39,49 @@ describe('AddressBookRequestsRepository', () => {
     vi.resetAllMocks();
 
     spaceEncryptionService = createMockSpaceEncryptionService();
+    spaceAuditRepository = createMockSpaceAuditRepository();
+
     requestRepository = {
       find: vi.fn().mockResolvedValue([]),
       findOne: vi.fn(),
-      insert: vi.fn(),
       count: vi.fn(),
       update: vi.fn(),
     };
+    entityManager = {
+      getRepository: vi.fn().mockReturnValue(requestRepository),
+      findBy: vi.fn().mockResolvedValue([]),
+      findOne: vi.fn(),
+      insert: vi.fn(),
+      delete: vi.fn(),
+    };
     db = {
       getRepository: vi.fn().mockResolvedValue(requestRepository),
+      transaction: vi.fn((fn: (em: unknown) => Promise<unknown>) =>
+        fn(entityManager),
+      ),
     } as MockedObject<PostgresDatabaseService>;
 
-    target = new AddressBookRequestsRepository(db, spaceEncryptionService);
+    target = new AddressBookRequestsRepository(
+      db,
+      spaceEncryptionService,
+      spaceAuditRepository,
+    );
   });
 
   describe('create', () => {
-    it('encrypts the address and name before insert and returns the decrypted row', async () => {
+    it('encrypts the address and name before insert, records the audit event, and returns the decrypted row', async () => {
       const address = getAddress(faker.finance.ethereumAddress());
       const name = 'Alice';
       const chainIds = ['1'];
+      const spaceUuid = faker.string.uuid();
+
       spaceEncryptionService.encryptAddressBookRequest.mockResolvedValue({
         address: 'kms:v1:a',
         name: 'kms:v1:n',
         addressIndex: 'idx',
       });
-      requestRepository.insert.mockResolvedValue({ identifiers: [{ id: 5 }] });
+      entityManager.findOne.mockResolvedValue({ id: spaceId, uuid: spaceUuid });
+      entityManager.insert.mockResolvedValue({ identifiers: [{ id: 5 }] });
       requestRepository.findOne.mockResolvedValue({
         id: 5,
         address: 'kms:v1:a',
@@ -71,7 +100,8 @@ describe('AddressBookRequestsRepository', () => {
       expect(
         spaceEncryptionService.encryptAddressBookRequest,
       ).toHaveBeenCalledExactlyOnceWith(spaceId, { address, name });
-      expect(requestRepository.insert).toHaveBeenCalledExactlyOnceWith(
+      expect(entityManager.insert).toHaveBeenCalledExactlyOnceWith(
+        DbAddressBookRequest,
         expect.objectContaining({
           space: { id: spaceId },
           requestedBy: { id: requestedById },
@@ -81,7 +111,117 @@ describe('AddressBookRequestsRepository', () => {
           status: 'PENDING',
         }),
       );
+      expect(spaceAuditRepository.record).toHaveBeenCalledExactlyOnceWith(
+        entityManager,
+        {
+          spaceId,
+          spaceUuid,
+          eventType: SpaceAuditEventType.ADDRESS_BOOK_REQUEST_CREATED,
+          actorUserId: requestedById,
+          payload: { address, name },
+        },
+      );
       expect(result.address).toBe(address);
+    });
+
+    it('rejects with NotFoundException and writes nothing when the space does not exist', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      entityManager.findOne.mockResolvedValue(null);
+
+      await expect(
+        target.create({
+          spaceId,
+          requestedById,
+          item: { address, name: 'Alice', chainIds: ['1'] },
+        }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(entityManager.insert).not.toHaveBeenCalled();
+      expect(spaceAuditRepository.record).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reject', () => {
+    it('flips a pending request to REJECTED and records the audit event with the decrypted values', async () => {
+      const requestId = faker.number.int({ min: 1, max: 100_000 });
+      const reviewedBy = faker.number.int({ min: 1, max: 100_000 });
+      const spaceUuid = faker.string.uuid();
+      const address = getAddress(faker.finance.ethereumAddress());
+      const name = 'Alice';
+      const row = { id: requestId, address: 'kms:v1:a', name: 'kms:v1:n' };
+      const decrypted = [{ id: requestId, address, name }];
+      entityManager.findOne.mockResolvedValue({ id: spaceId, uuid: spaceUuid });
+      requestRepository.findOne.mockResolvedValue(row);
+      spaceEncryptionService.decryptAddressBookRequests.mockResolvedValue(
+        decrypted,
+      );
+      requestRepository.update.mockResolvedValue({ affected: 1 });
+
+      await expect(
+        target.reject({ id: requestId, spaceId, reviewedBy }),
+      ).resolves.toBe(true);
+
+      expect(requestRepository.findOne).toHaveBeenCalledExactlyOnceWith({
+        where: { id: requestId, space: { id: spaceId } },
+        relations: { requestedBy: true },
+      });
+      expect(requestRepository.update).toHaveBeenCalledExactlyOnceWith(
+        { id: requestId, space: { id: spaceId }, status: 'PENDING' },
+        { status: 'REJECTED', reviewedBy },
+      );
+      expect(spaceAuditRepository.record).toHaveBeenCalledExactlyOnceWith(
+        entityManager,
+        {
+          spaceId,
+          spaceUuid,
+          eventType: SpaceAuditEventType.ADDRESS_BOOK_REQUEST_REJECTED,
+          actorUserId: reviewedBy,
+          payload: { address, name },
+        },
+      );
+    });
+
+    it('returns false and records nothing when the request is no longer pending', async () => {
+      const requestId = faker.number.int({ min: 1, max: 100_000 });
+      const reviewedBy = faker.number.int({ min: 1, max: 100_000 });
+      const address = getAddress(faker.finance.ethereumAddress());
+      entityManager.findOne.mockResolvedValue({
+        id: spaceId,
+        uuid: faker.string.uuid(),
+      });
+      const decrypted = [{ id: requestId, address, name: 'Alice' }];
+      requestRepository.findOne.mockResolvedValue({
+        id: requestId,
+        address: 'kms:v1:a',
+        name: 'kms:v1:n',
+      });
+      spaceEncryptionService.decryptAddressBookRequests.mockResolvedValue(
+        decrypted,
+      );
+      requestRepository.update.mockResolvedValue({ affected: 0 });
+
+      await expect(
+        target.reject({ id: requestId, spaceId, reviewedBy }),
+      ).resolves.toBe(false);
+
+      expect(spaceAuditRepository.record).not.toHaveBeenCalled();
+    });
+
+    it('rejects with NotFoundException and writes nothing when the request does not exist', async () => {
+      const requestId = faker.number.int({ min: 1, max: 100_000 });
+      const reviewedBy = faker.number.int({ min: 1, max: 100_000 });
+      entityManager.findOne.mockResolvedValue({
+        id: spaceId,
+        uuid: faker.string.uuid(),
+      });
+      requestRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        target.reject({ id: requestId, spaceId, reviewedBy }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(requestRepository.update).not.toHaveBeenCalled();
+      expect(spaceAuditRepository.record).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/spaces/domain/address-books/address-book-requests.repository.ts
+++ b/src/modules/spaces/domain/address-books/address-book-requests.repository.ts
@@ -6,12 +6,15 @@ import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.s
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
 import { AddressBookRequest as DbAddressBookRequest } from '@/modules/spaces/datasources/address-books/entities/address-book-request.entity.db';
+import { Space as DbSpace } from '@/modules/spaces/datasources/spaces/entities/space.entity.db';
 import { IAddressBookRequestsRepository } from '@/modules/spaces/domain/address-books/address-book-requests.repository.interface';
 import type { AddressBookItem } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import type {
   AddressBookRequest,
   AddressBookRequestStatus,
 } from '@/modules/spaces/domain/address-books/entities/address-book-request.entity';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { SpaceEncryptionService } from '@/modules/spaces/domain/space-encryption.service';
 import type { User } from '@/modules/users/domain/entities/user.entity';
@@ -24,6 +27,8 @@ export class AddressBookRequestsRepository
     private readonly db: PostgresDatabaseService,
     @Inject(SpaceEncryptionService)
     private readonly spaceEncryptionService: SpaceEncryptionService,
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
   ) {}
 
   public async findBySpaceId(args: {
@@ -77,8 +82,11 @@ export class AddressBookRequestsRepository
   public async findOneOrFail(args: {
     id: AddressBookRequest['id'];
     spaceId: Space['id'];
+    entityManager?: EntityManager;
   }): Promise<AddressBookRequest> {
-    const repository = await this.db.getRepository(DbAddressBookRequest);
+    const repository = args.entityManager
+      ? args.entityManager.getRepository(DbAddressBookRequest)
+      : await this.db.getRepository(DbAddressBookRequest);
     const request = await repository.findOne({
       where: {
         id: args.id,
@@ -117,7 +125,6 @@ export class AddressBookRequestsRepository
     requestedById: User['id'];
     item: AddressBookItem;
   }): Promise<AddressBookRequest> {
-    const repository = await this.db.getRepository(DbAddressBookRequest);
     // The owning space id is known up front, so ciphertext + blind index are
     // computed before insert — no two-phase dance.
     const encrypted =
@@ -125,26 +132,44 @@ export class AddressBookRequestsRepository
         args.spaceId,
         { address: args.item.address, name: args.item.name },
       );
-    let result: InsertResult;
-    try {
-      result = await repository.insert({
-        space: { id: args.spaceId },
-        requestedBy: { id: args.requestedById },
-        address: encrypted.address as DbAddressBookRequest['address'],
-        addressIndex: encrypted.addressIndex,
-        name: encrypted.name,
-        chainIds: args.item.chainIds,
-        status: 'PENDING',
-      });
-    } catch (err) {
-      if (isUniqueConstraintError(err)) {
-        throw new UniqueConstraintError(
-          'A pending request for this address already exists.',
-        );
+
+    const insertedId = await this.db.transaction(async (entityManager) => {
+      let result: InsertResult;
+
+      const { id: spaceId, uuid: spaceUuid } =
+        await this.findSpaceForAuditOrFail(entityManager, args.spaceId);
+      try {
+        result = await entityManager.insert(DbAddressBookRequest, {
+          space: { id: spaceId },
+          requestedBy: { id: args.requestedById },
+          address: encrypted.address as DbAddressBookRequest['address'],
+          addressIndex: encrypted.addressIndex,
+          name: encrypted.name,
+          chainIds: args.item.chainIds,
+          status: 'PENDING',
+        });
+      } catch (err) {
+        if (isUniqueConstraintError(err)) {
+          throw new UniqueConstraintError(
+            'A pending request for this address already exists.',
+          );
+        }
+        throw err;
       }
-      throw err;
-    }
-    const insertedId = result.identifiers[0].id;
+
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId,
+        spaceUuid,
+        eventType: SpaceAuditEventType.ADDRESS_BOOK_REQUEST_CREATED,
+        actorUserId: args.requestedById,
+        payload: {
+          address: args.item.address,
+          name: args.item.name,
+        },
+      });
+      return result.identifiers[0].id;
+    });
+
     return this.findOneOrFail({ id: insertedId, spaceId: args.spaceId });
   }
 
@@ -163,5 +188,56 @@ export class AddressBookRequestsRepository
       { status: args.toStatus, reviewedBy: args.reviewedBy },
     );
     return (result.affected ?? 0) > 0;
+  }
+
+  public async reject(args: {
+    id: AddressBookRequest['id'];
+    spaceId: Space['id'];
+    reviewedBy: User['id'];
+  }): Promise<boolean> {
+    return await this.db.transaction(async (entityManager) => {
+      const { id: spaceId, uuid: spaceUuid } =
+        await this.findSpaceForAuditOrFail(entityManager, args.spaceId);
+
+      const { address, name } = await this.findOneOrFail({
+        id: args.id,
+        spaceId: args.spaceId,
+        entityManager,
+      });
+
+      const rejected = await this.transitionFromPending({
+        id: args.id,
+        spaceId: spaceId,
+        toStatus: 'REJECTED',
+        reviewedBy: args.reviewedBy,
+        entityManager,
+      });
+
+      if (rejected) {
+        await this.spaceAuditRepository.record(entityManager, {
+          spaceId,
+          spaceUuid,
+          eventType: SpaceAuditEventType.ADDRESS_BOOK_REQUEST_REJECTED,
+          actorUserId: args.reviewedBy,
+          payload: { address, name },
+        });
+      }
+
+      return rejected;
+    });
+  }
+
+  private async findSpaceForAuditOrFail(
+    entityManager: EntityManager,
+    spaceId: Space['id'],
+  ): Promise<Pick<DbSpace, 'id' | 'uuid'>> {
+    const space = await entityManager.findOne(DbSpace, {
+      where: { id: spaceId },
+      select: { id: true, uuid: true },
+    });
+    if (!space) {
+      throw new NotFoundException('Workspace not found.');
+    }
+    return space;
   }
 }

--- a/src/modules/spaces/domain/audit/entities/space-audit-event.entity.spec.ts
+++ b/src/modules/spaces/domain/audit/entities/space-audit-event.entity.spec.ts
@@ -53,4 +53,26 @@ describe('SpaceAuditEventSchema — plaintext addresses', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('accepts plaintext addresses in an ADDRESS_BOOK_REQUEST_CREATED payload', () => {
+    const result = SpaceAuditEventSchema.safeParse({
+      eventType: 'ADDRESS_BOOK_REQUEST_CREATED',
+      payload: {
+        address: plaintext,
+        name: faker.person.fullName(),
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts plaintext addresses in an ADDRESS_BOOK_REQUEST_REJECTED payload', () => {
+    const result = SpaceAuditEventSchema.safeParse({
+      eventType: 'ADDRESS_BOOK_REQUEST_REJECTED',
+      payload: {
+        address: plaintext,
+        name: faker.person.fullName(),
+      },
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts
+++ b/src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts
@@ -30,6 +30,8 @@ export enum SpaceAuditEventType {
   SAFE_REMOVED = 'SAFE_REMOVED',
   ADDRESS_BOOK_UPSERTED = 'ADDRESS_BOOK_UPSERTED',
   ADDRESS_BOOK_DELETED = 'ADDRESS_BOOK_DELETED',
+  ADDRESS_BOOK_REQUEST_CREATED = 'ADDRESS_BOOK_REQUEST_CREATED',
+  ADDRESS_BOOK_REQUEST_REJECTED = 'ADDRESS_BOOK_REQUEST_REJECTED',
 }
 
 export const SpaceAuditEventTypeSchema = z.enum(
@@ -143,10 +145,17 @@ export const AddressBookUpsertedEventSchema = z.object({
 
 export const AddressBookDeletedEventSchema = z.object({
   eventType: z.literal(SpaceAuditEventType.ADDRESS_BOOK_DELETED),
-  payload: z.object({
-    address: AddressSchema,
-    name: z.string(),
-  }),
+  payload: AddressBookEntrySchema,
+});
+
+export const AddressBookRequestCreatedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.ADDRESS_BOOK_REQUEST_CREATED),
+  payload: AddressBookEntrySchema,
+});
+
+export const AddressBookRequestRejectedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.ADDRESS_BOOK_REQUEST_REJECTED),
+  payload: AddressBookEntrySchema,
 });
 
 export const SpaceAuditEventSchema = z.discriminatedUnion('eventType', [
@@ -165,6 +174,8 @@ export const SpaceAuditEventSchema = z.discriminatedUnion('eventType', [
   SafeRemovedEventSchema,
   AddressBookUpsertedEventSchema,
   AddressBookDeletedEventSchema,
+  AddressBookRequestCreatedEventSchema,
+  AddressBookRequestRejectedEventSchema,
 ]);
 
 export type SpaceAuditEvent = z.infer<typeof SpaceAuditEventSchema>;

--- a/src/modules/spaces/routes/address-books/address-book-requests.service.ts
+++ b/src/modules/spaces/routes/address-books/address-book-requests.service.ts
@@ -148,10 +148,9 @@ export class AddressBookRequestsService {
     const userId = getAuthenticatedUserIdOrFail(authPayload);
     await assertAdmin(this.spacesRepository, spaceId, userId);
 
-    const rejected = await this.requestsRepository.transitionFromPending({
+    const rejected = await this.requestsRepository.reject({
       id: requestId,
       spaceId,
-      toStatus: 'REJECTED',
       reviewedBy: userId,
     });
     if (!rejected) {


### PR DESCRIPTION
## Summary

Pending address book requests created by Workspace members, and their rejection by an admin, left no trace in the Workspace audit log. Only the approve path was covered, indirectly, through the existing `ADDRESS_BOOK_UPSERTED` event emitted when the approved item is upserted.

This PR adds two audit event types, `ADDRESS_BOOK_REQUEST_CREATED` and `ADDRESS_BOOK_REQUEST_REJECTED`.

Resolves [WA-2618](https://linear.app/safe-global/issue/WA-2618/activity-pending-address-book-requests-from-members-are-not-logged)

## Changes

- `src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts` — add `ADDRESS_BOOK_REQUEST_CREATED` / `ADDRESS_BOOK_REQUEST_REJECTED` to the enum
- `src/modules/spaces/domain/address-books/address-book-requests.repository.ts` — inject `ISpaceAuditRepository`; wrap `create()` in `db.transaction` and record the created event; add `reject()` (transactional transition + audit); `findOneOrFail` accepts an optional `EntityManager`; add `findSpaceForAuditOrFail` helper (404 when the Workspace is missing)
- `src/modules/spaces/domain/address-books/address-book-requests.repository.interface.ts` — declare `reject()` and the optional `entityManager` on `findOneOrFail`
- `src/modules/spaces/routes/address-books/address-book-requests.service.ts` — `reject()` calls the new repository method instead of `transitionFromPending`